### PR TITLE
Permission-based access control (RBAC) for CRM + Fortnox

### DIFF
--- a/PERMISSIONS.md
+++ b/PERMISSIONS.md
@@ -1,0 +1,265 @@
+# Permissions (RBAC)
+
+Permission-based access control for the CRM + Fortnox surface. Roles are no longer checked
+directly; instead a role is a *named bundle* of granular permissions, and access decisions —
+in both the app layer and the database (RLS) — read the **same** effective-permission source.
+That means changing who can do what (e.g. "let konsult write offers") is a **data change**,
+not a code change across dozens of files.
+
+> Scope today: **CRM + Fortnox**. The rest of the app (planning, documents, admin, contacts,
+> news, dashboard) is still role-based and untouched — it will migrate the same way later
+> (see [Migration status](#migration-status)).
+
+---
+
+## Core idea
+
+A user's **effective permissions** = their role's bundle, **minus** per-user `revoke`
+overrides, **plus** per-user `grant` overrides (revoke wins). This one set is consumed by:
+
+- **The app layer** — `requirePermission('crm.offer.write')` in route handlers (via `can()`).
+- **The database** — `has_permission('crm.offer.write')` inside RLS policies.
+
+```
+                       ┌─────────────────────────────┐
+   role_permissions ──▶│  effective permissions       │◀── user_permissions
+   (role → keys)       │  = role bundle − revoke +    │    (per-user grant/revoke)
+                       │    grant                     │
+                       └──────────────┬──────────────┘
+                                      │ (single source of truth)
+                  ┌───────────────────┴────────────────────┐
+                  ▼                                         ▼
+         TS: can() / requirePermission()          SQL: has_permission()  ← used in RLS
+         (route guards, app/api/**)               (row-level security on the tables)
+```
+
+Because both layers read the same source, a granted permission flows **end-to-end** into the
+database write. Because the role **seed reproduces today's behavior exactly**, the migration
+was behavior-preserving and verifiable.
+
+---
+
+## Data model
+
+`supabase/sql/20260608_permissions_model.sql` (additive; nothing existing changed).
+
+| Object | Purpose |
+| --- | --- |
+| `permissions(key, description)` | Catalog of every known permission key. |
+| `role_permissions(role, permission_key)` | A role's bundle (the seed). |
+| `user_permissions(user_id, permission_key, effect)` | Per-user override, `effect` ∈ `grant`/`revoke` (one row per user+key; revoke wins). |
+| `has_permission(p_key text) → boolean` | The RLS predicate. `STABLE` + `SECURITY DEFINER` → evaluated ~once per query and bypasses RLS on the three tables (no recursion). Logic: `NOT revoke AND (role bundle OR grant)`. |
+| `effective_permissions() → setof text` | One-shot list for the app layer (one RPC per request). |
+| `set_role_permission(role, key, present)` | Admin-only setter for a role bundle entry (`SECURITY DEFINER`, checks `auth.uid()` is admin). |
+| `set_user_permission(user, key, effect)` | Admin-only setter for a per-user override (`effect=null` clears it). |
+
+RLS on the three tables: `permissions` / `role_permissions` are readable by all authenticated
+users; `user_permissions` is **self-read only**. No write policies exist — writes go only
+through the `SECURITY DEFINER` setters. (The resolver functions are `SECURITY DEFINER`, so they
+bypass these policies and there is no recursion — same pattern as the existing `set_user_role`.)
+
+---
+
+## Permission catalog
+
+Keys are `resource.action` (plus three coarse meta keys). `lib/auth/permissions.ts` mirrors
+this list as `PERMISSION_KEYS` (and derives the `PermissionKey` type from it, so typos are
+caught at compile time).
+
+**CRM resources** (each has `.read` + `.write`): `crm.prospect`, `crm.call`, `crm.customer`,
+`crm.contact`, `crm.opportunity`, `crm.offer` (= quotes), `crm.workorder`, `crm.task`.
+
+**CRM read-only:** `crm.report.read`, `crm.coach.read`.
+
+**CRM admin-managed:** `crm.goal.read` / `crm.goal.manage`, `crm.routingrule.read` /
+`crm.routingrule.manage`, `crm.aiprospect.read` / `crm.aiprospect.manage`,
+`crm.ringlist.manage`, `crm.article.manage`, `crm.unit.manage`.
+
+**Fortnox:** `fortnox.offer.push`, `fortnox.workorder.push`, `fortnox.invoice.create`,
+`fortnox.customer.sync`, `fortnox.read`.
+
+**Meta** (back the legacy `requireCrmUser/Writer/Admin` guards 1:1): `crm.access` (read),
+`crm.write` (write), `crm.admin`.
+
+---
+
+## Role seed
+
+The seed reproduces the pre-migration role behavior exactly. (Parity is asserted by
+`supabase/sql/20260608_permissions_parity_assert.sql` — every row must show `ok = true`.)
+
+| | member | sales | konsult | admin |
+| --- | :-: | :-: | :-: | :-: |
+| `crm.*.read` (all resources) + `crm.report.read` + `crm.coach.read` + `crm.goal.read` | – | ✓ | ✓ | ✓ |
+| `crm.*.write` (all resources) | – | ✓ | – | ✓ |
+| `crm.routingrule.read` | – | ✓ | **–** | ✓ |
+| `crm.aiprospect.*` + every `.manage` key | – | – | – | ✓ |
+| `fortnox.offer.push` / `workorder.push` / `invoice.create` / `customer.sync` | – | ✓ | – | ✓ |
+| `fortnox.read` | – | ✓ | ✓ | ✓ |
+| meta `crm.access` | – | ✓ | ✓ | ✓ |
+| meta `crm.write` | – | ✓ | – | ✓ |
+| meta `crm.admin` | – | – | – | ✓ |
+
+**Asymmetries to remember:** `crm.routingrule.read` excludes konsult (its RLS SELECT did too);
+`crm.aiprospect.*` is admin-only; `member` gets no CRM keys (installers reach their own work
+orders via the `assigned_to` ownership branch, not via a role/permission).
+
+---
+
+## How the layers use it
+
+### App layer (`lib/auth/permissions.ts` + `app/api/crm/_shared.ts`)
+
+- `getEffectivePermissions()` calls `rpc('effective_permissions')`, **cached per request**
+  (React `cache()`) so all guards in one request share one round-trip. **Fails closed** — on
+  any error (e.g. migration not applied) it returns an empty set, so access is never granted
+  by accident.
+- `requirePermission(key)` → resolves the user, checks `can(perms, key)`, returns the standard
+  `{ currentUser, response }` (401 / 403 / pass).
+- The legacy guards are thin wrappers: `requireCrmUser → requirePermission('crm.access')`,
+  `requireCrmWriter → 'crm.write'`, `requireCrmAdmin → 'crm.admin'`. Most routes still call
+  these; the hot resource/Fortnox routes call `requirePermission` with an explicit key.
+
+### Database (RLS)
+
+Role predicates were swapped to `has_permission(...)` while the **ownership branches were
+preserved** (`supabase/sql/20260609_rls_permissions_crm_*.sql`). The mapping rule (each key's
+seed equals the role set the old predicate admitted, so behavior is identical):
+
+| Old RLS predicate | New |
+| --- | --- |
+| `role = 'admin'` (see-all / manage / update-any / delete-any) | `has_permission('crm.admin')` |
+| `role in ('sales','admin')` (write-self insert) | `has_permission('crm.<res>.write')` |
+| `role = any('sales','admin','konsult')` (blanket read — quotes/work orders only) | `has_permission('crm.<res>.read')` |
+| routing/goals/ai-prospect admin branches | the resource's `.read` / `.manage` key |
+| `auth.uid() = assigned_to` / `user_id` / customer-ownership joins | **unchanged** |
+
+---
+
+## Managing permissions (admin UI)
+
+**Admin → Behörigheter** (`app/admin/permissions/AdminPermissions.tsx`):
+
+- **Rollbehörigheter** — pick a role, toggle its permission checkboxes. (The admin role is not
+  editable here.)
+- **Per användare** — pick a user; for each key set **Ärv** (no override) / **Ge** (grant) /
+  **Neka** (revoke).
+
+Backed by `app/api/admin/permissions/` (admin-gated). The `SECURITY DEFINER` setters are
+called via the **session** client so `auth.uid()` is the calling admin; a user's overrides are
+read via the service-role client (because `user_permissions` is self-read).
+
+---
+
+## Recipes
+
+### Grant a user a specific permission
+
+UI: Admin → Behörigheter → Per användare → pick the user → set the key to **Ge**. Or SQL:
+
+```sql
+select public.set_user_permission('<user-uuid>', 'crm.offer.write', 'grant'); -- or 'revoke', or null to clear
+select public.set_role_permission('konsult', 'crm.offer.write', true);        -- whole role; false removes
+```
+
+For this to take effect end-to-end, the relevant route must guard on that key (see next) — RLS
+already honors it.
+
+### Add a new permission key
+
+1. Add the key + description to the `permissions` insert in a new dated migration (or extend
+   the catalog) **and** to `PERMISSION_KEYS` in `lib/auth/permissions.ts` (keep them in sync —
+   the unit test guards the count).
+2. Seed it onto the roles that should have it (`role_permissions`), and update the parity
+   assert / `tests/auth/permissions.test.ts` if needed.
+3. Use it: in a route via `requirePermission('<key>')`, and/or in an RLS policy via
+   `has_permission('<key>')`.
+
+### Guard a route with a granular key
+
+```ts
+const crmUser = await requirePermission('crm.offer.write');
+if (crmUser.response || !crmUser.currentUser) return crmUser.response;
+```
+
+(`requirePermission` is re-exported from the relevant `_lib.ts` modules.) **Rule:** the key you
+guard with should align with the table the route writes, so the route check and RLS agree.
+
+### Migrate an RLS policy (for the later non-CRM phases)
+
+Replace each `EXISTS(select 1 from public.profiles p where p.id = auth.uid() and p.role …)`
+with `public.has_permission('<key>')` where the key's seed equals the roles that predicate
+admitted. **Leave every ownership branch untouched.** Never widen. Read the *latest* policy
+file per table (grep `on public.<table>` across **both** `supabase/sql/` and
+`supabase/migrations/`, sort by date) — the filename does not tell you which table it edits.
+
+---
+
+## Deploy ordering ⚠️
+
+`getEffectivePermissions` **fails closed**, so the SQL must be applied **before** the app code
+is deployed (otherwise the RPC is missing and all CRM access 403s). Run, in order:
+
+1. `20260608_permissions_model.sql`
+2. `20260608_permissions_parity_assert.sql` — verify every row `ok = true`
+3. `20260609_rls_permissions_crm_core.sql`
+4. `20260609_rls_permissions_crm_quotes_workorders.sql`
+5. `20260609_rls_permissions_crm_admin.sql`
+6. `20260609_rls_permissions_verify.sql` — verify no row has `still_references_role = true`
+7. `20260609_permissions_admin_lockout_guard.sql`
+
+Then deploy the code.
+
+---
+
+## Admin lockout guard
+
+`20260609_permissions_admin_lockout_guard.sql` prevents an admin from stripping their own admin
+access: removing `crm.admin` from the admin role, or revoking `crm.admin` on an admin user,
+both raise an exception (and the UI disables the latter). Recovery from a pre-existing lockout
+is a manual delete of the offending `role_permissions` / `user_permissions` row.
+
+---
+
+## Migration status
+
+| Phase | What | Status |
+| --- | --- | --- |
+| 1 | Model, resolver, seed, parity assert | ✅ |
+| 2 | TS layer + guard wrappers + tests | ✅ |
+| 3 | RLS swap (CRM/Fortnox tables) | ✅ |
+| 4 | Granular route keys (resource writes + Fortnox actions) | ✅ |
+| 5 | Admin UI + lockout guard | ✅ |
+| 6 | The rest of the app (planning, documents, admin, contacts, news) | ⏳ later |
+
+**Left on the `crm.write` meta key intentionally:** the prospects routes (they write
+`crm_customers` — `crm_prospects` was removed), the tasks routes (their table isn't RLS-migrated
+yet), and coach. Swap them to granular keys once those are reconciled.
+
+---
+
+## Gotchas
+
+- **Meta vs resource key:** in routes still on a meta key, a per-user grant of a *resource* key
+  (e.g. konsult `crm.offer.write`) is honored by RLS but the route's `crm.write` check still
+  blocks it. Swap that route to the resource key (Phase 4 did this for the main ones).
+- **`crm_prospects` is gone** (`20260604_crm_remove_legacy_prospects.sql`) — prospects are
+  `crm_customers` with `customer_stage = 'prospect'`; `crm_calls`/`crm_quotes` join
+  `crm_customers` via `prospect_id`.
+- **Keep the catalog in sync** between the SQL `permissions` table and `PERMISSION_KEYS`.
+
+---
+
+## File reference
+
+| Area | Files |
+| --- | --- |
+| Model + resolver + seed | `supabase/sql/20260608_permissions_model.sql`, `…_parity_assert.sql` |
+| RLS swaps | `supabase/sql/20260609_rls_permissions_crm_{core,quotes_workorders,admin}.sql`, `…_verify.sql` |
+| Lockout guard | `supabase/sql/20260609_permissions_admin_lockout_guard.sql` |
+| App layer | `lib/auth/permissions.ts`, `app/api/crm/_shared.ts` (`requirePermission` + guard wrappers) |
+| Admin UI | `app/admin/permissions/AdminPermissions.tsx`, `app/api/admin/permissions/**` |
+
+## Related docs
+
+- `ARCHITECTURE.md`, `API_CONVENTIONS.md`, `SUPABASE_CONVENTIONS.md`

--- a/app/admin/AdminTabsClient.tsx
+++ b/app/admin/AdminTabsClient.tsx
@@ -10,11 +10,13 @@ import { TabsList, TabsTrigger } from '../../components/ui/Tabs';
 const AdminContacts = dynamic(() => import('./contacts/AdminContacts'), { ssr: false });
 const AdminDepotUsage = dynamic(() => import('./depots/AdminDepotUsage'), { ssr: false });
 const AdminNews = dynamic(() => import('./news/AdminNews'), { ssr: false });
+const AdminPermissions = dynamic(() => import('./permissions/AdminPermissions'), { ssr: false });
 
-type AdminTab = 'users'|'contacts'|'depots'|'blikk'|'news';
+type AdminTab = 'users'|'permissions'|'contacts'|'depots'|'blikk'|'news';
 
 const tabs: Array<{ id: AdminTab; label: string; summary: string }> = [
   { id: 'users', label: 'Användare', summary: 'Konton, roller och taggar' },
+  { id: 'permissions', label: 'Behörigheter', summary: 'Roller och per-användar-behörigheter' },
   { id: 'contacts', label: 'Kontakter', summary: 'Kategorier, personer och adresser' },
   { id: 'depots', label: 'Depå-uttag', summary: 'Förbrukning och senaste uttag' },
   { id: 'blikk', label: 'Blikk-koppling', summary: 'Matchning mellan profiler och Blikk' },
@@ -100,6 +102,7 @@ export default function AdminTabsClient() {
 
       <section className="rounded-[30px] border border-slate-200 bg-[linear-gradient(180deg,#f8fbff_0%,#ffffff_100%)] shadow-[0_18px_44px_rgba(15,23,42,0.04)]">
         {tab==='users' && <AdminUsers />}
+        {tab==='permissions' && <AdminPermissions />}
         {tab==='contacts' && <AdminContacts />}
         {tab==='depots' && <AdminDepotUsage />}
         {tab==='blikk' && <AdminBlikkUsersMapping />}

--- a/app/admin/permissions/AdminPermissions.tsx
+++ b/app/admin/permissions/AdminPermissions.tsx
@@ -245,7 +245,7 @@ export default function AdminPermissions() {
                             <button
                               key={mode}
                               type="button"
-                              disabled={busy}
+                              disabled={busy || (mode === 'revoke' && entry.key === 'crm.admin' && userState.role === 'admin')}
                               onClick={() => setUserOverride(entry.key, mode === 'inherit' ? null : mode)}
                               className={
                                 'px-2.5 py-1 text-[11px] font-semibold ' +

--- a/app/admin/permissions/AdminPermissions.tsx
+++ b/app/admin/permissions/AdminPermissions.tsx
@@ -1,0 +1,276 @@
+"use client";
+import React from 'react';
+import Badge from '../../../components/ui/Badge';
+
+type CatalogEntry = { key: string; description: string };
+type RoleBundles = Record<string, string[]>;
+type UserRow = { id: string; full_name: string | null; email: string | null; role: string };
+type UserState = { role: string; roleKeys: string[]; overrides: Array<{ key: string; effect: 'grant' | 'revoke' }>; effective: string[] };
+
+const ROLE_LABELS: Record<string, string> = {
+  member: 'Member (installatör)',
+  sales: 'Sales (säljare)',
+  konsult: 'Konsult (läsbehörig)',
+  admin: 'Admin',
+};
+
+// Group catalog keys by their top-level domain (crm / fortnox) for readable sections.
+function groupByDomain(catalog: CatalogEntry[]) {
+  const groups: Record<string, CatalogEntry[]> = {};
+  for (const entry of catalog) {
+    const domain = entry.key.split('.')[0];
+    (groups[domain] ??= []).push(entry);
+  }
+  return Object.entries(groups).sort(([a], [b]) => a.localeCompare(b));
+}
+
+async function getJson(url: string) {
+  const res = await fetch(url, { credentials: 'same-origin' });
+  const body = await res.json().catch(() => null);
+  if (!res.ok || !body?.ok) throw new Error(body?.error || `Fel (${res.status})`);
+  return body.data;
+}
+
+async function postJson(url: string, payload: unknown) {
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'same-origin',
+    body: JSON.stringify(payload),
+  });
+  const body = await res.json().catch(() => null);
+  if (!res.ok || !body?.ok) throw new Error(body?.error || `Fel (${res.status})`);
+  return body.data;
+}
+
+export default function AdminPermissions() {
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState<string | null>(null);
+  const [catalog, setCatalog] = React.useState<CatalogEntry[]>([]);
+  const [roleBundles, setRoleBundles] = React.useState<RoleBundles>({});
+  const [roles, setRoles] = React.useState<string[]>([]);
+  const [selectedRole, setSelectedRole] = React.useState<string>('sales');
+  const [busyKey, setBusyKey] = React.useState<string | null>(null);
+
+  const [users, setUsers] = React.useState<UserRow[]>([]);
+  const [selectedUserId, setSelectedUserId] = React.useState<string>('');
+  const [userState, setUserState] = React.useState<UserState | null>(null);
+  const [userLoading, setUserLoading] = React.useState(false);
+
+  React.useEffect(() => {
+    (async () => {
+      try {
+        const [perms, usersData] = await Promise.all([
+          getJson('/api/admin/permissions'),
+          getJson('/api/admin/users').catch(() => ({ users: [] })),
+        ]);
+        setCatalog(perms.catalog);
+        setRoleBundles(perms.roleBundles);
+        setRoles(perms.roles);
+        setUsers(usersData.users || []);
+      } catch (e) {
+        setError((e as Error).message);
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, []);
+
+  const grouped = React.useMemo(() => groupByDomain(catalog), [catalog]);
+
+  async function toggleRole(key: string, present: boolean) {
+    setBusyKey(`role:${key}`);
+    // Optimistic update.
+    setRoleBundles((prev) => {
+      const list = new Set(prev[selectedRole] ?? []);
+      if (present) list.add(key); else list.delete(key);
+      return { ...prev, [selectedRole]: [...list] };
+    });
+    try {
+      await postJson('/api/admin/permissions', { scope: 'role', role: selectedRole, key, present });
+    } catch (e) {
+      setError((e as Error).message);
+      // Revert on failure.
+      setRoleBundles((prev) => {
+        const list = new Set(prev[selectedRole] ?? []);
+        if (present) list.delete(key); else list.add(key);
+        return { ...prev, [selectedRole]: [...list] };
+      });
+    } finally {
+      setBusyKey(null);
+    }
+  }
+
+  async function loadUser(id: string) {
+    setSelectedUserId(id);
+    setUserState(null);
+    if (!id) return;
+    setUserLoading(true);
+    try {
+      setUserState(await getJson(`/api/admin/permissions/users/${id}`));
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setUserLoading(false);
+    }
+  }
+
+  async function setUserOverride(key: string, effect: 'grant' | 'revoke' | null) {
+    if (!selectedUserId) return;
+    setBusyKey(`user:${key}`);
+    try {
+      await postJson('/api/admin/permissions', { scope: 'user', userId: selectedUserId, key, effect });
+      setUserState(await getJson(`/api/admin/permissions/users/${selectedUserId}`));
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setBusyKey(null);
+    }
+  }
+
+  if (loading) return <div className="p-6 text-sm text-slate-500">Laddar behörigheter…</div>;
+
+  return (
+    <div className="grid gap-6 p-5">
+      {error ? (
+        <div className="rounded-xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700">
+          {error}
+          <button type="button" onClick={() => setError(null)} className="ml-3 underline">Stäng</button>
+        </div>
+      ) : null}
+
+      <div className="rounded-xl border border-sky-200 bg-sky-50 px-4 py-3 text-sm text-sky-900">
+        Roller är knippen av behörigheter. Per-användar-overrides läggs <strong>ovanpå</strong> rollen
+        (revoke vinner). Ändringar slår igenom direkt i både appen och databasen (RLS).
+      </div>
+
+      {/* ── Role bundles ─────────────────────────────────────────── */}
+      <section className="grid gap-3">
+        <h2 className="m-0 text-lg font-bold text-slate-900">Rollbehörigheter</h2>
+        <div className="flex flex-wrap gap-2">
+          {roles.map((role) => (
+            <button
+              key={role}
+              type="button"
+              onClick={() => setSelectedRole(role)}
+              className={
+                'rounded-full border px-3.5 py-1.5 text-sm font-semibold transition ' +
+                (selectedRole === role
+                  ? 'border-slate-900 bg-slate-900 text-white'
+                  : 'border-slate-200 bg-white text-slate-700 hover:border-slate-300')
+              }
+            >
+              {ROLE_LABELS[role] ?? role}
+            </button>
+          ))}
+        </div>
+
+        {selectedRole === 'admin' ? (
+          <p className="text-sm text-slate-500">Admin har alla behörigheter och redigeras inte här.</p>
+        ) : null}
+
+        <div className="grid gap-4">
+          {grouped.map(([domain, entries]) => (
+            <div key={domain} className="rounded-xl border border-slate-200 bg-white p-4">
+              <div className="mb-2 text-[11px] font-extrabold uppercase tracking-wide text-slate-500">{domain}</div>
+              <div className="grid gap-1.5 sm:grid-cols-2">
+                {entries.map((entry) => {
+                  const checked = (roleBundles[selectedRole] ?? []).includes(entry.key);
+                  const disabled = selectedRole === 'admin' || busyKey === `role:${entry.key}`;
+                  return (
+                    <label key={entry.key} className="flex items-start gap-2.5 rounded-lg px-2 py-1.5 hover:bg-slate-50">
+                      <input
+                        type="checkbox"
+                        checked={checked}
+                        disabled={disabled}
+                        onChange={(e) => toggleRole(entry.key, e.target.checked)}
+                        className="mt-0.5 h-4 w-4"
+                      />
+                      <span className="grid">
+                        <span className="font-mono text-[12px] text-slate-800">{entry.key}</span>
+                        <span className="text-[11px] text-slate-500">{entry.description}</span>
+                      </span>
+                    </label>
+                  );
+                })}
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* ── Per-user overrides ───────────────────────────────────── */}
+      <section className="grid gap-3">
+        <h2 className="m-0 text-lg font-bold text-slate-900">Per användare</h2>
+        <select
+          value={selectedUserId}
+          onChange={(e) => loadUser(e.target.value)}
+          className="max-w-md rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm"
+        >
+          <option value="">Välj användare…</option>
+          {users.map((u) => (
+            <option key={u.id} value={u.id}>
+              {(u.full_name || u.email || u.id)} — {u.role}
+            </option>
+          ))}
+        </select>
+
+        {userLoading ? <div className="text-sm text-slate-500">Laddar…</div> : null}
+
+        {userState ? (
+          <div className="grid gap-4">
+            <div className="flex flex-wrap items-center gap-2 text-sm text-slate-600">
+              <Badge>Roll: {ROLE_LABELS[userState.role] ?? userState.role}</Badge>
+              <Badge>{userState.effective.length} effektiva behörigheter</Badge>
+            </div>
+            {grouped.map(([domain, entries]) => (
+              <div key={domain} className="rounded-xl border border-slate-200 bg-white p-4">
+                <div className="mb-2 text-[11px] font-extrabold uppercase tracking-wide text-slate-500">{domain}</div>
+                <div className="grid gap-1.5">
+                  {entries.map((entry) => {
+                    const fromRole = userState.roleKeys.includes(entry.key);
+                    const override = userState.overrides.find((o) => o.key === entry.key);
+                    const effective = userState.effective.includes(entry.key);
+                    const busy = busyKey === `user:${entry.key}`;
+                    const current: 'inherit' | 'grant' | 'revoke' = override?.effect ?? 'inherit';
+                    return (
+                      <div key={entry.key} className="flex flex-wrap items-center gap-2 rounded-lg px-2 py-1.5 hover:bg-slate-50">
+                        <span className="min-w-[200px] grow">
+                          <span className="font-mono text-[12px] text-slate-800">{entry.key}</span>
+                          <span className="ml-2 text-[11px] text-slate-400">{fromRole ? 'i rollen' : 'ej i rollen'}</span>
+                        </span>
+                        <Badge variant={effective ? 'accent' : undefined}>{effective ? 'aktiv' : 'av'}</Badge>
+                        <div className="flex overflow-hidden rounded-lg border border-slate-200">
+                          {(['inherit', 'grant', 'revoke'] as const).map((mode) => (
+                            <button
+                              key={mode}
+                              type="button"
+                              disabled={busy}
+                              onClick={() => setUserOverride(entry.key, mode === 'inherit' ? null : mode)}
+                              className={
+                                'px-2.5 py-1 text-[11px] font-semibold ' +
+                                (current === mode
+                                  ? mode === 'revoke'
+                                    ? 'bg-rose-600 text-white'
+                                    : mode === 'grant'
+                                      ? 'bg-emerald-600 text-white'
+                                      : 'bg-slate-700 text-white'
+                                  : 'bg-white text-slate-600 hover:bg-slate-100')
+                              }
+                            >
+                              {mode === 'inherit' ? 'Ärv' : mode === 'grant' ? 'Ge' : 'Neka'}
+                            </button>
+                          ))}
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            ))}
+          </div>
+        ) : null}
+      </section>
+    </div>
+  );
+}

--- a/app/api/admin/permissions/_lib.ts
+++ b/app/api/admin/permissions/_lib.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import { z } from 'zod';
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
+import { requireAdminUser } from '@/lib/auth/route';
+import { getOptionalSupabaseAdmin } from '@/lib/supabase/server';
+import { PERMISSION_KEYS } from '@/lib/auth/permissions';
+
+export const PERMISSION_ROLES = ['member', 'sales', 'admin', 'konsult'] as const;
+
+export function ok<T>(data: T, status = 200) {
+  return NextResponse.json({ ok: true, data }, { status, headers: { 'Cache-Control': 'no-store' } });
+}
+
+export function routeError(status: number, code: string, message: string, details?: unknown) {
+  return NextResponse.json(
+    { ok: false, error: message, errorDetails: { code, message, ...(details !== undefined ? { details } : {}) } },
+    { status, headers: { 'Cache-Control': 'no-store' } },
+  );
+}
+
+export function validationError(parsedError: z.ZodError) {
+  const flat = parsedError.flatten();
+  const first = Object.values(flat.fieldErrors).flatMap((m) => m ?? [])[0] || flat.formErrors[0] || 'Invalid request';
+  return routeError(400, 'validation_error', first, flat);
+}
+
+const permissionKey = z.string().refine(
+  (k) => (PERMISSION_KEYS as readonly string[]).includes(k),
+  'unknown permission key',
+);
+
+// Set a role bundle entry, or a per-user grant/revoke override (effect=null clears it).
+export const setPermissionSchema = z.discriminatedUnion('scope', [
+  z.object({ scope: z.literal('role'), role: z.enum(PERMISSION_ROLES), key: permissionKey, present: z.boolean() }),
+  z.object({ scope: z.literal('user'), userId: z.string().uuid(), key: permissionKey, effect: z.enum(['grant', 'revoke']).nullable() }),
+]);
+
+// Admin context for the permission routes. Returns an `admin` (service-role) client for
+// reading any user's permissions, plus a request-scoped `session` client so the SECURITY
+// DEFINER setter functions see auth.uid() = the calling admin (a service-role client would
+// have a null auth.uid() and the functions' admin check would fail).
+export async function requirePermsAdmin() {
+  const currentUser = await requireAdminUser();
+  if (!currentUser) return { response: routeError(403, 'forbidden', 'Forbidden') };
+
+  const admin = getOptionalSupabaseAdmin();
+  if (!admin) return { response: routeError(500, 'service_role_missing', 'Service role not configured') };
+
+  const session = createRouteHandlerClient({ cookies });
+  return { currentUser, admin, session };
+}

--- a/app/api/admin/permissions/route.ts
+++ b/app/api/admin/permissions/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest } from 'next/server';
+import { ok, PERMISSION_ROLES, requirePermsAdmin, routeError, setPermissionSchema, validationError } from './_lib';
+
+// GET: the permission catalog + each role's bundle. Admin only.
+export async function GET() {
+  const ctx = await requirePermsAdmin();
+  if ('response' in ctx) return ctx.response;
+  const { admin } = ctx;
+
+  const [{ data: catalog, error: catErr }, { data: rows, error: rpErr }] = await Promise.all([
+    admin.from('permissions').select('key, description').order('key'),
+    admin.from('role_permissions').select('role, permission_key'),
+  ]);
+  if (catErr) return routeError(500, 'permissions_read_failed', catErr.message);
+  if (rpErr) return routeError(500, 'role_permissions_read_failed', rpErr.message);
+
+  const roleBundles: Record<string, string[]> = {};
+  for (const r of PERMISSION_ROLES) roleBundles[r] = [];
+  (rows ?? []).forEach((row: any) => {
+    (roleBundles[row.role] ??= []).push(row.permission_key);
+  });
+
+  return ok({ catalog: catalog ?? [], roles: PERMISSION_ROLES, roleBundles });
+}
+
+// POST: toggle a role-bundle entry, or set/clear a per-user override. The SECURITY DEFINER
+// setters run via the session client so they see the calling admin's auth.uid().
+export async function POST(req: NextRequest) {
+  const ctx = await requirePermsAdmin();
+  if ('response' in ctx) return ctx.response;
+
+  const parsed = setPermissionSchema.safeParse(await req.json().catch(() => null));
+  if (!parsed.success) return validationError(parsed.error);
+  const { session } = ctx;
+  const input = parsed.data;
+
+  if (input.scope === 'role') {
+    const { error } = await session.rpc('set_role_permission', {
+      p_role: input.role, p_key: input.key, p_present: input.present,
+    });
+    if (error) return routeError(400, 'set_role_permission_failed', error.message);
+  } else {
+    const { error } = await session.rpc('set_user_permission', {
+      p_user: input.userId, p_key: input.key, p_effect: input.effect,
+    });
+    if (error) return routeError(400, 'set_user_permission_failed', error.message);
+  }
+
+  return ok({ updated: true });
+}

--- a/app/api/admin/permissions/users/[id]/route.ts
+++ b/app/api/admin/permissions/users/[id]/route.ts
@@ -1,0 +1,36 @@
+import { ok, requirePermsAdmin, routeError } from '../../_lib';
+
+type RouteContext = { params: { id: string } };
+
+// GET a single user's permission state: their role, the role's bundle, their per-user
+// overrides, and the resulting effective set. Read via the service-role client because
+// user_permissions is self-read-only under RLS. Admin only.
+export async function GET(_req: Request, context: RouteContext) {
+  const ctx = await requirePermsAdmin();
+  if ('response' in ctx) return ctx.response;
+  const { admin } = ctx;
+  const id = context.params.id;
+
+  const { data: profile, error: profErr } = await admin
+    .from('profiles').select('role').eq('id', id).maybeSingle();
+  if (profErr) return routeError(500, 'profile_read_failed', profErr.message);
+  const role = (profile as { role?: string } | null)?.role ?? 'member';
+
+  const [{ data: rp, error: rpErr }, { data: up, error: upErr }] = await Promise.all([
+    admin.from('role_permissions').select('permission_key').eq('role', role),
+    admin.from('user_permissions').select('permission_key, effect').eq('user_id', id),
+  ]);
+  if (rpErr) return routeError(500, 'role_permissions_read_failed', rpErr.message);
+  if (upErr) return routeError(500, 'user_permissions_read_failed', upErr.message);
+
+  const roleKeys = (rp ?? []).map((r: any) => r.permission_key as string);
+  const overrides = (up ?? []).map((r: any) => ({ key: r.permission_key as string, effect: r.effect as 'grant' | 'revoke' }));
+
+  const effective = new Set(roleKeys);
+  for (const o of overrides) {
+    if (o.effect === 'grant') effective.add(o.key);
+    if (o.effect === 'revoke') effective.delete(o.key);
+  }
+
+  return ok({ role, roleKeys, overrides, effective: [...effective] });
+}

--- a/app/api/crm/_shared.ts
+++ b/app/api/crm/_shared.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import { getCurrentUser } from '@/lib/auth/route';
+import { can, getEffectivePermissions, type PermissionKey } from '@/lib/auth/permissions';
 
 export function ok<T>(data: T, status = 200) {
   return NextResponse.json({ ok: true, data }, { status, headers: { 'Cache-Control': 'no-store' } });
@@ -52,52 +53,40 @@ export function pickProvidedFields<T extends Record<string, unknown>>(parsed: T,
   return Object.fromEntries(Object.entries(parsed).filter(([key]) => sentKeys.includes(key))) as Partial<T>;
 }
 
-export async function requireCrmUser() {
+// Permission-based gate. Resolves the user, then checks the effective permission set
+// (role bundle ± per-user overrides) from the DB. Returns the same { currentUser, response }
+// shape every CRM guard uses. This is the single primitive the role guards below wrap, and
+// the one new per-resource routes should call directly (e.g. requirePermission('crm.offer.write')).
+export async function requirePermission(key: PermissionKey) {
   const currentUser = await getCurrentUser();
 
   if (!currentUser) {
     return { currentUser: null, response: routeError(401, 'unauthorized', 'Unauthorized') };
   }
 
-  // konsult has the same CRM rights as sales (external sellers working for us) — see lib/roles.ts.
-  if (!(currentUser.role === 'sales' || currentUser.role === 'admin' || currentUser.role === 'konsult')) {
+  const perms = await getEffectivePermissions();
+  if (!can(perms, key)) {
     return { currentUser: null, response: routeError(403, 'forbidden', 'Forbidden') };
   }
 
   return { currentUser, response: null };
 }
 
-// CRM WRITE access. konsult is a read-only role (the admin user-management UI stores a
-// "readonly" choice as konsult, isReadonlyRole treats it as readonly, and planning blocks it
-// from writes), so it must NOT create/edit CRM data or trigger Fortnox bookkeeping pushes —
-// only sales/admin may. Use this on every CRM mutation (POST/PATCH/PUT/DELETE); use
-// requireCrmUser for reads (where konsult may view).
-export async function requireCrmWriter() {
-  const currentUser = await getCurrentUser();
-
-  if (!currentUser) {
-    return { currentUser: null, response: routeError(401, 'unauthorized', 'Unauthorized') };
-  }
-
-  if (!(currentUser.role === 'sales' || currentUser.role === 'admin')) {
-    return { currentUser: null, response: routeError(403, 'forbidden', 'Forbidden') };
-  }
-
-  return { currentUser, response: null };
+// Legacy coarse guards, now thin wrappers over the permission layer. The seed in
+// 20260608_permissions_model.sql gives crm.access to sales/konsult/admin, crm.write to
+// sales/admin and crm.admin to admin — reproducing the old role checks exactly, so the ~170
+// call sites are unchanged. Migrate hot routes to explicit per-resource keys over time.
+export function requireCrmUser() {
+  return requirePermission('crm.access');
 }
 
-export async function requireCrmAdmin() {
-  const currentUser = await getCurrentUser();
+// CRM WRITE access (sales/admin). konsult is read-only. Used on every CRM mutation.
+export function requireCrmWriter() {
+  return requirePermission('crm.write');
+}
 
-  if (!currentUser) {
-    return { currentUser: null, response: routeError(401, 'unauthorized', 'Unauthorized') };
-  }
-
-  if (currentUser.role !== 'admin') {
-    return { currentUser: null, response: routeError(403, 'forbidden', 'Forbidden') };
-  }
-
-  return { currentUser, response: null };
+export function requireCrmAdmin() {
+  return requirePermission('crm.admin');
 }
 
 export async function requireSignedInUser() {

--- a/app/api/crm/calls/[id]/route.ts
+++ b/app/api/crm/calls/[id]/route.ts
@@ -3,7 +3,7 @@ import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
 import { updateCrmCall } from '@/lib/domains/crm/calls';
 import {
   ok,
-  requireCrmWriter,
+  requirePermission,
   routeError,
   updateCrmCallSchema,
   validationError,
@@ -17,7 +17,7 @@ type RouteContext = {
 
 export async function PATCH(req: Request, context: RouteContext) {
   try {
-    const crmUser = await requireCrmWriter();
+    const crmUser = await requirePermission('crm.call.write');
     if (crmUser.response || !crmUser.currentUser) return crmUser.response;
 
     const parsedBody = updateCrmCallSchema.safeParse(await req.json().catch(() => null));

--- a/app/api/crm/calls/_lib.ts
+++ b/app/api/crm/calls/_lib.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-export { ok, routeError, validationError, requireCrmUser, requireCrmWriter } from '../_shared';
+export { ok, routeError, validationError, requireCrmUser, requireCrmWriter, requirePermission } from '../_shared';
 
 function normalizeOptionalText(value: unknown) {
   if (value == null) return null;

--- a/app/api/crm/calls/route.ts
+++ b/app/api/crm/calls/route.ts
@@ -6,7 +6,7 @@ import {
   listCrmCallsQuerySchema,
   ok,
   requireCrmUser,
-  requireCrmWriter,
+  requirePermission,
   routeError,
   validationError,
 } from './_lib';
@@ -45,7 +45,7 @@ export async function GET(req: Request) {
 
 export async function POST(req: Request) {
   try {
-    const crmUser = await requireCrmWriter();
+    const crmUser = await requirePermission('crm.call.write');
     if (crmUser.response || !crmUser.currentUser) return crmUser.response;
 
     const parsedBody = createCrmCallSchema.safeParse(await req.json().catch(() => null));

--- a/app/api/crm/customers/[id]/contacts/[contactId]/route.ts
+++ b/app/api/crm/customers/[id]/contacts/[contactId]/route.ts
@@ -1,13 +1,13 @@
 import { cookies } from 'next/headers';
 import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
 import { deleteCrmCustomerContact, updateCrmCustomerContact } from '@/lib/domains/crm/customers';
-import { ok, requireCrmWriter, routeError, updateCrmCustomerContactSchema, validationError } from '../../../_lib';
+import { ok, requirePermission, routeError, updateCrmCustomerContactSchema, validationError } from '../../../_lib';
 
 type RouteContext = { params: { id: string; contactId: string } };
 
 export async function PATCH(req: Request, context: RouteContext) {
   try {
-    const crmUser = await requireCrmWriter();
+    const crmUser = await requirePermission('crm.customer.write');
     if (crmUser.response || !crmUser.currentUser) return crmUser.response;
 
     const parsedBody = updateCrmCustomerContactSchema.safeParse(await req.json().catch(() => null));
@@ -28,7 +28,7 @@ export async function PATCH(req: Request, context: RouteContext) {
 
 export async function DELETE(_req: Request, context: RouteContext) {
   try {
-    const crmUser = await requireCrmWriter();
+    const crmUser = await requirePermission('crm.customer.write');
     if (crmUser.response || !crmUser.currentUser) return crmUser.response;
 
     const supabase = createRouteHandlerClient({ cookies });

--- a/app/api/crm/customers/[id]/contacts/route.ts
+++ b/app/api/crm/customers/[id]/contacts/route.ts
@@ -1,13 +1,13 @@
 import { cookies } from 'next/headers';
 import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
 import { createCrmCustomerContact } from '@/lib/domains/crm/customers';
-import { createCrmCustomerContactSchema, ok, requireCrmWriter, routeError, validationError } from '../../_lib';
+import { createCrmCustomerContactSchema, ok, requirePermission, routeError, validationError } from '../../_lib';
 
 type RouteContext = { params: { id: string } };
 
 export async function POST(req: Request, context: RouteContext) {
   try {
-    const crmUser = await requireCrmWriter();
+    const crmUser = await requirePermission('crm.customer.write');
     if (crmUser.response || !crmUser.currentUser) return crmUser.response;
 
     const parsedBody = createCrmCustomerContactSchema.safeParse(await req.json().catch(() => null));

--- a/app/api/crm/customers/[id]/fortnox/route.ts
+++ b/app/api/crm/customers/[id]/fortnox/route.ts
@@ -2,7 +2,7 @@ import { cookies } from 'next/headers';
 import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
 import { getCrmCustomer } from '@/lib/domains/crm/customers';
 import { createFortnoxCustomer, updateFortnoxCustomer } from '@/lib/domains/fortnox/customers';
-import { ok, requireCrmWriter, routeError } from '../../_lib';
+import { ok, requirePermission, routeError } from '../../_lib';
 
 type RouteContext = { params: { id: string } };
 
@@ -10,7 +10,7 @@ type RouteContext = { params: { id: string } };
 // Fortnox if it isn't linked yet, otherwise re-syncs the existing record.
 export async function POST(_req: Request, context: RouteContext) {
   try {
-    const crmUser = await requireCrmWriter();
+    const crmUser = await requirePermission('fortnox.customer.sync');
     if (crmUser.response) return crmUser.response;
 
     const supabase = createRouteHandlerClient({ cookies });

--- a/app/api/crm/customers/[id]/route.ts
+++ b/app/api/crm/customers/[id]/route.ts
@@ -2,7 +2,7 @@ import { cookies } from 'next/headers';
 import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
 import { getCrmCustomer, updateCrmCustomer } from '@/lib/domains/crm/customers';
 import { updateFortnoxCustomer, fortnoxCustomerFieldsChanged } from '@/lib/domains/fortnox/customers';
-import { ok, requireCrmUser, requireCrmWriter, routeError, updateCrmCustomerSchema, validationError } from '../_lib';
+import { ok, requireCrmUser, requirePermission, routeError, updateCrmCustomerSchema, validationError } from '../_lib';
 
 type RouteContext = { params: { id: string } };
 
@@ -26,7 +26,7 @@ export async function GET(_req: Request, context: RouteContext) {
 
 export async function PATCH(req: Request, context: RouteContext) {
   try {
-    const crmUser = await requireCrmWriter();
+    const crmUser = await requirePermission('crm.customer.write');
     if (crmUser.response || !crmUser.currentUser) return crmUser.response;
 
     const parsedBody = updateCrmCustomerSchema.safeParse(await req.json().catch(() => null));

--- a/app/api/crm/customers/_lib.ts
+++ b/app/api/crm/customers/_lib.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-export { ok, routeError, validationError, requireCrmUser, requireCrmWriter } from '../_shared';
+export { ok, routeError, validationError, requireCrmUser, requireCrmWriter, requirePermission } from '../_shared';
 
 // Zod's built-in .email() rejects Unicode domain names (e.g. byggmästaren.se).
 // This helper validates the structural shape of an email while accepting IDN domains.

--- a/app/api/crm/customers/route.ts
+++ b/app/api/crm/customers/route.ts
@@ -7,7 +7,7 @@ import {
   listCrmCustomersQuerySchema,
   ok,
   requireCrmUser,
-  requireCrmWriter,
+  requirePermission,
   routeError,
   validationError,
 } from './_lib';
@@ -47,7 +47,7 @@ export async function GET(req: Request) {
 
 export async function POST(req: Request) {
   try {
-    const crmUser = await requireCrmWriter();
+    const crmUser = await requirePermission('crm.customer.write');
     if (crmUser.response || !crmUser.currentUser) return crmUser.response;
 
     const parsedBody = createCrmCustomerSchema.safeParse(await req.json().catch(() => null));

--- a/app/api/crm/opportunities/[id]/route.ts
+++ b/app/api/crm/opportunities/[id]/route.ts
@@ -4,7 +4,7 @@ import { getCrmOpportunity, updateCrmOpportunity } from '@/lib/domains/crm/oppor
 import {
   ok,
   requireCrmUser,
-  requireCrmWriter,
+  requirePermission,
   routeError,
   updateCrmOpportunitySchema,
   validationError,
@@ -36,7 +36,7 @@ export async function GET(_req: Request, context: RouteContext) {
 
 export async function PATCH(req: Request, context: RouteContext) {
   try {
-    const crmUser = await requireCrmWriter();
+    const crmUser = await requirePermission('crm.opportunity.write');
     if (crmUser.response || !crmUser.currentUser) return crmUser.response;
 
     const parsedBody = updateCrmOpportunitySchema.safeParse(await req.json().catch(() => null));

--- a/app/api/crm/opportunities/_lib.ts
+++ b/app/api/crm/opportunities/_lib.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-export { ok, routeError, validationError, requireCrmUser, requireCrmWriter } from '../_shared';
+export { ok, routeError, validationError, requireCrmUser, requireCrmWriter, requirePermission } from '../_shared';
 
 const opportunityStatusSchema = z.enum(['qualified', 'quoted', 'won', 'lost']);
 const customerTypeSchema = z.enum(['business', 'private']);

--- a/app/api/crm/opportunities/route.ts
+++ b/app/api/crm/opportunities/route.ts
@@ -6,7 +6,7 @@ import {
   listCrmOpportunitiesQuerySchema,
   ok,
   requireCrmUser,
-  requireCrmWriter,
+  requirePermission,
   routeError,
   validationError,
 } from './_lib';
@@ -45,7 +45,7 @@ export async function GET(req: Request) {
 
 export async function POST(req: Request) {
   try {
-    const crmUser = await requireCrmWriter();
+    const crmUser = await requirePermission('crm.opportunity.write');
     if (crmUser.response || !crmUser.currentUser) return crmUser.response;
 
     const parsedBody = createCrmOpportunitySchema.safeParse(await req.json().catch(() => null));

--- a/app/api/crm/quotes/[id]/route.ts
+++ b/app/api/crm/quotes/[id]/route.ts
@@ -7,7 +7,7 @@ import {
   ok,
   pickProvidedQuoteFields,
   requireCrmUser,
-  requireCrmWriter,
+  requirePermission,
   routeError,
   updateCrmQuoteSchema,
   validationError,
@@ -37,7 +37,7 @@ export async function GET(_req: Request, context: RouteContext) {
 
 export async function PATCH(req: Request, context: RouteContext) {
   try {
-    const crmUser = await requireCrmWriter();
+    const crmUser = await requirePermission('crm.offer.write');
     if (crmUser.response || !crmUser.currentUser) return crmUser.response;
 
     const rawBody = await req.json().catch(() => null);

--- a/app/api/crm/quotes/[id]/work-order/route.ts
+++ b/app/api/crm/quotes/[id]/work-order/route.ts
@@ -3,7 +3,7 @@ import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
 import { createCrmWorkOrderFromQuote } from '@/lib/domains/crm/work-orders';
 import { pushWorkOrderToFortnox } from '@/lib/domains/fortnox/orders';
 import { FortnoxNotConnectedError, friendlyFortnoxMessage } from '@/lib/domains/fortnox/client';
-import { ok, requireCrmWriter, routeError } from '../../_lib';
+import { ok, requirePermission, routeError } from '../../_lib';
 
 type RouteContext = {
   params: {
@@ -13,7 +13,7 @@ type RouteContext = {
 
 export async function POST(_req: Request, context: RouteContext) {
   try {
-    const crmUser = await requireCrmWriter();
+    const crmUser = await requirePermission('crm.workorder.write');
     if (crmUser.response || !crmUser.currentUser) return crmUser.response;
 
     const supabase = createRouteHandlerClient({ cookies });

--- a/app/api/crm/quotes/_lib.ts
+++ b/app/api/crm/quotes/_lib.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { ROT_HOUSE_WORK_TYPES } from '@/lib/domains/fortnox/types';
-export { ok, routeError, validationError, requireCrmUser, requireCrmWriter } from '../_shared';
+export { ok, routeError, validationError, requireCrmUser, requireCrmWriter, requirePermission } from '../_shared';
 
 function normalizeOptionalText(value: unknown) {
   if (value == null) return null;

--- a/app/api/crm/quotes/route.ts
+++ b/app/api/crm/quotes/route.ts
@@ -8,7 +8,7 @@ import {
   listCrmQuotesQuerySchema,
   ok,
   requireCrmUser,
-  requireCrmWriter,
+  requirePermission,
   routeError,
   validationError,
 } from './_lib';
@@ -51,7 +51,7 @@ export async function GET(req: Request) {
 
 export async function POST(req: Request) {
   try {
-    const crmUser = await requireCrmWriter();
+    const crmUser = await requirePermission('crm.offer.write');
     if (crmUser.response || !crmUser.currentUser) return crmUser.response;
 
     const parsedBody = createCrmQuoteSchema.safeParse(await req.json().catch(() => null));

--- a/app/api/crm/work-orders/[id]/fortnox/email/route.ts
+++ b/app/api/crm/work-orders/[id]/fortnox/email/route.ts
@@ -1,13 +1,13 @@
 import { emailFortnoxOrder } from '@/lib/domains/fortnox/orders';
 import { FortnoxApiError, FortnoxNotConnectedError, friendlyFortnoxMessage } from '@/lib/domains/fortnox/client';
-import { ok, requireCrmWriter, routeError } from '../../../_lib';
+import { ok, requirePermission, routeError } from '../../../_lib';
 
 type RouteContext = { params: { id: string } };
 
 // Asks Fortnox to e-mail the order confirmation to the customer.
 export async function POST(_req: Request, { params }: RouteContext) {
   try {
-    const crmUser = await requireCrmWriter();
+    const crmUser = await requirePermission('fortnox.workorder.push');
     if (crmUser.response) return crmUser.response;
 
     const result = await emailFortnoxOrder(params.id);

--- a/app/api/crm/work-orders/[id]/fortnox/route.ts
+++ b/app/api/crm/work-orders/[id]/fortnox/route.ts
@@ -3,7 +3,7 @@ import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
 import { getCrmWorkOrder } from '@/lib/domains/crm/work-orders';
 import { updateWorkOrderInFortnox } from '@/lib/domains/fortnox/orders';
 import { FortnoxNotConnectedError, FortnoxPushInProgressError, friendlyFortnoxMessage } from '@/lib/domains/fortnox/client';
-import { ok, requireCrmWriter, routeError, invalidUuidParam } from '../../_lib';
+import { ok, requirePermission, routeError, invalidUuidParam } from '../../_lib';
 
 type RouteContext = {
   params: {
@@ -16,7 +16,7 @@ type RouteContext = {
 // igen" must actually re-send, not short-circuit. If no order exists yet it creates one.
 export async function POST(_req: Request, context: RouteContext) {
   try {
-    const crmUser = await requireCrmWriter();
+    const crmUser = await requirePermission('fortnox.workorder.push');
     if (crmUser.response || !crmUser.currentUser) return crmUser.response;
 
     const badId = invalidUuidParam(context.params.id);

--- a/app/api/crm/work-orders/[id]/invoice/route.ts
+++ b/app/api/crm/work-orders/[id]/invoice/route.ts
@@ -3,7 +3,7 @@ import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
 import { getCrmWorkOrder } from '@/lib/domains/crm/work-orders';
 import { createInvoiceFromWorkOrder } from '@/lib/domains/fortnox/orders';
 import { FortnoxNotConnectedError, FortnoxPushInProgressError, friendlyFortnoxMessage } from '@/lib/domains/fortnox/client';
-import { ok, requireCrmWriter, routeError, invalidUuidParam } from '../../_lib';
+import { ok, requirePermission, routeError, invalidUuidParam } from '../../_lib';
 
 type RouteContext = { params: { id: string } };
 
@@ -12,7 +12,7 @@ type RouteContext = { params: { id: string } };
 // order moves to `invoiced` ("Avslutad"); the actual invoicing happens inside Fortnox.
 export async function POST(_req: Request, context: RouteContext) {
   try {
-    const crmUser = await requireCrmWriter();
+    const crmUser = await requirePermission('fortnox.invoice.create');
     if (crmUser.response || !crmUser.currentUser) return crmUser.response;
 
     const badId = invalidUuidParam(context.params.id);

--- a/app/api/crm/work-orders/[id]/line-items/route.ts
+++ b/app/api/crm/work-orders/[id]/line-items/route.ts
@@ -4,7 +4,7 @@ import { getCrmWorkOrder, updateCrmWorkOrderLineItems } from '@/lib/domains/crm/
 import { computePricing, type PricingLineItem } from '@/lib/domains/crm/pricing';
 import { updateWorkOrderInFortnox } from '@/lib/domains/fortnox/orders';
 import { FortnoxNotConnectedError } from '@/lib/domains/fortnox/client';
-import { ok, requireCrmWriter, routeError, updateWorkOrderLineItemsSchema, validationError, invalidUuidParam } from '../../_lib';
+import { ok, requirePermission, routeError, updateWorkOrderLineItemsSchema, validationError, invalidUuidParam } from '../../_lib';
 
 type RouteContext = {
   params: {
@@ -17,7 +17,7 @@ type RouteContext = {
 // sync is non-fatal — the save succeeds and the reason is returned so the UI can show it.
 export async function PATCH(req: Request, context: RouteContext) {
   try {
-    const crmUser = await requireCrmWriter();
+    const crmUser = await requirePermission('crm.workorder.write');
     if (crmUser.response || !crmUser.currentUser) return crmUser.response;
 
     const badId = invalidUuidParam(context.params.id);

--- a/app/api/crm/work-orders/[id]/route.ts
+++ b/app/api/crm/work-orders/[id]/route.ts
@@ -1,7 +1,7 @@
 import { cookies } from 'next/headers';
 import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
 import { getCrmWorkOrder, updateCrmWorkOrder } from '@/lib/domains/crm/work-orders';
-import { ok, pickProvidedFields, requireCrmUser, requireCrmWriter, requireSignedInUser, routeError, updateCrmWorkOrderSchema, validationError } from '../_lib';
+import { ok, pickProvidedFields, requireCrmUser, requirePermission, requireSignedInUser, routeError, updateCrmWorkOrderSchema, validationError } from '../_lib';
 
 type RouteContext = {
   params: {
@@ -29,7 +29,7 @@ export async function GET(_req: Request, context: RouteContext) {
 
 export async function PATCH(req: Request, context: RouteContext) {
   try {
-    const crmUser = await requireCrmWriter();
+    const crmUser = await requirePermission('crm.workorder.write');
     if (crmUser.response || !crmUser.currentUser) return crmUser.response;
 
     const rawBody = await req.json().catch(() => null);

--- a/app/api/crm/work-orders/_lib.ts
+++ b/app/api/crm/work-orders/_lib.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { quoteLineItemSchema } from '../quotes/_lib';
-export { ok, routeError, validationError, invalidUuidParam, requireCrmUser, requireCrmWriter, requireSignedInUser, pickProvidedFields } from '../_shared';
+export { ok, routeError, validationError, invalidUuidParam, requireCrmUser, requireCrmWriter, requirePermission, requireSignedInUser, pickProvidedFields } from '../_shared';
 
 // Reuses the quote line-item schema so work order article edits validate identically.
 export const updateWorkOrderLineItemsSchema = z.object({

--- a/app/api/crm/work-orders/route.ts
+++ b/app/api/crm/work-orders/route.ts
@@ -1,7 +1,7 @@
 import { cookies } from 'next/headers';
 import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
 import { listCrmWorkOrdersWithFilters, createStandaloneCrmWorkOrder } from '@/lib/domains/crm/work-orders';
-import { createStandaloneWorkOrderSchema, listCrmWorkOrdersQuerySchema, ok, requireCrmUser, requireCrmWriter, routeError, validationError } from './_lib';
+import { createStandaloneWorkOrderSchema, listCrmWorkOrdersQuerySchema, ok, requireCrmUser, requirePermission, routeError, validationError } from './_lib';
 
 export async function GET(req: Request) {
   try {
@@ -40,7 +40,7 @@ export async function GET(req: Request) {
 // Create a standalone work order (no quote). Articles are added afterwards on the detail.
 export async function POST(req: Request) {
   try {
-    const crmUser = await requireCrmWriter();
+    const crmUser = await requirePermission('crm.workorder.write');
     if (crmUser.response || !crmUser.currentUser) return crmUser.response;
 
     const parsed = createStandaloneWorkOrderSchema.safeParse(await req.json().catch(() => null));

--- a/app/api/fortnox/_shared.ts
+++ b/app/api/fortnox/_shared.ts
@@ -1,7 +1,7 @@
 import { routeError } from '../crm/_shared';
 import { FortnoxApiError, FortnoxNotConnectedError, friendlyFortnoxMessage } from '@/lib/domains/fortnox/client';
 
-export { ok, routeError, validationError, requireCrmAdmin, requireCrmUser, requireCrmWriter } from '../crm/_shared';
+export { ok, routeError, validationError, requireCrmAdmin, requireCrmUser, requireCrmWriter, requirePermission } from '../crm/_shared';
 
 // Translate a thrown error from a Fortnox write into a deliberate route response.
 // FortnoxNotConnectedError → 400 (admin must connect first); FortnoxApiError keeps

--- a/app/api/fortnox/offers/[quoteId]/email/route.ts
+++ b/app/api/fortnox/offers/[quoteId]/email/route.ts
@@ -1,4 +1,4 @@
-import { requireCrmWriter, ok, routeError } from '../../../_shared';
+import { requirePermission, ok, routeError } from '../../../_shared';
 import { emailFortnoxOffer } from '@/lib/domains/fortnox/offers';
 import { FortnoxApiError, FortnoxNotConnectedError, friendlyFortnoxMessage } from '@/lib/domains/fortnox/client';
 
@@ -7,7 +7,7 @@ type RouteContext = { params: { quoteId: string } };
 // Asks Fortnox to e-mail the offer to the customer (uses the offer's EmailInformation).
 export async function POST(_req: Request, { params }: RouteContext) {
   try {
-    const crmUser = await requireCrmWriter();
+    const crmUser = await requirePermission('fortnox.offer.push');
     if (crmUser.response) return crmUser.response;
 
     const result = await emailFortnoxOffer(params.quoteId);

--- a/app/api/fortnox/offers/route.ts
+++ b/app/api/fortnox/offers/route.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { requireCrmWriter, ok, validationError, fortnoxWriteError } from '../_shared';
+import { requirePermission, ok, validationError, fortnoxWriteError } from '../_shared';
 import { pushQuoteToFortnox } from '@/lib/domains/fortnox/offers';
 
 const bodySchema = z.object({
@@ -8,7 +8,7 @@ const bodySchema = z.object({
 
 export async function POST(req: Request) {
   try {
-    const crmUser = await requireCrmWriter();
+    const crmUser = await requirePermission('fortnox.offer.push');
     if (crmUser.response) return crmUser.response;
 
     const parsed = bodySchema.safeParse(await req.json().catch(() => null));

--- a/lib/auth/permissions.ts
+++ b/lib/auth/permissions.ts
@@ -1,0 +1,67 @@
+import { cache as reactCache } from 'react';
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
+import { cookies } from 'next/headers';
+
+// React's request-scoped cache() dedupes the RPC across every guard in one request. It's a
+// server-only API; in non-server contexts (e.g. unit tests that import this module) it may be
+// absent — fall back to identity so importing the module never throws. getEffectivePermissions
+// isn't called in those contexts anyway.
+const cache: typeof reactCache = typeof reactCache === 'function' ? reactCache : ((fn: any) => fn) as typeof reactCache;
+
+// Permission-based access (RBAC), CRM + Fortnox scope. This is the TS half of the single
+// source of truth defined in supabase/sql/20260608_permissions_model.sql: the same effective
+// permissions that drive RLS (via has_permission()) drive the app guards here.
+//
+// PERMISSION_KEYS mirrors the SQL `permissions` catalog. Keep them in sync — the parity test
+// (tests/auth/permissions.test.ts) guards the count, and PermissionKey is derived from this
+// array so the compiler rejects typos at the call sites.
+
+export const PERMISSION_KEYS = [
+  // CRM resources (read + write)
+  'crm.prospect.read', 'crm.prospect.write',
+  'crm.call.read', 'crm.call.write',
+  'crm.customer.read', 'crm.customer.write',
+  'crm.contact.read', 'crm.contact.write',
+  'crm.opportunity.read', 'crm.opportunity.write',
+  'crm.offer.read', 'crm.offer.write',
+  'crm.workorder.read', 'crm.workorder.write',
+  'crm.task.read', 'crm.task.write',
+  // CRM read-only surfaces
+  'crm.report.read', 'crm.coach.read',
+  // CRM admin-managed resources
+  'crm.goal.read', 'crm.goal.manage',
+  'crm.routingrule.read', 'crm.routingrule.manage',
+  'crm.aiprospect.read', 'crm.aiprospect.manage',
+  'crm.ringlist.manage', 'crm.article.manage', 'crm.unit.manage',
+  // Fortnox actions
+  'fortnox.offer.push', 'fortnox.workorder.push', 'fortnox.invoice.create',
+  'fortnox.customer.sync', 'fortnox.read',
+  // Coarse meta keys backing the legacy requireCrmUser/Writer/Admin guards 1:1
+  'crm.access', 'crm.write', 'crm.admin',
+] as const;
+
+export type PermissionKey = (typeof PERMISSION_KEYS)[number];
+
+// Resolves the current user's effective permissions in ONE round-trip (the SQL function
+// computes role bundle − revokes + grants). Wrapped in React cache() so every guard call in
+// a single request shares the same RPC. Fails CLOSED (empty set) on any error — e.g. if the
+// permission migration hasn't been applied yet — so access is never granted by accident.
+export const getEffectivePermissions = cache(async (): Promise<Set<PermissionKey>> => {
+  try {
+    const supabase = createRouteHandlerClient({ cookies });
+    const { data, error } = await supabase.rpc('effective_permissions');
+    if (error) {
+      console.error('[permissions] effective_permissions RPC failed:', error.message);
+      return new Set();
+    }
+    const keys = Array.isArray(data) ? data.map((row) => (typeof row === 'string' ? row : String(row))) : [];
+    return new Set(keys as PermissionKey[]);
+  } catch (e) {
+    console.error('[permissions] effective_permissions threw:', (e as Error)?.message);
+    return new Set();
+  }
+});
+
+export function can(perms: Set<PermissionKey>, key: PermissionKey): boolean {
+  return perms.has(key);
+}

--- a/supabase/sql/20260608_permissions_model.sql
+++ b/supabase/sql/20260608_permissions_model.sql
@@ -1,0 +1,275 @@
+-- Permission-based access control (RBAC) — model, resolver and seed.
+--
+-- Phase 1 of the role→permission migration (CRM + Fortnox scope). This file is ADDITIVE:
+-- it introduces the permission tables, the resolver function used by both the app layer and
+-- RLS, the admin setter functions, the permission catalog and a role seed that EXACTLY
+-- reproduces today's role behavior. Nothing existing is changed here — no current policy or
+-- route consumes these until later phases. Roles (profiles.role) stay the role pointer;
+-- they now seed a permission bundle that individual users can extend/override.
+--
+-- Source of truth: a user's EFFECTIVE permissions = (role bundle) minus user 'revoke'
+-- overrides plus user 'grant' overrides. Read by has_permission() in RLS and by the TS
+-- can()/requirePermission() helpers — so a grant flows end-to-end into the database.
+--
+-- NOTE (deliberate omission): crm_work_order_time_entries and crm_work_order_comments are
+-- purely ownership-based (no role check in RLS) and get NO permission key — their policies
+-- stay untouched in the RLS phase.
+--
+-- Run in the Supabase SQL editor. Idempotent.
+
+-- ── 1. Tables ────────────────────────────────────────────────────────────────
+
+-- Catalog of all known permission keys (resource.action, e.g. 'crm.offer.write').
+create table if not exists public.permissions (
+  key         text primary key,
+  description text not null default '',
+  created_at  timestamptz not null default now()
+);
+
+-- Role → permission bundle (the seed sets below).
+create table if not exists public.role_permissions (
+  role           public.user_role not null,
+  permission_key text not null references public.permissions(key) on delete cascade,
+  primary key (role, permission_key)
+);
+create index if not exists role_permissions_role_idx on public.role_permissions(role);
+
+-- Per-user override on top of the role bundle. effect='grant' adds, effect='revoke' removes
+-- (revoke wins). One row per (user, key) so contradictory pairs are impossible.
+create table if not exists public.user_permissions (
+  user_id        uuid not null references auth.users(id) on delete cascade,
+  permission_key text not null references public.permissions(key) on delete cascade,
+  effect         text not null check (effect in ('grant','revoke')),
+  created_by     uuid references auth.users(id),
+  created_at     timestamptz not null default now(),
+  primary key (user_id, permission_key)
+);
+create index if not exists user_permissions_user_idx on public.user_permissions(user_id);
+
+-- ── 2. RLS on the permission tables themselves ──────────────────────────────
+-- Catalog + role bundles are non-secret and readable by all authenticated users; per-user
+-- overrides are self-read only (mirrors profiles_select_self). No write policies exist —
+-- all writes go through the SECURITY DEFINER setter functions below. The resolver functions
+-- are SECURITY DEFINER too, so they bypass these policies entirely (no recursion).
+
+alter table public.permissions      enable row level security;
+alter table public.role_permissions enable row level security;
+alter table public.user_permissions enable row level security;
+
+grant select on public.permissions      to authenticated;
+grant select on public.role_permissions to authenticated;
+grant select on public.user_permissions to authenticated;
+
+drop policy if exists permissions_select_all on public.permissions;
+create policy permissions_select_all on public.permissions
+  for select to authenticated using (true);
+
+drop policy if exists role_permissions_select_all on public.role_permissions;
+create policy role_permissions_select_all on public.role_permissions
+  for select to authenticated using (true);
+
+drop policy if exists user_permissions_select_self on public.user_permissions;
+create policy user_permissions_select_self on public.user_permissions
+  for select to authenticated using (user_id = auth.uid());
+
+-- ── 3. Resolver (single source of truth) ────────────────────────────────────
+-- has_permission() is the predicate used inside RLS. STABLE + a constant key + constant
+-- auth.uid() ⇒ Postgres evaluates it ~once per query (not per row); every internal lookup
+-- is a PK point lookup. SECURITY DEFINER bypasses RLS on the three tables above → no
+-- recursion (same pattern as set_user_role/handle_new_user).
+create or replace function public.has_permission(p_key text)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select
+    -- an explicit revoke always wins
+    not exists (
+      select 1 from public.user_permissions up
+      where up.user_id = auth.uid() and up.permission_key = p_key and up.effect = 'revoke'
+    )
+    and (
+      -- granted by the user's role bundle
+      exists (
+        select 1
+        from public.profiles pr
+        join public.role_permissions rp on rp.role = pr.role
+        where pr.id = auth.uid() and rp.permission_key = p_key
+      )
+      -- or granted explicitly to the user
+      or exists (
+        select 1 from public.user_permissions up
+        where up.user_id = auth.uid() and up.permission_key = p_key and up.effect = 'grant'
+      )
+    );
+$$;
+revoke all on function public.has_permission(text) from public;
+grant execute on function public.has_permission(text) to authenticated;
+
+-- One-shot effective-permission list for the app layer (one RPC per request).
+create or replace function public.effective_permissions()
+returns setof text
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select rp.permission_key
+  from public.profiles pr
+  join public.role_permissions rp on rp.role = pr.role
+  where pr.id = auth.uid()
+  union
+  select up.permission_key from public.user_permissions up
+  where up.user_id = auth.uid() and up.effect = 'grant'
+  except
+  select up.permission_key from public.user_permissions up
+  where up.user_id = auth.uid() and up.effect = 'revoke';
+$$;
+revoke all on function public.effective_permissions() from public;
+grant execute on function public.effective_permissions() to authenticated;
+
+-- ── 4. Admin setter functions (only path that writes the tables) ────────────
+create or replace function public.set_role_permission(p_role public.user_role, p_key text, p_present boolean)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if not exists (select 1 from public.profiles where id = auth.uid() and role = 'admin') then
+    raise exception 'not authorized';
+  end if;
+  if not exists (select 1 from public.permissions where key = p_key) then
+    raise exception 'unknown permission %', p_key;
+  end if;
+  if p_present then
+    insert into public.role_permissions(role, permission_key) values (p_role, p_key)
+    on conflict do nothing;
+  else
+    delete from public.role_permissions where role = p_role and permission_key = p_key;
+  end if;
+end;$$;
+revoke all on function public.set_role_permission(public.user_role, text, boolean) from public;
+grant execute on function public.set_role_permission(public.user_role, text, boolean) to authenticated;
+
+-- p_effect: 'grant' | 'revoke' to set an override, NULL to clear it (fall back to the role).
+create or replace function public.set_user_permission(p_user uuid, p_key text, p_effect text)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if not exists (select 1 from public.profiles where id = auth.uid() and role = 'admin') then
+    raise exception 'not authorized';
+  end if;
+  if not exists (select 1 from public.permissions where key = p_key) then
+    raise exception 'unknown permission %', p_key;
+  end if;
+  if p_effect is null then
+    delete from public.user_permissions where user_id = p_user and permission_key = p_key;
+  elsif p_effect in ('grant','revoke') then
+    insert into public.user_permissions(user_id, permission_key, effect, created_by)
+    values (p_user, p_key, p_effect, auth.uid())
+    on conflict (user_id, permission_key) do update
+      set effect = excluded.effect, created_by = excluded.created_by;
+  else
+    raise exception 'invalid effect %', p_effect;
+  end if;
+end;$$;
+revoke all on function public.set_user_permission(uuid, text, text) from public;
+grant execute on function public.set_user_permission(uuid, text, text) to authenticated;
+
+-- ── 5. Permission catalog (CRM + Fortnox scope) ─────────────────────────────
+insert into public.permissions (key, description) values
+  -- CRM resources (read + write)
+  ('crm.prospect.read',     'CRM: view prospects'),
+  ('crm.prospect.write',    'CRM: create/edit prospects'),
+  ('crm.call.read',         'CRM: view calls'),
+  ('crm.call.write',        'CRM: log/edit calls'),
+  ('crm.customer.read',     'CRM: view customers'),
+  ('crm.customer.write',    'CRM: create/edit customers'),
+  ('crm.contact.read',      'CRM: view customer contacts'),
+  ('crm.contact.write',     'CRM: create/edit customer contacts'),
+  ('crm.opportunity.read',  'CRM: view opportunities'),
+  ('crm.opportunity.write', 'CRM: create/edit opportunities'),
+  ('crm.offer.read',        'CRM: view quotes/offers'),
+  ('crm.offer.write',       'CRM: create/edit quotes/offers'),
+  ('crm.workorder.read',    'CRM: view work orders'),
+  ('crm.workorder.write',   'CRM: create/edit work orders'),
+  ('crm.task.read',         'CRM: view tasks'),
+  ('crm.task.write',        'CRM: create/edit tasks'),
+  -- CRM read-only surfaces
+  ('crm.report.read',       'CRM: view reporting'),
+  ('crm.coach.read',        'CRM: use the AI coach'),
+  -- CRM admin-managed resources
+  ('crm.goal.read',         'CRM: view goals'),
+  ('crm.goal.manage',       'CRM: set goals (admin)'),
+  ('crm.routingrule.read',  'CRM: view lead-routing rules'),
+  ('crm.routingrule.manage','CRM: manage lead-routing rules (admin)'),
+  ('crm.aiprospect.read',   'CRM: view AI prospect suggestions (admin)'),
+  ('crm.aiprospect.manage', 'CRM: review AI prospect suggestions (admin)'),
+  ('crm.ringlist.manage',   'CRM: import/assign ring lists (admin)'),
+  ('crm.article.manage',    'CRM: manage Fortnox articles (admin)'),
+  ('crm.unit.manage',       'CRM: manage Fortnox units (admin)'),
+  -- Fortnox bookkeeping actions
+  ('fortnox.offer.push',     'Fortnox: push offers'),
+  ('fortnox.workorder.push', 'Fortnox: push work orders/orders'),
+  ('fortnox.invoice.create', 'Fortnox: create draft invoices'),
+  ('fortnox.customer.sync',  'Fortnox: sync customers'),
+  ('fortnox.read',           'Fortnox: read documents (PDF/email, registers)'),
+  -- Coarse meta keys (back the existing requireCrmUser/Writer/Admin guards 1:1)
+  ('crm.access', 'CRM: read access (any CRM role)'),
+  ('crm.write',  'CRM: write access (sales/admin)'),
+  ('crm.admin',  'CRM: admin access')
+on conflict (key) do nothing;
+
+-- ── 6. Role seed (reproduces today's behavior EXACTLY) ──────────────────────
+-- admin → every key in the catalog.
+insert into public.role_permissions (role, permission_key)
+select 'admin'::public.user_role, key from public.permissions
+on conflict do nothing;
+
+-- sales → all reads + all writes + reports/coach + goal.read + routingrule.read + all
+-- Fortnox actions + meta access/write. NOT: any .manage, aiprospect.*, crm.admin.
+insert into public.role_permissions (role, permission_key) values
+  ('sales','crm.prospect.read'),   ('sales','crm.prospect.write'),
+  ('sales','crm.call.read'),       ('sales','crm.call.write'),
+  ('sales','crm.customer.read'),   ('sales','crm.customer.write'),
+  ('sales','crm.contact.read'),    ('sales','crm.contact.write'),
+  ('sales','crm.opportunity.read'),('sales','crm.opportunity.write'),
+  ('sales','crm.offer.read'),      ('sales','crm.offer.write'),
+  ('sales','crm.workorder.read'),  ('sales','crm.workorder.write'),
+  ('sales','crm.task.read'),       ('sales','crm.task.write'),
+  ('sales','crm.report.read'),     ('sales','crm.coach.read'),
+  ('sales','crm.goal.read'),       ('sales','crm.routingrule.read'),
+  ('sales','fortnox.offer.push'),  ('sales','fortnox.workorder.push'),
+  ('sales','fortnox.invoice.create'),('sales','fortnox.customer.sync'),
+  ('sales','fortnox.read'),
+  ('sales','crm.access'),          ('sales','crm.write')
+on conflict do nothing;
+
+-- konsult → read-only CRM. NOT: routingrule.read (RLS excludes konsult), aiprospect.read,
+-- any write, any .manage, crm.write, crm.admin.
+insert into public.role_permissions (role, permission_key) values
+  ('konsult','crm.prospect.read'),
+  ('konsult','crm.call.read'),
+  ('konsult','crm.customer.read'),
+  ('konsult','crm.contact.read'),
+  ('konsult','crm.opportunity.read'),
+  ('konsult','crm.offer.read'),
+  ('konsult','crm.workorder.read'),
+  ('konsult','crm.task.read'),
+  ('konsult','crm.report.read'),
+  ('konsult','crm.coach.read'),
+  ('konsult','crm.goal.read'),
+  ('konsult','fortnox.read'),
+  ('konsult','crm.access')
+on conflict do nothing;
+
+-- member → no CRM/Fortnox keys (installer; today requireCrmUser rejects member, and their
+-- work-order access is ownership-based via assigned_to, which stays untouched).
+
+-- Done.

--- a/supabase/sql/20260608_permissions_parity_assert.sql
+++ b/supabase/sql/20260608_permissions_parity_assert.sql
@@ -1,0 +1,90 @@
+-- Parity assertion for the permission seed (run AFTER 20260608_permissions_model.sql).
+--
+-- Proves the role seed reproduces today's role behavior EXACTLY: for every permission key,
+-- the set of roles that hold it must equal the set of roles the old guard/RLS predicate
+-- admitted. This is the safety oracle for Phase 1 — every row must show ok = true, and the
+-- two completeness checks at the bottom must return zero rows.
+--
+-- Oracle (today's behavior):
+--   reads          → sales, konsult, admin   (requireCrmUser / SELECT policies w/ konsult)
+--   writes + push  → sales, admin            (requireCrmWriter)
+--   routingrule.read → sales, admin          (RLS SELECT excludes konsult)
+--   admin-managed  → admin                   (requireCrmAdmin / admin-only RLS)
+
+with expected(key, roles) as (
+  values
+    -- reads: sales + konsult + admin
+    ('crm.prospect.read',     array['admin','konsult','sales']),
+    ('crm.call.read',         array['admin','konsult','sales']),
+    ('crm.customer.read',     array['admin','konsult','sales']),
+    ('crm.contact.read',      array['admin','konsult','sales']),
+    ('crm.opportunity.read',  array['admin','konsult','sales']),
+    ('crm.offer.read',        array['admin','konsult','sales']),
+    ('crm.workorder.read',    array['admin','konsult','sales']),
+    ('crm.task.read',         array['admin','konsult','sales']),
+    ('crm.report.read',       array['admin','konsult','sales']),
+    ('crm.coach.read',        array['admin','konsult','sales']),
+    ('crm.goal.read',         array['admin','konsult','sales']),
+    ('fortnox.read',          array['admin','konsult','sales']),
+    ('crm.access',            array['admin','konsult','sales']),
+    -- writes / Fortnox actions / meta write / routingrule.read: sales + admin
+    ('crm.prospect.write',    array['admin','sales']),
+    ('crm.call.write',        array['admin','sales']),
+    ('crm.customer.write',    array['admin','sales']),
+    ('crm.contact.write',     array['admin','sales']),
+    ('crm.opportunity.write', array['admin','sales']),
+    ('crm.offer.write',       array['admin','sales']),
+    ('crm.workorder.write',   array['admin','sales']),
+    ('crm.task.write',        array['admin','sales']),
+    ('crm.routingrule.read',  array['admin','sales']),
+    ('fortnox.offer.push',    array['admin','sales']),
+    ('fortnox.workorder.push',array['admin','sales']),
+    ('fortnox.invoice.create',array['admin','sales']),
+    ('fortnox.customer.sync', array['admin','sales']),
+    ('crm.write',             array['admin','sales']),
+    -- admin-managed: admin only
+    ('crm.goal.manage',       array['admin']),
+    ('crm.routingrule.manage',array['admin']),
+    ('crm.aiprospect.read',   array['admin']),
+    ('crm.aiprospect.manage', array['admin']),
+    ('crm.ringlist.manage',   array['admin']),
+    ('crm.article.manage',    array['admin']),
+    ('crm.unit.manage',       array['admin']),
+    ('crm.admin',             array['admin'])
+),
+actual as (
+  select permission_key as key, array_agg(role::text order by role::text) as roles
+  from public.role_permissions
+  group by permission_key
+)
+select
+  e.key,
+  (select array_agg(r order by r) from unnest(e.roles) r) as expected_roles,
+  coalesce(a.roles, array[]::text[])                      as actual_roles,
+  (select array_agg(r order by r) from unnest(e.roles) r) = coalesce(a.roles, array[]::text[]) as ok
+from expected e
+left join actual a on a.key = e.key
+order by ok nulls first, e.key;
+
+-- Completeness check 1: every catalog key must appear in the oracle above (else 0 rows).
+-- (Edit the oracle if you add a key.)
+select 'catalog key missing from oracle' as problem, p.key
+from public.permissions p
+where p.key not in (
+  'crm.prospect.read','crm.call.read','crm.customer.read','crm.contact.read',
+  'crm.opportunity.read','crm.offer.read','crm.workorder.read','crm.task.read',
+  'crm.report.read','crm.coach.read','crm.goal.read','fortnox.read','crm.access',
+  'crm.prospect.write','crm.call.write','crm.customer.write','crm.contact.write',
+  'crm.opportunity.write','crm.offer.write','crm.workorder.write','crm.task.write',
+  'crm.routingrule.read','fortnox.offer.push','fortnox.workorder.push',
+  'fortnox.invoice.create','fortnox.customer.sync','crm.write',
+  'crm.goal.manage','crm.routingrule.manage','crm.aiprospect.read','crm.aiprospect.manage',
+  'crm.ringlist.manage','crm.article.manage','crm.unit.manage','crm.admin'
+);
+
+-- Completeness check 2: every seeded role_permission must reference a real catalog key
+-- (FK already guarantees this, but kept for parity with a future free-form seed).
+select 'orphan role_permission' as problem, rp.role, rp.permission_key
+from public.role_permissions rp
+left join public.permissions p on p.key = rp.permission_key
+where p.key is null;

--- a/supabase/sql/20260609_permissions_admin_lockout_guard.sql
+++ b/supabase/sql/20260609_permissions_admin_lockout_guard.sql
@@ -1,0 +1,69 @@
+-- Admin self-lockout guard for the permission setters (CREATE OR REPLACE over the functions
+-- from 20260608_permissions_model.sql). Without this, an admin could — via a direct API call,
+-- bypassing the UI which already blocks it — strip their own admin access two ways:
+--   1) remove crm.admin from the admin ROLE bundle (all admins lose it), or
+--   2) revoke crm.admin on an admin USER (revoke wins → that admin loses it).
+-- Both now raise an exception. Recovery from an existing lockout is still a manual SQL delete
+-- of the offending role_permissions / user_permissions row.
+--
+-- Run AFTER 20260608_permissions_model.sql. Idempotent (replaces the functions).
+
+create or replace function public.set_role_permission(p_role public.user_role, p_key text, p_present boolean)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if not exists (select 1 from public.profiles where id = auth.uid() and role = 'admin') then
+    raise exception 'not authorized';
+  end if;
+  if not exists (select 1 from public.permissions where key = p_key) then
+    raise exception 'unknown permission %', p_key;
+  end if;
+  -- Lockout guard: the admin role must always keep crm.admin.
+  if p_role = 'admin' and p_key = 'crm.admin' and p_present = false then
+    raise exception 'cannot remove crm.admin from the admin role';
+  end if;
+  if p_present then
+    insert into public.role_permissions(role, permission_key) values (p_role, p_key)
+    on conflict do nothing;
+  else
+    delete from public.role_permissions where role = p_role and permission_key = p_key;
+  end if;
+end;$$;
+revoke all on function public.set_role_permission(public.user_role, text, boolean) from public;
+grant execute on function public.set_role_permission(public.user_role, text, boolean) to authenticated;
+
+-- p_effect: 'grant' | 'revoke' to set an override, NULL to clear it (fall back to the role).
+create or replace function public.set_user_permission(p_user uuid, p_key text, p_effect text)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if not exists (select 1 from public.profiles where id = auth.uid() and role = 'admin') then
+    raise exception 'not authorized';
+  end if;
+  if not exists (select 1 from public.permissions where key = p_key) then
+    raise exception 'unknown permission %', p_key;
+  end if;
+  -- Lockout guard: never revoke crm.admin from a user who is an admin.
+  if p_key = 'crm.admin' and p_effect = 'revoke'
+     and exists (select 1 from public.profiles where id = p_user and role = 'admin') then
+    raise exception 'cannot revoke crm.admin from an admin';
+  end if;
+  if p_effect is null then
+    delete from public.user_permissions where user_id = p_user and permission_key = p_key;
+  elsif p_effect in ('grant', 'revoke') then
+    insert into public.user_permissions(user_id, permission_key, effect, created_by)
+    values (p_user, p_key, p_effect, auth.uid())
+    on conflict (user_id, permission_key) do update
+      set effect = excluded.effect, created_by = excluded.created_by;
+  else
+    raise exception 'invalid effect %', p_effect;
+  end if;
+end;$$;
+revoke all on function public.set_user_permission(uuid, text, text) from public;
+grant execute on function public.set_user_permission(uuid, text, text) to authenticated;

--- a/supabase/sql/20260609_rls_permissions_crm_admin.sql
+++ b/supabase/sql/20260609_rls_permissions_crm_admin.sql
@@ -1,0 +1,92 @@
+-- Phase 3c of the role→permission migration: the admin-managed CRM tables.
+-- Behavior-preserving role→key swaps; the user_id ownership branch on goals is preserved.
+--
+-- Mapping:
+--   crm_goals      : own row OR admin → user_id=auth.uid() OR has_permission('crm.goal.manage');
+--                    admin-only writes → has_permission('crm.goal.manage')
+--   crm_routing_rules: read (sales,admin) → has_permission('crm.routingrule.read');
+--                      manage (admin)     → has_permission('crm.routingrule.manage')
+--   crm_ai_prospect_suggestions: read (admin) → has_permission('crm.aiprospect.read');
+--                                writes (admin) → has_permission('crm.aiprospect.manage')
+--
+-- Run AFTER 20260608_permissions_model.sql. Idempotent.
+
+-- ── crm_goals ────────────────────────────────────────────────────────────────
+drop policy if exists "crm_goals_select_visible" on public.crm_goals;
+create policy "crm_goals_select_visible"
+  on public.crm_goals
+  for select
+  using (
+    user_id = auth.uid()
+    or public.has_permission('crm.goal.manage')
+  );
+
+drop policy if exists "crm_goals_insert_admin_only" on public.crm_goals;
+create policy "crm_goals_insert_admin_only"
+  on public.crm_goals
+  for insert
+  to authenticated
+  with check (
+    public.has_permission('crm.goal.manage')
+  );
+
+drop policy if exists "crm_goals_update_admin_only" on public.crm_goals;
+create policy "crm_goals_update_admin_only"
+  on public.crm_goals
+  for update
+  using (
+    public.has_permission('crm.goal.manage')
+  )
+  with check (
+    public.has_permission('crm.goal.manage')
+  );
+
+-- ── crm_routing_rules ────────────────────────────────────────────────────────
+drop policy if exists "crm_routing_rules_select_crm" on public.crm_routing_rules;
+create policy "crm_routing_rules_select_crm"
+  on public.crm_routing_rules
+  for select
+  using (
+    public.has_permission('crm.routingrule.read')
+  );
+
+drop policy if exists "crm_routing_rules_manage_admin" on public.crm_routing_rules;
+create policy "crm_routing_rules_manage_admin"
+  on public.crm_routing_rules
+  for all
+  using (
+    public.has_permission('crm.routingrule.manage')
+  )
+  with check (
+    public.has_permission('crm.routingrule.manage')
+  );
+
+-- ── crm_ai_prospect_suggestions ──────────────────────────────────────────────
+drop policy if exists "crm_ai_prospect_suggestions_select_visible" on public.crm_ai_prospect_suggestions;
+create policy "crm_ai_prospect_suggestions_select_visible"
+  on public.crm_ai_prospect_suggestions
+  for select
+  using (
+    public.has_permission('crm.aiprospect.read')
+  );
+
+drop policy if exists "crm_ai_prospect_suggestions_insert_admin_only" on public.crm_ai_prospect_suggestions;
+create policy "crm_ai_prospect_suggestions_insert_admin_only"
+  on public.crm_ai_prospect_suggestions
+  for insert
+  to authenticated
+  with check (
+    created_by = auth.uid()
+    and public.has_permission('crm.aiprospect.manage')
+  );
+
+drop policy if exists "crm_ai_prospect_suggestions_update_admin_only" on public.crm_ai_prospect_suggestions;
+create policy "crm_ai_prospect_suggestions_update_admin_only"
+  on public.crm_ai_prospect_suggestions
+  for update
+  using (
+    public.has_permission('crm.aiprospect.manage')
+  )
+  with check (
+    public.has_permission('crm.aiprospect.manage')
+  );

--- a/supabase/sql/20260609_rls_permissions_crm_core.sql
+++ b/supabase/sql/20260609_rls_permissions_crm_core.sql
@@ -1,0 +1,268 @@
+-- Phase 3a of the role→permission migration: swap the ROLE predicates in the core CRM
+-- tables' RLS to has_permission(). Behavior-preserving by construction — each role branch is
+-- replaced by a permission key whose seed (20260608_permissions_model.sql) admits exactly the
+-- same roles the old predicate did. Ownership branches (auth.uid() = assigned_to /
+-- customer-ownership joins) are left UNTOUCHED.
+--
+-- Mapping used here:
+--   role = 'admin'  (see-all / manage / update-any / delete-any)  → has_permission('crm.admin')
+--   role in (sales,admin) (write-self insert)                     → has_permission('crm.<res>.write')
+--
+-- Tables: crm_prospects, crm_calls, crm_customers, crm_customer_contacts, crm_opportunities.
+-- Run AFTER 20260608_permissions_model.sql. Idempotent (drop+create).
+
+-- ── crm_prospects ────────────────────────────────────────────────────────────
+drop policy if exists "crm_prospects_select_visible" on public.crm_prospects;
+create policy "crm_prospects_select_visible"
+  on public.crm_prospects
+  for select
+  using (
+    auth.uid() = assigned_to
+    or public.has_permission('crm.admin')
+  );
+
+drop policy if exists "crm_prospects_insert_sales_or_admin" on public.crm_prospects;
+create policy "crm_prospects_insert_sales_or_admin"
+  on public.crm_prospects
+  for insert
+  to authenticated
+  with check (
+    created_by = auth.uid()
+    and assigned_to = auth.uid()
+    and public.has_permission('crm.prospect.write')
+  );
+
+drop policy if exists "crm_prospects_insert_admin_manage" on public.crm_prospects;
+create policy "crm_prospects_insert_admin_manage"
+  on public.crm_prospects
+  for insert
+  to authenticated
+  with check (
+    created_by = auth.uid()
+    and public.has_permission('crm.admin')
+  );
+
+drop policy if exists "crm_prospects_update_visible" on public.crm_prospects;
+create policy "crm_prospects_update_visible"
+  on public.crm_prospects
+  for update
+  using (
+    auth.uid() = assigned_to
+    or public.has_permission('crm.admin')
+  )
+  with check (
+    auth.uid() = assigned_to
+    or public.has_permission('crm.admin')
+  );
+
+drop policy if exists "crm_prospects_delete_assigned_or_admin" on public.crm_prospects;
+create policy "crm_prospects_delete_assigned_or_admin"
+  on public.crm_prospects
+  for delete
+  using (
+    auth.uid() = assigned_to
+    or public.has_permission('crm.admin')
+  );
+
+-- ── crm_calls ────────────────────────────────────────────────────────────────
+drop policy if exists "crm_calls_select_visible" on public.crm_calls;
+create policy "crm_calls_select_visible"
+  on public.crm_calls
+  for select
+  using (
+    user_id = auth.uid()
+    or exists (
+      select 1 from public.crm_prospects p
+      where p.id = prospect_id and p.assigned_to = auth.uid()
+    )
+    or public.has_permission('crm.admin')
+  );
+
+drop policy if exists "crm_calls_insert_visible" on public.crm_calls;
+create policy "crm_calls_insert_visible"
+  on public.crm_calls
+  for insert
+  to authenticated
+  with check (
+    (
+      user_id = auth.uid()
+      and public.has_permission('crm.call.write')
+      and (
+        prospect_id is null
+        or exists (
+          select 1 from public.crm_prospects p
+          where p.id = prospect_id and p.assigned_to = auth.uid()
+        )
+      )
+    )
+    or public.has_permission('crm.admin')
+  );
+
+drop policy if exists "crm_calls_update_visible" on public.crm_calls;
+create policy "crm_calls_update_visible"
+  on public.crm_calls
+  for update
+  using (
+    user_id = auth.uid()
+    or public.has_permission('crm.admin')
+  )
+  with check (
+    (
+      user_id = auth.uid()
+      and public.has_permission('crm.call.write')
+      and (
+        prospect_id is null
+        or exists (
+          select 1 from public.crm_prospects p
+          where p.id = prospect_id and p.assigned_to = auth.uid()
+        )
+      )
+    )
+    or public.has_permission('crm.admin')
+  );
+
+-- ── crm_customers ────────────────────────────────────────────────────────────
+drop policy if exists "crm_customers_select_visible" on public.crm_customers;
+create policy "crm_customers_select_visible"
+  on public.crm_customers
+  for select
+  using (
+    auth.uid() = assigned_to
+    or public.has_permission('crm.admin')
+  );
+
+drop policy if exists "crm_customers_insert_sales_or_admin" on public.crm_customers;
+create policy "crm_customers_insert_sales_or_admin"
+  on public.crm_customers
+  for insert
+  to authenticated
+  with check (
+    created_by = auth.uid()
+    and public.has_permission('crm.customer.write')
+  );
+
+drop policy if exists "crm_customers_update_assigned_or_admin" on public.crm_customers;
+create policy "crm_customers_update_assigned_or_admin"
+  on public.crm_customers
+  for update
+  using (
+    auth.uid() = assigned_to
+    or public.has_permission('crm.admin')
+  )
+  with check (
+    auth.uid() = assigned_to
+    or public.has_permission('crm.admin')
+  );
+
+drop policy if exists "crm_customers_delete_admin" on public.crm_customers;
+create policy "crm_customers_delete_admin"
+  on public.crm_customers
+  for delete
+  using (
+    public.has_permission('crm.admin')
+  );
+
+-- ── crm_customer_contacts (inherit the customer's visibility) ────────────────
+-- The admin sub-branch inside the customer-ownership EXISTS becomes has_permission('crm.admin');
+-- the c.assigned_to = auth.uid() ownership branch is preserved.
+drop policy if exists "crm_customer_contacts_select_visible" on public.crm_customer_contacts;
+create policy "crm_customer_contacts_select_visible"
+  on public.crm_customer_contacts
+  for select
+  using (
+    exists (
+      select 1 from public.crm_customers c
+      where c.id = customer_id
+        and (c.assigned_to = auth.uid() or public.has_permission('crm.admin'))
+    )
+  );
+
+drop policy if exists "crm_customer_contacts_insert_sales_or_admin" on public.crm_customer_contacts;
+create policy "crm_customer_contacts_insert_sales_or_admin"
+  on public.crm_customer_contacts
+  for insert
+  to authenticated
+  with check (
+    exists (
+      select 1 from public.crm_customers c
+      where c.id = customer_id
+        and (c.assigned_to = auth.uid() or public.has_permission('crm.admin'))
+    )
+  );
+
+drop policy if exists "crm_customer_contacts_update_sales_or_admin" on public.crm_customer_contacts;
+create policy "crm_customer_contacts_update_sales_or_admin"
+  on public.crm_customer_contacts
+  for update
+  using (
+    exists (
+      select 1 from public.crm_customers c
+      where c.id = customer_id
+        and (c.assigned_to = auth.uid() or public.has_permission('crm.admin'))
+    )
+  );
+
+drop policy if exists "crm_customer_contacts_delete_sales_or_admin" on public.crm_customer_contacts;
+create policy "crm_customer_contacts_delete_sales_or_admin"
+  on public.crm_customer_contacts
+  for delete
+  using (
+    exists (
+      select 1 from public.crm_customers c
+      where c.id = customer_id
+        and (c.assigned_to = auth.uid() or public.has_permission('crm.admin'))
+    )
+  );
+
+-- ── crm_opportunities ────────────────────────────────────────────────────────
+drop policy if exists "crm_opportunities_select_visible" on public.crm_opportunities;
+create policy "crm_opportunities_select_visible"
+  on public.crm_opportunities
+  for select
+  using (
+    auth.uid() = assigned_to
+    or public.has_permission('crm.admin')
+  );
+
+drop policy if exists "crm_opportunities_insert_sales_or_admin" on public.crm_opportunities;
+create policy "crm_opportunities_insert_sales_or_admin"
+  on public.crm_opportunities
+  for insert
+  to authenticated
+  with check (
+    created_by = auth.uid()
+    and assigned_to = auth.uid()
+    and public.has_permission('crm.opportunity.write')
+  );
+
+drop policy if exists "crm_opportunities_insert_admin_manage" on public.crm_opportunities;
+create policy "crm_opportunities_insert_admin_manage"
+  on public.crm_opportunities
+  for insert
+  to authenticated
+  with check (
+    created_by = auth.uid()
+    and public.has_permission('crm.admin')
+  );
+
+drop policy if exists "crm_opportunities_update_visible" on public.crm_opportunities;
+create policy "crm_opportunities_update_visible"
+  on public.crm_opportunities
+  for update
+  using (
+    auth.uid() = assigned_to
+    or public.has_permission('crm.admin')
+  )
+  with check (
+    auth.uid() = assigned_to
+    or public.has_permission('crm.admin')
+  );
+
+drop policy if exists "crm_opportunities_delete_assigned_or_admin" on public.crm_opportunities;
+create policy "crm_opportunities_delete_assigned_or_admin"
+  on public.crm_opportunities
+  for delete
+  using (
+    auth.uid() = assigned_to
+    or public.has_permission('crm.admin')
+  );

--- a/supabase/sql/20260609_rls_permissions_crm_core.sql
+++ b/supabase/sql/20260609_rls_permissions_crm_core.sql
@@ -2,69 +2,19 @@
 -- tables' RLS to has_permission(). Behavior-preserving by construction — each role branch is
 -- replaced by a permission key whose seed (20260608_permissions_model.sql) admits exactly the
 -- same roles the old predicate did. Ownership branches (auth.uid() = assigned_to /
--- customer-ownership joins) are left UNTOUCHED.
+-- user_id = auth.uid() / customer-ownership joins) are left UNTOUCHED.
 --
 -- Mapping used here:
 --   role = 'admin'  (see-all / manage / update-any / delete-any)  → has_permission('crm.admin')
 --   role in (sales,admin) (write-self insert)                     → has_permission('crm.<res>.write')
 --
--- Tables: crm_prospects, crm_calls, crm_customers, crm_customer_contacts, crm_opportunities.
+-- Tables: crm_calls, crm_customers, crm_customer_contacts, crm_opportunities.
+-- NOTE: crm_prospects was dropped (20260604_crm_remove_legacy_prospects.sql) — prospects are
+-- now crm_customers with customer_stage='prospect', so crm_calls/quotes reference crm_customers
+-- via prospect_id. Reproduces the CURRENT (post-remove-legacy) policies.
 -- Run AFTER 20260608_permissions_model.sql. Idempotent (drop+create).
 
--- ── crm_prospects ────────────────────────────────────────────────────────────
-drop policy if exists "crm_prospects_select_visible" on public.crm_prospects;
-create policy "crm_prospects_select_visible"
-  on public.crm_prospects
-  for select
-  using (
-    auth.uid() = assigned_to
-    or public.has_permission('crm.admin')
-  );
-
-drop policy if exists "crm_prospects_insert_sales_or_admin" on public.crm_prospects;
-create policy "crm_prospects_insert_sales_or_admin"
-  on public.crm_prospects
-  for insert
-  to authenticated
-  with check (
-    created_by = auth.uid()
-    and assigned_to = auth.uid()
-    and public.has_permission('crm.prospect.write')
-  );
-
-drop policy if exists "crm_prospects_insert_admin_manage" on public.crm_prospects;
-create policy "crm_prospects_insert_admin_manage"
-  on public.crm_prospects
-  for insert
-  to authenticated
-  with check (
-    created_by = auth.uid()
-    and public.has_permission('crm.admin')
-  );
-
-drop policy if exists "crm_prospects_update_visible" on public.crm_prospects;
-create policy "crm_prospects_update_visible"
-  on public.crm_prospects
-  for update
-  using (
-    auth.uid() = assigned_to
-    or public.has_permission('crm.admin')
-  )
-  with check (
-    auth.uid() = assigned_to
-    or public.has_permission('crm.admin')
-  );
-
-drop policy if exists "crm_prospects_delete_assigned_or_admin" on public.crm_prospects;
-create policy "crm_prospects_delete_assigned_or_admin"
-  on public.crm_prospects
-  for delete
-  using (
-    auth.uid() = assigned_to
-    or public.has_permission('crm.admin')
-  );
-
--- ── crm_calls ────────────────────────────────────────────────────────────────
+-- ── crm_calls (prospect_id now references crm_customers) ─────────────────────
 drop policy if exists "crm_calls_select_visible" on public.crm_calls;
 create policy "crm_calls_select_visible"
   on public.crm_calls
@@ -72,8 +22,8 @@ create policy "crm_calls_select_visible"
   using (
     user_id = auth.uid()
     or exists (
-      select 1 from public.crm_prospects p
-      where p.id = prospect_id and p.assigned_to = auth.uid()
+      select 1 from public.crm_customers c
+      where c.id = prospect_id and c.assigned_to = auth.uid()
     )
     or public.has_permission('crm.admin')
   );
@@ -90,8 +40,8 @@ create policy "crm_calls_insert_visible"
       and (
         prospect_id is null
         or exists (
-          select 1 from public.crm_prospects p
-          where p.id = prospect_id and p.assigned_to = auth.uid()
+          select 1 from public.crm_customers c
+          where c.id = prospect_id and c.assigned_to = auth.uid()
         )
       )
     )
@@ -113,8 +63,8 @@ create policy "crm_calls_update_visible"
       and (
         prospect_id is null
         or exists (
-          select 1 from public.crm_prospects p
-          where p.id = prospect_id and p.assigned_to = auth.uid()
+          select 1 from public.crm_customers c
+          where c.id = prospect_id and c.assigned_to = auth.uid()
         )
       )
     )

--- a/supabase/sql/20260609_rls_permissions_crm_quotes_workorders.sql
+++ b/supabase/sql/20260609_rls_permissions_crm_quotes_workorders.sql
@@ -32,8 +32,8 @@ create policy "crm_quotes_insert_sales_or_admin"
     and (
       prospect_id is null
       or exists (
-        select 1 from public.crm_prospects prospect
-        where prospect.id = prospect_id and prospect.assigned_to = auth.uid()
+        select 1 from public.crm_customers c
+        where c.id = prospect_id and c.assigned_to = auth.uid()
       )
     )
   );

--- a/supabase/sql/20260609_rls_permissions_crm_quotes_workorders.sql
+++ b/supabase/sql/20260609_rls_permissions_crm_quotes_workorders.sql
@@ -1,0 +1,125 @@
+-- Phase 3b of the role→permission migration: crm_quotes + crm_work_orders RLS.
+-- Behavior-preserving role→key swaps; ownership (auth.uid() = assigned_to) and the
+-- prospect-ownership join are preserved.
+--
+-- Mapping:
+--   role = any(sales,admin,konsult)  (blanket read of all rows)  → has_permission('crm.<res>.read')
+--   role in (sales,admin)            (write-self insert)          → has_permission('crm.<res>.write')
+--   role = 'admin'                   (manage / update-any / delete-any) → has_permission('crm.admin')
+--
+-- Run AFTER 20260608_permissions_model.sql. Idempotent.
+
+-- ── crm_quotes ───────────────────────────────────────────────────────────────
+-- SELECT: any CRM role reads all quotes; the assigned_to branch keeps installer access.
+drop policy if exists "crm_quotes_select_visible" on public.crm_quotes;
+create policy "crm_quotes_select_visible"
+  on public.crm_quotes
+  for select
+  using (
+    auth.uid() = assigned_to
+    or public.has_permission('crm.offer.read')
+  );
+
+drop policy if exists "crm_quotes_insert_sales_or_admin" on public.crm_quotes;
+create policy "crm_quotes_insert_sales_or_admin"
+  on public.crm_quotes
+  for insert
+  to authenticated
+  with check (
+    created_by = auth.uid()
+    and assigned_to = auth.uid()
+    and public.has_permission('crm.offer.write')
+    and (
+      prospect_id is null
+      or exists (
+        select 1 from public.crm_prospects prospect
+        where prospect.id = prospect_id and prospect.assigned_to = auth.uid()
+      )
+    )
+  );
+
+drop policy if exists "crm_quotes_insert_admin_manage" on public.crm_quotes;
+create policy "crm_quotes_insert_admin_manage"
+  on public.crm_quotes
+  for insert
+  to authenticated
+  with check (
+    created_by = auth.uid()
+    and public.has_permission('crm.admin')
+  );
+
+drop policy if exists "crm_quotes_update_visible" on public.crm_quotes;
+create policy "crm_quotes_update_visible"
+  on public.crm_quotes
+  for update
+  using (
+    auth.uid() = assigned_to
+    or public.has_permission('crm.admin')
+  )
+  with check (
+    auth.uid() = assigned_to
+    or public.has_permission('crm.admin')
+  );
+
+drop policy if exists "crm_quotes_delete_assigned_or_admin" on public.crm_quotes;
+create policy "crm_quotes_delete_assigned_or_admin"
+  on public.crm_quotes
+  for delete
+  using (
+    auth.uid() = assigned_to
+    or public.has_permission('crm.admin')
+  );
+
+-- ── crm_work_orders ──────────────────────────────────────────────────────────
+-- SELECT: any CRM role reads all work orders; assigned_to keeps the installer's own jobs.
+drop policy if exists "crm_work_orders_select_visible" on public.crm_work_orders;
+create policy "crm_work_orders_select_visible"
+  on public.crm_work_orders
+  for select
+  using (
+    auth.uid() = assigned_to
+    or public.has_permission('crm.workorder.read')
+  );
+
+drop policy if exists crm_work_orders_insert_sales_or_admin on public.crm_work_orders;
+create policy crm_work_orders_insert_sales_or_admin
+  on public.crm_work_orders
+  for insert
+  to authenticated
+  with check (
+    created_by = auth.uid()
+    and assigned_to = auth.uid()
+    and public.has_permission('crm.workorder.write')
+  );
+
+drop policy if exists crm_work_orders_insert_admin_manage on public.crm_work_orders;
+create policy crm_work_orders_insert_admin_manage
+  on public.crm_work_orders
+  for insert
+  to authenticated
+  with check (
+    created_by = auth.uid()
+    and public.has_permission('crm.admin')
+  );
+
+drop policy if exists crm_work_orders_update_visible on public.crm_work_orders;
+create policy crm_work_orders_update_visible
+  on public.crm_work_orders
+  for update
+  using (
+    auth.uid() = assigned_to
+    or public.has_permission('crm.admin')
+  )
+  with check (
+    auth.uid() = assigned_to
+    or public.has_permission('crm.admin')
+  );
+
+drop policy if exists crm_work_orders_delete_assigned_or_admin on public.crm_work_orders;
+create policy crm_work_orders_delete_assigned_or_admin
+  on public.crm_work_orders
+  for delete
+  using (
+    auth.uid() = assigned_to
+    or public.has_permission('crm.admin')
+  );

--- a/supabase/sql/20260609_rls_permissions_verify.sql
+++ b/supabase/sql/20260609_rls_permissions_verify.sql
@@ -4,7 +4,7 @@
 --   uses_has_permission   — true once swapped
 --   still_references_role  — true if it STILL checks public.profiles.role directly (a miss)
 -- Expectation: still_references_role = false for ALL rows. (The crm_calls/crm_quotes prospect
--- joins reference crm_prospects.assigned_to, not profiles.role, so they don't trip the flag.)
+-- joins reference crm_customers.assigned_to, not profiles.role, so they don't trip the flag.)
 
 select
   tablename,
@@ -15,7 +15,7 @@ select
 from pg_policies
 where schemaname = 'public'
   and tablename in (
-    'crm_prospects', 'crm_calls', 'crm_customers', 'crm_customer_contacts',
+    'crm_calls', 'crm_customers', 'crm_customer_contacts',
     'crm_opportunities', 'crm_quotes', 'crm_work_orders', 'crm_goals',
     'crm_routing_rules', 'crm_ai_prospect_suggestions'
   )

--- a/supabase/sql/20260609_rls_permissions_verify.sql
+++ b/supabase/sql/20260609_rls_permissions_verify.sql
@@ -1,0 +1,22 @@
+-- Completeness check for Phase 3 (run AFTER the three 20260609_rls_permissions_crm_*.sql).
+-- Every role-based RLS predicate on the in-scope CRM tables should now route through
+-- has_permission(). This lists each policy with two flags:
+--   uses_has_permission   — true once swapped
+--   still_references_role  — true if it STILL checks public.profiles.role directly (a miss)
+-- Expectation: still_references_role = false for ALL rows. (The crm_calls/crm_quotes prospect
+-- joins reference crm_prospects.assigned_to, not profiles.role, so they don't trip the flag.)
+
+select
+  tablename,
+  policyname,
+  cmd,
+  (coalesce(qual, '') || ' ' || coalesce(with_check, '')) ilike '%has_permission%' as uses_has_permission,
+  (coalesce(qual, '') || ' ' || coalesce(with_check, '')) ~* '\mprofiles\M|\.role\M' as still_references_role
+from pg_policies
+where schemaname = 'public'
+  and tablename in (
+    'crm_prospects', 'crm_calls', 'crm_customers', 'crm_customer_contacts',
+    'crm_opportunities', 'crm_quotes', 'crm_work_orders', 'crm_goals',
+    'crm_routing_rules', 'crm_ai_prospect_suggestions'
+  )
+order by still_references_role desc, tablename, policyname;

--- a/tests/auth/permissions.test.ts
+++ b/tests/auth/permissions.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { can, PERMISSION_KEYS, type PermissionKey } from '@/lib/auth/permissions';
+
+describe('can', () => {
+  it('returns true only when the permission is in the set', () => {
+    const perms = new Set<PermissionKey>(['crm.offer.read', 'crm.offer.write']);
+    expect(can(perms, 'crm.offer.read')).toBe(true);
+    expect(can(perms, 'crm.offer.write')).toBe(true);
+    expect(can(perms, 'crm.customer.write')).toBe(false);
+    expect(can(perms, 'crm.admin')).toBe(false);
+  });
+
+  it('an empty set grants nothing (fail-closed default)', () => {
+    const perms = new Set<PermissionKey>();
+    expect(can(perms, 'crm.access')).toBe(false);
+  });
+});
+
+describe('PERMISSION_KEYS catalog', () => {
+  // Mirrors the SQL `permissions` catalog in 20260608_permissions_model.sql. If you add a key
+  // there, add it here too (and to the seed + parity assert) — this guards the count.
+  it('has the expected count and no duplicates', () => {
+    expect(PERMISSION_KEYS.length).toBe(35);
+    expect(new Set(PERMISSION_KEYS).size).toBe(PERMISSION_KEYS.length);
+  });
+
+  it('includes the meta keys backing the legacy guards', () => {
+    for (const key of ['crm.access', 'crm.write', 'crm.admin'] as const) {
+      expect(PERMISSION_KEYS).toContain(key);
+    }
+  });
+
+  it('includes a read+write pair for every core CRM resource', () => {
+    const resources = ['prospect', 'call', 'customer', 'contact', 'opportunity', 'offer', 'workorder', 'task'];
+    for (const r of resources) {
+      expect(PERMISSION_KEYS).toContain(`crm.${r}.read`);
+      expect(PERMISSION_KEYS).toContain(`crm.${r}.write`);
+    }
+  });
+
+  it('includes the Fortnox bookkeeping action keys', () => {
+    for (const key of ['fortnox.offer.push', 'fortnox.workorder.push', 'fortnox.invoice.create', 'fortnox.customer.sync', 'fortnox.read'] as const) {
+      expect(PERMISSION_KEYS).toContain(key);
+    }
+  });
+});

--- a/tests/crm/customers.route.test.ts
+++ b/tests/crm/customers.route.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { salesUser, adminUser, memberUser } from './helpers/supabase';
+import { salesUser, adminUser, memberUser, effectivePermissionsForRole } from './helpers/supabase';
 
 // ---------------------------------------------------------------------------
 // Mockar måste deklareras INNAN modulimporter
@@ -28,7 +28,13 @@ vi.mock('next/headers', () => ({
 // Importer (efter mock-deklarationer)
 // ---------------------------------------------------------------------------
 
+vi.mock('@/lib/auth/permissions', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/auth/permissions')>();
+  return { ...actual, getEffectivePermissions: vi.fn() };
+});
+
 import { getCurrentUser } from '@/lib/auth/route';
+import { getEffectivePermissions } from '@/lib/auth/permissions';
 import {
   listCrmCustomers,
   createCrmCustomer,
@@ -46,7 +52,11 @@ const mockCreate = vi.mocked(createCrmCustomer);
 const mockGet = vi.mocked(getCrmCustomer);
 const mockUpdate = vi.mocked(updateCrmCustomer);
 
-beforeEach(() => vi.clearAllMocks());
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getEffectivePermissions).mockImplementation(async () =>
+    effectivePermissionsForRole((await vi.mocked(getCurrentUser)())?.role));
+});
 
 // ---------------------------------------------------------------------------
 // Hjälpare

--- a/tests/crm/helpers/supabase.ts
+++ b/tests/crm/helpers/supabase.ts
@@ -1,5 +1,6 @@
 import { vi } from 'vitest';
 import type { CurrentUser } from '@/lib/auth/route';
+import { PERMISSION_KEYS, type PermissionKey } from '@/lib/auth/permissions';
 
 /**
  * Builds a chainable Supabase query mock.
@@ -51,3 +52,31 @@ export function makeSupabaseMock(result: { data: unknown; error: unknown }) {
 export const salesUser: CurrentUser = { id: 'user-sales-1', role: 'sales' };
 export const adminUser: CurrentUser = { id: 'user-admin-1', role: 'admin' };
 export const memberUser: CurrentUser = { id: 'user-member-1', role: 'member' };
+export const konsultUser: CurrentUser = { id: 'user-konsult-1', role: 'konsult' };
+
+// Mirrors the role seed in supabase/sql/20260608_permissions_model.sql. Route guards now
+// resolve effective permissions instead of reading the role directly, so route tests mock
+// getEffectivePermissions with this to reproduce the same allow/deny outcomes per role.
+const SALES_KEYS: PermissionKey[] = [
+  'crm.prospect.read', 'crm.prospect.write', 'crm.call.read', 'crm.call.write',
+  'crm.customer.read', 'crm.customer.write', 'crm.contact.read', 'crm.contact.write',
+  'crm.opportunity.read', 'crm.opportunity.write', 'crm.offer.read', 'crm.offer.write',
+  'crm.workorder.read', 'crm.workorder.write', 'crm.task.read', 'crm.task.write',
+  'crm.report.read', 'crm.coach.read', 'crm.goal.read', 'crm.routingrule.read',
+  'fortnox.offer.push', 'fortnox.workorder.push', 'fortnox.invoice.create', 'fortnox.customer.sync', 'fortnox.read',
+  'crm.access', 'crm.write',
+];
+const KONSULT_KEYS: PermissionKey[] = [
+  'crm.prospect.read', 'crm.call.read', 'crm.customer.read', 'crm.contact.read',
+  'crm.opportunity.read', 'crm.offer.read', 'crm.workorder.read', 'crm.task.read',
+  'crm.report.read', 'crm.coach.read', 'crm.goal.read', 'fortnox.read', 'crm.access',
+];
+
+export function effectivePermissionsForRole(role: string | undefined | null): Set<PermissionKey> {
+  switch (role) {
+    case 'admin': return new Set(PERMISSION_KEYS);
+    case 'sales': return new Set(SALES_KEYS);
+    case 'konsult': return new Set(KONSULT_KEYS);
+    default: return new Set();
+  }
+}

--- a/tests/crm/opportunities.test.ts
+++ b/tests/crm/opportunities.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { salesUser, adminUser, memberUser } from './helpers/supabase';
+import { salesUser, adminUser, memberUser, effectivePermissionsForRole } from './helpers/supabase';
 
 // ---------------------------------------------------------------------------
 // Mockar
@@ -24,7 +24,13 @@ vi.mock('next/headers', () => ({ cookies: vi.fn() }));
 // Importer
 // ---------------------------------------------------------------------------
 
+vi.mock('@/lib/auth/permissions', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/auth/permissions')>();
+  return { ...actual, getEffectivePermissions: vi.fn() };
+});
+
 import { getCurrentUser } from '@/lib/auth/route';
+import { getEffectivePermissions } from '@/lib/auth/permissions';
 import {
   listCrmOpportunities,
   createCrmOpportunity,
@@ -46,7 +52,11 @@ const mockCreate = vi.mocked(createCrmOpportunity);
 const mockGet = vi.mocked(getCrmOpportunity);
 const mockUpdate = vi.mocked(updateCrmOpportunity);
 
-beforeEach(() => vi.clearAllMocks());
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getEffectivePermissions).mockImplementation(async () =>
+    effectivePermissionsForRole((await vi.mocked(getCurrentUser)())?.role));
+});
 
 function req(url: string, init?: RequestInit) {
   return new Request(`http://localhost${url}`, init);

--- a/tests/crm/prospects.test.ts
+++ b/tests/crm/prospects.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { salesUser, adminUser, memberUser } from './helpers/supabase';
+import { salesUser, adminUser, memberUser, effectivePermissionsForRole } from './helpers/supabase';
 
 // ---------------------------------------------------------------------------
 // Mockar
@@ -23,7 +23,13 @@ vi.mock('next/headers', () => ({ cookies: vi.fn() }));
 // Importer
 // ---------------------------------------------------------------------------
 
+vi.mock('@/lib/auth/permissions', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/auth/permissions')>();
+  return { ...actual, getEffectivePermissions: vi.fn() };
+});
+
 import { getCurrentUser } from '@/lib/auth/route';
+import { getEffectivePermissions } from '@/lib/auth/permissions';
 import {
   listCrmProspects,
   createCrmProspect,
@@ -43,7 +49,11 @@ const mockList = vi.mocked(listCrmProspects);
 const mockCreate = vi.mocked(createCrmProspect);
 const mockUpdate = vi.mocked(updateCrmProspect);
 
-beforeEach(() => vi.clearAllMocks());
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getEffectivePermissions).mockImplementation(async () =>
+    effectivePermissionsForRole((await vi.mocked(getCurrentUser)())?.role));
+});
 
 function req(url: string, init?: RequestInit) {
   return new Request(`http://localhost${url}`, init);

--- a/tests/crm/quotes.test.ts
+++ b/tests/crm/quotes.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { salesUser, adminUser, memberUser } from './helpers/supabase';
+import { salesUser, adminUser, memberUser, effectivePermissionsForRole } from './helpers/supabase';
 
 // ---------------------------------------------------------------------------
 // Mockar
@@ -25,7 +25,13 @@ vi.mock('next/headers', () => ({ cookies: vi.fn() }));
 // Importer
 // ---------------------------------------------------------------------------
 
+vi.mock('@/lib/auth/permissions', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/auth/permissions')>();
+  return { ...actual, getEffectivePermissions: vi.fn() };
+});
+
 import { getCurrentUser } from '@/lib/auth/route';
+import { getEffectivePermissions } from '@/lib/auth/permissions';
 import {
   listCrmQuotesWithFilters,
   createCrmQuote,
@@ -45,7 +51,11 @@ const mockGet = vi.mocked(getCrmQuote);
 const mockUpdate = vi.mocked(updateCrmQuote);
 const mockMarkWon = vi.mocked(markCrmQuoteWon);
 
-beforeEach(() => vi.clearAllMocks());
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getEffectivePermissions).mockImplementation(async () =>
+    effectivePermissionsForRole((await vi.mocked(getCurrentUser)())?.role));
+});
 
 function req(url: string, init?: RequestInit) {
   return new Request(`http://localhost${url}`, init);


### PR DESCRIPTION
## Summary

Migrates CRM/Fortnox access from hard-coded roles to a permission-based (RBAC)
system. Roles become *named bundles* of granular permissions, and access
decisions in **both** the app layer and the database (RLS) read the same
effective-permission source. Changing who can do what (e.g. "let konsult write
offers") is now a **data change** in an admin UI, not a code change across ~50
files.

Behavior-preserving: the role seed reproduces today's access exactly, so nothing
changes for existing users until a permission is deliberately granted/revoked.

Scope: **CRM + Fortnox only**. The rest of the app stays role-based and untouched
(planned for a later phase).

## What's included

**Model & resolver** (`supabase/sql/20260608_permissions_model.sql`)
- `permissions` / `role_permissions` / `user_permissions` tables (with RLS)
- `has_permission()` + `effective_permissions()` — `STABLE` + `SECURITY DEFINER`
  (fast in RLS, no recursion)
- Admin setter functions, the 35-key catalog, and a role seed that reproduces
  current behavior (+ a parity-assertion script)

**App layer** (`lib/auth/permissions.ts`, `app/api/crm/_shared.ts`)
- `requirePermission(key)` + `can()`; `getEffectivePermissions()` is per-request
  cached and **fails closed**
- `requireCrmUser/Writer/Admin` rewritten as thin wrappers over meta-keys →
  ~170 call sites unchanged
- ~20 resource/Fortnox write routes swapped to granular keys (e.g.
  `crm.offer.write`, `fortnox.invoice.create`)

**RLS** (`supabase/sql/20260609_rls_permissions_crm_*.sql`)
- Role predicates swapped to `has_permission()`; ownership branches preserved.
  Each key's seed equals the role set the old predicate admitted → identical
  behavior.

**Admin UI** ("Behörigheter" tab, `app/admin/permissions/**`)
- Edit role bundles + per-user grant/revoke overrides without writing SQL
- Self-lockout guard so an admin can't strip their own `crm.admin`

**Docs:** `PERMISSIONS.md` (architecture, catalog, seed, deploy order, recipes).

## Deploy ordering (required before/with merge)

`getEffectivePermissions` fails closed, so the SQL must be applied **before** the
code is deployed (otherwise all CRM access returns 403). Run in Supabase, in order:

1. `20260608_permissions_model.sql`
2. `20260608_permissions_parity_assert.sql` — verify every row `ok = true`
3. `20260609_rls_permissions_crm_core.sql`
4. `20260609_rls_permissions_crm_quotes_workorders.sql`
5. `20260609_rls_permissions_crm_admin.sql`
6. `20260609_rls_permissions_verify.sql` — verify no `still_references_role = true`
7. `20260609_permissions_admin_lockout_guard.sql`

## Testing

- `npm run type-check`, `npm run build`, `npm test` — all green (316 tests, incl.
  new permission unit tests + updated route-auth mocks)
- Parity assert confirms the seed == prior role behavior
- Manual: grant a konsult `crm.offer.write` in the admin UI → they can create an
  offer (route + RLS); revoke → 403. Sales/admin unchanged.

## Notes / follow-ups

- Left on the coarse `crm.write` meta-key intentionally: prospects routes (write
  `crm_customers`), tasks (table not RLS-migrated yet), coach.
- Later phase: migrate the non-CRM domains (planning/documents/admin/…) the same
  way.