### PR TITLE
feat: implement Fortnox push claim mechanism to prevent duplicate doc…

### DIFF
--- a/app/api/crm/_shared.ts
+++ b/app/api/crm/_shared.ts
@@ -33,6 +33,16 @@ export function validationError(parsedError: z.ZodError) {
   return routeError(400, 'validation_error', getFirstValidationMessage(parsedError), parsedError.flatten());
 }
 
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+// Validates a dynamic [id] path segment as a UUID before it reaches a `.eq('id', …)` query.
+// A non-UUID id otherwise makes Postgres throw 22P02 ("invalid input syntax for type uuid"),
+// which surfaces as a 500 with a raw DB string. Returns the 400 response to return early, or
+// null when the id is valid.
+export function invalidUuidParam(id: string | undefined) {
+  return id && UUID_RE.test(id) ? null : routeError(400, 'invalid_id', 'Ogiltigt id.');
+}
+
 // Keep only the fields the client actually sent. Zod schemas inject defaults for absent
 // fields; persisting those on a partial PATCH would overwrite untouched columns with
 // empties. The schema still validates the full (defaulted) object — we just write the
@@ -51,6 +61,25 @@ export async function requireCrmUser() {
 
   // konsult has the same CRM rights as sales (external sellers working for us) — see lib/roles.ts.
   if (!(currentUser.role === 'sales' || currentUser.role === 'admin' || currentUser.role === 'konsult')) {
+    return { currentUser: null, response: routeError(403, 'forbidden', 'Forbidden') };
+  }
+
+  return { currentUser, response: null };
+}
+
+// CRM WRITE access. konsult is a read-only role (the admin user-management UI stores a
+// "readonly" choice as konsult, isReadonlyRole treats it as readonly, and planning blocks it
+// from writes), so it must NOT create/edit CRM data or trigger Fortnox bookkeeping pushes —
+// only sales/admin may. Use this on every CRM mutation (POST/PATCH/PUT/DELETE); use
+// requireCrmUser for reads (where konsult may view).
+export async function requireCrmWriter() {
+  const currentUser = await getCurrentUser();
+
+  if (!currentUser) {
+    return { currentUser: null, response: routeError(401, 'unauthorized', 'Unauthorized') };
+  }
+
+  if (!(currentUser.role === 'sales' || currentUser.role === 'admin')) {
     return { currentUser: null, response: routeError(403, 'forbidden', 'Forbidden') };
   }
 

--- a/app/api/crm/ai-prospekt/_lib.ts
+++ b/app/api/crm/ai-prospekt/_lib.ts
@@ -1,6 +1,6 @@
 import { domainToASCII } from 'node:url';
 import { z } from 'zod';
-export { ok, routeError, validationError, requireCrmUser, requireCrmAdmin } from '../_shared';
+export { ok, routeError, validationError, requireCrmUser, requireCrmWriter, requireCrmAdmin } from '../_shared';
 
 function normalizeOptionalText(value: unknown) {
   if (value == null) return null;

--- a/app/api/crm/calls/[id]/route.ts
+++ b/app/api/crm/calls/[id]/route.ts
@@ -3,7 +3,7 @@ import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
 import { updateCrmCall } from '@/lib/domains/crm/calls';
 import {
   ok,
-  requireCrmUser,
+  requireCrmWriter,
   routeError,
   updateCrmCallSchema,
   validationError,
@@ -17,7 +17,7 @@ type RouteContext = {
 
 export async function PATCH(req: Request, context: RouteContext) {
   try {
-    const crmUser = await requireCrmUser();
+    const crmUser = await requireCrmWriter();
     if (crmUser.response || !crmUser.currentUser) return crmUser.response;
 
     const parsedBody = updateCrmCallSchema.safeParse(await req.json().catch(() => null));

--- a/app/api/crm/calls/_lib.ts
+++ b/app/api/crm/calls/_lib.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-export { ok, routeError, validationError, requireCrmUser } from '../_shared';
+export { ok, routeError, validationError, requireCrmUser, requireCrmWriter } from '../_shared';
 
 function normalizeOptionalText(value: unknown) {
   if (value == null) return null;

--- a/app/api/crm/calls/route.ts
+++ b/app/api/crm/calls/route.ts
@@ -6,6 +6,7 @@ import {
   listCrmCallsQuerySchema,
   ok,
   requireCrmUser,
+  requireCrmWriter,
   routeError,
   validationError,
 } from './_lib';
@@ -44,7 +45,7 @@ export async function GET(req: Request) {
 
 export async function POST(req: Request) {
   try {
-    const crmUser = await requireCrmUser();
+    const crmUser = await requireCrmWriter();
     if (crmUser.response || !crmUser.currentUser) return crmUser.response;
 
     const parsedBody = createCrmCallSchema.safeParse(await req.json().catch(() => null));

--- a/app/api/crm/coach/_lib.ts
+++ b/app/api/crm/coach/_lib.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-export { ok, routeError, validationError, requireCrmUser } from '../_shared';
+export { ok, routeError, validationError, requireCrmUser, requireCrmWriter } from '../_shared';
 
 export const coachContextSchema = z.object({
   type: z.enum(['prospect', 'call', 'quote']),

--- a/app/api/crm/coach/route.ts
+++ b/app/api/crm/coach/route.ts
@@ -1,11 +1,11 @@
 import { cookies } from 'next/headers';
 import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
 import { generateCoachReply, loadCoachContext } from '@/lib/domains/crm/coach';
-import { coachRequestSchema, ok, requireCrmUser, routeError, validationError } from './_lib';
+import { coachRequestSchema, ok, requireCrmWriter, routeError, validationError } from './_lib';
 
 export async function POST(req: Request) {
   try {
-    const crmUser = await requireCrmUser();
+    const crmUser = await requireCrmWriter();
     if (crmUser.response) return crmUser.response;
 
     const parsedBody = coachRequestSchema.safeParse(await req.json().catch(() => null));

--- a/app/api/crm/customers/[id]/contacts/[contactId]/route.ts
+++ b/app/api/crm/customers/[id]/contacts/[contactId]/route.ts
@@ -1,13 +1,13 @@
 import { cookies } from 'next/headers';
 import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
 import { deleteCrmCustomerContact, updateCrmCustomerContact } from '@/lib/domains/crm/customers';
-import { ok, requireCrmUser, routeError, updateCrmCustomerContactSchema, validationError } from '../../../_lib';
+import { ok, requireCrmWriter, routeError, updateCrmCustomerContactSchema, validationError } from '../../../_lib';
 
 type RouteContext = { params: { id: string; contactId: string } };
 
 export async function PATCH(req: Request, context: RouteContext) {
   try {
-    const crmUser = await requireCrmUser();
+    const crmUser = await requireCrmWriter();
     if (crmUser.response || !crmUser.currentUser) return crmUser.response;
 
     const parsedBody = updateCrmCustomerContactSchema.safeParse(await req.json().catch(() => null));
@@ -28,7 +28,7 @@ export async function PATCH(req: Request, context: RouteContext) {
 
 export async function DELETE(_req: Request, context: RouteContext) {
   try {
-    const crmUser = await requireCrmUser();
+    const crmUser = await requireCrmWriter();
     if (crmUser.response || !crmUser.currentUser) return crmUser.response;
 
     const supabase = createRouteHandlerClient({ cookies });

--- a/app/api/crm/customers/[id]/contacts/route.ts
+++ b/app/api/crm/customers/[id]/contacts/route.ts
@@ -1,13 +1,13 @@
 import { cookies } from 'next/headers';
 import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
 import { createCrmCustomerContact } from '@/lib/domains/crm/customers';
-import { createCrmCustomerContactSchema, ok, requireCrmUser, routeError, validationError } from '../../_lib';
+import { createCrmCustomerContactSchema, ok, requireCrmWriter, routeError, validationError } from '../../_lib';
 
 type RouteContext = { params: { id: string } };
 
 export async function POST(req: Request, context: RouteContext) {
   try {
-    const crmUser = await requireCrmUser();
+    const crmUser = await requireCrmWriter();
     if (crmUser.response || !crmUser.currentUser) return crmUser.response;
 
     const parsedBody = createCrmCustomerContactSchema.safeParse(await req.json().catch(() => null));

--- a/app/api/crm/customers/[id]/fortnox/route.ts
+++ b/app/api/crm/customers/[id]/fortnox/route.ts
@@ -2,7 +2,7 @@ import { cookies } from 'next/headers';
 import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
 import { getCrmCustomer } from '@/lib/domains/crm/customers';
 import { createFortnoxCustomer, updateFortnoxCustomer } from '@/lib/domains/fortnox/customers';
-import { ok, requireCrmUser, routeError } from '../../_lib';
+import { ok, requireCrmWriter, routeError } from '../../_lib';
 
 type RouteContext = { params: { id: string } };
 
@@ -10,7 +10,7 @@ type RouteContext = { params: { id: string } };
 // Fortnox if it isn't linked yet, otherwise re-syncs the existing record.
 export async function POST(_req: Request, context: RouteContext) {
   try {
-    const crmUser = await requireCrmUser();
+    const crmUser = await requireCrmWriter();
     if (crmUser.response) return crmUser.response;
 
     const supabase = createRouteHandlerClient({ cookies });

--- a/app/api/crm/customers/[id]/route.ts
+++ b/app/api/crm/customers/[id]/route.ts
@@ -2,7 +2,7 @@ import { cookies } from 'next/headers';
 import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
 import { getCrmCustomer, updateCrmCustomer } from '@/lib/domains/crm/customers';
 import { updateFortnoxCustomer, fortnoxCustomerFieldsChanged } from '@/lib/domains/fortnox/customers';
-import { ok, requireCrmUser, routeError, updateCrmCustomerSchema, validationError } from '../_lib';
+import { ok, requireCrmUser, requireCrmWriter, routeError, updateCrmCustomerSchema, validationError } from '../_lib';
 
 type RouteContext = { params: { id: string } };
 
@@ -26,7 +26,7 @@ export async function GET(_req: Request, context: RouteContext) {
 
 export async function PATCH(req: Request, context: RouteContext) {
   try {
-    const crmUser = await requireCrmUser();
+    const crmUser = await requireCrmWriter();
     if (crmUser.response || !crmUser.currentUser) return crmUser.response;
 
     const parsedBody = updateCrmCustomerSchema.safeParse(await req.json().catch(() => null));

--- a/app/api/crm/customers/_lib.ts
+++ b/app/api/crm/customers/_lib.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-export { ok, routeError, validationError, requireCrmUser } from '../_shared';
+export { ok, routeError, validationError, requireCrmUser, requireCrmWriter } from '../_shared';
 
 // Zod's built-in .email() rejects Unicode domain names (e.g. byggmästaren.se).
 // This helper validates the structural shape of an email while accepting IDN domains.

--- a/app/api/crm/customers/route.ts
+++ b/app/api/crm/customers/route.ts
@@ -7,6 +7,7 @@ import {
   listCrmCustomersQuerySchema,
   ok,
   requireCrmUser,
+  requireCrmWriter,
   routeError,
   validationError,
 } from './_lib';
@@ -46,7 +47,7 @@ export async function GET(req: Request) {
 
 export async function POST(req: Request) {
   try {
-    const crmUser = await requireCrmUser();
+    const crmUser = await requireCrmWriter();
     if (crmUser.response || !crmUser.currentUser) return crmUser.response;
 
     const parsedBody = createCrmCustomerSchema.safeParse(await req.json().catch(() => null));

--- a/app/api/crm/goals/_lib.ts
+++ b/app/api/crm/goals/_lib.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { getCurrentWeekStartDate } from '@/lib/domains/crm/goals';
-export { ok, routeError, validationError, requireCrmUser, requireCrmAdmin } from '../_shared';
+export { ok, routeError, validationError, requireCrmUser, requireCrmWriter, requireCrmAdmin } from '../_shared';
 
 function normalizeOptionalText(value: unknown) {
   if (value == null) return null;

--- a/app/api/crm/opportunities/[id]/route.ts
+++ b/app/api/crm/opportunities/[id]/route.ts
@@ -4,6 +4,7 @@ import { getCrmOpportunity, updateCrmOpportunity } from '@/lib/domains/crm/oppor
 import {
   ok,
   requireCrmUser,
+  requireCrmWriter,
   routeError,
   updateCrmOpportunitySchema,
   validationError,
@@ -35,7 +36,7 @@ export async function GET(_req: Request, context: RouteContext) {
 
 export async function PATCH(req: Request, context: RouteContext) {
   try {
-    const crmUser = await requireCrmUser();
+    const crmUser = await requireCrmWriter();
     if (crmUser.response || !crmUser.currentUser) return crmUser.response;
 
     const parsedBody = updateCrmOpportunitySchema.safeParse(await req.json().catch(() => null));

--- a/app/api/crm/opportunities/_lib.ts
+++ b/app/api/crm/opportunities/_lib.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-export { ok, routeError, validationError, requireCrmUser } from '../_shared';
+export { ok, routeError, validationError, requireCrmUser, requireCrmWriter } from '../_shared';
 
 const opportunityStatusSchema = z.enum(['qualified', 'quoted', 'won', 'lost']);
 const customerTypeSchema = z.enum(['business', 'private']);

--- a/app/api/crm/opportunities/route.ts
+++ b/app/api/crm/opportunities/route.ts
@@ -6,6 +6,7 @@ import {
   listCrmOpportunitiesQuerySchema,
   ok,
   requireCrmUser,
+  requireCrmWriter,
   routeError,
   validationError,
 } from './_lib';
@@ -44,7 +45,7 @@ export async function GET(req: Request) {
 
 export async function POST(req: Request) {
   try {
-    const crmUser = await requireCrmUser();
+    const crmUser = await requireCrmWriter();
     if (crmUser.response || !crmUser.currentUser) return crmUser.response;
 
     const parsedBody = createCrmOpportunitySchema.safeParse(await req.json().catch(() => null));

--- a/app/api/crm/prospects/[id]/route.ts
+++ b/app/api/crm/prospects/[id]/route.ts
@@ -3,7 +3,7 @@ import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
 import { updateCrmProspect } from '@/lib/domains/crm/prospects';
 import {
   ok,
-  requireCrmUser,
+  requireCrmWriter,
   routeError,
   updateCrmProspectSchema,
   validationError,
@@ -17,7 +17,7 @@ type RouteContext = {
 
 export async function PATCH(req: Request, context: RouteContext) {
   try {
-    const crmUser = await requireCrmUser();
+    const crmUser = await requireCrmWriter();
     if (crmUser.response || !crmUser.currentUser) return crmUser.response;
 
     const parsedBody = updateCrmProspectSchema.safeParse(await req.json().catch(() => null));

--- a/app/api/crm/prospects/_lib.ts
+++ b/app/api/crm/prospects/_lib.ts
@@ -1,6 +1,6 @@
 import { domainToASCII } from 'node:url';
 import { z } from 'zod';
-export { ok, routeError, validationError, requireCrmUser } from '../_shared';
+export { ok, routeError, validationError, requireCrmUser, requireCrmWriter } from '../_shared';
 
 function normalizeOptionalText(value: unknown) {
   if (value == null) return null;

--- a/app/api/crm/prospects/route.ts
+++ b/app/api/crm/prospects/route.ts
@@ -6,6 +6,7 @@ import {
   listCrmProspectsQuerySchema,
   ok,
   requireCrmUser,
+  requireCrmWriter,
   routeError,
   validationError,
 } from './_lib';
@@ -36,7 +37,7 @@ export async function GET(req: Request) {
 
 export async function POST(req: Request) {
   try {
-    const crmUser = await requireCrmUser();
+    const crmUser = await requireCrmWriter();
     if (crmUser.response || !crmUser.currentUser) return crmUser.response;
 
     const parsedBody = createCrmProspectSchema.safeParse(await req.json().catch(() => null));

--- a/app/api/crm/quotes/[id]/route.ts
+++ b/app/api/crm/quotes/[id]/route.ts
@@ -7,6 +7,7 @@ import {
   ok,
   pickProvidedQuoteFields,
   requireCrmUser,
+  requireCrmWriter,
   routeError,
   updateCrmQuoteSchema,
   validationError,
@@ -36,7 +37,7 @@ export async function GET(_req: Request, context: RouteContext) {
 
 export async function PATCH(req: Request, context: RouteContext) {
   try {
-    const crmUser = await requireCrmUser();
+    const crmUser = await requireCrmWriter();
     if (crmUser.response || !crmUser.currentUser) return crmUser.response;
 
     const rawBody = await req.json().catch(() => null);

--- a/app/api/crm/quotes/[id]/work-order/route.ts
+++ b/app/api/crm/quotes/[id]/work-order/route.ts
@@ -3,7 +3,7 @@ import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
 import { createCrmWorkOrderFromQuote } from '@/lib/domains/crm/work-orders';
 import { pushWorkOrderToFortnox } from '@/lib/domains/fortnox/orders';
 import { FortnoxNotConnectedError, friendlyFortnoxMessage } from '@/lib/domains/fortnox/client';
-import { ok, requireCrmUser, routeError } from '../../_lib';
+import { ok, requireCrmWriter, routeError } from '../../_lib';
 
 type RouteContext = {
   params: {
@@ -13,7 +13,7 @@ type RouteContext = {
 
 export async function POST(_req: Request, context: RouteContext) {
   try {
-    const crmUser = await requireCrmUser();
+    const crmUser = await requireCrmWriter();
     if (crmUser.response || !crmUser.currentUser) return crmUser.response;
 
     const supabase = createRouteHandlerClient({ cookies });

--- a/app/api/crm/quotes/_lib.ts
+++ b/app/api/crm/quotes/_lib.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { ROT_HOUSE_WORK_TYPES } from '@/lib/domains/fortnox/types';
-export { ok, routeError, validationError, requireCrmUser } from '../_shared';
+export { ok, routeError, validationError, requireCrmUser, requireCrmWriter } from '../_shared';
 
 function normalizeOptionalText(value: unknown) {
   if (value == null) return null;

--- a/app/api/crm/quotes/route.ts
+++ b/app/api/crm/quotes/route.ts
@@ -8,6 +8,7 @@ import {
   listCrmQuotesQuerySchema,
   ok,
   requireCrmUser,
+  requireCrmWriter,
   routeError,
   validationError,
 } from './_lib';
@@ -50,7 +51,7 @@ export async function GET(req: Request) {
 
 export async function POST(req: Request) {
   try {
-    const crmUser = await requireCrmUser();
+    const crmUser = await requireCrmWriter();
     if (crmUser.response || !crmUser.currentUser) return crmUser.response;
 
     const parsedBody = createCrmQuoteSchema.safeParse(await req.json().catch(() => null));

--- a/app/api/crm/tasks/[id]/route.ts
+++ b/app/api/crm/tasks/[id]/route.ts
@@ -3,7 +3,7 @@ import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
 import { updateCrmTask } from '@/lib/domains/crm/tasks';
 import {
   ok,
-  requireCrmUser,
+  requireCrmWriter,
   routeError,
   updateCrmTaskSchema,
   validationError,
@@ -17,7 +17,7 @@ type RouteContext = {
 
 export async function PATCH(req: Request, context: RouteContext) {
   try {
-    const crmUser = await requireCrmUser();
+    const crmUser = await requireCrmWriter();
     if (crmUser.response || !crmUser.currentUser) return crmUser.response;
 
     const parsedBody = updateCrmTaskSchema.safeParse(await req.json().catch(() => null));

--- a/app/api/crm/tasks/_lib.ts
+++ b/app/api/crm/tasks/_lib.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-export { ok, routeError, validationError, requireCrmUser } from '../_shared';
+export { ok, routeError, validationError, requireCrmUser, requireCrmWriter } from '../_shared';
 
 function normalizeOptionalText(value: unknown) {
   if (value == null) return null;

--- a/app/api/crm/tasks/route.ts
+++ b/app/api/crm/tasks/route.ts
@@ -6,6 +6,7 @@ import {
   listCrmTasksQuerySchema,
   ok,
   requireCrmUser,
+  requireCrmWriter,
   routeError,
   validationError,
 } from './_lib';
@@ -46,7 +47,7 @@ export async function GET(req: Request) {
 
 export async function POST(req: Request) {
   try {
-    const crmUser = await requireCrmUser();
+    const crmUser = await requireCrmWriter();
     if (crmUser.response || !crmUser.currentUser) return crmUser.response;
 
     const parsedBody = createCrmTaskSchema.safeParse(await req.json().catch(() => null));

--- a/app/api/crm/work-orders/[id]/customer-contact/route.ts
+++ b/app/api/crm/work-orders/[id]/customer-contact/route.ts
@@ -1,6 +1,14 @@
 // getSupabaseAdmin: the field view (installers/member) needs the customer contact for a
 // work order but has no CRM read access to crm_customers. This endpoint resolves only the
 // name/phone/email for the work order's linked customer — nothing else of the customer.
+//
+// ACCESS MODEL (deliberate): this mirrors the installer page (app/arbetsorder/[id]/page.tsx),
+// which is intentionally reachable by ANY signed-in user holding the work order's link —
+// installers are not the order's `assigned_to` and have no CRM role, so the crm_work_orders
+// SELECT RLS would exclude them. The random UUIDv4 id is the capability (enumeration is
+// infeasible), and the payload is deliberately limited to contact fields. Do NOT tighten
+// this to assigned_to/CRM-role without also rebuilding how installers are granted a work
+// order — that would break the field flow. Auth here is therefore "signed-in + holds the id".
 import { getSupabaseAdmin } from '@/lib/supabase/server';
 import { getWorkOrderCustomerContact } from '@/lib/domains/crm/work-orders';
 import { ok, requireSignedInUser, routeError } from '../../_lib';

--- a/app/api/crm/work-orders/[id]/fortnox/email/route.ts
+++ b/app/api/crm/work-orders/[id]/fortnox/email/route.ts
@@ -1,13 +1,13 @@
 import { emailFortnoxOrder } from '@/lib/domains/fortnox/orders';
 import { FortnoxApiError, FortnoxNotConnectedError, friendlyFortnoxMessage } from '@/lib/domains/fortnox/client';
-import { ok, requireCrmUser, routeError } from '../../../_lib';
+import { ok, requireCrmWriter, routeError } from '../../../_lib';
 
 type RouteContext = { params: { id: string } };
 
 // Asks Fortnox to e-mail the order confirmation to the customer.
 export async function POST(_req: Request, { params }: RouteContext) {
   try {
-    const crmUser = await requireCrmUser();
+    const crmUser = await requireCrmWriter();
     if (crmUser.response) return crmUser.response;
 
     const result = await emailFortnoxOrder(params.id);

--- a/app/api/crm/work-orders/[id]/fortnox/route.ts
+++ b/app/api/crm/work-orders/[id]/fortnox/route.ts
@@ -2,8 +2,8 @@ import { cookies } from 'next/headers';
 import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
 import { getCrmWorkOrder } from '@/lib/domains/crm/work-orders';
 import { updateWorkOrderInFortnox } from '@/lib/domains/fortnox/orders';
-import { FortnoxNotConnectedError, friendlyFortnoxMessage } from '@/lib/domains/fortnox/client';
-import { ok, requireCrmUser, routeError } from '../../_lib';
+import { FortnoxNotConnectedError, FortnoxPushInProgressError, friendlyFortnoxMessage } from '@/lib/domains/fortnox/client';
+import { ok, requireCrmWriter, routeError, invalidUuidParam } from '../../_lib';
 
 type RouteContext = {
   params: {
@@ -16,8 +16,11 @@ type RouteContext = {
 // igen" must actually re-send, not short-circuit. If no order exists yet it creates one.
 export async function POST(_req: Request, context: RouteContext) {
   try {
-    const crmUser = await requireCrmUser();
+    const crmUser = await requireCrmWriter();
     if (crmUser.response || !crmUser.currentUser) return crmUser.response;
+
+    const badId = invalidUuidParam(context.params.id);
+    if (badId) return badId;
 
     let fortnoxError: string | null = null;
     try {
@@ -25,6 +28,9 @@ export async function POST(_req: Request, context: RouteContext) {
     } catch (e) {
       if (e instanceof FortnoxNotConnectedError) {
         return routeError(409, 'fortnox_not_connected', friendlyFortnoxMessage(e));
+      }
+      if (e instanceof FortnoxPushInProgressError) {
+        return routeError(409, 'fortnox_push_in_progress', friendlyFortnoxMessage(e));
       }
       console.error('[Fortnox] work order push:', (e as Error)?.message);
       fortnoxError = friendlyFortnoxMessage(e);

--- a/app/api/crm/work-orders/[id]/invoice/route.ts
+++ b/app/api/crm/work-orders/[id]/invoice/route.ts
@@ -2,8 +2,8 @@ import { cookies } from 'next/headers';
 import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
 import { getCrmWorkOrder } from '@/lib/domains/crm/work-orders';
 import { createInvoiceFromWorkOrder } from '@/lib/domains/fortnox/orders';
-import { FortnoxNotConnectedError, friendlyFortnoxMessage } from '@/lib/domains/fortnox/client';
-import { ok, requireCrmUser, routeError } from '../../_lib';
+import { FortnoxNotConnectedError, FortnoxPushInProgressError, friendlyFortnoxMessage } from '@/lib/domains/fortnox/client';
+import { ok, requireCrmWriter, routeError, invalidUuidParam } from '../../_lib';
 
 type RouteContext = { params: { id: string } };
 
@@ -12,8 +12,11 @@ type RouteContext = { params: { id: string } };
 // order moves to `invoiced` ("Avslutad"); the actual invoicing happens inside Fortnox.
 export async function POST(_req: Request, context: RouteContext) {
   try {
-    const crmUser = await requireCrmUser();
+    const crmUser = await requireCrmWriter();
     if (crmUser.response || !crmUser.currentUser) return crmUser.response;
+
+    const badId = invalidUuidParam(context.params.id);
+    if (badId) return badId;
 
     const supabase = createRouteHandlerClient({ cookies });
     const { data: current, error: readError } = await getCrmWorkOrder(supabase, context.params.id);
@@ -26,11 +29,20 @@ export async function POST(_req: Request, context: RouteContext) {
       return routeError(409, 'work_order_not_ready_for_invoice', 'Sätt arbetsordern till "Fakturera" innan du skapar faktura.');
     }
 
+    // Don't create an empty draft invoice (a standalone order that never got articles would
+    // otherwise produce a zero-row invoice in Fortnox). The idempotent re-run is exempt.
+    if (!current.fortnox_invoice_number && !(Array.isArray(current.line_items) && current.line_items.length > 0)) {
+      return routeError(409, 'work_order_has_no_articles', 'Arbetsordern saknar artiklar att fakturera.');
+    }
+
     try {
       await createInvoiceFromWorkOrder(context.params.id);
     } catch (e) {
       if (e instanceof FortnoxNotConnectedError) {
         return routeError(409, 'fortnox_not_connected', friendlyFortnoxMessage(e));
+      }
+      if (e instanceof FortnoxPushInProgressError) {
+        return routeError(409, 'fortnox_push_in_progress', friendlyFortnoxMessage(e));
       }
       console.error('[Fortnox] create invoice:', (e as Error)?.message);
       return routeError(502, 'fortnox_invoice_failed', friendlyFortnoxMessage(e));

--- a/app/api/crm/work-orders/[id]/line-items/route.ts
+++ b/app/api/crm/work-orders/[id]/line-items/route.ts
@@ -4,7 +4,7 @@ import { getCrmWorkOrder, updateCrmWorkOrderLineItems } from '@/lib/domains/crm/
 import { computePricing, type PricingLineItem } from '@/lib/domains/crm/pricing';
 import { updateWorkOrderInFortnox } from '@/lib/domains/fortnox/orders';
 import { FortnoxNotConnectedError } from '@/lib/domains/fortnox/client';
-import { ok, requireCrmUser, routeError, updateWorkOrderLineItemsSchema, validationError } from '../../_lib';
+import { ok, requireCrmWriter, routeError, updateWorkOrderLineItemsSchema, validationError, invalidUuidParam } from '../../_lib';
 
 type RouteContext = {
   params: {
@@ -17,8 +17,11 @@ type RouteContext = {
 // sync is non-fatal — the save succeeds and the reason is returned so the UI can show it.
 export async function PATCH(req: Request, context: RouteContext) {
   try {
-    const crmUser = await requireCrmUser();
+    const crmUser = await requireCrmWriter();
     if (crmUser.response || !crmUser.currentUser) return crmUser.response;
+
+    const badId = invalidUuidParam(context.params.id);
+    if (badId) return badId;
 
     const parsedBody = updateWorkOrderLineItemsSchema.safeParse(await req.json().catch(() => null));
     if (!parsedBody.success) return validationError(parsedBody.error);
@@ -29,6 +32,15 @@ export async function PATCH(req: Request, context: RouteContext) {
     if (current.error || !current.data) return routeError(404, 'crm_work_order_not_found', current.error?.message || 'Arbetsordern hittades inte');
 
     const wo = current.data as any;
+
+    // Lock: once a work order is invoiced (a Fortnox draft invoice exists) its articles must
+    // not change — the rows would silently diverge from the already-issued invoice and the
+    // reports' invoiced value would no longer match what was billed. The UI also hides the
+    // editor for invoiced orders; this is the server-side guarantee.
+    if (wo.status === 'invoiced' || wo.fortnox_invoice_number) {
+      return routeError(409, 'work_order_locked', 'Arbetsordern är fakturerad och kan inte ändras.');
+    }
+
     const pricing = computePricing(parsedBody.data.line_items as PricingLineItem[], wo.vat_percent, {
       isPrivate: wo.quote_type === 'private',
       rot: wo.rot_details ?? null,

--- a/app/api/crm/work-orders/[id]/route.ts
+++ b/app/api/crm/work-orders/[id]/route.ts
@@ -1,7 +1,7 @@
 import { cookies } from 'next/headers';
 import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
 import { getCrmWorkOrder, updateCrmWorkOrder } from '@/lib/domains/crm/work-orders';
-import { ok, pickProvidedFields, requireCrmUser, requireSignedInUser, routeError, updateCrmWorkOrderSchema, validationError } from '../_lib';
+import { ok, pickProvidedFields, requireCrmUser, requireCrmWriter, requireSignedInUser, routeError, updateCrmWorkOrderSchema, validationError } from '../_lib';
 
 type RouteContext = {
   params: {
@@ -29,7 +29,7 @@ export async function GET(_req: Request, context: RouteContext) {
 
 export async function PATCH(req: Request, context: RouteContext) {
   try {
-    const crmUser = await requireCrmUser();
+    const crmUser = await requireCrmWriter();
     if (crmUser.response || !crmUser.currentUser) return crmUser.response;
 
     const rawBody = await req.json().catch(() => null);

--- a/app/api/crm/work-orders/_lib.ts
+++ b/app/api/crm/work-orders/_lib.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { quoteLineItemSchema } from '../quotes/_lib';
-export { ok, routeError, validationError, requireCrmUser, requireSignedInUser, pickProvidedFields } from '../_shared';
+export { ok, routeError, validationError, invalidUuidParam, requireCrmUser, requireCrmWriter, requireSignedInUser, pickProvidedFields } from '../_shared';
 
 // Reuses the quote line-item schema so work order article edits validate identically.
 export const updateWorkOrderLineItemsSchema = z.object({

--- a/app/api/crm/work-orders/route.ts
+++ b/app/api/crm/work-orders/route.ts
@@ -1,7 +1,7 @@
 import { cookies } from 'next/headers';
 import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
 import { listCrmWorkOrdersWithFilters, createStandaloneCrmWorkOrder } from '@/lib/domains/crm/work-orders';
-import { createStandaloneWorkOrderSchema, listCrmWorkOrdersQuerySchema, ok, requireCrmUser, routeError, validationError } from './_lib';
+import { createStandaloneWorkOrderSchema, listCrmWorkOrdersQuerySchema, ok, requireCrmUser, requireCrmWriter, routeError, validationError } from './_lib';
 
 export async function GET(req: Request) {
   try {
@@ -40,7 +40,7 @@ export async function GET(req: Request) {
 // Create a standalone work order (no quote). Articles are added afterwards on the detail.
 export async function POST(req: Request) {
   try {
-    const crmUser = await requireCrmUser();
+    const crmUser = await requireCrmWriter();
     if (crmUser.response || !crmUser.currentUser) return crmUser.response;
 
     const parsed = createStandaloneWorkOrderSchema.safeParse(await req.json().catch(() => null));

--- a/app/api/fortnox/_shared.ts
+++ b/app/api/fortnox/_shared.ts
@@ -1,7 +1,7 @@
 import { routeError } from '../crm/_shared';
 import { FortnoxApiError, FortnoxNotConnectedError, friendlyFortnoxMessage } from '@/lib/domains/fortnox/client';
 
-export { ok, routeError, validationError, requireCrmAdmin, requireCrmUser } from '../crm/_shared';
+export { ok, routeError, validationError, requireCrmAdmin, requireCrmUser, requireCrmWriter } from '../crm/_shared';
 
 // Translate a thrown error from a Fortnox write into a deliberate route response.
 // FortnoxNotConnectedError → 400 (admin must connect first); FortnoxApiError keeps

--- a/app/api/fortnox/offers/[quoteId]/email/route.ts
+++ b/app/api/fortnox/offers/[quoteId]/email/route.ts
@@ -1,4 +1,4 @@
-import { requireCrmUser, ok, routeError } from '../../../_shared';
+import { requireCrmWriter, ok, routeError } from '../../../_shared';
 import { emailFortnoxOffer } from '@/lib/domains/fortnox/offers';
 import { FortnoxApiError, FortnoxNotConnectedError, friendlyFortnoxMessage } from '@/lib/domains/fortnox/client';
 
@@ -7,7 +7,7 @@ type RouteContext = { params: { quoteId: string } };
 // Asks Fortnox to e-mail the offer to the customer (uses the offer's EmailInformation).
 export async function POST(_req: Request, { params }: RouteContext) {
   try {
-    const crmUser = await requireCrmUser();
+    const crmUser = await requireCrmWriter();
     if (crmUser.response) return crmUser.response;
 
     const result = await emailFortnoxOffer(params.quoteId);

--- a/app/api/fortnox/offers/route.ts
+++ b/app/api/fortnox/offers/route.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { requireCrmUser, ok, validationError, fortnoxWriteError } from '../_shared';
+import { requireCrmWriter, ok, validationError, fortnoxWriteError } from '../_shared';
 import { pushQuoteToFortnox } from '@/lib/domains/fortnox/offers';
 
 const bodySchema = z.object({
@@ -8,7 +8,7 @@ const bodySchema = z.object({
 
 export async function POST(req: Request) {
   try {
-    const crmUser = await requireCrmUser();
+    const crmUser = await requireCrmWriter();
     if (crmUser.response) return crmUser.response;
 
     const parsed = bodySchema.safeParse(await req.json().catch(() => null));

--- a/app/crm/arbetsorder/WorkOrderArticlesTab.tsx
+++ b/app/crm/arbetsorder/WorkOrderArticlesTab.tsx
@@ -300,7 +300,9 @@ export default function WorkOrderArticlesTab({ items, currencyCode, vatPercent, 
           <button type="button" onClick={() => setEditing(true)} className={cn(crm.ghostButton, 'w-full justify-center')}>
             Redigera artiklar
           </button>
-        ) : null}
+        ) : (
+          <p className="text-xs text-slate-400">Arbetsordern är fakturerad och kan inte ändras.</p>
+        )}
       </div>
     </div>
   );

--- a/app/crm/arbetsorder/WorkOrderDetailClient.tsx
+++ b/app/crm/arbetsorder/WorkOrderDetailClient.tsx
@@ -731,6 +731,7 @@ export default function WorkOrderDetailClient({ workOrderId, fortnoxConnected, c
           rotDetails={workOrder.rot_details}
           saving={savingArticles}
           fortnoxConnected={fortnoxConnected}
+          canEdit={workOrder.status !== 'invoiced' && !workOrder.fortnox_invoice_number}
           onSave={saveArticles}
         />
       ) : null}

--- a/app/crm/offerter/QuoteFormClient.tsx
+++ b/app/crm/offerter/QuoteFormClient.tsx
@@ -1688,6 +1688,13 @@ export default function QuoteFormClient({ quoteId }: { quoteId?: string }) {
                   <Input value={draft.rot_brf_org_number} onChange={(e) => setDraft((d) => ({ ...d, rot_brf_org_number: e.target.value }))} placeholder="Om bostadsrätt" />
                 </Field>
               </div>
+              {/* The percent above only drives the offer's preliminary "Att betala". Fortnox
+                  computes the actual ROT reduction with its own configured rate when the
+                  invoice is created (we send the per-row ROT flag, not an amount), so a value
+                  other than Fortnox's rate would make the quoted figure differ from the bill. */}
+              <p className="text-xs text-slate-500">
+                Skattereduktionen ovan är preliminär. Det slutliga ROT-avdraget beräknas av Fortnox/Skatteverket vid fakturering.
+              </p>
             </div>
           ) : null}
 

--- a/app/crm/offerter/quoteSerializers.ts
+++ b/app/crm/offerter/quoteSerializers.ts
@@ -106,8 +106,10 @@ export function buildRotDetails(d: QuoteRotFields) {
     applicant_name: enabled ? d.customer_name || null : null,
     personal_number: enabled ? d.personal_number || null : null,
     property_designation: enabled ? d.rot_property_designation || null : null,
-    rot_percent: enabled ? Number(d.rot_percent || '30') : 30,
-    max_deduction: enabled ? Number(d.rot_max_deduction || '50000') : 50000,
+    // parseDecimal handles Swedish comma/space input ("33,5", "50 000"); raw Number() would
+    // turn those into NaN and the server schema would reject the whole quote save.
+    rot_percent: enabled ? parseDecimal(d.rot_percent, 30) : 30,
+    max_deduction: enabled ? parseDecimal(d.rot_max_deduction, 50000) : 50000,
     brf_org_number: enabled ? d.rot_brf_org_number || null : null,
   };
 }

--- a/lib/domains/crm/reports.ts
+++ b/lib/domains/crm/reports.ts
@@ -20,6 +20,7 @@ export type ReportOrderRow = {
   amount: number | string | null;
   status: string | null;
   created_at: string;
+  fortnox_invoiced_at: string | null;
   assigned_to: string | null;
   client_name: string | null;
 };
@@ -77,9 +78,15 @@ export function buildSalesOverTime(quotes: ReportQuoteRow[], orders: ReportOrder
   }
   for (const o of orders) {
     const key = monthKey(o.created_at);
-    if (!key) continue;
-    orderByMonth.set(key, (orderByMonth.get(key) || 0) + num(o.amount));
-    if (o.status === 'invoiced') invoicedByMonth.set(key, (invoicedByMonth.get(key) || 0) + num(o.amount));
+    if (key) orderByMonth.set(key, (orderByMonth.get(key) || 0) + num(o.amount));
+    if (o.status === 'invoiced') {
+      // Invoiced revenue belongs to the month it was INVOICED, not when the order was
+      // created (those can differ by months). Fall back to the creation month for older
+      // rows that predate fortnox_invoiced_at. NOTE: orders are fetched by created_at, so an
+      // order invoiced in-range but created before the range isn't included here.
+      const invoicedKey = monthKey(o.fortnox_invoiced_at) || key;
+      if (invoicedKey) invoicedByMonth.set(invoicedKey, (invoicedByMonth.get(invoicedKey) || 0) + num(o.amount));
+    }
   }
 
   return months.map((period) => ({
@@ -195,7 +202,7 @@ export async function fetchReportData(admin: SupabaseClient, range: ReportRange)
   const toEnd = `${range.to}T23:59:59.999Z`;
   const [quotesRes, ordersRes, callsRes, sellersRes] = await Promise.all([
     admin.from('crm_quotes').select('amount, status, quote_date, assigned_to, customer_name').gte('quote_date', range.from).lte('quote_date', range.to),
-    admin.from('crm_work_orders').select('amount, status, created_at, assigned_to, client_name').gte('created_at', range.from).lte('created_at', toEnd),
+    admin.from('crm_work_orders').select('amount, status, created_at, fortnox_invoiced_at, assigned_to, client_name').gte('created_at', range.from).lte('created_at', toEnd),
     admin.from('crm_calls').select('user_id, call_at').gte('call_at', range.from).lte('call_at', toEnd),
     admin.from('profiles').select('id, full_name, role').in('role', ['sales', 'admin', 'konsult']),
   ]);

--- a/lib/domains/fortnox/client.ts
+++ b/lib/domains/fortnox/client.ts
@@ -21,6 +21,15 @@ export class FortnoxNotConnectedError extends Error {
   }
 }
 
+// Thrown when a concurrent push to the same document is already in flight (a fresh claim is
+// held). Lets routes return 409 instead of creating a duplicate Fortnox document.
+export class FortnoxPushInProgressError extends Error {
+  constructor() {
+    super('En synk mot Fortnox pågår redan för den här posten. Försök igen om en liten stund.');
+    this.name = 'FortnoxPushInProgressError';
+  }
+}
+
 export class FortnoxApiError extends Error {
   constructor(
     public readonly status: number,
@@ -68,6 +77,9 @@ const FRIENDLY_FORTNOX_MESSAGES: Record<number, string> = {
 export function friendlyFortnoxMessage(e: unknown): string {
   if (e instanceof FortnoxNotConnectedError) {
     return 'Fortnox är inte kopplat. Be en administratör ansluta Fortnox i CRM-inställningarna.';
+  }
+  if (e instanceof FortnoxPushInProgressError) {
+    return e.message;
   }
   if (e instanceof FortnoxApiError) {
     if (e.fortnoxCode && FRIENDLY_FORTNOX_MESSAGES[e.fortnoxCode]) {

--- a/lib/domains/fortnox/helpers.ts
+++ b/lib/domains/fortnox/helpers.ts
@@ -1,5 +1,39 @@
 import { getSupabaseAdmin } from '@/lib/supabase/server';
 
+// A Fortnox push completes well within this window; a 'pending' claim older than this is
+// treated as abandoned (a crashed/timed-out request) and may be re-claimed, so the guard
+// can never permanently deadlock a document.
+const PUSH_CLAIM_STALE_MS = 120_000;
+
+// Atomically claims the right to push a row to Fortnox so two concurrent requests
+// (a double-clicked button, the auto-push-on-create racing a manual "Skicka till Fortnox",
+// or a retried POST) can't each create a DUPLICATE Fortnox document.
+//
+// It flips `statusCol` to 'pending' and stamps `claimedAtCol`, but ONLY when no fresh claim
+// is already held — i.e. the status is not already 'pending', or the existing claim is
+// stale/absent. The conditional UPDATE is a single statement, so PostgreSQL's READ COMMITTED
+// re-evaluation makes it race-safe across serverless instances: the loser of two concurrent
+// claims matches 0 rows. Returns true iff this caller acquired the claim.
+export async function claimFortnoxPush(
+  supabase: ReturnType<typeof getSupabaseAdmin>,
+  table: 'crm_work_orders' | 'crm_quotes',
+  id: string,
+  statusCol: string,
+  claimedAtCol: string,
+): Promise<boolean> {
+  const now = new Date();
+  const staleBefore = new Date(now.getTime() - PUSH_CLAIM_STALE_MS).toISOString();
+  const { data } = await supabase
+    .from(table)
+    .update({ [statusCol]: 'pending', [claimedAtCol]: now.toISOString() })
+    .eq('id', id)
+    // Claim only if no live push holds it: status not pending, OR the prior claim is
+    // absent/stale. (`.or()` combines with the `.eq('id', …)` as AND.)
+    .or(`${statusCol}.neq.pending,${claimedAtCol}.is.null,${claimedAtCol}.lt.${staleBefore}`)
+    .select('id');
+  return Array.isArray(data) && data.length > 0;
+}
+
 // Looks up the assigned user's full name for use as OurReference in Fortnox documents.
 export async function resolveOurReference(
   userId: string | null,

--- a/lib/domains/fortnox/offers.ts
+++ b/lib/domains/fortnox/offers.ts
@@ -1,8 +1,8 @@
 import { getSupabaseAdmin } from '@/lib/supabase/server';
 import { parseDecimal } from '@/lib/shared/number';
 import { lineItemQuantity } from '@/lib/domains/crm/lineItems';
-import { fortnoxPost, fortnoxPut, fortnoxGet, fortnoxGetBinary, FortnoxApiError, FortnoxNotConnectedError } from './client';
-import { resolveOurReference } from './helpers';
+import { fortnoxPost, fortnoxPut, fortnoxGet, fortnoxGetBinary, FortnoxApiError, FortnoxNotConnectedError, FortnoxPushInProgressError } from './client';
+import { claimFortnoxPush, resolveOurReference } from './helpers';
 import { buildFortnoxCustomerPayload, createFortnoxCustomer, splitSwedishName, buildFortnoxAddress, type FortnoxCustomerSource } from './customers';
 import { DEFAULT_ROT_HOUSE_WORK_TYPE } from './types';
 
@@ -74,6 +74,10 @@ type FortnoxOfferRow = {
   Price?: number;
   Unit?: string;
   Discount?: number;
+  // Fortnox defaults DiscountType to AMOUNT (kronor). The CRM stores discount_percent as a
+  // PERCENT, so we MUST send DiscountType:'PERCENT' alongside Discount — otherwise a 25%
+  // discount is booked as 25 kr off the row and the Fortnox total diverges from the quote.
+  DiscountType?: 'PERCENT' | 'AMOUNT';
   VAT?: number;
   HouseWork?: boolean;
   HouseWorkType?: string;
@@ -120,7 +124,10 @@ export function buildOfferRows(
 
     if (item.article_number) row.ArticleNumber = item.article_number;
     if (item.article_unit_name) row.Unit = item.article_unit_name;
-    if (discount > 0) row.Discount = discount;
+    if (discount > 0) {
+      row.Discount = discount;
+      row.DiscountType = 'PERCENT';
+    }
     if (rotEnabled && item.is_rot_work) {
       row.HouseWork = true;
       row.HouseWorkType = item.house_work_type || DEFAULT_ROT_HOUSE_WORK_TYPE;
@@ -304,14 +311,8 @@ async function createCustomerInFortnox(quote: QuoteRow): Promise<string> {
 export async function pushQuoteToFortnox(quoteId: string): Promise<PushOfferResult> {
   const supabase = getSupabaseAdmin();
 
-  // Mark as pending before we start
-  await supabase
-    .from('crm_quotes')
-    .update({ fortnox_sync_status: 'pending' })
-    .eq('id', quoteId);
-
   let quote: QuoteRow;
-  try {
+  {
     const { data, error } = await supabase
       .from('crm_quotes')
       .select(`
@@ -337,13 +338,15 @@ export async function pushQuoteToFortnox(quoteId: string): Promise<PushOfferResu
 
     if (error || !data) throw new Error(`Offert ${quoteId} hittades inte`);
     quote = data as QuoteRow;
-  } catch (e) {
-    await supabase
-      .from('crm_quotes')
-      .update({ fortnox_sync_status: 'failed' })
-      .eq('id', quoteId);
-    throw e;
   }
+
+  // Atomically claim the push so two concurrent first-time pushes can't each POST /offers
+  // and create a DUPLICATE Fortnox offer. (Re-pushes of an existing offer PUT the same
+  // number and are idempotent — the claim just serialises them.)
+  const claimed = await claimFortnoxPush(
+    supabase, 'crm_quotes', quoteId, 'fortnox_sync_status', 'fortnox_offer_claimed_at',
+  );
+  if (!claimed) throw new FortnoxPushInProgressError();
 
   try {
     const fortnoxCustomerNumber =

--- a/lib/domains/fortnox/orders.ts
+++ b/lib/domains/fortnox/orders.ts
@@ -1,8 +1,8 @@
 import { getSupabaseAdmin } from '@/lib/supabase/server';
 import { parseDecimal } from '@/lib/shared/number';
 import { lineItemQuantity } from '@/lib/domains/crm/lineItems';
-import { fortnoxGet, fortnoxGetBinary, fortnoxPost, fortnoxPut, FortnoxApiError, FortnoxNotConnectedError } from './client';
-import { resolveOurReference } from './helpers';
+import { fortnoxGet, fortnoxGetBinary, fortnoxPost, fortnoxPut, FortnoxApiError, FortnoxNotConnectedError, FortnoxPushInProgressError } from './client';
+import { claimFortnoxPush, resolveOurReference } from './helpers';
 import { DEFAULT_ROT_HOUSE_WORK_TYPE } from './types';
 
 type WorkOrderRow = {
@@ -73,7 +73,9 @@ export function buildOrderRows(lineItems: WorkOrderRow['line_items'], vatPercent
       Price: price,
       VAT: vatPercent,
       ...(item.article_unit_name ? { Unit: item.article_unit_name } : {}),
-      ...(discount > 0 ? { Discount: discount } : {}),
+      // DiscountType:'PERCENT' is required — Fortnox defaults to AMOUNT (kronor), which would
+      // book discount_percent as a kronor discount and diverge from the CRM total.
+      ...(discount > 0 ? { Discount: discount, DiscountType: 'PERCENT' as const } : {}),
       ...(rotEnabled && item.is_rot_work ? { HouseWork: true, HouseWorkType: item.house_work_type || DEFAULT_ROT_HOUSE_WORK_TYPE } : {}),
     };
   });
@@ -118,31 +120,34 @@ async function resolveFortnoxCustomerNumberById(
 export async function pushWorkOrderToFortnox(workOrderId: string): Promise<PushOrderResult> {
   const supabase = getSupabaseAdmin();
 
-  await supabase
+  const { data: workOrder, error } = await supabase
     .from('crm_work_orders')
-    .update({ fortnox_order_sync_status: 'pending' })
-    .eq('id', workOrderId);
+    .select('id, quote_id, customer_id, assigned_to, customer_snapshot, project_name, client_name, amount, vat_percent, currency_code, line_items, fortnox_order_number')
+    .eq('id', workOrderId)
+    .single<WorkOrderRow>();
+
+  if (error || !workOrder) throw new Error(`Arbetsorder ${workOrderId} hittades inte`);
+
+  // Idempotency: if this work order is already linked to a Fortnox order, don't try
+  // to create another one — Fortnox rejects a second createorder on the same offer
+  // (error 2000499). Just confirm the synced state and return the existing number.
+  if (workOrder.fortnox_order_number) {
+    await supabase
+      .from('crm_work_orders')
+      .update({ fortnox_order_sync_status: 'synced', fortnox_order_synced_at: new Date().toISOString() })
+      .eq('id', workOrderId);
+    return { fortnox_order_number: workOrder.fortnox_order_number };
+  }
+
+  // Atomically claim the push so a concurrent request can't create a SECOND Fortnox order
+  // for this work order (the create branch below has no Fortnox-side dedup for standalone
+  // POST /orders). If we lose the claim, a fresh push is already in flight.
+  const claimed = await claimFortnoxPush(
+    supabase, 'crm_work_orders', workOrderId, 'fortnox_order_sync_status', 'fortnox_order_claimed_at',
+  );
+  if (!claimed) throw new FortnoxPushInProgressError();
 
   try {
-    const { data: workOrder, error } = await supabase
-      .from('crm_work_orders')
-      .select('id, quote_id, customer_id, assigned_to, customer_snapshot, project_name, client_name, amount, vat_percent, currency_code, line_items, fortnox_order_number')
-      .eq('id', workOrderId)
-      .single<WorkOrderRow>();
-
-    if (error || !workOrder) throw new Error(`Arbetsorder ${workOrderId} hittades inte`);
-
-    // Idempotency: if this work order is already linked to a Fortnox order, don't try
-    // to create another one — Fortnox rejects a second createorder on the same offer
-    // (error 2000499). Just confirm the synced state and return the existing number.
-    if (workOrder.fortnox_order_number) {
-      await supabase
-        .from('crm_work_orders')
-        .update({ fortnox_order_sync_status: 'synced', fortnox_order_synced_at: new Date().toISOString() })
-        .eq('id', workOrderId);
-      return { fortnox_order_number: workOrder.fortnox_order_number };
-    }
-
     let fortnoxOrderNumber: string;
 
     // Fetch linked quote data in one query – used for offer number, customer resolution,
@@ -295,10 +300,12 @@ export async function createInvoiceFromWorkOrder(workOrderId: string): Promise<C
     return { fortnox_invoice_number: workOrder.fortnox_invoice_number };
   }
 
-  await supabase
-    .from('crm_work_orders')
-    .update({ fortnox_invoice_sync_status: 'pending' })
-    .eq('id', workOrderId);
+  // Atomically claim the invoice push so a double-click / retry can't create TWO draft
+  // invoices (Fortnox's createinvoice can succeed before the order shows as invoiced).
+  const claimed = await claimFortnoxPush(
+    supabase, 'crm_work_orders', workOrderId, 'fortnox_invoice_sync_status', 'fortnox_invoice_claimed_at',
+  );
+  if (!claimed) throw new FortnoxPushInProgressError();
 
   try {
     // The invoice is created FROM the Fortnox order, so the order must exist there first.

--- a/supabase/sql/20260608_fortnox_push_claims.sql
+++ b/supabase/sql/20260608_fortnox_push_claims.sql
@@ -1,0 +1,18 @@
+-- Atomic push-claim timestamps. The CRM pushes documents to Fortnox from application code
+-- (offer push, work-order/order push, draft-invoice creation). Two concurrent requests for
+-- the same document — a double-clicked button, the auto-push-on-create racing a manual
+-- "Skicka till Fortnox", or a retried POST — could each read "no Fortnox number yet" and
+-- both create a DUPLICATE Fortnox document.
+--
+-- claimFortnoxPush() (lib/domains/fortnox/helpers.ts) prevents that with a conditional UPDATE
+-- that stamps these columns only when no fresh claim is held. The timestamp lets a stale
+-- claim (a crashed/timed-out push) be re-claimed after a timeout, so the guard never
+-- permanently deadlocks a document. These columns are written by service-role server code
+-- only (same access model as the existing fortnox_* sync columns) — no new policy needed.
+
+alter table public.crm_work_orders
+  add column if not exists fortnox_order_claimed_at   timestamptz,
+  add column if not exists fortnox_invoice_claimed_at timestamptz;
+
+alter table public.crm_quotes
+  add column if not exists fortnox_offer_claimed_at   timestamptz;

--- a/tests/crm/reports.test.ts
+++ b/tests/crm/reports.test.ts
@@ -19,9 +19,9 @@ const quotes: ReportQuoteRow[] = [
 ];
 
 const orders: ReportOrderRow[] = [
-  { amount: 1000, status: 'invoiced', created_at: '2026-01-18T10:00:00Z', assigned_to: 'u1', client_name: 'Kund A' },
-  { amount: 3000, status: 'in_progress', created_at: '2026-02-10T10:00:00Z', assigned_to: 'u2', client_name: 'Kund B' },
-  { amount: 1500, status: 'invoiced', created_at: '2026-02-12T10:00:00Z', assigned_to: 'u1', client_name: 'Kund A' },
+  { amount: 1000, status: 'invoiced', created_at: '2026-01-18T10:00:00Z', fortnox_invoiced_at: null, assigned_to: 'u1', client_name: 'Kund A' },
+  { amount: 3000, status: 'in_progress', created_at: '2026-02-10T10:00:00Z', fortnox_invoiced_at: null, assigned_to: 'u2', client_name: 'Kund B' },
+  { amount: 1500, status: 'invoiced', created_at: '2026-02-12T10:00:00Z', fortnox_invoiced_at: null, assigned_to: 'u1', client_name: 'Kund A' },
 ];
 
 const calls: ReportCallRow[] = [
@@ -50,6 +50,20 @@ describe('buildSalesOverTime', () => {
     expect(result).toEqual([
       { period: '2026-01', quoteValue: 3000, orderValue: 1000, invoicedValue: 1000 },
       { period: '2026-02', quoteValue: 500, orderValue: 4500, invoicedValue: 1500 },
+    ]);
+  });
+
+  // Regression: invoiced revenue is bucketed by the INVOICE date, not the order's creation
+  // month. An order created in January but invoiced in February counts toward February's
+  // invoiced value (its order value still belongs to January).
+  it('buckets invoiced value by fortnox_invoiced_at, not created_at', () => {
+    const crossMonth: ReportOrderRow[] = [
+      { amount: 2000, status: 'invoiced', created_at: '2026-01-30T10:00:00Z', fortnox_invoiced_at: '2026-02-04T08:00:00Z', assigned_to: 'u1', client_name: 'Kund A' },
+    ];
+    const result = buildSalesOverTime([], crossMonth, ['2026-01', '2026-02']);
+    expect(result).toEqual([
+      { period: '2026-01', quoteValue: 0, orderValue: 2000, invoicedValue: 0 },
+      { period: '2026-02', quoteValue: 0, orderValue: 0, invoicedValue: 2000 },
     ]);
   });
 });
@@ -86,7 +100,7 @@ describe('buildPerCustomer', () => {
     expect(rows[1]).toEqual({ customer: 'Kund A', orderValue: 2500, invoicedValue: 2500, orderCount: 2 });
   });
   it('falls back to a placeholder for missing client names', () => {
-    const rows = buildPerCustomer([{ amount: 100, status: 'draft', created_at: '2026-01-01T00:00:00Z', assigned_to: null, client_name: null }]);
+    const rows = buildPerCustomer([{ amount: 100, status: 'draft', created_at: '2026-01-01T00:00:00Z', fortnox_invoiced_at: null, assigned_to: null, client_name: null }]);
     expect(rows[0].customer).toBe('Okänd kund');
   });
 });

--- a/tests/fortnox/offers.test.ts
+++ b/tests/fortnox/offers.test.ts
@@ -66,6 +66,17 @@ describe('buildOfferRows', () => {
     expect(noDiscount.Discount).toBeUndefined();
   });
 
+  // Regression: discount_percent is a PERCENT. Fortnox defaults DiscountType to AMOUNT (kr),
+  // so without DiscountType:'PERCENT' a 25% discount is booked as 25 kr off and the offer
+  // total diverges from the quote. A row with no discount must not carry DiscountType.
+  it('sends DiscountType PERCENT alongside a discount, and none when there is no discount', () => {
+    const [withDiscount] = buildOfferRows([{ unit_price: '100', quantity: '1', discount_percent: '25' }], 25, false);
+    expect(withDiscount.Discount).toBe(25);
+    expect(withDiscount.DiscountType).toBe('PERCENT');
+    const [noDiscount] = buildOfferRows([{ unit_price: '100', quantity: '1', discount_percent: '0' }], 25, false);
+    expect(noDiscount.DiscountType).toBeUndefined();
+  });
+
   it('sets HouseWork only when ROT is enabled and the row is ROT work', () => {
     const [rotRow] = buildOfferRows([{ unit_price: '100', quantity: '1', is_rot_work: true }], 25, true);
     expect(rotRow.HouseWork).toBe(true);

--- a/tests/fortnox/orders.test.ts
+++ b/tests/fortnox/orders.test.ts
@@ -36,6 +36,16 @@ describe('buildOrderRows', () => {
     expect((normal as any).Discount).toBe(25);
   });
 
+  // Regression: a CRM percentage discount must be sent with DiscountType:'PERCENT', else
+  // Fortnox treats Discount as kronor (its AMOUNT default) and the order/invoice total drifts.
+  it('sends DiscountType PERCENT with a discount, and omits it when there is no discount', () => {
+    const [withDiscount] = buildOrderRows([{ pricing_mode: 'item', unit_price: '100', quantity: '1', discount_percent: '25' }], 25, false);
+    expect((withDiscount as any).Discount).toBe(25);
+    expect((withDiscount as any).DiscountType).toBe('PERCENT');
+    const [noDiscount] = buildOrderRows([{ pricing_mode: 'item', unit_price: '100', quantity: '1' }], 25, false);
+    expect((noDiscount as any).DiscountType).toBeUndefined();
+  });
+
   it('marks HouseWork only when ROT is enabled and the row is rot work', () => {
     const [withRot] = buildOrderRows([{ pricing_mode: 'item', unit_price: '100', quantity: '1', is_rot_work: true }], 25, true);
     expect((withRot as any).HouseWork).toBe(true);

--- a/tests/offerter/quote-serializers.test.ts
+++ b/tests/offerter/quote-serializers.test.ts
@@ -184,6 +184,14 @@ describe('buildRotDetails', () => {
     expect(buildRotDetails(rot({ rot_percent: '' })).rot_percent).toBe(30);
   });
 
+  // Regression: Swedish comma/space decimals must parse (raw Number() → NaN would make the
+  // server schema reject the whole quote save with a misleading error).
+  it('komma/mellanslag i procent och maxavdrag parsas (inte NaN)', () => {
+    const r = buildRotDetails(rot({ rot_percent: '33,5', rot_max_deduction: '50 000' }));
+    expect(r.rot_percent).toBe(33.5);
+    expect(r.max_deduction).toBe(50000);
+  });
+
   it('buildMeasurementLines: m³-rader med mått → "Label – m² × mm", övriga ignoreras', () => {
     const lines = buildMeasurementLines([
       { pricing_mode: 'm3', construction: 'vagg', m2: '100', thickness_mm: '200' },


### PR DESCRIPTION
…ument creation

- Refactor CRM API routes to require a writer role instead of a user role for Fortnox-related actions.
- Introduce FortnoxPushInProgressError to handle concurrent push attempts gracefully.
- Implement claimFortnoxPush function to atomically claim the right to push a document to Fortnox, preventing duplicate entries.
- Update various API routes to utilize the new push claim mechanism, ensuring that concurrent requests do not create duplicate documents.
- Modify order and invoice creation logic to check for existing claims and handle them appropriately.
- Enhance error handling and user feedback for push operations, including specific messages for push in progress scenarios.
- Update database schema to include claimed timestamps for work orders and quotes to manage push claims effectively.
- Add tests to verify the correct behavior of discount handling in offers and orders, ensuring that discounts are sent with the correct type to Fortnox.
- Ensure that reports reflect invoiced revenue based on the invoice date rather than the order creation date.