### PR TITLE
Feature/planning crm first

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ USER_INTERVIEWS.md
 USER_FEEDBACK.md   
 FORTNOX_INTEGRATION.md
 TIC_INTEGRATION.md
+mockups/planning-board.html

--- a/app/api/crm/planering/_lib.ts
+++ b/app/api/crm/planering/_lib.ts
@@ -28,3 +28,10 @@ export const moveSegmentSchema = z.object({
   sort_index: z.coerce.number().int().min(0).optional(),
   job_type: jobType.optional(),
 });
+
+// Assign a crew member to a segment. member_name is the durable display snapshot (profiles are
+// self-read-only, so the board never re-reads the person) — required even though member_id is too.
+export const assignCrewSchema = z.object({
+  member_id: z.string().uuid('Ogiltig montör'),
+  member_name: z.string().trim().min(1, 'Namn krävs').max(120),
+});

--- a/app/api/crm/planering/_lib.ts
+++ b/app/api/crm/planering/_lib.ts
@@ -37,6 +37,12 @@ export const assignCrewSchema = z.object({
   member_name: z.string().trim().min(1, 'Namn krävs').max(120),
 });
 
+// Create a day note (dagsanteckning) pinned to a calendar day.
+export const createDayNoteSchema = z.object({
+  note_day: isoDate,
+  body: z.string().trim().min(1, 'Skriv en notering').max(500, 'Noteringen är för lång'),
+});
+
 // Send an order confirmation (orderbekräftelse) for a scheduled job. At least one channel must be
 // chosen; the matching recipient is required (enforced in the route for a clear Swedish message).
 export const sendConfirmationSchema = z.object({

--- a/app/api/crm/planering/_lib.ts
+++ b/app/api/crm/planering/_lib.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { MATERIAL_SHORTS } from '@/lib/domains/crm/materials';
 
 // Planning is a CRM surface, so it shares the CRM route helpers + permission gate directly.
 export { ok, routeError, validationError, invalidUuidParam, requirePermission } from '../_shared';
@@ -77,6 +78,16 @@ export const updateDepotSchema = z.object({
   name: z.string().trim().min(1, 'Ange ett namn').max(80, 'Namnet är för långt').optional(),
   location: z.string().trim().max(200).nullable().optional(),
   active: z.boolean().optional(),
+});
+
+// Record a delivery of sacks into a depot. material must be a known catalogue short so deliveries
+// reconcile with derived consumption.
+export const createDeliverySchema = z.object({
+  depot_id: z.string().uuid('Ogiltig depå'),
+  material: z.string().trim().refine((m) => MATERIAL_SHORTS.includes(m), 'Okänt material'),
+  sacks: z.coerce.number().int().positive('Ange ett antal säckar'),
+  delivered_on: isoDate,
+  note: z.string().trim().max(300).nullable().optional(),
 });
 
 // Send an order confirmation (orderbekräftelse) for a scheduled job. At least one channel must be

--- a/app/api/crm/planering/_lib.ts
+++ b/app/api/crm/planering/_lib.ts
@@ -37,6 +37,15 @@ export const assignCrewSchema = z.object({
   member_name: z.string().trim().min(1, 'Namn krävs').max(120),
 });
 
+// Assign a crew member to a truck for a date range (weekly truck crew / rotation).
+export const assignTruckCrewSchema = z.object({
+  truck_id: z.string().uuid('Ogiltig bil'),
+  member_id: z.string().uuid('Ogiltig montör'),
+  member_name: z.string().trim().min(1, 'Namn krävs').max(120),
+  start_day: isoDate,
+  end_day: isoDate,
+});
+
 // Create a day note (dagsanteckning) pinned to a calendar day.
 export const createDayNoteSchema = z.object({
   note_day: isoDate,

--- a/app/api/crm/planering/_lib.ts
+++ b/app/api/crm/planering/_lib.ts
@@ -1,0 +1,26 @@
+import { z } from 'zod';
+
+// Planning is a CRM surface, so it shares the CRM route helpers + permission gate directly.
+export { ok, routeError, validationError, invalidUuidParam, requirePermission } from '../_shared';
+
+const isoDate = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Ogiltigt datum (YYYY-MM-DD)');
+
+export const listSegmentsQuerySchema = z.object({
+  from: isoDate,
+  to: isoDate,
+});
+
+export const placeSegmentSchema = z.object({
+  work_order_id: z.string().uuid('Ogiltig arbetsorder'),
+  truck_id: z.string().uuid('Ogiltig bil'),
+  start_day: isoDate,
+  end_day: isoDate,
+  sort_index: z.coerce.number().int().min(0).optional(),
+});
+
+export const moveSegmentSchema = z.object({
+  truck_id: z.string().uuid('Ogiltig bil').optional(),
+  start_day: isoDate.optional(),
+  end_day: isoDate.optional(),
+  sort_index: z.coerce.number().int().min(0).optional(),
+});

--- a/app/api/crm/planering/_lib.ts
+++ b/app/api/crm/planering/_lib.ts
@@ -47,6 +47,15 @@ export const assignTruckCrewSchema = z.object({
   end_day: isoDate,
 });
 
+// Copy a truck's crew from one week to another.
+export const copyTruckCrewSchema = z.object({
+  truck_id: z.string().uuid('Ogiltig bil'),
+  source_start: isoDate,
+  source_end: isoDate,
+  target_start: isoDate,
+  target_end: isoDate,
+});
+
 // Create a day note (dagsanteckning) pinned to a calendar day.
 export const createDayNoteSchema = z.object({
   note_day: isoDate,

--- a/app/api/crm/planering/_lib.ts
+++ b/app/api/crm/planering/_lib.ts
@@ -64,6 +64,19 @@ export const updateTruckSchema = z.object({
   name: z.string().trim().min(1, 'Ange ett namn').max(60, 'Namnet är för långt').optional(),
   color: hexColor.optional(),
   active: z.boolean().optional(),
+  depot_id: z.string().uuid('Ogiltig depå').nullable().optional(),
+});
+
+// Depot (depå) administration (planning.depot.manage).
+export const createDepotSchema = z.object({
+  name: z.string().trim().min(1, 'Ange ett namn').max(80, 'Namnet är för långt'),
+  location: z.string().trim().max(200).nullable().optional(),
+});
+
+export const updateDepotSchema = z.object({
+  name: z.string().trim().min(1, 'Ange ett namn').max(80, 'Namnet är för långt').optional(),
+  location: z.string().trim().max(200).nullable().optional(),
+  active: z.boolean().optional(),
 });
 
 // Send an order confirmation (orderbekräftelse) for a scheduled job. At least one channel must be

--- a/app/api/crm/planering/_lib.ts
+++ b/app/api/crm/planering/_lib.ts
@@ -27,6 +27,7 @@ export const moveSegmentSchema = z.object({
   end_day: isoDate.optional(),
   sort_index: z.coerce.number().int().min(0).optional(),
   job_type: jobType.optional(),
+  on_hold: z.boolean().optional(),
 });
 
 // Assign a crew member to a segment. member_name is the durable display snapshot (profiles are

--- a/app/api/crm/planering/_lib.ts
+++ b/app/api/crm/planering/_lib.ts
@@ -80,6 +80,20 @@ export const updateDepotSchema = z.object({
   active: z.boolean().optional(),
 });
 
+// Job-type administration (planning.truck.manage). The key is derived from the label server-side
+// and never edited.
+export const createJobTypeSchema = z.object({
+  label: z.string().trim().min(1, 'Ange ett namn').max(40, 'Namnet är för långt'),
+  color: hexColor.unwrap(),
+});
+
+export const updateJobTypeSchema = z.object({
+  label: z.string().trim().min(1, 'Ange ett namn').max(40, 'Namnet är för långt').optional(),
+  color: hexColor.unwrap().optional(),
+  active: z.boolean().optional(),
+  sort_index: z.coerce.number().int().min(0).optional(),
+});
+
 // Record a delivery of sacks into a depot. material must be a known catalogue short so deliveries
 // reconcile with derived consumption.
 export const createDeliverySchema = z.object({

--- a/app/api/crm/planering/_lib.ts
+++ b/app/api/crm/planering/_lib.ts
@@ -10,12 +10,15 @@ export const listSegmentsQuerySchema = z.object({
   to: isoDate,
 });
 
+const jobType = z.preprocess((v) => (v == null ? null : String(v).trim() || null), z.string().max(40).nullable());
+
 export const placeSegmentSchema = z.object({
   work_order_id: z.string().uuid('Ogiltig arbetsorder'),
   truck_id: z.string().uuid('Ogiltig bil'),
   start_day: isoDate,
   end_day: isoDate,
   sort_index: z.coerce.number().int().min(0).optional(),
+  job_type: jobType.optional(),
 });
 
 export const moveSegmentSchema = z.object({
@@ -23,4 +26,5 @@ export const moveSegmentSchema = z.object({
   start_day: isoDate.optional(),
   end_day: isoDate.optional(),
   sort_index: z.coerce.number().int().min(0).optional(),
+  job_type: jobType.optional(),
 });

--- a/app/api/crm/planering/_lib.ts
+++ b/app/api/crm/planering/_lib.ts
@@ -43,6 +43,20 @@ export const createDayNoteSchema = z.object({
   body: z.string().trim().min(1, 'Skriv en notering').max(500, 'Noteringen är för lång'),
 });
 
+const hexColor = z.string().regex(/^#[0-9a-fA-F]{6}$/, 'Ogiltig färg').nullable();
+
+// Fleet administration (planning.truck.manage).
+export const createTruckSchema = z.object({
+  name: z.string().trim().min(1, 'Ange ett namn').max(60, 'Namnet är för långt'),
+  color: hexColor.optional(),
+});
+
+export const updateTruckSchema = z.object({
+  name: z.string().trim().min(1, 'Ange ett namn').max(60, 'Namnet är för långt').optional(),
+  color: hexColor.optional(),
+  active: z.boolean().optional(),
+});
+
 // Send an order confirmation (orderbekräftelse) for a scheduled job. At least one channel must be
 // chosen; the matching recipient is required (enforced in the route for a clear Swedish message).
 export const sendConfirmationSchema = z.object({

--- a/app/api/crm/planering/_lib.ts
+++ b/app/api/crm/planering/_lib.ts
@@ -35,3 +35,13 @@ export const assignCrewSchema = z.object({
   member_id: z.string().uuid('Ogiltig montör'),
   member_name: z.string().trim().min(1, 'Namn krävs').max(120),
 });
+
+// Send an order confirmation (orderbekräftelse) for a scheduled job. At least one channel must be
+// chosen; the matching recipient is required (enforced in the route for a clear Swedish message).
+export const sendConfirmationSchema = z.object({
+  send_email: z.boolean().optional().default(false),
+  recipient_email: z.string().trim().email('Ogiltig e-postadress').nullable().optional(),
+  send_sms: z.boolean().optional().default(false),
+  recipient_phone: z.string().trim().min(3, 'Ogiltigt telefonnummer').nullable().optional(),
+  custom_message: z.string().trim().max(2000).nullable().optional(),
+});

--- a/app/api/crm/planering/backlog/route.ts
+++ b/app/api/crm/planering/backlog/route.ts
@@ -1,0 +1,20 @@
+import { cookies } from 'next/headers';
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
+import { listSchedulableWorkOrders } from '@/lib/domains/planning/backlog';
+import { ok, routeError, requirePermission } from '../_lib';
+
+// CRM work orders eligible to be scheduled (the planning backlog). Source of jobs = CRM.
+export async function GET() {
+  try {
+    const gate = await requirePermission('planning.schedule.read');
+    if (gate.response) return gate.response;
+
+    const supabase = createRouteHandlerClient({ cookies });
+    const { data, error } = await listSchedulableWorkOrders(supabase);
+    if (error) return routeError(500, 'planning_backlog_failed', error.message);
+
+    return ok({ items: data });
+  } catch (e: any) {
+    return routeError(500, 'planning_backlog_unexpected', e?.message || 'Failed to load backlog');
+  }
+}

--- a/app/api/crm/planering/crew/route.ts
+++ b/app/api/crm/planering/crew/route.ts
@@ -1,0 +1,25 @@
+// getSupabaseAdmin: the crew picker lists every named employee (installers included), which reads
+// across users — session RLS would restrict profiles to the requester's own row (same reason the
+// @-mention list uses the admin client). Read access is still gated on planning.schedule.read.
+import { getSupabaseAdmin } from '@/lib/supabase/server';
+import { listMentionableProfiles } from '@/lib/domains/crm/work-orders';
+import { ok, routeError, requirePermission } from '../_lib';
+
+// People the planner can assign as crew on a segment.
+export async function GET() {
+  try {
+    const gate = await requirePermission('planning.schedule.read');
+    if (gate.response) return gate.response;
+
+    const supabase = getSupabaseAdmin();
+    const { data, error } = await listMentionableProfiles(supabase);
+    if (error) return routeError(500, 'planning_crew_list_failed', error.message);
+
+    const people = (data || [])
+      .filter((p): p is { id: string; full_name: string } => Boolean(p.full_name))
+      .map((p) => ({ id: p.id, full_name: p.full_name }));
+    return ok({ people });
+  } catch (e: any) {
+    return routeError(500, 'planning_crew_list_unexpected', e?.message || 'Failed to list crew');
+  }
+}

--- a/app/api/crm/planering/day-notes/[id]/route.ts
+++ b/app/api/crm/planering/day-notes/[id]/route.ts
@@ -1,0 +1,29 @@
+import { cookies } from 'next/headers';
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
+import { deleteDayNote } from '@/lib/domains/planning/dayNotes';
+import { ok, routeError, invalidUuidParam, requirePermission } from '../../_lib';
+
+type RouteContext = {
+  params: {
+    id: string;
+  };
+};
+
+// Remove a day note.
+export async function DELETE(_req: Request, context: RouteContext) {
+  try {
+    const gate = await requirePermission('planning.schedule.write');
+    if (gate.response) return gate.response;
+
+    const badId = invalidUuidParam(context.params.id);
+    if (badId) return badId;
+
+    const supabase = createRouteHandlerClient({ cookies });
+    const { error } = await deleteDayNote(supabase, context.params.id);
+    if (error) return routeError(500, 'planning_day_note_delete_failed', error.message);
+
+    return ok({ ok: true });
+  } catch (e: any) {
+    return routeError(500, 'planning_day_note_delete_unexpected', e?.message || 'Failed to delete day note');
+  }
+}

--- a/app/api/crm/planering/day-notes/route.ts
+++ b/app/api/crm/planering/day-notes/route.ts
@@ -1,0 +1,50 @@
+import { cookies } from 'next/headers';
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
+import { listDayNotes, createDayNote } from '@/lib/domains/planning/dayNotes';
+import { ok, routeError, validationError, requirePermission, listSegmentsQuerySchema, createDayNoteSchema } from '../_lib';
+
+// Day notes whose day falls inside the visible window.
+export async function GET(req: Request) {
+  try {
+    const gate = await requirePermission('planning.schedule.read');
+    if (gate.response) return gate.response;
+
+    const url = new URL(req.url);
+    const parsed = listSegmentsQuerySchema.safeParse({
+      from: url.searchParams.get('from') || undefined,
+      to: url.searchParams.get('to') || undefined,
+    });
+    if (!parsed.success) return validationError(parsed.error);
+
+    const supabase = createRouteHandlerClient({ cookies });
+    const { data, error } = await listDayNotes(supabase, { from: parsed.data.from, to: parsed.data.to });
+    if (error) return routeError(500, 'planning_day_notes_failed', error.message);
+
+    return ok({ notes: data });
+  } catch (e: any) {
+    return routeError(500, 'planning_day_notes_unexpected', e?.message || 'Failed to load day notes');
+  }
+}
+
+// Pin a note to a day.
+export async function POST(req: Request) {
+  try {
+    const gate = await requirePermission('planning.schedule.write');
+    if (gate.response || !gate.currentUser) return gate.response;
+
+    const parsed = createDayNoteSchema.safeParse(await req.json().catch(() => null));
+    if (!parsed.success) return validationError(parsed.error);
+
+    const supabase = createRouteHandlerClient({ cookies });
+    const { data, error } = await createDayNote(supabase, {
+      noteDay: parsed.data.note_day,
+      body: parsed.data.body,
+      actorUserId: gate.currentUser.id,
+    });
+    if (error) return routeError(500, 'planning_day_note_create_failed', error.message);
+
+    return ok({ item: data }, 201);
+  } catch (e: any) {
+    return routeError(500, 'planning_day_note_create_unexpected', e?.message || 'Failed to create day note');
+  }
+}

--- a/app/api/crm/planering/depot-deliveries/route.ts
+++ b/app/api/crm/planering/depot-deliveries/route.ts
@@ -1,0 +1,30 @@
+import { cookies } from 'next/headers';
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
+import { createDelivery } from '@/lib/domains/planning/depotStock';
+import { ok, routeError, validationError, requirePermission, createDeliverySchema } from '../_lib';
+
+// Record a delivery of sacks into a depot (stock in).
+export async function POST(req: Request) {
+  try {
+    const gate = await requirePermission('planning.schedule.write');
+    if (gate.response || !gate.currentUser) return gate.response;
+
+    const parsed = createDeliverySchema.safeParse(await req.json().catch(() => null));
+    if (!parsed.success) return validationError(parsed.error);
+
+    const supabase = createRouteHandlerClient({ cookies });
+    const { data, error } = await createDelivery(supabase, {
+      depotId: parsed.data.depot_id,
+      material: parsed.data.material,
+      sacks: parsed.data.sacks,
+      deliveredOn: parsed.data.delivered_on,
+      note: parsed.data.note ?? null,
+      actorUserId: gate.currentUser.id,
+    });
+    if (error) return routeError(500, 'planning_depot_delivery_failed', error.message);
+
+    return ok({ item: data }, 201);
+  } catch (e: any) {
+    return routeError(500, 'planning_depot_delivery_unexpected', e?.message || 'Failed to record delivery');
+  }
+}

--- a/app/api/crm/planering/depot-stock/route.ts
+++ b/app/api/crm/planering/depot-stock/route.ts
@@ -1,0 +1,20 @@
+import { cookies } from 'next/headers';
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
+import { getDepotStock } from '@/lib/domains/planning/depotStock';
+import { ok, routeError, requirePermission } from '../_lib';
+
+// Per-depot, per-material balances (deliveries − derived consumption).
+export async function GET() {
+  try {
+    const gate = await requirePermission('planning.schedule.read');
+    if (gate.response) return gate.response;
+
+    const supabase = createRouteHandlerClient({ cookies });
+    const { data, error } = await getDepotStock(supabase);
+    if (error) return routeError(500, 'planning_depot_stock_failed', error.message);
+
+    return ok({ depots: data });
+  } catch (e: any) {
+    return routeError(500, 'planning_depot_stock_unexpected', e?.message || 'Failed to load depot stock');
+  }
+}

--- a/app/api/crm/planering/depots/[id]/route.ts
+++ b/app/api/crm/planering/depots/[id]/route.ts
@@ -1,0 +1,55 @@
+import { cookies } from 'next/headers';
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
+import { updateDepot, deleteDepot } from '@/lib/domains/planning/depots';
+import { ok, routeError, validationError, invalidUuidParam, requirePermission, updateDepotSchema } from '../../_lib';
+
+type RouteContext = {
+  params: {
+    id: string;
+  };
+};
+
+// Rename / relocate / (de)activate a depot.
+export async function PATCH(req: Request, context: RouteContext) {
+  try {
+    const gate = await requirePermission('planning.depot.manage');
+    if (gate.response) return gate.response;
+
+    const badId = invalidUuidParam(context.params.id);
+    if (badId) return badId;
+
+    const parsed = updateDepotSchema.safeParse(await req.json().catch(() => null));
+    if (!parsed.success) return validationError(parsed.error);
+
+    const supabase = createRouteHandlerClient({ cookies });
+    const { data, error } = await updateDepot(supabase, context.params.id, {
+      name: parsed.data.name,
+      location: parsed.data.location,
+      active: parsed.data.active,
+    });
+    if (error) return routeError(500, 'planning_depot_update_failed', error.message);
+
+    return ok({ item: data });
+  } catch (e: any) {
+    return routeError(500, 'planning_depot_update_unexpected', e?.message || 'Failed to update depot');
+  }
+}
+
+// Delete a depot. Trucks referencing it are ON DELETE SET NULL.
+export async function DELETE(_req: Request, context: RouteContext) {
+  try {
+    const gate = await requirePermission('planning.depot.manage');
+    if (gate.response) return gate.response;
+
+    const badId = invalidUuidParam(context.params.id);
+    if (badId) return badId;
+
+    const supabase = createRouteHandlerClient({ cookies });
+    const { error } = await deleteDepot(supabase, context.params.id);
+    if (error) return routeError(500, 'planning_depot_delete_failed', error.message);
+
+    return ok({ ok: true });
+  } catch (e: any) {
+    return routeError(500, 'planning_depot_delete_unexpected', e?.message || 'Failed to delete depot');
+  }
+}

--- a/app/api/crm/planering/depots/route.ts
+++ b/app/api/crm/planering/depots/route.ts
@@ -1,0 +1,39 @@
+import { cookies } from 'next/headers';
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
+import { listAllDepots, createDepot } from '@/lib/domains/planning/depots';
+import { ok, routeError, validationError, requirePermission, createDepotSchema } from '../_lib';
+
+// All depots (incl inactive) — readable by anyone who can read the schedule (board lanes / pickers).
+export async function GET() {
+  try {
+    const gate = await requirePermission('planning.schedule.read');
+    if (gate.response) return gate.response;
+
+    const supabase = createRouteHandlerClient({ cookies });
+    const { data, error } = await listAllDepots(supabase);
+    if (error) return routeError(500, 'planning_depots_list_failed', error.message);
+
+    return ok({ depots: data || [] });
+  } catch (e: any) {
+    return routeError(500, 'planning_depots_list_unexpected', e?.message || 'Failed to list depots');
+  }
+}
+
+// Add a depot.
+export async function POST(req: Request) {
+  try {
+    const gate = await requirePermission('planning.depot.manage');
+    if (gate.response) return gate.response;
+
+    const parsed = createDepotSchema.safeParse(await req.json().catch(() => null));
+    if (!parsed.success) return validationError(parsed.error);
+
+    const supabase = createRouteHandlerClient({ cookies });
+    const { data, error } = await createDepot(supabase, { name: parsed.data.name, location: parsed.data.location ?? null });
+    if (error) return routeError(500, 'planning_depot_create_failed', error.message);
+
+    return ok({ item: data }, 201);
+  } catch (e: any) {
+    return routeError(500, 'planning_depot_create_unexpected', e?.message || 'Failed to create depot');
+  }
+}

--- a/app/api/crm/planering/job-types/[id]/route.ts
+++ b/app/api/crm/planering/job-types/[id]/route.ts
@@ -1,0 +1,56 @@
+import { cookies } from 'next/headers';
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
+import { updateJobType, deleteJobType } from '@/lib/domains/planning/jobTypes';
+import { ok, routeError, validationError, invalidUuidParam, requirePermission, updateJobTypeSchema } from '../../_lib';
+
+type RouteContext = {
+  params: {
+    id: string;
+  };
+};
+
+// Rename / recolor / (de)activate / reorder a job type (key stays fixed).
+export async function PATCH(req: Request, context: RouteContext) {
+  try {
+    const gate = await requirePermission('planning.truck.manage');
+    if (gate.response) return gate.response;
+
+    const badId = invalidUuidParam(context.params.id);
+    if (badId) return badId;
+
+    const parsed = updateJobTypeSchema.safeParse(await req.json().catch(() => null));
+    if (!parsed.success) return validationError(parsed.error);
+
+    const supabase = createRouteHandlerClient({ cookies });
+    const { data, error } = await updateJobType(supabase, context.params.id, {
+      label: parsed.data.label,
+      color: parsed.data.color,
+      active: parsed.data.active,
+      sortIndex: parsed.data.sort_index,
+    });
+    if (error) return routeError(500, 'planning_job_type_update_failed', error.message);
+
+    return ok({ item: data });
+  } catch (e: any) {
+    return routeError(500, 'planning_job_type_update_unexpected', e?.message || 'Failed to update job type');
+  }
+}
+
+// Delete a job type. Segments still carrying its key resolve to a neutral chip.
+export async function DELETE(_req: Request, context: RouteContext) {
+  try {
+    const gate = await requirePermission('planning.truck.manage');
+    if (gate.response) return gate.response;
+
+    const badId = invalidUuidParam(context.params.id);
+    if (badId) return badId;
+
+    const supabase = createRouteHandlerClient({ cookies });
+    const { error } = await deleteJobType(supabase, context.params.id);
+    if (error) return routeError(500, 'planning_job_type_delete_failed', error.message);
+
+    return ok({ ok: true });
+  } catch (e: any) {
+    return routeError(500, 'planning_job_type_delete_unexpected', e?.message || 'Failed to delete job type');
+  }
+}

--- a/app/api/crm/planering/job-types/route.ts
+++ b/app/api/crm/planering/job-types/route.ts
@@ -1,0 +1,44 @@
+import { cookies } from 'next/headers';
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
+import { listJobTypes, createJobType } from '@/lib/domains/planning/jobTypes';
+import { ok, routeError, validationError, requirePermission, createJobTypeSchema } from '../_lib';
+
+// All job types (incl inactive) for the card chip, the picker and the admin panel.
+export async function GET() {
+  try {
+    const gate = await requirePermission('planning.schedule.read');
+    if (gate.response) return gate.response;
+
+    const supabase = createRouteHandlerClient({ cookies });
+    const { data, error } = await listJobTypes(supabase);
+    if (error) return routeError(500, 'planning_job_types_failed', error.message);
+
+    return ok({ jobTypes: data || [] });
+  } catch (e: any) {
+    return routeError(500, 'planning_job_types_unexpected', e?.message || 'Failed to list job types');
+  }
+}
+
+// Add a job type.
+export async function POST(req: Request) {
+  try {
+    const gate = await requirePermission('planning.truck.manage');
+    if (gate.response) return gate.response;
+
+    const parsed = createJobTypeSchema.safeParse(await req.json().catch(() => null));
+    if (!parsed.success) return validationError(parsed.error);
+
+    const supabase = createRouteHandlerClient({ cookies });
+    const { data, error } = await createJobType(supabase, { label: parsed.data.label, color: parsed.data.color });
+    if (error) {
+      if ((error as { code?: string }).code === '23505') {
+        return routeError(409, 'job_type_exists', 'En jobbtyp med liknande namn finns redan.');
+      }
+      return routeError(500, 'planning_job_type_create_failed', error.message);
+    }
+
+    return ok({ item: data }, 201);
+  } catch (e: any) {
+    return routeError(500, 'planning_job_type_create_unexpected', e?.message || 'Failed to create job type');
+  }
+}

--- a/app/api/crm/planering/segments/[id]/confirmation/route.ts
+++ b/app/api/crm/planering/segments/[id]/confirmation/route.ts
@@ -1,7 +1,7 @@
 import { cookies } from 'next/headers';
 import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
 import { getWorkOrderCustomerContact } from '@/lib/domains/crm/work-orders';
-import { sendOrderConfirmation } from '@/lib/domains/planning/confirmations';
+import { sendOrderConfirmation } from '@/lib/domains/planning/confirmationsSend';
 import { ok, routeError, validationError, invalidUuidParam, requirePermission, sendConfirmationSchema } from '../../../_lib';
 
 type RouteContext = {

--- a/app/api/crm/planering/segments/[id]/confirmation/route.ts
+++ b/app/api/crm/planering/segments/[id]/confirmation/route.ts
@@ -1,0 +1,76 @@
+import { cookies } from 'next/headers';
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
+import { getWorkOrderCustomerContact } from '@/lib/domains/crm/work-orders';
+import { sendOrderConfirmation } from '@/lib/domains/planning/confirmations';
+import { ok, routeError, validationError, invalidUuidParam, requirePermission, sendConfirmationSchema } from '../../../_lib';
+
+type RouteContext = {
+  params: {
+    id: string;
+  };
+};
+
+// Prepare data for the confirmation modal: the CRM customer's contact (recipient) + the placement's
+// date range. The recipient comes straight from the CRM customer — the CRM-first source of truth.
+export async function GET(_req: Request, context: RouteContext) {
+  try {
+    const gate = await requirePermission('planning.schedule.read');
+    if (gate.response) return gate.response;
+
+    const badId = invalidUuidParam(context.params.id);
+    if (badId) return badId;
+
+    const supabase = createRouteHandlerClient({ cookies });
+    const { data: seg, error: segErr } = await supabase
+      .from('ops_segments')
+      .select('work_order_id, start_day, end_day')
+      .eq('id', context.params.id)
+      .single();
+    if (segErr || !seg) return routeError(404, 'planning_segment_not_found', 'Segmentet kunde inte hittas');
+
+    const { data: contact } = await getWorkOrderCustomerContact(supabase, (seg as { work_order_id: string }).work_order_id);
+    return ok({
+      contact: contact ?? { contactName: null, phone: null, email: null },
+      start_day: (seg as { start_day: string }).start_day,
+      end_day: (seg as { end_day: string }).end_day,
+    });
+  } catch (e: any) {
+    return routeError(500, 'planning_confirmation_prepare_unexpected', e?.message || 'Failed to prepare confirmation');
+  }
+}
+
+// Send the order confirmation (email and/or SMS) to the customer and record it.
+export async function POST(req: Request, context: RouteContext) {
+  try {
+    const gate = await requirePermission('planning.schedule.write');
+    if (gate.response || !gate.currentUser) return gate.response;
+
+    const badId = invalidUuidParam(context.params.id);
+    if (badId) return badId;
+
+    const parsed = sendConfirmationSchema.safeParse(await req.json().catch(() => null));
+    if (!parsed.success) return validationError(parsed.error);
+
+    const { send_email, recipient_email, send_sms, recipient_phone, custom_message } = parsed.data;
+    if (!send_email && !send_sms) return routeError(400, 'no_channel', 'Välj minst en kanal (mejl eller SMS).');
+    if (send_email && !recipient_email) return routeError(400, 'missing_email', 'Ange en e-postadress för mejlet.');
+    if (send_sms && !recipient_phone) return routeError(400, 'missing_phone', 'Ange ett telefonnummer för SMS:et.');
+
+    const supabase = createRouteHandlerClient({ cookies });
+    const { data, error } = await sendOrderConfirmation(supabase, {
+      segmentId: context.params.id,
+      sendEmail: send_email,
+      recipientEmail: recipient_email ?? null,
+      sendSms: send_sms,
+      recipientPhone: recipient_phone ?? null,
+      customMessage: custom_message ?? null,
+      actorUserId: gate.currentUser.id,
+      actorName: gate.currentUser.name ?? null,
+    });
+    if (error) return routeError(500, 'planning_confirmation_send_failed', error.message);
+
+    return ok({ result: data });
+  } catch (e: any) {
+    return routeError(500, 'planning_confirmation_send_unexpected', e?.message || 'Failed to send confirmation');
+  }
+}

--- a/app/api/crm/planering/segments/[id]/crew/route.ts
+++ b/app/api/crm/planering/segments/[id]/crew/route.ts
@@ -1,0 +1,60 @@
+import { cookies } from 'next/headers';
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
+import { assignCrew, unassignCrew } from '@/lib/domains/planning/crew';
+import { ok, routeError, validationError, invalidUuidParam, requirePermission, assignCrewSchema } from '../../../_lib';
+
+type RouteContext = {
+  params: {
+    id: string;
+  };
+};
+
+// Assign a crew member to this placement (besättning på jobbet).
+export async function POST(req: Request, context: RouteContext) {
+  try {
+    const gate = await requirePermission('planning.schedule.write');
+    if (gate.response || !gate.currentUser) return gate.response;
+
+    const badId = invalidUuidParam(context.params.id);
+    if (badId) return badId;
+
+    const parsed = assignCrewSchema.safeParse(await req.json().catch(() => null));
+    if (!parsed.success) return validationError(parsed.error);
+
+    const supabase = createRouteHandlerClient({ cookies });
+    const { data, error } = await assignCrew(supabase, {
+      segmentId: context.params.id,
+      memberId: parsed.data.member_id,
+      memberName: parsed.data.member_name,
+      actorUserId: gate.currentUser.id,
+    });
+    if (error) return routeError(500, 'planning_crew_assign_failed', error.message);
+
+    return ok({ item: data }, 201);
+  } catch (e: any) {
+    return routeError(500, 'planning_crew_assign_unexpected', e?.message || 'Failed to assign crew');
+  }
+}
+
+// Remove a crew member from this placement (?member_id=…).
+export async function DELETE(req: Request, context: RouteContext) {
+  try {
+    const gate = await requirePermission('planning.schedule.write');
+    if (gate.response) return gate.response;
+
+    const badId = invalidUuidParam(context.params.id);
+    if (badId) return badId;
+
+    const memberId = new URL(req.url).searchParams.get('member_id') || undefined;
+    const badMember = invalidUuidParam(memberId);
+    if (badMember) return badMember;
+
+    const supabase = createRouteHandlerClient({ cookies });
+    const { error } = await unassignCrew(supabase, context.params.id, memberId as string);
+    if (error) return routeError(500, 'planning_crew_unassign_failed', error.message);
+
+    return ok({ ok: true });
+  } catch (e: any) {
+    return routeError(500, 'planning_crew_unassign_unexpected', e?.message || 'Failed to remove crew');
+  }
+}

--- a/app/api/crm/planering/segments/[id]/crew/route.ts
+++ b/app/api/crm/planering/segments/[id]/crew/route.ts
@@ -28,7 +28,12 @@ export async function POST(req: Request, context: RouteContext) {
       memberName: parsed.data.member_name,
       actorUserId: gate.currentUser.id,
     });
-    if (error) return routeError(500, 'planning_crew_assign_failed', error.message);
+    if (error) {
+      if ((error as { code?: string }).code === '23505') {
+        return routeError(409, 'planning_crew_already_assigned', 'Personen är redan tillagd på jobbet.');
+      }
+      return routeError(500, 'planning_crew_assign_failed', error.message);
+    }
 
     return ok({ item: data }, 201);
   } catch (e: any) {

--- a/app/api/crm/planering/segments/[id]/route.ts
+++ b/app/api/crm/planering/segments/[id]/route.ts
@@ -30,6 +30,7 @@ export async function PATCH(req: Request, context: RouteContext) {
       startDay: parsed.data.start_day,
       endDay: parsed.data.end_day,
       sortIndex: parsed.data.sort_index,
+      jobType: parsed.data.job_type,
     });
     if (error) return routeError(500, 'planning_segment_move_failed', error.message);
 

--- a/app/api/crm/planering/segments/[id]/route.ts
+++ b/app/api/crm/planering/segments/[id]/route.ts
@@ -33,7 +33,14 @@ export async function PATCH(req: Request, context: RouteContext) {
       jobType: parsed.data.job_type,
       onHold: parsed.data.on_hold,
     });
-    if (error) return routeError(500, 'planning_segment_move_failed', error.message);
+    if (error) {
+      // A one-sided patch (only start_day or only end_day) can't be range-checked above against the
+      // existing row, so an inverted range is caught by the DB CHECK — surface it as a clean 400.
+      if ((error as { code?: string }).code === '23514') {
+        return routeError(400, 'invalid_range', 'Slutdatum kan inte vara före startdatum.');
+      }
+      return routeError(500, 'planning_segment_move_failed', error.message);
+    }
 
     return ok({ item: data });
   } catch (e: any) {

--- a/app/api/crm/planering/segments/[id]/route.ts
+++ b/app/api/crm/planering/segments/[id]/route.ts
@@ -1,0 +1,40 @@
+import { cookies } from 'next/headers';
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
+import { moveSegment } from '@/lib/domains/planning/schedule';
+import { ok, routeError, validationError, invalidUuidParam, requirePermission, moveSegmentSchema } from '../../_lib';
+
+type RouteContext = {
+  params: {
+    id: string;
+  };
+};
+
+// Move/reorder a placement (drag to another truck/day, change day-range).
+export async function PATCH(req: Request, context: RouteContext) {
+  try {
+    const gate = await requirePermission('planning.schedule.write');
+    if (gate.response) return gate.response;
+
+    const badId = invalidUuidParam(context.params.id);
+    if (badId) return badId;
+
+    const parsed = moveSegmentSchema.safeParse(await req.json().catch(() => null));
+    if (!parsed.success) return validationError(parsed.error);
+    if (parsed.data.start_day && parsed.data.end_day && parsed.data.end_day < parsed.data.start_day) {
+      return routeError(400, 'invalid_range', 'Slutdatum kan inte vara före startdatum.');
+    }
+
+    const supabase = createRouteHandlerClient({ cookies });
+    const { data, error } = await moveSegment(supabase, context.params.id, {
+      truckId: parsed.data.truck_id,
+      startDay: parsed.data.start_day,
+      endDay: parsed.data.end_day,
+      sortIndex: parsed.data.sort_index,
+    });
+    if (error) return routeError(500, 'planning_segment_move_failed', error.message);
+
+    return ok({ item: data });
+  } catch (e: any) {
+    return routeError(500, 'planning_segment_move_unexpected', e?.message || 'Failed to move segment');
+  }
+}

--- a/app/api/crm/planering/segments/[id]/route.ts
+++ b/app/api/crm/planering/segments/[id]/route.ts
@@ -1,6 +1,6 @@
 import { cookies } from 'next/headers';
 import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
-import { moveSegment } from '@/lib/domains/planning/schedule';
+import { moveSegment, removeSegment } from '@/lib/domains/planning/schedule';
 import { ok, routeError, validationError, invalidUuidParam, requirePermission, moveSegmentSchema } from '../../_lib';
 
 type RouteContext = {
@@ -36,5 +36,24 @@ export async function PATCH(req: Request, context: RouteContext) {
     return ok({ item: data });
   } catch (e: any) {
     return routeError(500, 'planning_segment_move_unexpected', e?.message || 'Failed to move segment');
+  }
+}
+
+// Unschedule a placement (dragged back to the backlog / removed from the calendar).
+export async function DELETE(_req: Request, context: RouteContext) {
+  try {
+    const gate = await requirePermission('planning.schedule.write');
+    if (gate.response) return gate.response;
+
+    const badId = invalidUuidParam(context.params.id);
+    if (badId) return badId;
+
+    const supabase = createRouteHandlerClient({ cookies });
+    const { error } = await removeSegment(supabase, context.params.id);
+    if (error) return routeError(500, 'planning_segment_delete_failed', error.message);
+
+    return ok({ ok: true });
+  } catch (e: any) {
+    return routeError(500, 'planning_segment_delete_unexpected', e?.message || 'Failed to remove segment');
   }
 }

--- a/app/api/crm/planering/segments/[id]/route.ts
+++ b/app/api/crm/planering/segments/[id]/route.ts
@@ -31,6 +31,7 @@ export async function PATCH(req: Request, context: RouteContext) {
       endDay: parsed.data.end_day,
       sortIndex: parsed.data.sort_index,
       jobType: parsed.data.job_type,
+      onHold: parsed.data.on_hold,
     });
     if (error) return routeError(500, 'planning_segment_move_failed', error.message);
 

--- a/app/api/crm/planering/segments/route.ts
+++ b/app/api/crm/planering/segments/route.ts
@@ -49,6 +49,7 @@ export async function POST(req: Request) {
       startDay: parsed.data.start_day,
       endDay: parsed.data.end_day,
       sortIndex: parsed.data.sort_index,
+      jobType: parsed.data.job_type,
       actorUserId: gate.currentUser.id,
     });
     if (error) return routeError(500, 'planning_segment_create_failed', error.message);

--- a/app/api/crm/planering/segments/route.ts
+++ b/app/api/crm/planering/segments/route.ts
@@ -1,0 +1,60 @@
+import { cookies } from 'next/headers';
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
+import { listSegments, listTrucks, placeSegment } from '@/lib/domains/planning/schedule';
+import { ok, routeError, validationError, requirePermission, listSegmentsQuerySchema, placeSegmentSchema } from '../_lib';
+
+// Schedule (segments overlapping a date window) + the active trucks to render lanes for.
+export async function GET(req: Request) {
+  try {
+    const gate = await requirePermission('planning.schedule.read');
+    if (gate.response) return gate.response;
+
+    const url = new URL(req.url);
+    const parsed = listSegmentsQuerySchema.safeParse({
+      from: url.searchParams.get('from') || undefined,
+      to: url.searchParams.get('to') || undefined,
+    });
+    if (!parsed.success) return validationError(parsed.error);
+
+    const supabase = createRouteHandlerClient({ cookies });
+    const [segRes, truckRes] = await Promise.all([
+      listSegments(supabase, { from: parsed.data.from, to: parsed.data.to }),
+      listTrucks(supabase),
+    ]);
+    if (segRes.error) return routeError(500, 'planning_segments_failed', segRes.error.message);
+    if (truckRes.error) return routeError(500, 'planning_trucks_failed', truckRes.error.message);
+
+    return ok({ segments: segRes.data || [], trucks: truckRes.data || [] });
+  } catch (e: any) {
+    return routeError(500, 'planning_segments_unexpected', e?.message || 'Failed to load schedule');
+  }
+}
+
+// Place a work order on a truck/day-range (creates an ops_segment).
+export async function POST(req: Request) {
+  try {
+    const gate = await requirePermission('planning.schedule.write');
+    if (gate.response || !gate.currentUser) return gate.response;
+
+    const parsed = placeSegmentSchema.safeParse(await req.json().catch(() => null));
+    if (!parsed.success) return validationError(parsed.error);
+    if (parsed.data.end_day < parsed.data.start_day) {
+      return routeError(400, 'invalid_range', 'Slutdatum kan inte vara före startdatum.');
+    }
+
+    const supabase = createRouteHandlerClient({ cookies });
+    const { data, error } = await placeSegment(supabase, {
+      workOrderId: parsed.data.work_order_id,
+      truckId: parsed.data.truck_id,
+      startDay: parsed.data.start_day,
+      endDay: parsed.data.end_day,
+      sortIndex: parsed.data.sort_index,
+      actorUserId: gate.currentUser.id,
+    });
+    if (error) return routeError(500, 'planning_segment_create_failed', error.message);
+
+    return ok({ item: data }, 201);
+  } catch (e: any) {
+    return routeError(500, 'planning_segment_create_unexpected', e?.message || 'Failed to place segment');
+  }
+}

--- a/app/api/crm/planering/truck-crew/[id]/route.ts
+++ b/app/api/crm/planering/truck-crew/[id]/route.ts
@@ -1,0 +1,29 @@
+import { cookies } from 'next/headers';
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
+import { unassignTruckCrew } from '@/lib/domains/planning/truckCrew';
+import { ok, routeError, invalidUuidParam, requirePermission } from '../../_lib';
+
+type RouteContext = {
+  params: {
+    id: string;
+  };
+};
+
+// Remove a crew member from a truck's rota.
+export async function DELETE(_req: Request, context: RouteContext) {
+  try {
+    const gate = await requirePermission('planning.schedule.write');
+    if (gate.response) return gate.response;
+
+    const badId = invalidUuidParam(context.params.id);
+    if (badId) return badId;
+
+    const supabase = createRouteHandlerClient({ cookies });
+    const { error } = await unassignTruckCrew(supabase, context.params.id);
+    if (error) return routeError(500, 'planning_truck_crew_unassign_failed', error.message);
+
+    return ok({ ok: true });
+  } catch (e: any) {
+    return routeError(500, 'planning_truck_crew_unassign_unexpected', e?.message || 'Failed to remove truck crew');
+  }
+}

--- a/app/api/crm/planering/truck-crew/copy/route.ts
+++ b/app/api/crm/planering/truck-crew/copy/route.ts
@@ -1,0 +1,31 @@
+import { cookies } from 'next/headers';
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
+import { copyTruckCrewWeek } from '@/lib/domains/planning/truckCrew';
+import { ok, routeError, validationError, requirePermission, copyTruckCrewSchema } from '../../_lib';
+
+// Copy a truck's crew from one week to another (e.g. this week → next week), skipping anyone already
+// on the target week.
+export async function POST(req: Request) {
+  try {
+    const gate = await requirePermission('planning.schedule.write');
+    if (gate.response || !gate.currentUser) return gate.response;
+
+    const parsed = copyTruckCrewSchema.safeParse(await req.json().catch(() => null));
+    if (!parsed.success) return validationError(parsed.error);
+
+    const supabase = createRouteHandlerClient({ cookies });
+    const { data, error } = await copyTruckCrewWeek(supabase, {
+      truckId: parsed.data.truck_id,
+      sourceFrom: parsed.data.source_start,
+      sourceTo: parsed.data.source_end,
+      targetFrom: parsed.data.target_start,
+      targetTo: parsed.data.target_end,
+      actorUserId: gate.currentUser.id,
+    });
+    if (error) return routeError(500, 'planning_truck_crew_copy_failed', error.message);
+
+    return ok({ copied: data?.copied ?? 0 });
+  } catch (e: any) {
+    return routeError(500, 'planning_truck_crew_copy_unexpected', e?.message || 'Failed to copy truck crew');
+  }
+}

--- a/app/api/crm/planering/truck-crew/route.ts
+++ b/app/api/crm/planering/truck-crew/route.ts
@@ -1,0 +1,56 @@
+import { cookies } from 'next/headers';
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
+import { listTruckCrew, assignTruckCrew } from '@/lib/domains/planning/truckCrew';
+import { ok, routeError, validationError, requirePermission, listSegmentsQuerySchema, assignTruckCrewSchema } from '../_lib';
+
+// Truck crew rows overlapping the visible window.
+export async function GET(req: Request) {
+  try {
+    const gate = await requirePermission('planning.schedule.read');
+    if (gate.response) return gate.response;
+
+    const url = new URL(req.url);
+    const parsed = listSegmentsQuerySchema.safeParse({
+      from: url.searchParams.get('from') || undefined,
+      to: url.searchParams.get('to') || undefined,
+    });
+    if (!parsed.success) return validationError(parsed.error);
+
+    const supabase = createRouteHandlerClient({ cookies });
+    const { data, error } = await listTruckCrew(supabase, { from: parsed.data.from, to: parsed.data.to });
+    if (error) return routeError(500, 'planning_truck_crew_failed', error.message);
+
+    return ok({ crew: data });
+  } catch (e: any) {
+    return routeError(500, 'planning_truck_crew_unexpected', e?.message || 'Failed to load truck crew');
+  }
+}
+
+// Assign a crew member to a truck for a date range.
+export async function POST(req: Request) {
+  try {
+    const gate = await requirePermission('planning.schedule.write');
+    if (gate.response || !gate.currentUser) return gate.response;
+
+    const parsed = assignTruckCrewSchema.safeParse(await req.json().catch(() => null));
+    if (!parsed.success) return validationError(parsed.error);
+    if (parsed.data.end_day < parsed.data.start_day) {
+      return routeError(400, 'invalid_range', 'Slutdatum kan inte vara före startdatum.');
+    }
+
+    const supabase = createRouteHandlerClient({ cookies });
+    const { data, error } = await assignTruckCrew(supabase, {
+      truckId: parsed.data.truck_id,
+      memberId: parsed.data.member_id,
+      memberName: parsed.data.member_name,
+      startDay: parsed.data.start_day,
+      endDay: parsed.data.end_day,
+      actorUserId: gate.currentUser.id,
+    });
+    if (error) return routeError(500, 'planning_truck_crew_assign_failed', error.message);
+
+    return ok({ item: data }, 201);
+  } catch (e: any) {
+    return routeError(500, 'planning_truck_crew_assign_unexpected', e?.message || 'Failed to assign truck crew');
+  }
+}

--- a/app/api/crm/planering/truck-crew/route.ts
+++ b/app/api/crm/planering/truck-crew/route.ts
@@ -47,7 +47,12 @@ export async function POST(req: Request) {
       endDay: parsed.data.end_day,
       actorUserId: gate.currentUser.id,
     });
-    if (error) return routeError(500, 'planning_truck_crew_assign_failed', error.message);
+    if (error) {
+      if ((error as { code?: string }).code === '23505') {
+        return routeError(409, 'planning_truck_crew_already_assigned', 'Personen är redan i bilbesättningen den veckan.');
+      }
+      return routeError(500, 'planning_truck_crew_assign_failed', error.message);
+    }
 
     return ok({ item: data }, 201);
   } catch (e: any) {

--- a/app/api/crm/planering/trucks/[id]/route.ts
+++ b/app/api/crm/planering/trucks/[id]/route.ts
@@ -1,0 +1,61 @@
+import { cookies } from 'next/headers';
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
+import { updateTruck, deleteTruck } from '@/lib/domains/planning/trucks';
+import { ok, routeError, validationError, invalidUuidParam, requirePermission, updateTruckSchema } from '../../_lib';
+
+type RouteContext = {
+  params: {
+    id: string;
+  };
+};
+
+// Rename / recolor / (de)activate a truck.
+export async function PATCH(req: Request, context: RouteContext) {
+  try {
+    const gate = await requirePermission('planning.truck.manage');
+    if (gate.response) return gate.response;
+
+    const badId = invalidUuidParam(context.params.id);
+    if (badId) return badId;
+
+    const parsed = updateTruckSchema.safeParse(await req.json().catch(() => null));
+    if (!parsed.success) return validationError(parsed.error);
+
+    const supabase = createRouteHandlerClient({ cookies });
+    const { data, error } = await updateTruck(supabase, context.params.id, {
+      name: parsed.data.name,
+      color: parsed.data.color,
+      active: parsed.data.active,
+    });
+    if (error) return routeError(500, 'planning_truck_update_failed', error.message);
+
+    return ok({ item: data });
+  } catch (e: any) {
+    return routeError(500, 'planning_truck_update_unexpected', e?.message || 'Failed to update truck');
+  }
+}
+
+// Delete a truck. A truck still used by a placement is FK-restricted (23503) — surface a friendly
+// "deactivate instead" message rather than a raw DB error.
+export async function DELETE(_req: Request, context: RouteContext) {
+  try {
+    const gate = await requirePermission('planning.truck.manage');
+    if (gate.response) return gate.response;
+
+    const badId = invalidUuidParam(context.params.id);
+    if (badId) return badId;
+
+    const supabase = createRouteHandlerClient({ cookies });
+    const { error } = await deleteTruck(supabase, context.params.id);
+    if (error) {
+      if ((error as { code?: string }).code === '23503') {
+        return routeError(409, 'truck_in_use', 'Bilen används av schemalagda jobb — avaktivera den istället.');
+      }
+      return routeError(500, 'planning_truck_delete_failed', error.message);
+    }
+
+    return ok({ ok: true });
+  } catch (e: any) {
+    return routeError(500, 'planning_truck_delete_unexpected', e?.message || 'Failed to delete truck');
+  }
+}

--- a/app/api/crm/planering/trucks/[id]/route.ts
+++ b/app/api/crm/planering/trucks/[id]/route.ts
@@ -26,6 +26,7 @@ export async function PATCH(req: Request, context: RouteContext) {
       name: parsed.data.name,
       color: parsed.data.color,
       active: parsed.data.active,
+      depotId: parsed.data.depot_id,
     });
     if (error) return routeError(500, 'planning_truck_update_failed', error.message);
 

--- a/app/api/crm/planering/trucks/route.ts
+++ b/app/api/crm/planering/trucks/route.ts
@@ -1,0 +1,39 @@
+import { cookies } from 'next/headers';
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
+import { listAllTrucks, createTruck } from '@/lib/domains/planning/trucks';
+import { ok, routeError, validationError, requirePermission, createTruckSchema } from '../_lib';
+
+// All trucks (incl inactive) for the fleet-management panel.
+export async function GET() {
+  try {
+    const gate = await requirePermission('planning.truck.manage');
+    if (gate.response) return gate.response;
+
+    const supabase = createRouteHandlerClient({ cookies });
+    const { data, error } = await listAllTrucks(supabase);
+    if (error) return routeError(500, 'planning_trucks_list_failed', error.message);
+
+    return ok({ trucks: data || [] });
+  } catch (e: any) {
+    return routeError(500, 'planning_trucks_list_unexpected', e?.message || 'Failed to list trucks');
+  }
+}
+
+// Add a truck.
+export async function POST(req: Request) {
+  try {
+    const gate = await requirePermission('planning.truck.manage');
+    if (gate.response) return gate.response;
+
+    const parsed = createTruckSchema.safeParse(await req.json().catch(() => null));
+    if (!parsed.success) return validationError(parsed.error);
+
+    const supabase = createRouteHandlerClient({ cookies });
+    const { data, error } = await createTruck(supabase, { name: parsed.data.name, color: parsed.data.color ?? null });
+    if (error) return routeError(500, 'planning_truck_create_failed', error.message);
+
+    return ok({ item: data }, 201);
+  } catch (e: any) {
+    return routeError(500, 'planning_truck_create_unexpected', e?.message || 'Failed to create truck');
+  }
+}

--- a/app/api/twilio/sms-status/route.ts
+++ b/app/api/twilio/sms-status/route.ts
@@ -87,6 +87,15 @@ export async function POST(req: NextRequest) {
 
     if (error) throw error;
 
+    // Also update the new CRM-first planning's confirmation log (Wave 7). A given MessageSid lives
+    // in at most one of the two tables, so both updates are safe no-ops otherwise. Best-effort —
+    // never let the new table break the established callback.
+    const { error: opsError } = await supabase
+      .from('ops_work_order_confirmations')
+      .update({ status: messageStatus })
+      .eq('provider_message_id', messageSid);
+    if (opsError) console.error('[api/twilio/sms-status] ops_work_order_confirmations update failed', opsError);
+
     return new NextResponse(null, { status: 204 });
   } catch (e: any) {
     console.error('[api/twilio/sms-status] error', e);

--- a/app/crm/_lib/nav.ts
+++ b/app/crm/_lib/nav.ts
@@ -14,6 +14,7 @@ export const CRM_NAV_ITEMS: CrmNavItem[] = [
   { href: '/crm/kunder', label: 'Kunder', description: 'Prospekt, kunder och Fortnox-konton', roles: ['sales', 'admin'] },
   { href: '/crm/offerter', label: 'Offerter', description: 'Offertflöde och uppföljning', roles: ['sales', 'admin'] },
   { href: '/crm/arbetsorder', label: 'Arbetsorder', description: 'Intern order och nästa operativa steg', roles: ['sales', 'admin'] },
+  { href: '/crm/planering', label: 'Planering', description: 'Schemalägg arbetsordrar på bilar', roles: ['sales', 'admin'] },
   { href: '/crm/samtal', label: 'Samtal', description: 'Ringlista och snabb loggning', roles: ['sales', 'admin'] },
   { href: '/crm/uppgifter', label: 'Uppgifter', description: 'Uppföljningar och deadlines', roles: ['sales', 'admin'] },
   { href: '/crm/affarsmojligheter', label: 'Affärsmöjligheter', description: 'Pipeline och aktiva affärer', roles: ['sales', 'admin'] },

--- a/app/crm/components/CrmSidebar.tsx
+++ b/app/crm/components/CrmSidebar.tsx
@@ -72,6 +72,12 @@ const navIcons: Record<string, JSX.Element> = {
       <path d="M21 16V8a2 2 0 00-1-1.73l-7-4a2 2 0 00-2 0l-7 4A2 2 0 003 8v8a2 2 0 001 1.73l7 4a2 2 0 002 0l7-4A2 2 0 0021 16z" />
     </svg>
   ),
+  '/crm/planering': (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <rect x="3" y="4" width="18" height="18" rx="2" /><line x1="16" y1="2" x2="16" y2="6" />
+      <line x1="8" y1="2" x2="8" y2="6" /><line x1="3" y1="10" x2="21" y2="10" />
+    </svg>
+  ),
   '/crm/ringlistor': (
     <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
       <line x1="8" y1="6" x2="21" y2="6" /><line x1="8" y1="12" x2="21" y2="12" />

--- a/app/crm/components/CrmSidebar.tsx
+++ b/app/crm/components/CrmSidebar.tsx
@@ -109,6 +109,8 @@ type CrmSidebarProps = {
   userInitial?: string;
 };
 
+const COLLAPSE_KEY = 'crm-sidebar-collapsed';
+
 export default function CrmSidebar({ role, userName, userInitial = 'U' }: CrmSidebarProps) {
   const pathname = usePathname();
   const items = getVisibleCrmNavItems(role);
@@ -116,6 +118,29 @@ export default function CrmSidebar({ role, userName, userInitial = 'U' }: CrmSid
   const [mobileOpen, setMobileOpen] = useState(false);
   // Per-group manual expand override; falls back to "open when a child is active".
   const [expanded, setExpanded] = useState<Record<string, boolean>>({});
+  // Desktop collapse to an icon rail (gives wide surfaces like planning more room). Persisted;
+  // defaults to collapsed on the planning route until the user expresses a preference.
+  const [collapsed, setCollapsed] = useState(false);
+
+  useEffect(() => {
+    const stored = typeof window !== 'undefined' ? window.localStorage.getItem(COLLAPSE_KEY) : null;
+    if (stored === '1') setCollapsed(true);
+    else if (stored === '0') setCollapsed(false);
+    else setCollapsed(pathname.startsWith('/crm/planering'));
+    // run once on mount — later route changes shouldn't override a manual choice
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const toggleCollapsed = () =>
+    setCollapsed((c) => {
+      const next = !c;
+      try {
+        window.localStorage.setItem(COLLAPSE_KEY, next ? '1' : '0');
+      } catch {
+        /* ignore storage failures */
+      }
+      return next;
+    });
 
   // Reset pending state and close the mobile drawer whenever navigation completes.
   useEffect(() => {
@@ -175,17 +200,37 @@ export default function CrmSidebar({ role, userName, userInitial = 'U' }: CrmSid
           // Mobile: off-canvas drawer pinned below the global header
           'fixed left-0 z-50 h-[calc(100dvh-var(--header-base,56px)-var(--safe-top,0px))] top-[calc(var(--header-base,56px)_+_var(--safe-top,0px))] transition-transform duration-300 ease-out',
           mobileOpen ? 'translate-x-0' : '-translate-x-full',
-          // Desktop: static sticky sidebar (unchanged behavior)
-          'lg:sticky lg:top-0 lg:z-auto lg:translate-x-0 lg:transition-none'
+          // Desktop: static sticky sidebar; width depends on the collapsed state
+          'lg:sticky lg:top-0 lg:z-auto lg:translate-x-0 lg:transition-[width] lg:duration-200',
+          collapsed ? 'lg:w-[68px]' : 'lg:w-56',
         )}
         style={{ backgroundColor: 'var(--crm-sidebar-bg)' }}
       >
-      {/* Logo */}
-      <div className="flex items-center justify-between px-4 pb-3 pt-5">
-        <div>
+      {/* Logo + collapse toggle */}
+      <div className={cn('flex items-center justify-between px-4 pb-3 pt-5', collapsed && 'lg:px-3')}>
+        <div className={cn(collapsed && 'lg:hidden')}>
           <p className="text-base font-bold leading-tight text-white">Ekovilla</p>
           <p className="text-[11px] font-medium" style={{ color: 'var(--crm-sidebar-text-muted)' }}>CRM System</p>
         </div>
+        {/* Collapsed brand mark (desktop only) */}
+        <div
+          className={cn('hidden h-9 w-9 place-items-center rounded-lg text-sm font-extrabold text-white', collapsed ? 'lg:grid' : 'lg:hidden')}
+          style={{ backgroundColor: 'rgba(124,200,150,.18)', color: '#cfe8d6' }}
+        >
+          E
+        </div>
+        {/* Desktop collapse toggle */}
+        <button
+          type="button"
+          onClick={toggleCollapsed}
+          aria-label={collapsed ? 'Visa meny' : 'Fäll ihop meny'}
+          className={cn('hidden h-8 w-8 shrink-0 place-items-center rounded-lg text-white/80 transition-colors hover:bg-white/10 hover:text-white lg:grid', collapsed && 'lg:absolute lg:right-2 lg:top-2')}
+        >
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.9" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true" className={cn('transition-transform', collapsed && 'rotate-180')}>
+            <polyline points="15 18 9 12 15 6" />
+          </svg>
+        </button>
+        {/* Mobile close */}
         <button
           type="button"
           onClick={() => setMobileOpen(false)}
@@ -201,7 +246,7 @@ export default function CrmSidebar({ role, userName, userInitial = 'U' }: CrmSid
       <div className="mx-3 mb-3 h-px" style={{ backgroundColor: 'var(--crm-sidebar-border)' }} />
 
       {/* Nav items */}
-      <nav className="flex-1 px-2">
+      <nav className={cn('flex-1 px-2', collapsed && 'lg:px-2')}>
         <ul role="list" className="grid list-none gap-0.5 p-0">
           {items.map((item) => {
             // Renders a single navigable link, shared by top-level items and
@@ -213,10 +258,12 @@ export default function CrmSidebar({ role, userName, userInitial = 'U' }: CrmSid
                 <Link
                   href={navItem.href}
                   aria-current={active ? 'page' : undefined}
+                  title={collapsed ? navItem.label : undefined}
                   onClick={() => { if (!active) setPendingHref(navItem.href); }}
                   className={cn(
                     'flex items-center gap-3 rounded-xl text-sm font-medium no-underline transition-colors',
                     isChild ? 'py-2 pl-11 pr-3 text-[13px]' : 'px-3 py-2.5',
+                    collapsed && !isChild && 'lg:justify-center lg:gap-0 lg:px-0',
                     active ? 'text-white' : pending ? 'text-emerald-300' : 'hover:text-white'
                   )}
                   style={
@@ -236,7 +283,7 @@ export default function CrmSidebar({ role, userName, userInitial = 'U' }: CrmSid
                   {!isChild && (
                     <span className={cn('shrink-0', active ? 'text-emerald-300' : '')}>{icon}</span>
                   )}
-                  <span className="truncate">{navItem.label}</span>
+                  <span className={cn('truncate', collapsed && 'lg:hidden')}>{navItem.label}</span>
                 </Link>
               );
             };
@@ -253,9 +300,11 @@ export default function CrmSidebar({ role, userName, userInitial = 'U' }: CrmSid
                   <button
                     type="button"
                     aria-expanded={open}
+                    title={collapsed ? item.label : undefined}
                     onClick={() => setExpanded((prev) => ({ ...prev, [item.href]: !open }))}
                     className={cn(
                       'flex w-full items-center gap-3 rounded-xl px-3 py-2.5 text-sm font-medium transition-colors',
+                      collapsed && 'lg:justify-center lg:gap-0 lg:px-0',
                       groupActive ? 'text-white' : 'hover:text-white'
                     )}
                     style={{ color: groupActive ? '#ffffff' : 'var(--crm-sidebar-text)' }}
@@ -263,17 +312,17 @@ export default function CrmSidebar({ role, userName, userInitial = 'U' }: CrmSid
                     onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.backgroundColor = ''; }}
                   >
                     <span className={cn('shrink-0', groupActive ? 'text-emerald-300' : '')}>{icon}</span>
-                    <span className="flex-1 truncate text-left">{item.label}</span>
+                    <span className={cn('flex-1 truncate text-left', collapsed && 'lg:hidden')}>{item.label}</span>
                     <svg
                       width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor"
                       strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"
-                      className={cn('shrink-0 transition-transform', open && 'rotate-180')}
+                      className={cn('shrink-0 transition-transform', open && 'rotate-180', collapsed && 'lg:hidden')}
                     >
                       <polyline points="6 9 12 15 18 9" />
                     </svg>
                   </button>
                   {open && (
-                    <ul role="list" className="mt-0.5 grid list-none gap-0.5 p-0">
+                    <ul role="list" className={cn('mt-0.5 grid list-none gap-0.5 p-0', collapsed && 'lg:hidden')}>
                       {children.map((child) => (
                         <li key={child.href}>{renderLink(child, childActive === child.href, true)}</li>
                       ))}
@@ -290,11 +339,11 @@ export default function CrmSidebar({ role, userName, userInitial = 'U' }: CrmSid
 
       {/* User profile */}
       <div className="mx-3 mt-2 mb-3 h-px" style={{ backgroundColor: 'var(--crm-sidebar-border)' }} />
-      <div className="flex items-center gap-2.5 px-4 pb-5">
+      <div className={cn('flex items-center gap-2.5 px-4 pb-5', collapsed && 'lg:justify-center lg:px-2')}>
         <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-emerald-700 text-xs font-bold text-white">
           {userInitial}
         </div>
-        <div className="min-w-0">
+        <div className={cn('min-w-0', collapsed && 'lg:hidden')}>
           <p className="truncate text-[13px] font-semibold text-white">{userName || 'Användare'}</p>
           <p className="truncate text-[11px]" style={{ color: 'var(--crm-sidebar-text-muted)' }}>CRM</p>
         </div>

--- a/app/crm/lib/crmTokens.ts
+++ b/app/crm/lib/crmTokens.ts
@@ -140,4 +140,23 @@ export const crm = {
   // Destructive / secondary button (cancel, delete)
   ghostButton:
     'inline-flex h-8 items-center justify-center rounded-xl border border-slate-200 bg-white px-3 text-sm font-semibold text-slate-600 transition hover:border-slate-300 hover:text-slate-800 disabled:opacity-50',
+
+  // ── Form fields (shared across modals/forms; sized for h-9 rows) ───────────
+  // Text/number/date/email input. In a flex row use it as-is; the global
+  // `input { width:100% }` makes it fill — pair with a grid/flex track for sizing.
+  input:
+    'h-9 w-full rounded-lg border border-[#dce4d8] bg-white px-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-2 focus:ring-emerald-500/15',
+  // <select>
+  select:
+    'h-9 w-full rounded-lg border border-[#dce4d8] bg-white px-2.5 text-sm text-slate-700 outline-none transition focus:border-emerald-500',
+  // <input type="color"> — put it in a fixed grid track (e.g. grid-cols-[2.5rem_1fr])
+  // so it fills the track instead of the global input width:100% blowing it up.
+  colorInput: 'h-9 w-full cursor-pointer rounded-lg border border-[#dce4d8] bg-white p-1',
+  // Solid primary form button (Spara / Lägg till / Registrera). Pair with
+  // style={{ backgroundColor: 'var(--crm-primary)' }}.
+  formButton:
+    'inline-flex h-9 shrink-0 items-center justify-center rounded-lg px-4 text-[13px] font-semibold text-white transition disabled:cursor-not-allowed disabled:opacity-50',
+  // Destructive outline button (Ta bort) for form rows.
+  dangerButton:
+    'inline-flex h-9 shrink-0 items-center gap-1.5 rounded-lg border border-[#e0e8dc] bg-white px-3 text-[13px] font-semibold text-slate-500 transition hover:border-rose-300 hover:text-rose-600 disabled:cursor-not-allowed disabled:opacity-50',
 } as const;

--- a/app/crm/offerter/quoteSerializers.ts
+++ b/app/crm/offerter/quoteSerializers.ts
@@ -6,8 +6,7 @@
 // callers pass `draft` directly, and tests build small plain objects.
 
 import { parseDecimal } from '@/lib/shared/number';
-import { lineItemQuantity } from '@/lib/domains/crm/lineItems';
-import { inferMaterialFromArticle, sacksFor } from '@/lib/domains/crm/materials';
+import { inferMaterialFromArticle, lineItemSacks } from '@/lib/domains/crm/materials';
 
 export type QuoteCustomerFields = {
   quote_type: 'private' | 'business';
@@ -161,13 +160,10 @@ export function buildMeasurementLines(items: MeasurementLineItem[]): string[] {
     let row = label ? `${label} – ${dims}` : dims;
 
     const material = inferMaterialFromArticle(it.article_name);
-    const density = parseDecimal(it.density);
-    if (material && density > 0) {
-      const sacks = sacksFor(lineItemQuantity(it), density, material.bagWeight);
-      if (sacks > 0) {
-        row += ` @ ${(it.density ?? '').trim()} kg/m³ – ${sacks} säck`;
-        totalSacks += sacks;
-      }
+    const sacks = lineItemSacks(it);
+    if (sacks > 0) {
+      row += ` @ ${(it.density ?? '').trim()} kg/m³ – ${sacks} säck`;
+      totalSacks += sacks;
     }
 
     const heading = material?.short ?? '';

--- a/app/crm/planering/Backlog.tsx
+++ b/app/crm/planering/Backlog.tsx
@@ -2,7 +2,7 @@ import type React from 'react';
 import { cn } from '@/lib/shared/cn';
 import { crm } from '@/app/crm/lib/crmTokens';
 import type { SchedulableWorkOrder } from '@/lib/domains/planning/types';
-import { statusMeta, SackBadge, JobRef } from './jobCard';
+import { statusMeta, SackBadge, JobRef, MapLink } from './jobCard';
 import { formatDate } from '@/app/crm/lib/format';
 
 type BacklogProps = {
@@ -74,7 +74,12 @@ export default function Backlog({
                       <JobRef job={item} />
                     </div>
                     <div className="mt-0.5 text-[11px] text-slate-500">{item.client_name}</div>
-                    {item.address && <div className="text-[11px] text-slate-400">{item.address}</div>}
+                    {item.address && (
+                      <div className="flex items-center gap-1 text-[11px] text-slate-400">
+                        <span className="truncate">{item.address}</span>
+                        <MapLink address={item.address} />
+                      </div>
+                    )}
                     <div className="mt-2 flex flex-wrap items-center gap-1.5">
                       <SackBadge sacks={item.total_sacks} />
                       {item.desired_installation_date && (

--- a/app/crm/planering/Backlog.tsx
+++ b/app/crm/planering/Backlog.tsx
@@ -45,12 +45,12 @@ export default function Backlog({
             Inga arbetsordrar att planera. Skapa en order i CRM:et så dyker den upp här.
           </p>
         ) : (
-          <ul className="grid gap-2">
+          <div className="grid gap-2">
             {items.map((item) => {
               const isSelected = item.id === selectedId;
               return (
-                <li key={item.id}>
                   <div
+                    key={item.id}
                     role="button"
                     tabIndex={0}
                     draggable={canWrite}
@@ -92,10 +92,9 @@ export default function Backlog({
                       </span>
                     </div>
                   </div>
-                </li>
               );
             })}
-          </ul>
+          </div>
         )}
       </div>
 

--- a/app/crm/planering/Backlog.tsx
+++ b/app/crm/planering/Backlog.tsx
@@ -1,0 +1,104 @@
+import type React from 'react';
+import { cn } from '@/lib/shared/cn';
+import { crm } from '@/app/crm/lib/crmTokens';
+import type { SchedulableWorkOrder } from '@/lib/domains/planning/types';
+import { statusMeta, SackBadge, JobRef } from './jobCard';
+import { formatDate } from '@/app/crm/lib/format';
+
+type BacklogProps = {
+  items: SchedulableWorkOrder[];
+  loading: boolean;
+  canWrite: boolean;
+  selectedId: string | null;
+  onSelect: (id: string) => void;
+  onDragStartItem: (e: React.DragEvent, item: SchedulableWorkOrder) => void;
+  onDropUnschedule: (e: React.DragEvent) => void;
+  onDragOver: (e: React.DragEvent) => void;
+  dropActive: boolean;
+};
+
+function shortDate(value: string | null): string | null {
+  if (!value) return null;
+  const formatted = formatDate(value);
+  return formatted || value;
+}
+
+export default function Backlog({
+  items, loading, canWrite, selectedId, onSelect, onDragStartItem, onDropUnschedule, onDragOver, dropActive,
+}: BacklogProps) {
+  return (
+    <section
+      className={cn(crm.card, 'flex max-h-[calc(100dvh-220px)] flex-col', dropActive && 'ring-2 ring-rose-300')}
+      onDragOver={onDragOver}
+      onDrop={onDropUnschedule}
+    >
+      <div className="flex items-center justify-between px-3.5 pb-2 pt-3.5">
+        <h2 className={crm.sectionTitle}>Att planera</h2>
+        <span className="text-[11px] tabular-nums text-slate-400">{items.length} st</span>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto px-2.5 pb-3">
+        {loading ? (
+          <p className="py-6 text-center text-sm text-slate-400">Laddar…</p>
+        ) : items.length === 0 ? (
+          <p className="px-2 py-6 text-center text-sm text-slate-400">
+            Inga arbetsordrar att planera. Skapa en order i CRM:et så dyker den upp här.
+          </p>
+        ) : (
+          <ul className="grid gap-2">
+            {items.map((item) => {
+              const isSelected = item.id === selectedId;
+              return (
+                <li key={item.id}>
+                  <div
+                    role="button"
+                    tabIndex={0}
+                    draggable={canWrite}
+                    onDragStart={(e) => onDragStartItem(e, item)}
+                    onClick={() => canWrite && onSelect(item.id)}
+                    onKeyDown={(e) => {
+                      if ((e.key === 'Enter' || e.key === ' ') && canWrite) {
+                        e.preventDefault();
+                        onSelect(item.id);
+                      }
+                    }}
+                    className={cn(
+                      'relative rounded-xl border bg-white p-2.5 pl-3.5 text-left shadow-[0_1px_2px_rgba(20,44,27,0.06)] transition',
+                      isSelected ? 'border-emerald-400 ring-2 ring-emerald-500/20' : 'border-[#e0e8dc] hover:border-[#c8d4c3]',
+                      canWrite ? 'cursor-grab active:cursor-grabbing' : 'cursor-default',
+                    )}
+                  >
+                    <span className={cn('absolute bottom-2.5 left-0 top-2.5 w-[3px] rounded-full', statusMeta(item.status).rail)} />
+                    <div className="flex items-baseline justify-between gap-2">
+                      <span className="text-[13px] font-bold text-slate-900">{item.project_name}</span>
+                      <JobRef job={item} />
+                    </div>
+                    <div className="mt-0.5 text-[11px] text-slate-500">{item.client_name}</div>
+                    {item.address && <div className="text-[11px] text-slate-400">{item.address}</div>}
+                    <div className="mt-2 flex flex-wrap items-center gap-1.5">
+                      <SackBadge sacks={item.total_sacks} />
+                      {item.desired_installation_date && (
+                        <span className="whitespace-nowrap rounded-full border border-sky-200 bg-sky-50 px-2 py-px text-[10px] font-bold text-sky-700">
+                          Önskat {shortDate(item.desired_installation_date)}
+                        </span>
+                      )}
+                      <span className={cn('whitespace-nowrap rounded-full border px-2 py-px text-[10px] font-bold', statusMeta(item.status).pill)}>
+                        {statusMeta(item.status).label}
+                      </span>
+                    </div>
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+
+      {canWrite && (
+        <p className="border-t border-[#e8efe5] px-3.5 py-2 text-[10px] text-slate-400">
+          Dra ett kort till schemat för att planera — eller dra ett planerat jobb hit för att avplanera.
+        </p>
+      )}
+    </section>
+  );
+}

--- a/app/crm/planering/ConfirmModal.tsx
+++ b/app/crm/planering/ConfirmModal.tsx
@@ -80,14 +80,21 @@ export default function ConfirmModal({
         return;
       }
       const res = j.data.result as {
-        email: { sent: boolean; error: string | null };
-        sms: { sent: boolean; error: string | null };
+        email: { sent: boolean; recorded: boolean; error: string | null };
+        sms: { sent: boolean; recorded: boolean; error: string | null };
       };
-      const errors = [res.email?.error && `Mejl: ${res.email.error}`, res.sms?.error && `SMS: ${res.sms.error}`].filter(Boolean);
-      if (errors.length) toast.error(errors.join(' · '));
+      // Hard failures = a channel that did NOT send. A channel that sent but couldn't be logged
+      // (recorded=false) is surfaced as a warning so the planner doesn't re-send and double-notify.
+      const hardErrors = [
+        res.email?.error && !res.email?.sent && `Mejl: ${res.email.error}`,
+        res.sms?.error && !res.sms?.sent && `SMS: ${res.sms.error}`,
+      ].filter(Boolean);
+      if (hardErrors.length) toast.error(hardErrors.join(' · '));
       if (res.email?.sent || res.sms?.sent) {
         const channels = [res.email?.sent && 'mejl', res.sms?.sent && 'SMS'].filter(Boolean).join(' + ');
-        toast.success(`Bekräftelse skickad (${channels})`);
+        const unrecorded = (res.email?.sent && !res.email?.recorded) || (res.sms?.sent && !res.sms?.recorded);
+        if (unrecorded) toast.error(`Skickat (${channels}), men kunde inte loggas — skicka INTE igen.`);
+        else toast.success(`Bekräftelse skickad (${channels})`);
         onSent();
         onClose();
       }

--- a/app/crm/planering/ConfirmModal.tsx
+++ b/app/crm/planering/ConfirmModal.tsx
@@ -1,0 +1,183 @@
+'use client';
+
+import { useEffect, useState, type FormEvent } from 'react';
+import { cn } from '@/lib/shared/cn';
+import { useToast } from '@/lib/Toast';
+import { crm } from '@/app/crm/lib/crmTokens';
+import CrmModal from '@/app/crm/components/CrmModal';
+import type { OpsSegment } from '@/lib/domains/planning/types';
+
+const FIELD = 'h-9 w-full rounded-lg border border-[#dce4d8] bg-white px-3 text-[13px] text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-2 focus:ring-emerald-500/20 disabled:bg-slate-50 disabled:text-slate-400';
+const FORM_ID = 'planning-confirm-form';
+
+// Send an order confirmation (orderbekräftelse) to the customer for a scheduled job. The recipient
+// is prefilled from the CRM customer (GET prepare) and stays editable; email/SMS are independent.
+export default function ConfirmModal({
+  segment,
+  onClose,
+  onSent,
+}: {
+  segment: OpsSegment;
+  onClose: () => void;
+  onSent: () => void;
+}) {
+  const toast = useToast();
+  const job = segment.job;
+
+  const [loading, setLoading] = useState(true);
+  const [sending, setSending] = useState(false);
+  const [sendEmail, setSendEmail] = useState(false);
+  const [sendSms, setSendSms] = useState(false);
+  const [email, setEmail] = useState('');
+  const [phone, setPhone] = useState('');
+  const [message, setMessage] = useState('');
+
+  const dateText = segment.start_day === segment.end_day ? segment.start_day : `${segment.start_day} – ${segment.end_day}`;
+
+  // Prefill recipient from the CRM customer.
+  useEffect(() => {
+    let active = true;
+    fetch(`/api/crm/planering/segments/${segment.id}/confirmation`, { cache: 'no-store' })
+      .then((r) => r.json())
+      .then((j) => {
+        if (!active || !j.ok) return;
+        const c = j.data.contact ?? {};
+        setEmail(c.email || '');
+        setPhone(c.phone || '');
+        setSendEmail(Boolean(c.email));
+      })
+      .catch(() => {})
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [segment.id]);
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    if (!sendEmail && !sendSms) {
+      toast.error('Välj minst en kanal (mejl eller SMS).');
+      return;
+    }
+    setSending(true);
+    try {
+      const r = await fetch(`/api/crm/planering/segments/${segment.id}/confirmation`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          send_email: sendEmail,
+          recipient_email: email.trim() || null,
+          send_sms: sendSms,
+          recipient_phone: phone.trim() || null,
+          custom_message: message.trim() || null,
+        }),
+      });
+      const j = await r.json();
+      if (!j.ok) {
+        toast.error(j.error || 'Kunde inte skicka bekräftelsen');
+        return;
+      }
+      const res = j.data.result as {
+        email: { sent: boolean; error: string | null };
+        sms: { sent: boolean; error: string | null };
+      };
+      const errors = [res.email?.error && `Mejl: ${res.email.error}`, res.sms?.error && `SMS: ${res.sms.error}`].filter(Boolean);
+      if (errors.length) toast.error(errors.join(' · '));
+      if (res.email?.sent || res.sms?.sent) {
+        const channels = [res.email?.sent && 'mejl', res.sms?.sent && 'SMS'].filter(Boolean).join(' + ');
+        toast.success(`Bekräftelse skickad (${channels})`);
+        onSent();
+        onClose();
+      }
+    } catch {
+      toast.error('Något gick fel vid utskicket');
+    } finally {
+      setSending(false);
+    }
+  }
+
+  return (
+    <CrmModal
+      onClose={onClose}
+      ariaLabel="Skicka orderbekräftelse"
+      maxWidth="sm:max-w-[520px]"
+      header={
+        <div>
+          <h2 className="text-[15px] font-bold text-slate-900">Skicka orderbekräftelse</h2>
+          <p className="mt-0.5 text-[12px] text-slate-500">
+            {job?.project_name ?? 'Order'} · {dateText}
+          </p>
+        </div>
+      }
+      footer={
+        <>
+          <button type="button" onClick={onClose} className={cn(crm.ghostButton, 'ml-auto')}>
+            Avbryt
+          </button>
+          <button
+            type="submit"
+            form={FORM_ID}
+            disabled={sending || loading || (!sendEmail && !sendSms)}
+            className="inline-flex h-9 items-center rounded-lg px-4 text-[13px] font-semibold text-white transition disabled:cursor-not-allowed disabled:opacity-50"
+            style={{ backgroundColor: 'var(--crm-primary)' }}
+          >
+            {sending ? 'Skickar…' : 'Skicka'}
+          </button>
+        </>
+      }
+    >
+      <form id={FORM_ID} onSubmit={handleSubmit} className="grid gap-4">
+        <p className="rounded-lg border border-[#e0e8dc] bg-[#f3f6f1] px-3 py-2 text-[11.5px] text-slate-500">
+          Mottagaren hämtas från kundkortet i CRM. Kontrollera och justera vid behov innan du skickar.
+        </p>
+
+        {/* Email */}
+        <div className="grid gap-1.5">
+          <label className="flex items-center gap-2 text-[13px] font-semibold text-slate-700">
+            <input type="checkbox" checked={sendEmail} onChange={(e) => setSendEmail(e.target.checked)} className="h-4 w-4 accent-emerald-600" />
+            Skicka mejl
+          </label>
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            disabled={!sendEmail}
+            placeholder="kund@exempel.se"
+            className={FIELD}
+          />
+        </div>
+
+        {/* SMS */}
+        <div className="grid gap-1.5">
+          <label className="flex items-center gap-2 text-[13px] font-semibold text-slate-700">
+            <input type="checkbox" checked={sendSms} onChange={(e) => setSendSms(e.target.checked)} className="h-4 w-4 accent-emerald-600" />
+            Skicka SMS
+          </label>
+          <input
+            type="tel"
+            value={phone}
+            onChange={(e) => setPhone(e.target.value)}
+            disabled={!sendSms}
+            placeholder="+46 70 123 45 67"
+            className={FIELD}
+          />
+        </div>
+
+        {/* Optional custom message (email only) */}
+        <div className="grid gap-1.5">
+          <label className="text-[12px] font-semibold text-slate-500">Eget meddelande i mejlet (valfritt)</label>
+          <textarea
+            value={message}
+            onChange={(e) => setMessage(e.target.value)}
+            disabled={!sendEmail}
+            rows={3}
+            placeholder="Lämna tomt för standardtext."
+            className="w-full rounded-lg border border-[#dce4d8] bg-white px-3 py-2 text-[13px] text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-2 focus:ring-emerald-500/20 disabled:bg-slate-50 disabled:text-slate-400"
+          />
+        </div>
+      </form>
+    </CrmModal>
+  );
+}

--- a/app/crm/planering/ConfirmModal.tsx
+++ b/app/crm/planering/ConfirmModal.tsx
@@ -7,7 +7,7 @@ import { crm } from '@/app/crm/lib/crmTokens';
 import CrmModal from '@/app/crm/components/CrmModal';
 import type { OpsSegment } from '@/lib/domains/planning/types';
 
-const FIELD = 'h-9 w-full rounded-lg border border-[#dce4d8] bg-white px-3 text-[13px] text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-2 focus:ring-emerald-500/20 disabled:bg-slate-50 disabled:text-slate-400';
+const FIELD = cn(crm.input, 'disabled:bg-slate-50 disabled:text-slate-400');
 const FORM_ID = 'planning-confirm-form';
 
 // Send an order confirmation (orderbekräftelse) to the customer for a scheduled job. The recipient
@@ -127,7 +127,7 @@ export default function ConfirmModal({
             type="submit"
             form={FORM_ID}
             disabled={sending || loading || (!sendEmail && !sendSms)}
-            className="inline-flex h-9 items-center rounded-lg px-4 text-[13px] font-semibold text-white transition disabled:cursor-not-allowed disabled:opacity-50"
+            className={crm.formButton}
             style={{ backgroundColor: 'var(--crm-primary)' }}
           >
             {sending ? 'Skickar…' : 'Skicka'}

--- a/app/crm/planering/DayNotesCell.tsx
+++ b/app/crm/planering/DayNotesCell.tsx
@@ -46,7 +46,7 @@ export default function DayNotesCell({
   return (
     <div
       className={cn(
-        'flex min-h-[30px] flex-col gap-1 border-l border-[#d3ddcb] px-1 py-1',
+        'flex min-h-[30px] flex-col gap-1 px-1 py-1',
         isToday ? 'bg-emerald-50/50' : isWeekend ? 'bg-slate-400/[0.04]' : '',
       )}
     >

--- a/app/crm/planering/DayNotesCell.tsx
+++ b/app/crm/planering/DayNotesCell.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import { useState, type KeyboardEvent } from 'react';
+import { cn } from '@/lib/shared/cn';
+import type { DayNote } from '@/lib/domains/planning/dayNotes';
+
+// One day's notes column in the week board's notes strip: amber note chips (removable) + an inline
+// "+ notering" add affordance that becomes a small input.
+export default function DayNotesCell({
+  dayISO,
+  notes,
+  canWrite,
+  isWeekend,
+  isToday,
+  onAdd,
+  onRemove,
+}: {
+  dayISO: string;
+  notes: DayNote[];
+  canWrite: boolean;
+  isWeekend: boolean;
+  isToday: boolean;
+  onAdd: (dayISO: string, body: string) => void;
+  onRemove: (id: string) => void;
+}) {
+  const [adding, setAdding] = useState(false);
+  const [text, setText] = useState('');
+
+  function submit() {
+    const body = text.trim();
+    setText('');
+    setAdding(false);
+    if (body) onAdd(dayISO, body);
+  }
+
+  function onKey(e: KeyboardEvent<HTMLInputElement>) {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      submit();
+    } else if (e.key === 'Escape') {
+      setText('');
+      setAdding(false);
+    }
+  }
+
+  return (
+    <div
+      className={cn(
+        'flex min-h-[30px] flex-col gap-1 px-1 py-1',
+        isToday ? 'bg-emerald-50/50' : isWeekend ? 'bg-slate-400/[0.04]' : '',
+      )}
+    >
+      {notes.map((n) => (
+        <div key={n.id} className="group/note flex items-start gap-1 rounded-md border border-amber-200/70 bg-amber-50 px-1.5 py-0.5">
+          <span className="flex-1 break-words text-[10px] leading-snug text-amber-800">{n.body}</span>
+          {canWrite && (
+            <button
+              type="button"
+              onClick={() => onRemove(n.id)}
+              aria-label="Ta bort notering"
+              className="mt-px hidden shrink-0 text-amber-400 transition hover:text-rose-500 group-hover/note:block"
+            >
+              <svg width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round">
+                <path d="M18 6 6 18M6 6l12 12" />
+              </svg>
+            </button>
+          )}
+        </div>
+      ))}
+
+      {canWrite &&
+        (adding ? (
+          <input
+            autoFocus
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+            onKeyDown={onKey}
+            onBlur={submit}
+            placeholder="Notering…"
+            className="h-6 w-full rounded-md border border-emerald-300 bg-white px-1.5 text-[10px] text-slate-800 outline-none focus:ring-1 focus:ring-emerald-400"
+          />
+        ) : (
+          <button
+            type="button"
+            onClick={() => setAdding(true)}
+            className="text-left text-[9.5px] font-semibold text-slate-300 transition hover:text-emerald-600"
+          >
+            + notering
+          </button>
+        ))}
+    </div>
+  );
+}

--- a/app/crm/planering/DayNotesCell.tsx
+++ b/app/crm/planering/DayNotesCell.tsx
@@ -46,7 +46,7 @@ export default function DayNotesCell({
   return (
     <div
       className={cn(
-        'flex min-h-[30px] flex-col gap-1 px-1 py-1',
+        'flex min-h-[30px] flex-col gap-1 border-l border-[#d3ddcb] px-1 py-1',
         isToday ? 'bg-emerald-50/50' : isWeekend ? 'bg-slate-400/[0.04]' : '',
       )}
     >

--- a/app/crm/planering/DepotManagerModal.tsx
+++ b/app/crm/planering/DepotManagerModal.tsx
@@ -1,0 +1,156 @@
+'use client';
+
+import { useEffect, useState, type FormEvent } from 'react';
+import { cn } from '@/lib/shared/cn';
+import { useToast } from '@/lib/Toast';
+import { crm } from '@/app/crm/lib/crmTokens';
+import CrmModal from '@/app/crm/components/CrmModal';
+import type { OpsDepot } from '@/lib/domains/planning/types';
+
+const API = '/api/crm/planering/depots';
+const TEXT_INPUT = 'h-8 w-full rounded-lg border border-[#dce4d8] bg-white px-2 text-[13px] text-slate-900 outline-none transition focus:border-emerald-500';
+const PRIMARY = 'inline-flex h-8 shrink-0 items-center rounded-lg px-3 text-[12px] font-semibold text-white transition disabled:cursor-not-allowed disabled:opacity-50';
+
+// Depot management: list every depot (incl inactive), rename/relocate/(de)activate, add or remove.
+// onChanged lets the truck pickers + board refresh after a change.
+export default function DepotManagerModal({ onClose, onChanged }: { onClose: () => void; onChanged: () => void }) {
+  const toast = useToast();
+  const [depots, setDepots] = useState<OpsDepot[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState(false);
+  const [newName, setNewName] = useState('');
+  const [newLocation, setNewLocation] = useState('');
+
+  useEffect(() => {
+    let active = true;
+    fetch(API, { cache: 'no-store' })
+      .then((r) => r.json())
+      .then((j) => {
+        if (active && j.ok) setDepots(j.data.depots as OpsDepot[]);
+      })
+      .catch(() => {})
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  function patchLocal(id: string, patch: Partial<OpsDepot>) {
+    setDepots((prev) => prev.map((d) => (d.id === id ? { ...d, ...patch } : d)));
+  }
+
+  async function saveDepot(d: OpsDepot) {
+    setBusy(true);
+    try {
+      const r = await fetch(`${API}/${d.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: d.name, location: d.location, active: d.active }),
+      });
+      const j = await r.json();
+      if (!j.ok) return toast.error(j.error || 'Kunde inte spara depån');
+      toast.success('Sparad');
+      onChanged();
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function removeDepot(id: string) {
+    setBusy(true);
+    try {
+      const r = await fetch(`${API}/${id}`, { method: 'DELETE' });
+      const j = await r.json();
+      if (!j.ok) return toast.error(j.error || 'Kunde inte ta bort depån');
+      setDepots((prev) => prev.filter((d) => d.id !== id));
+      onChanged();
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function addDepot(e: FormEvent) {
+    e.preventDefault();
+    if (!newName.trim()) return;
+    setBusy(true);
+    try {
+      const r = await fetch(API, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: newName.trim(), location: newLocation.trim() || null }),
+      });
+      const j = await r.json();
+      if (!j.ok) return toast.error(j.error || 'Kunde inte lägga till depån');
+      setDepots((prev) => [...prev, j.data.item as OpsDepot]);
+      setNewName('');
+      setNewLocation('');
+      onChanged();
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <CrmModal
+      onClose={onClose}
+      ariaLabel="Hantera depåer"
+      maxWidth="sm:max-w-[560px]"
+      header={
+        <div>
+          <h2 className="text-[15px] font-bold text-slate-900">Hantera depåer</h2>
+          <p className="mt-0.5 text-[12px] text-slate-500">Lager där säckarna förvaras. Koppla bilar till en depå under Bilar.</p>
+        </div>
+      }
+      footer={
+        <button type="button" onClick={onClose} className={cn(crm.ghostButton, 'ml-auto')}>
+          Stäng
+        </button>
+      }
+    >
+      {loading ? (
+        <p className="py-8 text-center text-sm text-slate-400">Laddar…</p>
+      ) : (
+        <div className="grid gap-2">
+          {depots.map((d) => (
+            <div key={d.id} className={cn('grid grid-cols-[1fr_1fr_auto_auto] items-center gap-2 rounded-xl border border-[#e0e8dc] bg-white p-2', !d.active && 'opacity-60')}>
+              <input value={d.name} onChange={(e) => patchLocal(d.id, { name: e.target.value })} className={TEXT_INPUT} aria-label="Namn" placeholder="Namn" />
+              <input value={d.location ?? ''} onChange={(e) => patchLocal(d.id, { location: e.target.value })} className={TEXT_INPUT} aria-label="Plats" placeholder="Plats (valfritt)" />
+              <label className="flex shrink-0 items-center gap-1 text-[11px] font-semibold text-slate-500">
+                <input type="checkbox" checked={d.active} onChange={(e) => patchLocal(d.id, { active: e.target.checked })} className="h-3.5 w-3.5 accent-emerald-600" />
+                Aktiv
+              </label>
+              <div className="flex shrink-0 items-center gap-1.5">
+                <button type="button" onClick={() => saveDepot(d)} disabled={busy} className={PRIMARY} style={{ backgroundColor: 'var(--crm-primary)' }}>
+                  Spara
+                </button>
+                <button
+                  type="button"
+                  onClick={() => removeDepot(d.id)}
+                  disabled={busy}
+                  aria-label="Ta bort depå"
+                  className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-[#e0e8dc] bg-white text-slate-400 transition hover:border-rose-300 hover:text-rose-500 disabled:opacity-50"
+                >
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                    <path d="M3 6h18M8 6V4h8v2M19 6l-1 14H6L5 6" />
+                  </svg>
+                </button>
+              </div>
+            </div>
+          ))}
+
+          {depots.length === 0 && <p className="py-2 text-center text-[12px] text-slate-400">Inga depåer upplagda än.</p>}
+
+          <form onSubmit={addDepot} className="mt-1 grid grid-cols-[1fr_1fr_auto] items-center gap-2 rounded-xl border border-dashed border-[#c8d4c3] bg-[#f9fbf7] p-2">
+            <input value={newName} onChange={(e) => setNewName(e.target.value)} placeholder="Ny depå…" className={TEXT_INPUT} aria-label="Namn på ny depå" />
+            <input value={newLocation} onChange={(e) => setNewLocation(e.target.value)} placeholder="Plats (valfritt)" className={TEXT_INPUT} aria-label="Plats" />
+            <button type="submit" disabled={busy || !newName.trim()} className={PRIMARY} style={{ backgroundColor: 'var(--crm-primary)' }}>
+              Lägg till
+            </button>
+          </form>
+        </div>
+      )}
+    </CrmModal>
+  );
+}

--- a/app/crm/planering/DepotManagerModal.tsx
+++ b/app/crm/planering/DepotManagerModal.tsx
@@ -1,95 +1,40 @@
 'use client';
 
-import { useEffect, useState, type FormEvent } from 'react';
+import { useState, type FormEvent } from 'react';
 import { cn } from '@/lib/shared/cn';
-import { useToast } from '@/lib/Toast';
 import { crm } from '@/app/crm/lib/crmTokens';
 import CrmModal from '@/app/crm/components/CrmModal';
+import { useEntityCrud } from './useEntityCrud';
+import { TrashIcon } from './managerModalUi';
 import type { OpsDepot } from '@/lib/domains/planning/types';
 
 const API = '/api/crm/planering/depots';
-const TEXT_INPUT = 'h-9 w-full rounded-lg border border-[#dce4d8] bg-white px-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-2 focus:ring-emerald-500/15';
-const PRIMARY = 'inline-flex h-9 shrink-0 items-center justify-center rounded-lg px-4 text-[13px] font-semibold text-white transition disabled:cursor-not-allowed disabled:opacity-50';
-const DANGER = 'inline-flex h-9 shrink-0 items-center gap-1.5 rounded-lg border border-[#e0e8dc] bg-white px-3 text-[13px] font-semibold text-slate-500 transition hover:border-rose-300 hover:text-rose-600 disabled:cursor-not-allowed disabled:opacity-50';
 
-// Depot management: list every depot (incl inactive), rename/relocate/(de)activate, add or remove.
-// onChanged lets the truck pickers + board refresh after a change.
+// Depot management: rename/relocate/(de)activate, add or remove. onChanged refreshes the truck
+// pickers + board after a change.
 export default function DepotManagerModal({ onClose, onChanged }: { onClose: () => void; onChanged: () => void }) {
-  const toast = useToast();
-  const [depots, setDepots] = useState<OpsDepot[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [busy, setBusy] = useState(false);
+  const { items: depots, loading, busy, patchLocal, save, remove, add } = useEntityCrud<OpsDepot>({
+    api: API,
+    listKey: 'depots',
+    toPayload: (d) => ({ name: d.name, location: d.location, active: d.active }),
+    labels: { saveFail: 'Kunde inte spara depån', removeFail: 'Kunde inte ta bort depån', addFail: 'Kunde inte lägga till depån' },
+  });
   const [newName, setNewName] = useState('');
   const [newLocation, setNewLocation] = useState('');
 
-  useEffect(() => {
-    let active = true;
-    fetch(API, { cache: 'no-store' })
-      .then((r) => r.json())
-      .then((j) => {
-        if (active && j.ok) setDepots(j.data.depots as OpsDepot[]);
-      })
-      .catch(() => {})
-      .finally(() => {
-        if (active) setLoading(false);
-      });
-    return () => {
-      active = false;
-    };
-  }, []);
-
-  function patchLocal(id: string, patch: Partial<OpsDepot>) {
-    setDepots((prev) => prev.map((d) => (d.id === id ? { ...d, ...patch } : d)));
+  async function onSave(d: OpsDepot) {
+    if (await save(d)) onChanged();
   }
-
-  async function saveDepot(d: OpsDepot) {
-    setBusy(true);
-    try {
-      const r = await fetch(`${API}/${d.id}`, {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name: d.name, location: d.location, active: d.active }),
-      });
-      const j = await r.json();
-      if (!j.ok) return toast.error(j.error || 'Kunde inte spara depån');
-      toast.success('Sparad');
-      onChanged();
-    } finally {
-      setBusy(false);
-    }
+  async function onRemove(id: string) {
+    if (await remove(id)) onChanged();
   }
-
-  async function removeDepot(id: string) {
-    setBusy(true);
-    try {
-      const r = await fetch(`${API}/${id}`, { method: 'DELETE' });
-      const j = await r.json();
-      if (!j.ok) return toast.error(j.error || 'Kunde inte ta bort depån');
-      setDepots((prev) => prev.filter((d) => d.id !== id));
-      onChanged();
-    } finally {
-      setBusy(false);
-    }
-  }
-
-  async function addDepot(e: FormEvent) {
+  async function onAdd(e: FormEvent) {
     e.preventDefault();
     if (!newName.trim()) return;
-    setBusy(true);
-    try {
-      const r = await fetch(API, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name: newName.trim(), location: newLocation.trim() || null }),
-      });
-      const j = await r.json();
-      if (!j.ok) return toast.error(j.error || 'Kunde inte lägga till depån');
-      setDepots((prev) => [...prev, j.data.item as OpsDepot]);
+    if (await add({ name: newName.trim(), location: newLocation.trim() || null })) {
       setNewName('');
       setNewLocation('');
       onChanged();
-    } finally {
-      setBusy(false);
     }
   }
 
@@ -117,8 +62,8 @@ export default function DepotManagerModal({ onClose, onChanged }: { onClose: () 
           {depots.map((d) => (
             <div key={d.id} className={cn('rounded-xl border border-[#e0e8dc] bg-white p-3', !d.active && 'opacity-60')}>
               <div className="grid grid-cols-2 gap-2.5">
-                <input value={d.name} onChange={(e) => patchLocal(d.id, { name: e.target.value })} className={TEXT_INPUT} placeholder="Namn" aria-label="Namn" />
-                <input value={d.location ?? ''} onChange={(e) => patchLocal(d.id, { location: e.target.value })} className={TEXT_INPUT} placeholder="Plats (valfritt)" aria-label="Plats" />
+                <input value={d.name} onChange={(e) => patchLocal(d.id, { name: e.target.value })} className={crm.input} placeholder="Namn" aria-label="Namn" />
+                <input value={d.location ?? ''} onChange={(e) => patchLocal(d.id, { location: e.target.value })} className={crm.input} placeholder="Plats (valfritt)" aria-label="Plats" />
               </div>
               <div className="mt-3 flex items-center justify-between gap-2 border-t border-[#eef3eb] pt-2.5">
                 <label className="flex h-9 cursor-pointer select-none items-center gap-2 rounded-lg border border-[#e0e8dc] bg-[#f9fbf7] px-3 text-[13px] font-semibold text-slate-600">
@@ -126,13 +71,11 @@ export default function DepotManagerModal({ onClose, onChanged }: { onClose: () 
                   Aktiv
                 </label>
                 <div className="flex items-center gap-2">
-                  <button type="button" onClick={() => removeDepot(d.id)} disabled={busy} className={DANGER}>
-                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                      <path d="M3 6h18M8 6V4h8v2M19 6l-1 14H6L5 6" />
-                    </svg>
+                  <button type="button" onClick={() => onRemove(d.id)} disabled={busy} className={crm.dangerButton}>
+                    <TrashIcon />
                     Ta bort
                   </button>
-                  <button type="button" onClick={() => saveDepot(d)} disabled={busy} className={PRIMARY} style={{ backgroundColor: 'var(--crm-primary)' }}>
+                  <button type="button" onClick={() => onSave(d)} disabled={busy} className={crm.formButton} style={{ backgroundColor: 'var(--crm-primary)' }}>
                     Spara
                   </button>
                 </div>
@@ -142,12 +85,12 @@ export default function DepotManagerModal({ onClose, onChanged }: { onClose: () 
 
           {depots.length === 0 && <p className="py-2 text-center text-[13px] text-slate-400">Inga depåer upplagda än.</p>}
 
-          <form onSubmit={addDepot} className="rounded-xl border border-dashed border-[#c8d4c3] bg-[#f9fbf7] p-3">
+          <form onSubmit={onAdd} className="rounded-xl border border-dashed border-[#c8d4c3] bg-[#f9fbf7] p-3">
             <p className="mb-2 px-0.5 text-[11px] font-bold uppercase tracking-wide text-slate-400">Lägg till ny depå</p>
             <div className="grid grid-cols-[1fr_1fr_auto] items-center gap-2.5">
-              <input value={newName} onChange={(e) => setNewName(e.target.value)} placeholder="Namn…" className={TEXT_INPUT} aria-label="Namn på ny depå" />
-              <input value={newLocation} onChange={(e) => setNewLocation(e.target.value)} placeholder="Plats (valfritt)" className={TEXT_INPUT} aria-label="Plats" />
-              <button type="submit" disabled={busy || !newName.trim()} className={PRIMARY} style={{ backgroundColor: 'var(--crm-primary)' }}>
+              <input value={newName} onChange={(e) => setNewName(e.target.value)} placeholder="Namn…" className={crm.input} aria-label="Namn på ny depå" />
+              <input value={newLocation} onChange={(e) => setNewLocation(e.target.value)} placeholder="Plats (valfritt)" className={crm.input} aria-label="Plats" />
+              <button type="submit" disabled={busy || !newName.trim()} className={crm.formButton} style={{ backgroundColor: 'var(--crm-primary)' }}>
                 Lägg till
               </button>
             </div>

--- a/app/crm/planering/DepotManagerModal.tsx
+++ b/app/crm/planering/DepotManagerModal.tsx
@@ -8,8 +8,9 @@ import CrmModal from '@/app/crm/components/CrmModal';
 import type { OpsDepot } from '@/lib/domains/planning/types';
 
 const API = '/api/crm/planering/depots';
-const TEXT_INPUT = 'h-8 w-full rounded-lg border border-[#dce4d8] bg-white px-2 text-[13px] text-slate-900 outline-none transition focus:border-emerald-500';
-const PRIMARY = 'inline-flex h-8 shrink-0 items-center rounded-lg px-3 text-[12px] font-semibold text-white transition disabled:cursor-not-allowed disabled:opacity-50';
+const TEXT_INPUT = 'h-9 w-full rounded-lg border border-[#dce4d8] bg-white px-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-2 focus:ring-emerald-500/15';
+const PRIMARY = 'inline-flex h-9 shrink-0 items-center justify-center rounded-lg px-4 text-[13px] font-semibold text-white transition disabled:cursor-not-allowed disabled:opacity-50';
+const DANGER = 'inline-flex h-9 shrink-0 items-center gap-1.5 rounded-lg border border-[#e0e8dc] bg-white px-3 text-[13px] font-semibold text-slate-500 transition hover:border-rose-300 hover:text-rose-600 disabled:cursor-not-allowed disabled:opacity-50';
 
 // Depot management: list every depot (incl inactive), rename/relocate/(de)activate, add or remove.
 // onChanged lets the truck pickers + board refresh after a change.
@@ -112,42 +113,44 @@ export default function DepotManagerModal({ onClose, onChanged }: { onClose: () 
       {loading ? (
         <p className="py-8 text-center text-sm text-slate-400">Laddar…</p>
       ) : (
-        <div className="grid gap-2">
+        <div className="grid gap-3">
           {depots.map((d) => (
-            <div key={d.id} className={cn('grid grid-cols-[1fr_1fr_auto_auto] items-center gap-2 rounded-xl border border-[#e0e8dc] bg-white p-2', !d.active && 'opacity-60')}>
-              <input value={d.name} onChange={(e) => patchLocal(d.id, { name: e.target.value })} className={TEXT_INPUT} aria-label="Namn" placeholder="Namn" />
-              <input value={d.location ?? ''} onChange={(e) => patchLocal(d.id, { location: e.target.value })} className={TEXT_INPUT} aria-label="Plats" placeholder="Plats (valfritt)" />
-              <label className="flex shrink-0 items-center gap-1 text-[11px] font-semibold text-slate-500">
-                <input type="checkbox" checked={d.active} onChange={(e) => patchLocal(d.id, { active: e.target.checked })} className="h-3.5 w-3.5 accent-emerald-600" />
-                Aktiv
-              </label>
-              <div className="flex shrink-0 items-center gap-1.5">
-                <button type="button" onClick={() => saveDepot(d)} disabled={busy} className={PRIMARY} style={{ backgroundColor: 'var(--crm-primary)' }}>
-                  Spara
-                </button>
-                <button
-                  type="button"
-                  onClick={() => removeDepot(d.id)}
-                  disabled={busy}
-                  aria-label="Ta bort depå"
-                  className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-[#e0e8dc] bg-white text-slate-400 transition hover:border-rose-300 hover:text-rose-500 disabled:opacity-50"
-                >
-                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                    <path d="M3 6h18M8 6V4h8v2M19 6l-1 14H6L5 6" />
-                  </svg>
-                </button>
+            <div key={d.id} className={cn('rounded-xl border border-[#e0e8dc] bg-white p-3', !d.active && 'opacity-60')}>
+              <div className="grid grid-cols-2 gap-2.5">
+                <input value={d.name} onChange={(e) => patchLocal(d.id, { name: e.target.value })} className={TEXT_INPUT} placeholder="Namn" aria-label="Namn" />
+                <input value={d.location ?? ''} onChange={(e) => patchLocal(d.id, { location: e.target.value })} className={TEXT_INPUT} placeholder="Plats (valfritt)" aria-label="Plats" />
+              </div>
+              <div className="mt-3 flex items-center justify-between gap-2 border-t border-[#eef3eb] pt-2.5">
+                <label className="flex h-9 cursor-pointer select-none items-center gap-2 rounded-lg border border-[#e0e8dc] bg-[#f9fbf7] px-3 text-[13px] font-semibold text-slate-600">
+                  <input type="checkbox" checked={d.active} onChange={(e) => patchLocal(d.id, { active: e.target.checked })} className="h-4 w-4 accent-emerald-600" />
+                  Aktiv
+                </label>
+                <div className="flex items-center gap-2">
+                  <button type="button" onClick={() => removeDepot(d.id)} disabled={busy} className={DANGER}>
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                      <path d="M3 6h18M8 6V4h8v2M19 6l-1 14H6L5 6" />
+                    </svg>
+                    Ta bort
+                  </button>
+                  <button type="button" onClick={() => saveDepot(d)} disabled={busy} className={PRIMARY} style={{ backgroundColor: 'var(--crm-primary)' }}>
+                    Spara
+                  </button>
+                </div>
               </div>
             </div>
           ))}
 
-          {depots.length === 0 && <p className="py-2 text-center text-[12px] text-slate-400">Inga depåer upplagda än.</p>}
+          {depots.length === 0 && <p className="py-2 text-center text-[13px] text-slate-400">Inga depåer upplagda än.</p>}
 
-          <form onSubmit={addDepot} className="mt-1 grid grid-cols-[1fr_1fr_auto] items-center gap-2 rounded-xl border border-dashed border-[#c8d4c3] bg-[#f9fbf7] p-2">
-            <input value={newName} onChange={(e) => setNewName(e.target.value)} placeholder="Ny depå…" className={TEXT_INPUT} aria-label="Namn på ny depå" />
-            <input value={newLocation} onChange={(e) => setNewLocation(e.target.value)} placeholder="Plats (valfritt)" className={TEXT_INPUT} aria-label="Plats" />
-            <button type="submit" disabled={busy || !newName.trim()} className={PRIMARY} style={{ backgroundColor: 'var(--crm-primary)' }}>
-              Lägg till
-            </button>
+          <form onSubmit={addDepot} className="rounded-xl border border-dashed border-[#c8d4c3] bg-[#f9fbf7] p-3">
+            <p className="mb-2 px-0.5 text-[11px] font-bold uppercase tracking-wide text-slate-400">Lägg till ny depå</p>
+            <div className="grid grid-cols-[1fr_1fr_auto] items-center gap-2.5">
+              <input value={newName} onChange={(e) => setNewName(e.target.value)} placeholder="Namn…" className={TEXT_INPUT} aria-label="Namn på ny depå" />
+              <input value={newLocation} onChange={(e) => setNewLocation(e.target.value)} placeholder="Plats (valfritt)" className={TEXT_INPUT} aria-label="Plats" />
+              <button type="submit" disabled={busy || !newName.trim()} className={PRIMARY} style={{ backgroundColor: 'var(--crm-primary)' }}>
+                Lägg till
+              </button>
+            </div>
           </form>
         </div>
       )}

--- a/app/crm/planering/DepotStockModal.tsx
+++ b/app/crm/planering/DepotStockModal.tsx
@@ -10,7 +10,8 @@ import type { DepotBalance } from '@/lib/domains/planning/depotStock';
 
 const STOCK_API = '/api/crm/planering/depot-stock';
 const DELIVERIES_API = '/api/crm/planering/depot-deliveries';
-const FIELD = 'h-8 rounded-lg border border-[#dce4d8] bg-white px-2 text-[13px] text-slate-900 outline-none transition focus:border-emerald-500';
+const FIELD = 'h-9 w-full rounded-lg border border-[#dce4d8] bg-white px-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-2 focus:ring-emerald-500/15';
+const PRIMARY = 'inline-flex h-9 shrink-0 items-center justify-center rounded-lg px-4 text-[13px] font-semibold text-white transition disabled:cursor-not-allowed disabled:opacity-50';
 
 function balanceClass(balance: number): string {
   if (balance < 0) return 'text-rose-600';
@@ -91,29 +92,29 @@ export default function DepotStockModal({ canWrite, onClose }: { canWrite: boole
       ) : (
         <div className="grid gap-4">
           {canWrite && (
-            <form onSubmit={record} className="grid gap-2 rounded-xl border border-dashed border-[#c8d4c3] bg-[#f9fbf7] p-3">
-              <p className="text-[12px] font-semibold text-slate-600">Registrera leverans</p>
-              <div className="flex flex-wrap items-center gap-2">
-                <select value={depotId} onChange={(e) => setDepotId(e.target.value)} aria-label="Depå" className={cn(FIELD, 'min-w-[120px] flex-1')}>
+            <form onSubmit={record} className="grid gap-2.5 rounded-xl border border-dashed border-[#c8d4c3] bg-[#f9fbf7] p-3">
+              <p className="px-0.5 text-[11px] font-bold uppercase tracking-wide text-slate-400">Registrera leverans</p>
+              <div className="grid grid-cols-2 gap-2.5">
+                <select value={depotId} onChange={(e) => setDepotId(e.target.value)} aria-label="Depå" className={FIELD}>
                   {depots.length === 0 && <option value="">Ingen depå</option>}
                   {depots.map((d) => (
                     <option key={d.depot_id} value={d.depot_id}>{d.depot_name}</option>
                   ))}
                 </select>
-                <select value={material} onChange={(e) => setMaterial(e.target.value)} aria-label="Material" className={cn(FIELD, 'min-w-[130px] flex-1')}>
+                <select value={material} onChange={(e) => setMaterial(e.target.value)} aria-label="Material" className={FIELD}>
                   {MATERIAL_SHORTS.map((m) => (
                     <option key={m} value={m}>{m}</option>
                   ))}
                 </select>
-                <input type="number" min={1} value={sacks} onChange={(e) => setSacks(e.target.value)} placeholder="Säckar" aria-label="Antal säckar" className={cn(FIELD, 'w-[88px]')} />
-                <input type="date" value={deliveredOn} onChange={(e) => setDeliveredOn(e.target.value)} aria-label="Datum" className={cn(FIELD, 'w-[140px] tabular-nums')} />
+                <input type="number" min={1} value={sacks} onChange={(e) => setSacks(e.target.value)} placeholder="Antal säckar" aria-label="Antal säckar" className={FIELD} />
+                <input type="date" value={deliveredOn} onChange={(e) => setDeliveredOn(e.target.value)} aria-label="Datum" className={cn(FIELD, 'tabular-nums')} />
               </div>
-              <div className="flex items-center gap-2">
-                <input value={note} onChange={(e) => setNote(e.target.value)} placeholder="Notering (valfritt)" aria-label="Notering" className={cn(FIELD, 'flex-1')} />
+              <div className="grid grid-cols-[1fr_auto] gap-2.5">
+                <input value={note} onChange={(e) => setNote(e.target.value)} placeholder="Notering (valfritt)" aria-label="Notering" className={FIELD} />
                 <button
                   type="submit"
                   disabled={busy || !depotId || !(Number(sacks) > 0)}
-                  className="inline-flex h-8 shrink-0 items-center rounded-lg px-3.5 text-[12px] font-semibold text-white transition disabled:cursor-not-allowed disabled:opacity-50"
+                  className={PRIMARY}
                   style={{ backgroundColor: 'var(--crm-primary)' }}
                 >
                   Registrera

--- a/app/crm/planering/DepotStockModal.tsx
+++ b/app/crm/planering/DepotStockModal.tsx
@@ -1,0 +1,170 @@
+'use client';
+
+import { useEffect, useState, type FormEvent } from 'react';
+import { cn } from '@/lib/shared/cn';
+import { useToast } from '@/lib/Toast';
+import { crm } from '@/app/crm/lib/crmTokens';
+import CrmModal from '@/app/crm/components/CrmModal';
+import { MATERIAL_SHORTS } from '@/lib/domains/crm/materials';
+import type { DepotBalance } from '@/lib/domains/planning/depotStock';
+
+const STOCK_API = '/api/crm/planering/depot-stock';
+const DELIVERIES_API = '/api/crm/planering/depot-deliveries';
+const FIELD = 'h-8 rounded-lg border border-[#dce4d8] bg-white px-2 text-[13px] text-slate-900 outline-none transition focus:border-emerald-500';
+
+function balanceClass(balance: number): string {
+  if (balance < 0) return 'text-rose-600';
+  if (balance === 0) return 'text-amber-600';
+  return 'text-emerald-700';
+}
+
+// Depot stock view: per-depot, per-material balance (deliveries − derived consumption) + a form to
+// record a new delivery. Consumption stays 0 until the installer sack-reporting flow populates it.
+export default function DepotStockModal({ canWrite, onClose }: { canWrite: boolean; onClose: () => void }) {
+  const toast = useToast();
+  const [depots, setDepots] = useState<DepotBalance[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState(false);
+
+  const today = new Date().toISOString().slice(0, 10);
+  const [depotId, setDepotId] = useState('');
+  const [material, setMaterial] = useState(MATERIAL_SHORTS[0] ?? '');
+  const [sacks, setSacks] = useState('');
+  const [deliveredOn, setDeliveredOn] = useState(today);
+  const [note, setNote] = useState('');
+
+  async function load() {
+    const r = await fetch(STOCK_API, { cache: 'no-store' });
+    const j = await r.json();
+    if (j.ok) {
+      const list = j.data.depots as DepotBalance[];
+      setDepots(list);
+      if (!depotId && list.length) setDepotId(list[0].depot_id);
+    }
+  }
+
+  useEffect(() => {
+    load().finally(() => setLoading(false));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  async function record(e: FormEvent) {
+    e.preventDefault();
+    if (!depotId || !material || !(Number(sacks) > 0)) return;
+    setBusy(true);
+    try {
+      const r = await fetch(DELIVERIES_API, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ depot_id: depotId, material, sacks: Number(sacks), delivered_on: deliveredOn, note: note.trim() || null }),
+      });
+      const j = await r.json();
+      if (!j.ok) return toast.error(j.error || 'Kunde inte registrera leveransen');
+      toast.success('Leverans registrerad');
+      setSacks('');
+      setNote('');
+      await load();
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <CrmModal
+      onClose={onClose}
+      ariaLabel="Lager"
+      maxWidth="sm:max-w-[600px]"
+      header={
+        <div>
+          <h2 className="text-[15px] font-bold text-slate-900">Lager</h2>
+          <p className="mt-0.5 text-[12px] text-slate-500">Saldo per depå och material (leveranser − förbrukning).</p>
+        </div>
+      }
+      footer={
+        <button type="button" onClick={onClose} className={cn(crm.ghostButton, 'ml-auto')}>
+          Stäng
+        </button>
+      }
+    >
+      {loading ? (
+        <p className="py-8 text-center text-sm text-slate-400">Laddar…</p>
+      ) : (
+        <div className="grid gap-4">
+          {canWrite && (
+            <form onSubmit={record} className="grid gap-2 rounded-xl border border-dashed border-[#c8d4c3] bg-[#f9fbf7] p-3">
+              <p className="text-[12px] font-semibold text-slate-600">Registrera leverans</p>
+              <div className="flex flex-wrap items-center gap-2">
+                <select value={depotId} onChange={(e) => setDepotId(e.target.value)} aria-label="Depå" className={cn(FIELD, 'min-w-[120px] flex-1')}>
+                  {depots.length === 0 && <option value="">Ingen depå</option>}
+                  {depots.map((d) => (
+                    <option key={d.depot_id} value={d.depot_id}>{d.depot_name}</option>
+                  ))}
+                </select>
+                <select value={material} onChange={(e) => setMaterial(e.target.value)} aria-label="Material" className={cn(FIELD, 'min-w-[130px] flex-1')}>
+                  {MATERIAL_SHORTS.map((m) => (
+                    <option key={m} value={m}>{m}</option>
+                  ))}
+                </select>
+                <input type="number" min={1} value={sacks} onChange={(e) => setSacks(e.target.value)} placeholder="Säckar" aria-label="Antal säckar" className={cn(FIELD, 'w-[88px]')} />
+                <input type="date" value={deliveredOn} onChange={(e) => setDeliveredOn(e.target.value)} aria-label="Datum" className={cn(FIELD, 'w-[140px] tabular-nums')} />
+              </div>
+              <div className="flex items-center gap-2">
+                <input value={note} onChange={(e) => setNote(e.target.value)} placeholder="Notering (valfritt)" aria-label="Notering" className={cn(FIELD, 'flex-1')} />
+                <button
+                  type="submit"
+                  disabled={busy || !depotId || !(Number(sacks) > 0)}
+                  className="inline-flex h-8 shrink-0 items-center rounded-lg px-3.5 text-[12px] font-semibold text-white transition disabled:cursor-not-allowed disabled:opacity-50"
+                  style={{ backgroundColor: 'var(--crm-primary)' }}
+                >
+                  Registrera
+                </button>
+              </div>
+            </form>
+          )}
+
+          {depots.length === 0 ? (
+            <p className="py-4 text-center text-[12px] text-slate-400">Inga depåer upplagda än. Lägg till under Depåer.</p>
+          ) : (
+            <div className="grid gap-2.5">
+              {depots.map((d) => (
+                <div key={d.depot_id} className="rounded-xl border border-[#e0e8dc] bg-white p-3">
+                  <div className="mb-1.5 flex items-baseline justify-between">
+                    <span className="text-[13px] font-bold text-slate-800">{d.depot_name}</span>
+                    <span className={cn('text-[12px] font-bold tabular-nums', balanceClass(d.total_balance))}>{d.total_balance} säck</span>
+                  </div>
+                  {d.rows.length === 0 ? (
+                    <p className="text-[11px] text-slate-400">Inga rörelser än.</p>
+                  ) : (
+                    <table className="w-full text-[11.5px]">
+                      <thead>
+                        <tr className="text-left text-[10px] uppercase tracking-wide text-slate-400">
+                          <th className="font-semibold">Material</th>
+                          <th className="text-right font-semibold">Levererat</th>
+                          <th className="text-right font-semibold">Förbrukat</th>
+                          <th className="text-right font-semibold">Saldo</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {d.rows.map((r) => (
+                          <tr key={r.material} className="border-t border-[#eef3eb]">
+                            <td className="py-1 font-semibold text-slate-700">{r.material}</td>
+                            <td className="py-1 text-right tabular-nums text-slate-500">{r.delivered}</td>
+                            <td className="py-1 text-right tabular-nums text-slate-500">{r.consumed}</td>
+                            <td className={cn('py-1 text-right font-bold tabular-nums', balanceClass(r.balance))}>{r.balance}</td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  )}
+                </div>
+              ))}
+              <p className="text-[10.5px] text-slate-400">
+                Förbrukning fylls i automatiskt när installatörernas säckrapportering är på plats.
+              </p>
+            </div>
+          )}
+        </div>
+      )}
+    </CrmModal>
+  );
+}

--- a/app/crm/planering/DepotStockModal.tsx
+++ b/app/crm/planering/DepotStockModal.tsx
@@ -128,9 +128,14 @@ export default function DepotStockModal({ canWrite, onClose }: { canWrite: boole
             <div className="grid gap-2.5">
               {depots.map((d) => (
                 <div key={d.depot_id} className="rounded-xl border border-[#e0e8dc] bg-white p-3">
-                  <div className="mb-1.5 flex items-baseline justify-between">
-                    <span className="text-[13px] font-bold text-slate-800">{d.depot_name}</span>
-                    <span className={cn('text-[12px] font-bold tabular-nums', balanceClass(d.total_balance))}>{d.total_balance} säck</span>
+                  <div className="mb-1.5 flex items-baseline justify-between gap-2">
+                    <span className="flex items-center gap-2">
+                      <span className="text-[13px] font-bold text-slate-800">{d.depot_name}</span>
+                      {d.rows.some((r) => r.balance < 0) && (
+                        <span className="rounded-full border border-rose-200 bg-rose-50 px-2 py-px text-[9px] font-bold text-rose-700">Underskott</span>
+                      )}
+                    </span>
+                    <span className={cn('shrink-0 text-[12px] font-bold tabular-nums', balanceClass(d.total_balance))}>{d.total_balance} säck</span>
                   </div>
                   {d.rows.length === 0 ? (
                     <p className="text-[11px] text-slate-400">Inga rörelser än.</p>

--- a/app/crm/planering/DepotStockModal.tsx
+++ b/app/crm/planering/DepotStockModal.tsx
@@ -10,8 +10,8 @@ import type { DepotBalance } from '@/lib/domains/planning/depotStock';
 
 const STOCK_API = '/api/crm/planering/depot-stock';
 const DELIVERIES_API = '/api/crm/planering/depot-deliveries';
-const FIELD = 'h-9 w-full rounded-lg border border-[#dce4d8] bg-white px-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-2 focus:ring-emerald-500/15';
-const PRIMARY = 'inline-flex h-9 shrink-0 items-center justify-center rounded-lg px-4 text-[13px] font-semibold text-white transition disabled:cursor-not-allowed disabled:opacity-50';
+const FIELD = crm.input;
+const PRIMARY = crm.formButton;
 
 function balanceClass(balance: number): string {
   if (balance < 0) return 'text-rose-600';

--- a/app/crm/planering/JobTypeManagerModal.tsx
+++ b/app/crm/planering/JobTypeManagerModal.tsx
@@ -8,9 +8,10 @@ import CrmModal from '@/app/crm/components/CrmModal';
 import type { JobTypeRow } from '@/lib/domains/planning/jobTypes';
 
 const API = '/api/crm/planering/job-types';
-const COLOR_INPUT = 'h-8 w-9 shrink-0 cursor-pointer rounded-lg border border-[#dce4d8] bg-white p-0.5';
-const TEXT_INPUT = 'h-8 flex-1 rounded-lg border border-[#dce4d8] bg-white px-2 text-[13px] text-slate-900 outline-none transition focus:border-emerald-500';
-const PRIMARY = 'inline-flex h-8 shrink-0 items-center rounded-lg px-3 text-[12px] font-semibold text-white transition disabled:cursor-not-allowed disabled:opacity-50';
+const COLOR_INPUT = 'h-9 w-full cursor-pointer rounded-lg border border-[#dce4d8] bg-white p-1';
+const TEXT_INPUT = 'h-9 w-full rounded-lg border border-[#dce4d8] bg-white px-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-2 focus:ring-emerald-500/15';
+const PRIMARY = 'inline-flex h-9 shrink-0 items-center justify-center rounded-lg px-4 text-[13px] font-semibold text-white transition disabled:cursor-not-allowed disabled:opacity-50';
+const DANGER = 'inline-flex h-9 shrink-0 items-center gap-1.5 rounded-lg border border-[#e0e8dc] bg-white px-3 text-[13px] font-semibold text-slate-500 transition hover:border-rose-300 hover:text-rose-600 disabled:cursor-not-allowed disabled:opacity-50';
 
 // Job-type management: rename, recolor, (de)activate or add/remove job types. The key is stable
 // (shown read-only). onChanged refreshes the board's picker + chips.
@@ -112,40 +113,44 @@ export default function JobTypeManagerModal({ onClose, onChanged }: { onClose: (
       {loading ? (
         <p className="py-8 text-center text-sm text-slate-400">Laddar…</p>
       ) : (
-        <div className="grid gap-2">
+        <div className="grid gap-3">
           {types.map((t) => (
-            <div key={t.id} className={cn('flex items-center gap-2 rounded-xl border border-[#e0e8dc] bg-white p-2', !t.active && 'opacity-60')}>
-              <input type="color" value={t.color} onChange={(e) => patchLocal(t.id, { color: e.target.value })} className={COLOR_INPUT} aria-label="Färg" />
-              <input value={t.label} onChange={(e) => patchLocal(t.id, { label: e.target.value })} className={TEXT_INPUT} aria-label="Namn" />
-              <label className="flex shrink-0 items-center gap-1 text-[11px] font-semibold text-slate-500">
-                <input type="checkbox" checked={t.active} onChange={(e) => patchLocal(t.id, { active: e.target.checked })} className="h-3.5 w-3.5 accent-emerald-600" />
-                Aktiv
-              </label>
-              <button type="button" onClick={() => saveType(t)} disabled={busy} className={PRIMARY} style={{ backgroundColor: 'var(--crm-primary)' }}>
-                Spara
-              </button>
-              <button
-                type="button"
-                onClick={() => removeType(t.id)}
-                disabled={busy}
-                aria-label="Ta bort jobbtyp"
-                className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-[#e0e8dc] bg-white text-slate-400 transition hover:border-rose-300 hover:text-rose-500 disabled:opacity-50"
-              >
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                  <path d="M3 6h18M8 6V4h8v2M19 6l-1 14H6L5 6" />
-                </svg>
-              </button>
+            <div key={t.id} className={cn('rounded-xl border border-[#e0e8dc] bg-white p-3', !t.active && 'opacity-60')}>
+              <div className="grid grid-cols-[2.5rem_1fr] items-center gap-2.5">
+                <input type="color" value={t.color} onChange={(e) => patchLocal(t.id, { color: e.target.value })} className={COLOR_INPUT} aria-label="Färg" />
+                <input value={t.label} onChange={(e) => patchLocal(t.id, { label: e.target.value })} className={TEXT_INPUT} placeholder="Jobbtypens namn" aria-label="Namn" />
+              </div>
+              <div className="mt-3 flex items-center justify-between gap-2 border-t border-[#eef3eb] pt-2.5">
+                <label className="flex h-9 cursor-pointer select-none items-center gap-2 rounded-lg border border-[#e0e8dc] bg-[#f9fbf7] px-3 text-[13px] font-semibold text-slate-600">
+                  <input type="checkbox" checked={t.active} onChange={(e) => patchLocal(t.id, { active: e.target.checked })} className="h-4 w-4 accent-emerald-600" />
+                  Aktiv
+                </label>
+                <div className="flex items-center gap-2">
+                  <button type="button" onClick={() => removeType(t.id)} disabled={busy} className={DANGER}>
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                      <path d="M3 6h18M8 6V4h8v2M19 6l-1 14H6L5 6" />
+                    </svg>
+                    Ta bort
+                  </button>
+                  <button type="button" onClick={() => saveType(t)} disabled={busy} className={PRIMARY} style={{ backgroundColor: 'var(--crm-primary)' }}>
+                    Spara
+                  </button>
+                </div>
+              </div>
             </div>
           ))}
 
-          {types.length === 0 && <p className="py-2 text-center text-[12px] text-slate-400">Inga jobbtyper upplagda än.</p>}
+          {types.length === 0 && <p className="py-2 text-center text-[13px] text-slate-400">Inga jobbtyper upplagda än.</p>}
 
-          <form onSubmit={addType} className="mt-1 flex items-center gap-2 rounded-xl border border-dashed border-[#c8d4c3] bg-[#f9fbf7] p-2">
-            <input type="color" value={newColor} onChange={(e) => setNewColor(e.target.value)} className={COLOR_INPUT} aria-label="Färg" />
-            <input value={newLabel} onChange={(e) => setNewLabel(e.target.value)} placeholder="Ny jobbtyp…" className={TEXT_INPUT} aria-label="Namn på ny jobbtyp" />
-            <button type="submit" disabled={busy || !newLabel.trim()} className={PRIMARY} style={{ backgroundColor: 'var(--crm-primary)' }}>
-              Lägg till
-            </button>
+          <form onSubmit={addType} className="rounded-xl border border-dashed border-[#c8d4c3] bg-[#f9fbf7] p-3">
+            <p className="mb-2 px-0.5 text-[11px] font-bold uppercase tracking-wide text-slate-400">Lägg till ny jobbtyp</p>
+            <div className="grid grid-cols-[2.5rem_1fr_auto] items-center gap-2.5">
+              <input type="color" value={newColor} onChange={(e) => setNewColor(e.target.value)} className={COLOR_INPUT} aria-label="Färg" />
+              <input value={newLabel} onChange={(e) => setNewLabel(e.target.value)} placeholder="Jobbtypens namn…" className={TEXT_INPUT} aria-label="Namn på ny jobbtyp" />
+              <button type="submit" disabled={busy || !newLabel.trim()} className={PRIMARY} style={{ backgroundColor: 'var(--crm-primary)' }}>
+                Lägg till
+              </button>
+            </div>
           </form>
         </div>
       )}

--- a/app/crm/planering/JobTypeManagerModal.tsx
+++ b/app/crm/planering/JobTypeManagerModal.tsx
@@ -1,0 +1,154 @@
+'use client';
+
+import { useEffect, useState, type FormEvent } from 'react';
+import { cn } from '@/lib/shared/cn';
+import { useToast } from '@/lib/Toast';
+import { crm } from '@/app/crm/lib/crmTokens';
+import CrmModal from '@/app/crm/components/CrmModal';
+import type { JobTypeRow } from '@/lib/domains/planning/jobTypes';
+
+const API = '/api/crm/planering/job-types';
+const COLOR_INPUT = 'h-8 w-9 shrink-0 cursor-pointer rounded-lg border border-[#dce4d8] bg-white p-0.5';
+const TEXT_INPUT = 'h-8 flex-1 rounded-lg border border-[#dce4d8] bg-white px-2 text-[13px] text-slate-900 outline-none transition focus:border-emerald-500';
+const PRIMARY = 'inline-flex h-8 shrink-0 items-center rounded-lg px-3 text-[12px] font-semibold text-white transition disabled:cursor-not-allowed disabled:opacity-50';
+
+// Job-type management: rename, recolor, (de)activate or add/remove job types. The key is stable
+// (shown read-only). onChanged refreshes the board's picker + chips.
+export default function JobTypeManagerModal({ onClose, onChanged }: { onClose: () => void; onChanged: () => void }) {
+  const toast = useToast();
+  const [types, setTypes] = useState<JobTypeRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState(false);
+  const [newLabel, setNewLabel] = useState('');
+  const [newColor, setNewColor] = useState('#0d9488');
+
+  useEffect(() => {
+    let active = true;
+    fetch(API, { cache: 'no-store' })
+      .then((r) => r.json())
+      .then((j) => {
+        if (active && j.ok) setTypes(j.data.jobTypes as JobTypeRow[]);
+      })
+      .catch(() => {})
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  function patchLocal(id: string, patch: Partial<JobTypeRow>) {
+    setTypes((prev) => prev.map((t) => (t.id === id ? { ...t, ...patch } : t)));
+  }
+
+  async function saveType(t: JobTypeRow) {
+    setBusy(true);
+    try {
+      const r = await fetch(`${API}/${t.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ label: t.label, color: t.color, active: t.active }),
+      });
+      const j = await r.json();
+      if (!j.ok) return toast.error(j.error || 'Kunde inte spara jobbtypen');
+      toast.success('Sparad');
+      onChanged();
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function removeType(id: string) {
+    setBusy(true);
+    try {
+      const r = await fetch(`${API}/${id}`, { method: 'DELETE' });
+      const j = await r.json();
+      if (!j.ok) return toast.error(j.error || 'Kunde inte ta bort jobbtypen');
+      setTypes((prev) => prev.filter((t) => t.id !== id));
+      onChanged();
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function addType(e: FormEvent) {
+    e.preventDefault();
+    if (!newLabel.trim()) return;
+    setBusy(true);
+    try {
+      const r = await fetch(API, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ label: newLabel.trim(), color: newColor }),
+      });
+      const j = await r.json();
+      if (!j.ok) return toast.error(j.error || 'Kunde inte lägga till jobbtypen');
+      setTypes((prev) => [...prev, j.data.item as JobTypeRow]);
+      setNewLabel('');
+      onChanged();
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <CrmModal
+      onClose={onClose}
+      ariaLabel="Hantera jobbtyper"
+      maxWidth="sm:max-w-[560px]"
+      header={
+        <div>
+          <h2 className="text-[15px] font-bold text-slate-900">Hantera jobbtyper</h2>
+          <p className="mt-0.5 text-[12px] text-slate-500">Namn + färg på korten. Avaktivera för att dölja ur väljaren utan att tappa historik.</p>
+        </div>
+      }
+      footer={
+        <button type="button" onClick={onClose} className={cn(crm.ghostButton, 'ml-auto')}>
+          Stäng
+        </button>
+      }
+    >
+      {loading ? (
+        <p className="py-8 text-center text-sm text-slate-400">Laddar…</p>
+      ) : (
+        <div className="grid gap-2">
+          {types.map((t) => (
+            <div key={t.id} className={cn('flex items-center gap-2 rounded-xl border border-[#e0e8dc] bg-white p-2', !t.active && 'opacity-60')}>
+              <input type="color" value={t.color} onChange={(e) => patchLocal(t.id, { color: e.target.value })} className={COLOR_INPUT} aria-label="Färg" />
+              <input value={t.label} onChange={(e) => patchLocal(t.id, { label: e.target.value })} className={TEXT_INPUT} aria-label="Namn" />
+              <label className="flex shrink-0 items-center gap-1 text-[11px] font-semibold text-slate-500">
+                <input type="checkbox" checked={t.active} onChange={(e) => patchLocal(t.id, { active: e.target.checked })} className="h-3.5 w-3.5 accent-emerald-600" />
+                Aktiv
+              </label>
+              <button type="button" onClick={() => saveType(t)} disabled={busy} className={PRIMARY} style={{ backgroundColor: 'var(--crm-primary)' }}>
+                Spara
+              </button>
+              <button
+                type="button"
+                onClick={() => removeType(t.id)}
+                disabled={busy}
+                aria-label="Ta bort jobbtyp"
+                className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-[#e0e8dc] bg-white text-slate-400 transition hover:border-rose-300 hover:text-rose-500 disabled:opacity-50"
+              >
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M3 6h18M8 6V4h8v2M19 6l-1 14H6L5 6" />
+                </svg>
+              </button>
+            </div>
+          ))}
+
+          {types.length === 0 && <p className="py-2 text-center text-[12px] text-slate-400">Inga jobbtyper upplagda än.</p>}
+
+          <form onSubmit={addType} className="mt-1 flex items-center gap-2 rounded-xl border border-dashed border-[#c8d4c3] bg-[#f9fbf7] p-2">
+            <input type="color" value={newColor} onChange={(e) => setNewColor(e.target.value)} className={COLOR_INPUT} aria-label="Färg" />
+            <input value={newLabel} onChange={(e) => setNewLabel(e.target.value)} placeholder="Ny jobbtyp…" className={TEXT_INPUT} aria-label="Namn på ny jobbtyp" />
+            <button type="submit" disabled={busy || !newLabel.trim()} className={PRIMARY} style={{ backgroundColor: 'var(--crm-primary)' }}>
+              Lägg till
+            </button>
+          </form>
+        </div>
+      )}
+    </CrmModal>
+  );
+}

--- a/app/crm/planering/JobTypeManagerModal.tsx
+++ b/app/crm/planering/JobTypeManagerModal.tsx
@@ -1,95 +1,39 @@
 'use client';
 
-import { useEffect, useState, type FormEvent } from 'react';
+import { useState, type FormEvent } from 'react';
 import { cn } from '@/lib/shared/cn';
-import { useToast } from '@/lib/Toast';
 import { crm } from '@/app/crm/lib/crmTokens';
 import CrmModal from '@/app/crm/components/CrmModal';
+import { useEntityCrud } from './useEntityCrud';
+import { TrashIcon } from './managerModalUi';
 import type { JobTypeRow } from '@/lib/domains/planning/jobTypes';
 
 const API = '/api/crm/planering/job-types';
-const COLOR_INPUT = 'h-9 w-full cursor-pointer rounded-lg border border-[#dce4d8] bg-white p-1';
-const TEXT_INPUT = 'h-9 w-full rounded-lg border border-[#dce4d8] bg-white px-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-2 focus:ring-emerald-500/15';
-const PRIMARY = 'inline-flex h-9 shrink-0 items-center justify-center rounded-lg px-4 text-[13px] font-semibold text-white transition disabled:cursor-not-allowed disabled:opacity-50';
-const DANGER = 'inline-flex h-9 shrink-0 items-center gap-1.5 rounded-lg border border-[#e0e8dc] bg-white px-3 text-[13px] font-semibold text-slate-500 transition hover:border-rose-300 hover:text-rose-600 disabled:cursor-not-allowed disabled:opacity-50';
 
-// Job-type management: rename, recolor, (de)activate or add/remove job types. The key is stable
-// (shown read-only). onChanged refreshes the board's picker + chips.
+// Job-type management: rename, recolor, (de)activate or add/remove. The stable key is server-managed.
+// onChanged refreshes the board's picker + chips.
 export default function JobTypeManagerModal({ onClose, onChanged }: { onClose: () => void; onChanged: () => void }) {
-  const toast = useToast();
-  const [types, setTypes] = useState<JobTypeRow[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [busy, setBusy] = useState(false);
+  const { items: types, loading, busy, patchLocal, save, remove, add } = useEntityCrud<JobTypeRow>({
+    api: API,
+    listKey: 'jobTypes',
+    toPayload: (t) => ({ label: t.label, color: t.color, active: t.active }),
+    labels: { saveFail: 'Kunde inte spara jobbtypen', removeFail: 'Kunde inte ta bort jobbtypen', addFail: 'Kunde inte lägga till jobbtypen' },
+  });
   const [newLabel, setNewLabel] = useState('');
   const [newColor, setNewColor] = useState('#0d9488');
 
-  useEffect(() => {
-    let active = true;
-    fetch(API, { cache: 'no-store' })
-      .then((r) => r.json())
-      .then((j) => {
-        if (active && j.ok) setTypes(j.data.jobTypes as JobTypeRow[]);
-      })
-      .catch(() => {})
-      .finally(() => {
-        if (active) setLoading(false);
-      });
-    return () => {
-      active = false;
-    };
-  }, []);
-
-  function patchLocal(id: string, patch: Partial<JobTypeRow>) {
-    setTypes((prev) => prev.map((t) => (t.id === id ? { ...t, ...patch } : t)));
+  async function onSave(t: JobTypeRow) {
+    if (await save(t)) onChanged();
   }
-
-  async function saveType(t: JobTypeRow) {
-    setBusy(true);
-    try {
-      const r = await fetch(`${API}/${t.id}`, {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ label: t.label, color: t.color, active: t.active }),
-      });
-      const j = await r.json();
-      if (!j.ok) return toast.error(j.error || 'Kunde inte spara jobbtypen');
-      toast.success('Sparad');
-      onChanged();
-    } finally {
-      setBusy(false);
-    }
+  async function onRemove(id: string) {
+    if (await remove(id)) onChanged();
   }
-
-  async function removeType(id: string) {
-    setBusy(true);
-    try {
-      const r = await fetch(`${API}/${id}`, { method: 'DELETE' });
-      const j = await r.json();
-      if (!j.ok) return toast.error(j.error || 'Kunde inte ta bort jobbtypen');
-      setTypes((prev) => prev.filter((t) => t.id !== id));
-      onChanged();
-    } finally {
-      setBusy(false);
-    }
-  }
-
-  async function addType(e: FormEvent) {
+  async function onAdd(e: FormEvent) {
     e.preventDefault();
     if (!newLabel.trim()) return;
-    setBusy(true);
-    try {
-      const r = await fetch(API, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ label: newLabel.trim(), color: newColor }),
-      });
-      const j = await r.json();
-      if (!j.ok) return toast.error(j.error || 'Kunde inte lägga till jobbtypen');
-      setTypes((prev) => [...prev, j.data.item as JobTypeRow]);
+    if (await add({ label: newLabel.trim(), color: newColor })) {
       setNewLabel('');
       onChanged();
-    } finally {
-      setBusy(false);
     }
   }
 
@@ -117,8 +61,8 @@ export default function JobTypeManagerModal({ onClose, onChanged }: { onClose: (
           {types.map((t) => (
             <div key={t.id} className={cn('rounded-xl border border-[#e0e8dc] bg-white p-3', !t.active && 'opacity-60')}>
               <div className="grid grid-cols-[2.5rem_1fr] items-center gap-2.5">
-                <input type="color" value={t.color} onChange={(e) => patchLocal(t.id, { color: e.target.value })} className={COLOR_INPUT} aria-label="Färg" />
-                <input value={t.label} onChange={(e) => patchLocal(t.id, { label: e.target.value })} className={TEXT_INPUT} placeholder="Jobbtypens namn" aria-label="Namn" />
+                <input type="color" value={t.color} onChange={(e) => patchLocal(t.id, { color: e.target.value })} className={crm.colorInput} aria-label="Färg" />
+                <input value={t.label} onChange={(e) => patchLocal(t.id, { label: e.target.value })} className={crm.input} placeholder="Jobbtypens namn" aria-label="Namn" />
               </div>
               <div className="mt-3 flex items-center justify-between gap-2 border-t border-[#eef3eb] pt-2.5">
                 <label className="flex h-9 cursor-pointer select-none items-center gap-2 rounded-lg border border-[#e0e8dc] bg-[#f9fbf7] px-3 text-[13px] font-semibold text-slate-600">
@@ -126,13 +70,11 @@ export default function JobTypeManagerModal({ onClose, onChanged }: { onClose: (
                   Aktiv
                 </label>
                 <div className="flex items-center gap-2">
-                  <button type="button" onClick={() => removeType(t.id)} disabled={busy} className={DANGER}>
-                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                      <path d="M3 6h18M8 6V4h8v2M19 6l-1 14H6L5 6" />
-                    </svg>
+                  <button type="button" onClick={() => onRemove(t.id)} disabled={busy} className={crm.dangerButton}>
+                    <TrashIcon />
                     Ta bort
                   </button>
-                  <button type="button" onClick={() => saveType(t)} disabled={busy} className={PRIMARY} style={{ backgroundColor: 'var(--crm-primary)' }}>
+                  <button type="button" onClick={() => onSave(t)} disabled={busy} className={crm.formButton} style={{ backgroundColor: 'var(--crm-primary)' }}>
                     Spara
                   </button>
                 </div>
@@ -142,12 +84,12 @@ export default function JobTypeManagerModal({ onClose, onChanged }: { onClose: (
 
           {types.length === 0 && <p className="py-2 text-center text-[13px] text-slate-400">Inga jobbtyper upplagda än.</p>}
 
-          <form onSubmit={addType} className="rounded-xl border border-dashed border-[#c8d4c3] bg-[#f9fbf7] p-3">
+          <form onSubmit={onAdd} className="rounded-xl border border-dashed border-[#c8d4c3] bg-[#f9fbf7] p-3">
             <p className="mb-2 px-0.5 text-[11px] font-bold uppercase tracking-wide text-slate-400">Lägg till ny jobbtyp</p>
             <div className="grid grid-cols-[2.5rem_1fr_auto] items-center gap-2.5">
-              <input type="color" value={newColor} onChange={(e) => setNewColor(e.target.value)} className={COLOR_INPUT} aria-label="Färg" />
-              <input value={newLabel} onChange={(e) => setNewLabel(e.target.value)} placeholder="Jobbtypens namn…" className={TEXT_INPUT} aria-label="Namn på ny jobbtyp" />
-              <button type="submit" disabled={busy || !newLabel.trim()} className={PRIMARY} style={{ backgroundColor: 'var(--crm-primary)' }}>
+              <input type="color" value={newColor} onChange={(e) => setNewColor(e.target.value)} className={crm.colorInput} aria-label="Färg" />
+              <input value={newLabel} onChange={(e) => setNewLabel(e.target.value)} placeholder="Jobbtypens namn…" className={crm.input} aria-label="Namn på ny jobbtyp" />
+              <button type="submit" disabled={busy || !newLabel.trim()} className={crm.formButton} style={{ backgroundColor: 'var(--crm-primary)' }}>
                 Lägg till
               </button>
             </div>

--- a/app/crm/planering/MonthGrid.tsx
+++ b/app/crm/planering/MonthGrid.tsx
@@ -6,6 +6,7 @@ import type { MonthWeek } from './planningDates';
 import { statusMeta, JobRef, CrewAvatars } from './jobCard';
 import { sacksRemaining } from '@/lib/domains/planning/reports';
 import { describeSmsStatus } from '@/lib/domains/planning/confirmations';
+import { groupNotesByDay, type DayNote } from '@/lib/domains/planning/dayNotes';
 
 type MonthGridProps = {
   weeks: MonthWeek[];
@@ -18,14 +19,16 @@ type MonthGridProps = {
   onDayDrop: (e: React.DragEvent, dayISO: string) => void;
   onSegDragStart: (e: React.DragEvent, seg: OpsSegment) => void;
   onSegClick: (seg: OpsSegment) => void;
+  dayNotes: DayNote[];
 };
 
 const WEEKDAYS = ['mån', 'tis', 'ons', 'tor', 'fre', 'lör', 'sön'];
 
 export default function MonthGrid({
-  weeks, trucks, segments, todayISO, canWrite, placing, onDayClick, onDayDrop, onSegDragStart, onSegClick,
+  weeks, trucks, segments, todayISO, canWrite, placing, onDayClick, onDayDrop, onSegDragStart, onSegClick, dayNotes,
 }: MonthGridProps) {
   const truckColor = new Map(trucks.map((t) => [t.id, t.color || '#94a3b8']));
+  const notesByDay = groupNotesByDay(dayNotes);
 
   return (
     <section className={cn(crm.card, 'overflow-x-auto p-3')}>
@@ -48,6 +51,7 @@ export default function MonthGrid({
                 const isToday = cell.iso === todayISO;
                 const dayActive = placing && canWrite;
                 const daySegs = segments.filter((s) => s.start_day <= cell.iso && s.end_day >= cell.iso);
+                const cellNotes = notesByDay.get(cell.iso) ?? [];
                 return (
                   <div
                     key={cell.iso}
@@ -74,7 +78,17 @@ export default function MonthGrid({
                       <span className={cn('text-[11px] font-bold tabular-nums', !cell.inMonth ? 'text-slate-300' : isToday ? 'text-emerald-700' : 'text-slate-500')}>
                         {cell.day}
                       </span>
-                      {isToday && <span className="rounded-full bg-emerald-600 px-1.5 py-px text-[8.5px] font-extrabold text-white">idag</span>}
+                      <span className="flex items-center gap-1">
+                        {cellNotes.length > 0 && (
+                          <span
+                            title={cellNotes.map((n) => n.body).join(' · ')}
+                            className="inline-flex h-3.5 min-w-[14px] items-center justify-center rounded-full bg-amber-100 px-1 text-[8px] font-bold tabular-nums text-amber-700"
+                          >
+                            {cellNotes.length}
+                          </span>
+                        )}
+                        {isToday && <span className="rounded-full bg-emerald-600 px-1.5 py-px text-[8.5px] font-extrabold text-white">idag</span>}
+                      </span>
                     </div>
 
                     {daySegs.map((seg) => {

--- a/app/crm/planering/MonthGrid.tsx
+++ b/app/crm/planering/MonthGrid.tsx
@@ -1,4 +1,5 @@
 import type React from 'react';
+import { useEffect, useState } from 'react';
 import { cn } from '@/lib/shared/cn';
 import { crm } from '@/app/crm/lib/crmTokens';
 import type { OpsSegment, OpsTruck } from '@/lib/domains/planning/types';
@@ -49,6 +50,12 @@ export default function MonthGrid({
   const truckName = new Map(trucks.map((t) => [t.id, t.name]));
   const truckOrder = new Map(trucks.map((t, i) => [t.id, i]));
   const notesByDay = groupNotesByDay(dayNotes);
+  const [dragDay, setDragDay] = useState<string | null>(null);
+  useEffect(() => {
+    const clear = () => setDragDay(null);
+    window.addEventListener('dragend', clear);
+    return () => window.removeEventListener('dragend', clear);
+  }, []);
 
   return (
     <section className={cn(crm.card, 'planning-board overflow-x-auto p-3')}>
@@ -88,11 +95,14 @@ export default function MonthGrid({
                       if (placing) onDayClick(cell.iso);
                     }}
                     onDragOver={(e) => {
-                      if (canWrite) e.preventDefault();
+                      if (!canWrite) return;
+                      e.preventDefault();
+                      if (dragDay !== cell.iso) setDragDay(cell.iso);
                     }}
                     onDrop={(e) => {
                       if (!canWrite) return;
                       e.preventDefault();
+                      setDragDay(null);
                       onDayDrop(e, cell.iso);
                     }}
                     className={cn(
@@ -102,6 +112,7 @@ export default function MonthGrid({
                       hol && cell.inMonth && 'bg-rose-400/[0.06]',
                       isToday && 'bg-emerald-50',
                       dayActive && 'cursor-copy',
+                      dragDay === cell.iso && 'ring-2 ring-inset ring-emerald-400',
                     )}
                   >
                     <div className="flex items-center justify-between">

--- a/app/crm/planering/MonthGrid.tsx
+++ b/app/crm/planering/MonthGrid.tsx
@@ -4,7 +4,7 @@ import { crm } from '@/app/crm/lib/crmTokens';
 import type { OpsSegment, OpsTruck } from '@/lib/domains/planning/types';
 import type { MonthWeek } from './planningDates';
 import { statusMeta, JobRef, CrewAvatars } from './jobCard';
-import { sacksRemaining } from '@/lib/domains/planning/reports';
+import { sacksRemaining, sacksOverrun } from '@/lib/domains/planning/reports';
 import { describeSmsStatus } from '@/lib/domains/planning/confirmations';
 import { groupNotesByDay, type DayNote } from '@/lib/domains/planning/dayNotes';
 import { swedishHoliday } from '@/lib/domains/planning/holidays';
@@ -146,17 +146,27 @@ export default function MonthGrid({
                                   );
                                 })()}
                               </span>
-                              {job && job.total_sacks > 0 && (
-                                <span
-                                  className={cn(
-                                    'shrink-0 text-[9px] font-bold tabular-nums',
-                                    seg.sacks_reported > 0 ? 'text-amber-700' : 'text-emerald-700',
-                                  )}
-                                  title={seg.sacks_reported > 0 ? `kvar ${sacksRemaining(job.total_sacks, seg.sacks_reported)} / ${job.total_sacks} säck` : `${job.total_sacks} säck`}
-                                >
-                                  {seg.sacks_reported > 0 ? sacksRemaining(job.total_sacks, seg.sacks_reported) : job.total_sacks}
-                                </span>
-                              )}
+                              {job && job.total_sacks > 0 && (() => {
+                                const over = sacksOverrun(job.total_sacks, seg.sacks_reported);
+                                const reported = seg.sacks_reported;
+                                return (
+                                  <span
+                                    className={cn(
+                                      'shrink-0 text-[9px] font-bold tabular-nums',
+                                      reported > 0 ? (over > 0 ? 'text-rose-600' : 'text-amber-700') : 'text-emerald-700',
+                                    )}
+                                    title={
+                                      reported > 0
+                                        ? over > 0
+                                          ? `över ${over} / ${job.total_sacks} säck`
+                                          : `kvar ${sacksRemaining(job.total_sacks, reported)} / ${job.total_sacks} säck`
+                                        : `${job.total_sacks} säck`
+                                    }
+                                  >
+                                    {reported > 0 ? (over > 0 ? `+${over}` : sacksRemaining(job.total_sacks, reported)) : job.total_sacks}
+                                  </span>
+                                );
+                              })()}
                             </div>
                             <div className="truncate text-[10px] text-slate-600">{job?.client_name ?? job?.project_name ?? 'Order'}</div>
                             {seg.crew.length > 0 && (

--- a/app/crm/planering/MonthGrid.tsx
+++ b/app/crm/planering/MonthGrid.tsx
@@ -96,7 +96,12 @@ export default function MonthGrid({
                           <span className="mt-1 h-2 w-2 shrink-0 rounded-full" style={{ backgroundColor: truckColor.get(seg.truck_id) || '#94a3b8' }} />
                           <div className="min-w-0 flex-1">
                             <div className="flex items-baseline justify-between gap-1.5">
-                              {job ? <JobRef job={job} className="text-[10px]" /> : <span className="text-[10px] text-slate-400">—</span>}
+                              <span className="flex min-w-0 items-center gap-1">
+                                {job ? <JobRef job={job} className="text-[10px]" /> : <span className="text-[10px] text-slate-400">—</span>}
+                                {(seg.confirmation.email_sent_at || seg.confirmation.sms_sent_at) && (
+                                  <span title="Bekräftad" className="inline-flex h-2.5 w-2.5 shrink-0 items-center justify-center rounded-full bg-emerald-500 text-[6px] font-bold leading-none text-white">✓</span>
+                                )}
+                              </span>
                               {job && job.total_sacks > 0 && (
                                 <span
                                   className={cn(

--- a/app/crm/planering/MonthGrid.tsx
+++ b/app/crm/planering/MonthGrid.tsx
@@ -7,6 +7,7 @@ import { statusMeta, JobRef, CrewAvatars } from './jobCard';
 import { sacksRemaining } from '@/lib/domains/planning/reports';
 import { describeSmsStatus } from '@/lib/domains/planning/confirmations';
 import { groupNotesByDay, type DayNote } from '@/lib/domains/planning/dayNotes';
+import { swedishHoliday } from '@/lib/domains/planning/holidays';
 
 type MonthGridProps = {
   weeks: MonthWeek[];
@@ -52,9 +53,11 @@ export default function MonthGrid({
                 const dayActive = placing && canWrite;
                 const daySegs = segments.filter((s) => s.start_day <= cell.iso && s.end_day >= cell.iso);
                 const cellNotes = notesByDay.get(cell.iso) ?? [];
+                const hol = swedishHoliday(cell.iso);
                 return (
                   <div
                     key={cell.iso}
+                    title={hol ?? undefined}
                     onClick={() => {
                       if (placing) onDayClick(cell.iso);
                     }}
@@ -70,13 +73,17 @@ export default function MonthGrid({
                       'flex min-h-[130px] flex-col gap-1 border-l border-t border-[#e8efe5] p-1.5',
                       cell.inMonth ? 'bg-[#f9fbf7]' : 'bg-[#eef2ec]',
                       cell.isWeekend && cell.inMonth && 'bg-slate-400/[0.05]',
+                      hol && cell.inMonth && 'bg-rose-400/[0.06]',
                       isToday && 'bg-emerald-50',
                       dayActive && 'cursor-copy',
                     )}
                   >
                     <div className="flex items-center justify-between">
-                      <span className={cn('text-[11px] font-bold tabular-nums', !cell.inMonth ? 'text-slate-300' : isToday ? 'text-emerald-700' : 'text-slate-500')}>
-                        {cell.day}
+                      <span className="flex items-center gap-1">
+                        <span className={cn('text-[11px] font-bold tabular-nums', !cell.inMonth ? 'text-slate-300' : isToday ? 'text-emerald-700' : hol ? 'text-rose-600' : 'text-slate-500')}>
+                          {cell.day}
+                        </span>
+                        {hol && cell.inMonth && <span className="h-1.5 w-1.5 rounded-full bg-rose-400" />}
                       </span>
                       <span className="flex items-center gap-1">
                         {cellNotes.length > 0 && (

--- a/app/crm/planering/MonthGrid.tsx
+++ b/app/crm/planering/MonthGrid.tsx
@@ -2,10 +2,21 @@ import type React from 'react';
 import { cn } from '@/lib/shared/cn';
 import { crm } from '@/app/crm/lib/crmTokens';
 import type { OpsSegment, OpsTruck } from '@/lib/domains/planning/types';
-import type { MonthWeek } from './planningDates';
-import { statusMeta, JobRef, CrewAvatars } from './jobCard';
-import { sacksRemaining, sacksOverrun } from '@/lib/domains/planning/reports';
-import { describeSmsStatus } from '@/lib/domains/planning/confirmations';
+import { addDaysISO, daysBetweenInclusive, type MonthWeek } from './planningDates';
+import {
+  statusMeta,
+  StatusPill,
+  JobRef,
+  CrewAvatars,
+  SegmentMenu,
+  JobTypeOrMaterial,
+  HoldBadge,
+  SackProgress,
+  ConfirmationBadge,
+  MapLink,
+} from './jobCard';
+import { resolveJobTypeFrom, type JobType } from '@/lib/domains/planning/jobTypes';
+import type { AssignablePerson } from '@/lib/domains/planning/crew';
 import { groupNotesByDay, type DayNote } from '@/lib/domains/planning/dayNotes';
 import { swedishHoliday } from '@/lib/domains/planning/holidays';
 
@@ -16,24 +27,54 @@ type MonthGridProps = {
   todayISO: string;
   canWrite: boolean;
   placing: boolean;
+  people: AssignablePerson[];
+  jobTypes: JobType[];
   onDayClick: (dayISO: string) => void;
   onDayDrop: (e: React.DragEvent, dayISO: string) => void;
   onSegDragStart: (e: React.DragEvent, seg: OpsSegment) => void;
   onSegClick: (seg: OpsSegment) => void;
+  onSetStatus: (seg: OpsSegment, status: string) => void;
+  onSetJobType: (seg: OpsSegment, jobType: string | null) => void;
+  onToggleHold: (seg: OpsSegment, value: boolean) => void;
+  onOpenConfirm: (seg: OpsSegment) => void;
+  onResize: (seg: OpsSegment, startDay: string, endDay: string) => void;
+  onAddCrew: (seg: OpsSegment, person: AssignablePerson) => void;
+  onRemoveCrew: (seg: OpsSegment, memberId: string) => void;
   dayNotes: DayNote[];
 };
 
 const WEEKDAYS = ['mån', 'tis', 'ons', 'tor', 'fre', 'lör', 'sön'];
 
 export default function MonthGrid({
-  weeks, trucks, segments, todayISO, canWrite, placing, onDayClick, onDayDrop, onSegDragStart, onSegClick, dayNotes,
+  weeks,
+  trucks,
+  segments,
+  todayISO,
+  canWrite,
+  placing,
+  people,
+  jobTypes,
+  onDayClick,
+  onDayDrop,
+  onSegDragStart,
+  onSegClick,
+  onSetStatus,
+  onSetJobType,
+  onToggleHold,
+  onOpenConfirm,
+  onResize,
+  onAddCrew,
+  onRemoveCrew,
+  dayNotes,
 }: MonthGridProps) {
   const truckColor = new Map(trucks.map((t) => [t.id, t.color || '#94a3b8']));
+  const truckName = new Map(trucks.map((t) => [t.id, t.name]));
+  const truckOrder = new Map(trucks.map((t, i) => [t.id, i]));
   const notesByDay = groupNotesByDay(dayNotes);
 
   return (
     <section className={cn(crm.card, 'overflow-x-auto p-3')}>
-      <div className="min-w-[960px]">
+      <div className="min-w-[1240px]">
         {/* weekday header */}
         <div className="grid grid-cols-[34px_repeat(7,1fr)]">
           <div />
@@ -44,14 +85,21 @@ export default function MonthGrid({
           ))}
         </div>
 
-        <div className="border-b border-r border-[#e8efe5] rounded-b-lg">
+        <div className="rounded-b-lg border-b border-r border-[#e8efe5]">
           {weeks.map((week) => (
             <div key={`${week.weekNo}-${week.days[0].iso}`} className="grid grid-cols-[34px_repeat(7,1fr)]">
               <div className="flex justify-center pt-2 text-[10px] font-bold tabular-nums text-slate-300">{week.weekNo}</div>
               {week.days.map((cell) => {
                 const isToday = cell.iso === todayISO;
                 const dayActive = placing && canWrite;
-                const daySegs = segments.filter((s) => s.start_day <= cell.iso && s.end_day >= cell.iso);
+                const daySegs = segments
+                  .filter((s) => s.start_day <= cell.iso && s.end_day >= cell.iso)
+                  .sort(
+                    (a, b) =>
+                      (truckOrder.get(a.truck_id) ?? 999) - (truckOrder.get(b.truck_id) ?? 999) ||
+                      a.start_day.localeCompare(b.start_day) ||
+                      a.id.localeCompare(b.id),
+                  );
                 const cellNotes = notesByDay.get(cell.iso) ?? [];
                 const hol = swedishHoliday(cell.iso);
                 return (
@@ -70,7 +118,7 @@ export default function MonthGrid({
                       onDayDrop(e, cell.iso);
                     }}
                     className={cn(
-                      'flex min-h-[130px] flex-col gap-1 border-l border-t border-[#e8efe5] p-1.5',
+                      'flex min-h-[140px] flex-col gap-1 border-l border-t border-[#e8efe5] p-1.5',
                       cell.inMonth ? 'bg-[#f9fbf7]' : 'bg-[#eef2ec]',
                       cell.isWeekend && cell.inMonth && 'bg-slate-400/[0.05]',
                       hol && cell.inMonth && 'bg-rose-400/[0.06]',
@@ -110,71 +158,64 @@ export default function MonthGrid({
                             onSegClick(seg);
                           }}
                           className={cn(
-                            'relative flex items-start gap-1.5 overflow-hidden rounded-lg border border-[#e0e8dc] bg-white px-2 py-1 pl-2.5 shadow-[0_1px_2px_rgba(20,44,27,0.06)] transition hover:-translate-y-px',
+                            'relative overflow-hidden rounded-lg border border-[#e0e8dc] bg-white p-2 pl-2.5 shadow-[0_1px_2px_rgba(20,44,27,0.06)] transition hover:shadow-[0_3px_10px_rgba(20,44,27,0.12)]',
                             canWrite ? 'cursor-grab active:cursor-grabbing' : 'cursor-pointer',
-                            seg.on_hold && 'opacity-55 ring-1 ring-amber-200',
+                            seg.on_hold && 'opacity-60 ring-1 ring-amber-200',
                           )}
                         >
-                          <span className={cn('absolute inset-y-0 left-0 w-[3px]', statusMeta(job?.status ?? '').rail)} />
-                          <span className="mt-1 h-2 w-2 shrink-0 rounded-full" style={{ backgroundColor: truckColor.get(seg.truck_id) || '#94a3b8' }} />
-                          <div className="min-w-0 flex-1">
-                            <div className="flex items-baseline justify-between gap-1.5">
-                              <span className="flex min-w-0 items-center gap-1">
-                                {seg.on_hold && (
-                                  <span title="Pausad" className="inline-flex shrink-0 text-amber-500">
-                                    <svg width="8" height="8" viewBox="0 0 24 24" fill="currentColor">
-                                      <rect x="6" y="5" width="4" height="14" rx="1" />
-                                      <rect x="14" y="5" width="4" height="14" rx="1" />
-                                    </svg>
-                                  </span>
+                          <span className={cn('absolute inset-y-0 left-0 w-1', statusMeta(job?.status ?? '').rail)} />
+                          {job ? (
+                            <>
+                              <div className="flex items-center gap-1.5">
+                                <span className="h-2 w-2 shrink-0 rounded-full" style={{ backgroundColor: truckColor.get(seg.truck_id) || '#94a3b8' }} />
+                                <JobRef job={job} className="text-[10.5px]" />
+                                <StatusPill status={job.status} className="ml-auto" />
+                                {canWrite && (
+                                  <SegmentMenu
+                                    status={job.status}
+                                    jobType={seg.job_type}
+                                    jobTypes={jobTypes}
+                                    onHold={seg.on_hold}
+                                    lengthDays={daysBetweenInclusive(seg.start_day, seg.end_day)}
+                                    crew={seg.crew}
+                                    people={people}
+                                    onSetStatus={(st) => onSetStatus(seg, st)}
+                                    onSetJobType={(key) => onSetJobType(seg, key)}
+                                    onToggleHold={() => onToggleHold(seg, !seg.on_hold)}
+                                    onOpenConfirm={() => onOpenConfirm(seg)}
+                                    onSetLength={(d) => onResize(seg, seg.start_day, addDaysISO(seg.start_day, d - 1))}
+                                    onAddCrew={(p) => onAddCrew(seg, p)}
+                                    onRemoveCrew={(mid) => onRemoveCrew(seg, mid)}
+                                  />
                                 )}
-                                {job ? <JobRef job={job} className="text-[10px]" /> : <span className="text-[10px] text-slate-400">—</span>}
-                                {(() => {
-                                  const c = seg.confirmation;
-                                  if (!c.email_sent_at && !c.sms_sent_at) return null;
-                                  const smsFailed = describeSmsStatus(c.sms_status)?.tone === 'fail' && !c.email_sent_at;
-                                  return (
-                                    <span
-                                      title={smsFailed ? 'SMS ej levererat' : 'Bekräftad'}
-                                      className={cn(
-                                        'inline-flex h-2.5 w-2.5 shrink-0 items-center justify-center rounded-full text-[6px] font-bold leading-none text-white',
-                                        smsFailed ? 'bg-rose-500' : 'bg-emerald-500',
-                                      )}
-                                    >
-                                      {smsFailed ? '!' : '✓'}
-                                    </span>
-                                  );
-                                })()}
-                              </span>
-                              {job && job.total_sacks > 0 && (() => {
-                                const over = sacksOverrun(job.total_sacks, seg.sacks_reported);
-                                const reported = seg.sacks_reported;
-                                return (
-                                  <span
-                                    className={cn(
-                                      'shrink-0 text-[9px] font-bold tabular-nums',
-                                      reported > 0 ? (over > 0 ? 'text-rose-600' : 'text-amber-700') : 'text-emerald-700',
-                                    )}
-                                    title={
-                                      reported > 0
-                                        ? over > 0
-                                          ? `över ${over} / ${job.total_sacks} säck`
-                                          : `kvar ${sacksRemaining(job.total_sacks, reported)} / ${job.total_sacks} säck`
-                                        : `${job.total_sacks} säck`
-                                    }
-                                  >
-                                    {reported > 0 ? (over > 0 ? `+${over}` : sacksRemaining(job.total_sacks, reported)) : job.total_sacks}
-                                  </span>
-                                );
-                              })()}
-                            </div>
-                            <div className="truncate text-[10px] text-slate-600">{job?.client_name ?? job?.project_name ?? 'Order'}</div>
-                            {seg.crew.length > 0 && (
-                              <div className="mt-0.5">
-                                <CrewAvatars crew={seg.crew} size={14} />
                               </div>
-                            )}
-                          </div>
+                              <div className="mt-1 truncate text-[11.5px] font-bold leading-tight text-slate-900">{job.project_name}</div>
+                              <div className="truncate text-[10px] text-slate-500">{job.client_name}</div>
+                              {job.address && (
+                                <div className="mt-0.5 flex items-center gap-1 text-[9.5px] text-slate-400">
+                                  <span className="truncate">{job.address}</span>
+                                  <MapLink address={job.address} />
+                                </div>
+                              )}
+                              <div className="mt-1 flex flex-wrap items-center gap-1">
+                                {seg.on_hold && <HoldBadge />}
+                                <JobTypeOrMaterial jobType={resolveJobTypeFrom(jobTypes, seg.job_type)} material={job.material} />
+                              </div>
+                              <div className="mt-1 flex flex-wrap items-center gap-1.5">
+                                <SackProgress planned={job.total_sacks} reported={seg.sacks_reported} />
+                                <ConfirmationBadge confirmation={seg.confirmation} />
+                                <div className="ml-auto flex items-center gap-1">
+                                  <span className="truncate text-[9px] font-semibold text-slate-400">{truckName.get(seg.truck_id) ?? ''}</span>
+                                  {seg.crew.length > 0 && <CrewAvatars crew={seg.crew} size={14} />}
+                                </div>
+                              </div>
+                            </>
+                          ) : (
+                            <div className="flex items-center gap-1.5">
+                              <span className="h-2 w-2 shrink-0 rounded-full" style={{ backgroundColor: truckColor.get(seg.truck_id) || '#94a3b8' }} />
+                              <span className="text-[10px] text-slate-400">Order saknas</span>
+                            </div>
+                          )}
                         </div>
                       );
                     })}

--- a/app/crm/planering/MonthGrid.tsx
+++ b/app/crm/planering/MonthGrid.tsx
@@ -4,6 +4,7 @@ import { crm } from '@/app/crm/lib/crmTokens';
 import type { OpsSegment, OpsTruck } from '@/lib/domains/planning/types';
 import type { MonthWeek } from './planningDates';
 import { statusMeta, JobRef } from './jobCard';
+import { sacksRemaining } from '@/lib/domains/planning/reports';
 
 type MonthGridProps = {
   weeks: MonthWeek[];
@@ -97,7 +98,15 @@ export default function MonthGrid({
                             <div className="flex items-baseline justify-between gap-1.5">
                               {job ? <JobRef job={job} className="text-[10px]" /> : <span className="text-[10px] text-slate-400">—</span>}
                               {job && job.total_sacks > 0 && (
-                                <span className="shrink-0 text-[9px] font-bold tabular-nums text-emerald-700">{job.total_sacks}</span>
+                                <span
+                                  className={cn(
+                                    'shrink-0 text-[9px] font-bold tabular-nums',
+                                    seg.sacks_reported > 0 ? 'text-amber-700' : 'text-emerald-700',
+                                  )}
+                                  title={seg.sacks_reported > 0 ? `kvar ${sacksRemaining(job.total_sacks, seg.sacks_reported)} / ${job.total_sacks} säck` : `${job.total_sacks} säck`}
+                                >
+                                  {seg.sacks_reported > 0 ? sacksRemaining(job.total_sacks, seg.sacks_reported) : job.total_sacks}
+                                </span>
                               )}
                             </div>
                             <div className="truncate text-[10px] text-slate-600">{job?.client_name ?? job?.project_name ?? 'Order'}</div>

--- a/app/crm/planering/MonthGrid.tsx
+++ b/app/crm/planering/MonthGrid.tsx
@@ -111,7 +111,7 @@ export default function MonthGrid({
                       cell.isWeekend && cell.inMonth && 'bg-slate-400/[0.05]',
                       hol && cell.inMonth && 'bg-rose-400/[0.06]',
                       isToday && 'bg-emerald-50',
-                      dayActive && 'cursor-copy',
+                      dayActive && 'cursor-copy bg-emerald-400/[0.05] hover:bg-emerald-400/15 hover:outline-dashed hover:outline-2 hover:-outline-offset-2 hover:outline-emerald-400/70',
                       dragDay === cell.iso && 'ring-2 ring-inset ring-emerald-400',
                     )}
                   >

--- a/app/crm/planering/MonthGrid.tsx
+++ b/app/crm/planering/MonthGrid.tsx
@@ -4,6 +4,7 @@ import { crm } from '@/app/crm/lib/crmTokens';
 import type { OpsSegment, OpsTruck } from '@/lib/domains/planning/types';
 import type { MonthWeek } from './planningDates';
 import { SegmentCardBody, type SegmentActions } from './jobCard';
+import { orderInfo } from '@/lib/domains/planning/order';
 import type { JobType } from '@/lib/domains/planning/jobTypes';
 import type { AssignablePerson } from '@/lib/domains/planning/crew';
 import { groupNotesByDay, type DayNote } from '@/lib/domains/planning/dayNotes';
@@ -146,6 +147,7 @@ export default function MonthGrid({
                           actions={actions}
                           truckColor={truckColor.get(seg.truck_id) || '#94a3b8'}
                           truckName={truckName.get(seg.truck_id) ?? ''}
+                          order={orderInfo(segments, seg)}
                         />
                       </div>
                     ))}

--- a/app/crm/planering/MonthGrid.tsx
+++ b/app/crm/planering/MonthGrid.tsx
@@ -50,7 +50,7 @@ export default function MonthGrid({
   const notesByDay = groupNotesByDay(dayNotes);
 
   return (
-    <section className={cn(crm.card, 'overflow-x-auto p-3')}>
+    <section className={cn(crm.card, 'planning-board overflow-x-auto p-3')}>
       <div className="min-w-[1240px]">
         {/* weekday header */}
         <div className="grid grid-cols-[34px_repeat(7,1fr)]">

--- a/app/crm/planering/MonthGrid.tsx
+++ b/app/crm/planering/MonthGrid.tsx
@@ -1,0 +1,117 @@
+import type React from 'react';
+import { cn } from '@/lib/shared/cn';
+import { crm } from '@/app/crm/lib/crmTokens';
+import type { OpsSegment, OpsTruck } from '@/lib/domains/planning/types';
+import type { MonthWeek } from './planningDates';
+import { statusMeta, JobRef } from './jobCard';
+
+type MonthGridProps = {
+  weeks: MonthWeek[];
+  trucks: OpsTruck[];
+  segments: OpsSegment[];
+  todayISO: string;
+  canWrite: boolean;
+  placing: boolean;
+  onDayClick: (dayISO: string) => void;
+  onDayDrop: (e: React.DragEvent, dayISO: string) => void;
+  onSegDragStart: (e: React.DragEvent, seg: OpsSegment) => void;
+  onSegClick: (seg: OpsSegment) => void;
+};
+
+const WEEKDAYS = ['mån', 'tis', 'ons', 'tor', 'fre', 'lör', 'sön'];
+
+export default function MonthGrid({
+  weeks, trucks, segments, todayISO, canWrite, placing, onDayClick, onDayDrop, onSegDragStart, onSegClick,
+}: MonthGridProps) {
+  const truckColor = new Map(trucks.map((t) => [t.id, t.color || '#94a3b8']));
+
+  return (
+    <section className={cn(crm.card, 'overflow-x-auto p-3')}>
+      <div className="min-w-[960px]">
+        {/* weekday header */}
+        <div className="grid grid-cols-[34px_repeat(7,1fr)]">
+          <div />
+          {WEEKDAYS.map((wd, i) => (
+            <div key={wd} className={cn('py-1 text-center text-[11px] font-bold capitalize', i >= 5 ? 'text-slate-400' : 'text-slate-500')}>
+              {wd}
+            </div>
+          ))}
+        </div>
+
+        <div className="border-b border-r border-[#e8efe5] rounded-b-lg">
+          {weeks.map((week) => (
+            <div key={`${week.weekNo}-${week.days[0].iso}`} className="grid grid-cols-[34px_repeat(7,1fr)]">
+              <div className="flex justify-center pt-2 text-[10px] font-bold tabular-nums text-slate-300">{week.weekNo}</div>
+              {week.days.map((cell) => {
+                const isToday = cell.iso === todayISO;
+                const dayActive = placing && canWrite;
+                const daySegs = segments.filter((s) => s.start_day <= cell.iso && s.end_day >= cell.iso);
+                return (
+                  <div
+                    key={cell.iso}
+                    onClick={() => {
+                      if (placing) onDayClick(cell.iso);
+                    }}
+                    onDragOver={(e) => {
+                      if (canWrite) e.preventDefault();
+                    }}
+                    onDrop={(e) => {
+                      if (!canWrite) return;
+                      e.preventDefault();
+                      onDayDrop(e, cell.iso);
+                    }}
+                    className={cn(
+                      'flex min-h-[130px] flex-col gap-1 border-l border-t border-[#e8efe5] p-1.5',
+                      cell.inMonth ? 'bg-[#f9fbf7]' : 'bg-[#eef2ec]',
+                      cell.isWeekend && cell.inMonth && 'bg-slate-400/[0.05]',
+                      isToday && 'bg-emerald-50',
+                      dayActive && 'cursor-copy',
+                    )}
+                  >
+                    <div className="flex items-center justify-between">
+                      <span className={cn('text-[11px] font-bold tabular-nums', !cell.inMonth ? 'text-slate-300' : isToday ? 'text-emerald-700' : 'text-slate-500')}>
+                        {cell.day}
+                      </span>
+                      {isToday && <span className="rounded-full bg-emerald-600 px-1.5 py-px text-[8.5px] font-extrabold text-white">idag</span>}
+                    </div>
+
+                    {daySegs.map((seg) => {
+                      const job = seg.job;
+                      return (
+                        <div
+                          key={seg.id}
+                          draggable={canWrite}
+                          onDragStart={(ev) => onSegDragStart(ev, seg)}
+                          onClick={(ev) => {
+                            ev.stopPropagation();
+                            onSegClick(seg);
+                          }}
+                          className={cn(
+                            'relative flex items-start gap-1.5 overflow-hidden rounded-lg border border-[#e0e8dc] bg-white px-2 py-1 pl-2.5 shadow-[0_1px_2px_rgba(20,44,27,0.06)] transition hover:-translate-y-px',
+                            canWrite ? 'cursor-grab active:cursor-grabbing' : 'cursor-pointer',
+                          )}
+                        >
+                          <span className={cn('absolute inset-y-0 left-0 w-[3px]', statusMeta(job?.status ?? '').rail)} />
+                          <span className="mt-1 h-2 w-2 shrink-0 rounded-full" style={{ backgroundColor: truckColor.get(seg.truck_id) || '#94a3b8' }} />
+                          <div className="min-w-0 flex-1">
+                            <div className="flex items-baseline justify-between gap-1.5">
+                              {job ? <JobRef job={job} className="text-[10px]" /> : <span className="text-[10px] text-slate-400">—</span>}
+                              {job && job.total_sacks > 0 && (
+                                <span className="shrink-0 text-[9px] font-bold tabular-nums text-emerald-700">{job.total_sacks}</span>
+                              )}
+                            </div>
+                            <div className="truncate text-[10px] text-slate-600">{job?.client_name ?? job?.project_name ?? 'Order'}</div>
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
+                );
+              })}
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/app/crm/planering/MonthGrid.tsx
+++ b/app/crm/planering/MonthGrid.tsx
@@ -3,7 +3,7 @@ import { cn } from '@/lib/shared/cn';
 import { crm } from '@/app/crm/lib/crmTokens';
 import type { OpsSegment, OpsTruck } from '@/lib/domains/planning/types';
 import type { MonthWeek } from './planningDates';
-import { statusMeta, JobRef } from './jobCard';
+import { statusMeta, JobRef, CrewAvatars } from './jobCard';
 import { sacksRemaining } from '@/lib/domains/planning/reports';
 
 type MonthGridProps = {
@@ -110,6 +110,11 @@ export default function MonthGrid({
                               )}
                             </div>
                             <div className="truncate text-[10px] text-slate-600">{job?.client_name ?? job?.project_name ?? 'Order'}</div>
+                            {seg.crew.length > 0 && (
+                              <div className="mt-0.5">
+                                <CrewAvatars crew={seg.crew} size={14} />
+                              </div>
+                            )}
                           </div>
                         </div>
                       );

--- a/app/crm/planering/MonthGrid.tsx
+++ b/app/crm/planering/MonthGrid.tsx
@@ -5,6 +5,7 @@ import type { OpsSegment, OpsTruck } from '@/lib/domains/planning/types';
 import type { MonthWeek } from './planningDates';
 import { statusMeta, JobRef, CrewAvatars } from './jobCard';
 import { sacksRemaining } from '@/lib/domains/planning/reports';
+import { describeSmsStatus } from '@/lib/domains/planning/confirmations';
 
 type MonthGridProps = {
   weeks: MonthWeek[];
@@ -98,9 +99,22 @@ export default function MonthGrid({
                             <div className="flex items-baseline justify-between gap-1.5">
                               <span className="flex min-w-0 items-center gap-1">
                                 {job ? <JobRef job={job} className="text-[10px]" /> : <span className="text-[10px] text-slate-400">—</span>}
-                                {(seg.confirmation.email_sent_at || seg.confirmation.sms_sent_at) && (
-                                  <span title="Bekräftad" className="inline-flex h-2.5 w-2.5 shrink-0 items-center justify-center rounded-full bg-emerald-500 text-[6px] font-bold leading-none text-white">✓</span>
-                                )}
+                                {(() => {
+                                  const c = seg.confirmation;
+                                  if (!c.email_sent_at && !c.sms_sent_at) return null;
+                                  const smsFailed = describeSmsStatus(c.sms_status)?.tone === 'fail' && !c.email_sent_at;
+                                  return (
+                                    <span
+                                      title={smsFailed ? 'SMS ej levererat' : 'Bekräftad'}
+                                      className={cn(
+                                        'inline-flex h-2.5 w-2.5 shrink-0 items-center justify-center rounded-full text-[6px] font-bold leading-none text-white',
+                                        smsFailed ? 'bg-rose-500' : 'bg-emerald-500',
+                                      )}
+                                    >
+                                      {smsFailed ? '!' : '✓'}
+                                    </span>
+                                  );
+                                })()}
                               </span>
                               {job && job.total_sacks > 0 && (
                                 <span

--- a/app/crm/planering/MonthGrid.tsx
+++ b/app/crm/planering/MonthGrid.tsx
@@ -91,6 +91,7 @@ export default function MonthGrid({
                           className={cn(
                             'relative flex items-start gap-1.5 overflow-hidden rounded-lg border border-[#e0e8dc] bg-white px-2 py-1 pl-2.5 shadow-[0_1px_2px_rgba(20,44,27,0.06)] transition hover:-translate-y-px',
                             canWrite ? 'cursor-grab active:cursor-grabbing' : 'cursor-pointer',
+                            seg.on_hold && 'opacity-55 ring-1 ring-amber-200',
                           )}
                         >
                           <span className={cn('absolute inset-y-0 left-0 w-[3px]', statusMeta(job?.status ?? '').rail)} />
@@ -98,6 +99,14 @@ export default function MonthGrid({
                           <div className="min-w-0 flex-1">
                             <div className="flex items-baseline justify-between gap-1.5">
                               <span className="flex min-w-0 items-center gap-1">
+                                {seg.on_hold && (
+                                  <span title="Pausad" className="inline-flex shrink-0 text-amber-500">
+                                    <svg width="8" height="8" viewBox="0 0 24 24" fill="currentColor">
+                                      <rect x="6" y="5" width="4" height="14" rx="1" />
+                                      <rect x="14" y="5" width="4" height="14" rx="1" />
+                                    </svg>
+                                  </span>
+                                )}
                                 {job ? <JobRef job={job} className="text-[10px]" /> : <span className="text-[10px] text-slate-400">—</span>}
                                 {(() => {
                                   const c = seg.confirmation;

--- a/app/crm/planering/MonthGrid.tsx
+++ b/app/crm/planering/MonthGrid.tsx
@@ -85,7 +85,7 @@ export default function MonthGrid({
           ))}
         </div>
 
-        <div className="rounded-b-lg border-b border-r border-[#e8efe5]">
+        <div className="rounded-b-lg border-b border-r border-solid border-[#e8efe5]">
           {weeks.map((week) => (
             <div key={`${week.weekNo}-${week.days[0].iso}`} className="grid grid-cols-[34px_repeat(7,1fr)]">
               <div className="flex justify-center pt-2 text-[10px] font-bold tabular-nums text-slate-300">{week.weekNo}</div>
@@ -118,7 +118,7 @@ export default function MonthGrid({
                       onDayDrop(e, cell.iso);
                     }}
                     className={cn(
-                      'flex min-h-[140px] flex-col gap-1 border-l border-t border-[#e8efe5] p-1.5',
+                      'flex min-h-[140px] flex-col gap-1 border-l border-t border-solid border-[#e8efe5] p-1.5',
                       cell.inMonth ? 'bg-[#f9fbf7]' : 'bg-[#eef2ec]',
                       cell.isWeekend && cell.inMonth && 'bg-slate-400/[0.05]',
                       hol && cell.inMonth && 'bg-rose-400/[0.06]',

--- a/app/crm/planering/MonthGrid.tsx
+++ b/app/crm/planering/MonthGrid.tsx
@@ -2,20 +2,9 @@ import type React from 'react';
 import { cn } from '@/lib/shared/cn';
 import { crm } from '@/app/crm/lib/crmTokens';
 import type { OpsSegment, OpsTruck } from '@/lib/domains/planning/types';
-import { addDaysISO, daysBetweenInclusive, type MonthWeek } from './planningDates';
-import {
-  statusMeta,
-  StatusPill,
-  JobRef,
-  CrewAvatars,
-  SegmentMenu,
-  JobTypeOrMaterial,
-  HoldBadge,
-  SackProgress,
-  ConfirmationBadge,
-  MapLink,
-} from './jobCard';
-import { resolveJobTypeFrom, type JobType } from '@/lib/domains/planning/jobTypes';
+import type { MonthWeek } from './planningDates';
+import { SegmentCardBody, type SegmentActions } from './jobCard';
+import type { JobType } from '@/lib/domains/planning/jobTypes';
 import type { AssignablePerson } from '@/lib/domains/planning/crew';
 import { groupNotesByDay, type DayNote } from '@/lib/domains/planning/dayNotes';
 import { swedishHoliday } from '@/lib/domains/planning/holidays';
@@ -33,13 +22,7 @@ type MonthGridProps = {
   onDayDrop: (e: React.DragEvent, dayISO: string) => void;
   onSegDragStart: (e: React.DragEvent, seg: OpsSegment) => void;
   onSegClick: (seg: OpsSegment) => void;
-  onSetStatus: (seg: OpsSegment, status: string) => void;
-  onSetJobType: (seg: OpsSegment, jobType: string | null) => void;
-  onToggleHold: (seg: OpsSegment, value: boolean) => void;
-  onOpenConfirm: (seg: OpsSegment) => void;
-  onResize: (seg: OpsSegment, startDay: string, endDay: string) => void;
-  onAddCrew: (seg: OpsSegment, person: AssignablePerson) => void;
-  onRemoveCrew: (seg: OpsSegment, memberId: string) => void;
+  actions: SegmentActions;
   dayNotes: DayNote[];
 };
 
@@ -58,13 +41,7 @@ export default function MonthGrid({
   onDayDrop,
   onSegDragStart,
   onSegClick,
-  onSetStatus,
-  onSetJobType,
-  onToggleHold,
-  onOpenConfirm,
-  onResize,
-  onAddCrew,
-  onRemoveCrew,
+  actions,
   dayNotes,
 }: MonthGridProps) {
   const truckColor = new Map(trucks.map((t) => [t.id, t.color || '#94a3b8']));
@@ -146,79 +123,32 @@ export default function MonthGrid({
                       </span>
                     </div>
 
-                    {daySegs.map((seg) => {
-                      const job = seg.job;
-                      return (
-                        <div
-                          key={seg.id}
-                          draggable={canWrite}
-                          onDragStart={(ev) => onSegDragStart(ev, seg)}
-                          onClick={(ev) => {
-                            ev.stopPropagation();
-                            onSegClick(seg);
-                          }}
-                          className={cn(
-                            'relative overflow-hidden rounded-lg border border-[#e0e8dc] bg-white p-2 pl-2.5 shadow-[0_1px_2px_rgba(20,44,27,0.06)] transition hover:shadow-[0_3px_10px_rgba(20,44,27,0.12)]',
-                            canWrite ? 'cursor-grab active:cursor-grabbing' : 'cursor-pointer',
-                            seg.on_hold && 'opacity-60 ring-1 ring-amber-200',
-                          )}
-                        >
-                          <span className={cn('absolute inset-y-0 left-0 w-1', statusMeta(job?.status ?? '').rail)} />
-                          {job ? (
-                            <>
-                              <div className="flex items-center gap-1.5">
-                                <span className="h-2 w-2 shrink-0 rounded-full" style={{ backgroundColor: truckColor.get(seg.truck_id) || '#94a3b8' }} />
-                                <JobRef job={job} className="text-[10.5px]" />
-                                <StatusPill status={job.status} className="ml-auto" />
-                                {canWrite && (
-                                  <SegmentMenu
-                                    status={job.status}
-                                    jobType={seg.job_type}
-                                    jobTypes={jobTypes}
-                                    onHold={seg.on_hold}
-                                    lengthDays={daysBetweenInclusive(seg.start_day, seg.end_day)}
-                                    crew={seg.crew}
-                                    people={people}
-                                    onSetStatus={(st) => onSetStatus(seg, st)}
-                                    onSetJobType={(key) => onSetJobType(seg, key)}
-                                    onToggleHold={() => onToggleHold(seg, !seg.on_hold)}
-                                    onOpenConfirm={() => onOpenConfirm(seg)}
-                                    onSetLength={(d) => onResize(seg, seg.start_day, addDaysISO(seg.start_day, d - 1))}
-                                    onAddCrew={(p) => onAddCrew(seg, p)}
-                                    onRemoveCrew={(mid) => onRemoveCrew(seg, mid)}
-                                  />
-                                )}
-                              </div>
-                              <div className="mt-1 truncate text-[11.5px] font-bold leading-tight text-slate-900">{job.project_name}</div>
-                              <div className="truncate text-[10px] text-slate-500">{job.client_name}</div>
-                              {job.address && (
-                                <div className="mt-0.5 flex items-center gap-1 text-[9.5px] text-slate-400">
-                                  <span className="truncate">{job.address}</span>
-                                  <MapLink address={job.address} />
-                                </div>
-                              )}
-                              <div className="mt-1 flex flex-wrap items-center gap-1">
-                                {seg.on_hold && <HoldBadge />}
-                                <JobTypeOrMaterial jobType={resolveJobTypeFrom(jobTypes, seg.job_type)} material={job.material} />
-                              </div>
-                              <div className="mt-1 flex flex-wrap items-center gap-1.5">
-                                <SackProgress planned={job.total_sacks} reported={seg.sacks_reported} />
-                                <ConfirmationBadge confirmation={seg.confirmation} />
-                                <div className="ml-auto flex items-center gap-1">
-                                  <span className="truncate text-[9px] font-semibold text-slate-400">{truckName.get(seg.truck_id) ?? ''}</span>
-                                  {seg.crew.length > 0 && <CrewAvatars crew={seg.crew} size={14} />}
-                                </div>
-                              </div>
-                            </>
-                          ) : (
-                            <div className="flex items-center gap-1.5">
-                              <span className="h-2 w-2 shrink-0 rounded-full" style={{ backgroundColor: truckColor.get(seg.truck_id) || '#94a3b8' }} />
-                              <span className="text-[10px] text-slate-400">Order saknas</span>
-                            </div>
-                          )}
-                        </div>
-                      );
-                    })}
+                    {daySegs.map((seg) => (
+                      <div
+                        key={seg.id}
+                        draggable={canWrite}
+                        onDragStart={(ev) => onSegDragStart(ev, seg)}
+                        onClick={(ev) => {
+                          ev.stopPropagation();
+                          onSegClick(seg);
+                        }}
+                        className={cn(
+                          'relative overflow-hidden rounded-lg border border-[#e0e8dc] bg-white p-2 pl-2.5 shadow-[0_1px_2px_rgba(20,44,27,0.06)] transition hover:shadow-[0_3px_10px_rgba(20,44,27,0.12)]',
+                          canWrite ? 'cursor-grab active:cursor-grabbing' : 'cursor-pointer',
+                          seg.on_hold && 'opacity-60 ring-1 ring-amber-200',
+                        )}
+                      >
+                        <SegmentCardBody
+                          seg={seg}
+                          canWrite={canWrite}
+                          jobTypes={jobTypes}
+                          people={people}
+                          actions={actions}
+                          truckColor={truckColor.get(seg.truck_id) || '#94a3b8'}
+                          truckName={truckName.get(seg.truck_id) ?? ''}
+                        />
+                      </div>
+                    ))}
                   </div>
                 );
               })}

--- a/app/crm/planering/PlanningClient.tsx
+++ b/app/crm/planering/PlanningClient.tsx
@@ -2,6 +2,7 @@
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
+import { createClientComponentClient } from '@supabase/auth-helpers-nextjs';
 import { cn } from '@/lib/shared/cn';
 import { useToast } from '@/lib/Toast';
 import { crm } from '@/app/crm/lib/crmTokens';
@@ -176,6 +177,49 @@ export default function PlanningClient({
     loadDayNotes(range.from, range.to).catch(() => {});
     loadTruckCrew(range.from, range.to).catch(() => {});
   }, [range.from, range.to, loadSegments, loadDayNotes, loadTruckCrew]);
+
+  // ── Realtime: ~10 planners work this board at once, so reflect each other's changes live to
+  // avoid double-bookings + missed updates. Subscribe once to ops_* changes and debounce-refetch
+  // the visible board (RLS still applies, so we only receive rows we may read). The ref keeps the
+  // handler pointed at the current range/loaders without re-subscribing on every nav.
+  const [supabase] = useState(() => createClientComponentClient());
+  const reloadBoardRef = useRef<() => void>(() => {});
+  reloadBoardRef.current = () => {
+    loadSegments(range.from, range.to).catch(() => {});
+    loadDayNotes(range.from, range.to).catch(() => {});
+    loadTruckCrew(range.from, range.to).catch(() => {});
+    loadBacklog().catch(() => {});
+    loadJobTypes().catch(() => {});
+  };
+
+  useEffect(() => {
+    const tables = [
+      'ops_segments',
+      'ops_segment_crew',
+      'ops_truck_crew',
+      'ops_day_notes',
+      'ops_segment_reports',
+      'ops_work_order_confirmations',
+      'ops_trucks',
+      'ops_depots',
+      'ops_depot_deliveries',
+      'ops_job_types',
+    ];
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const ping = () => {
+      if (timer) clearTimeout(timer);
+      timer = setTimeout(() => reloadBoardRef.current(), 400);
+    };
+    let ch = supabase.channel('planning-board-sync');
+    for (const table of tables) {
+      ch = ch.on('postgres_changes', { event: '*', schema: 'public', table }, ping);
+    }
+    ch.subscribe();
+    return () => {
+      if (timer) clearTimeout(timer);
+      void supabase.removeChannel(ch);
+    };
+  }, [supabase]);
 
   const refresh = useCallback(async () => {
     try {

--- a/app/crm/planering/PlanningClient.tsx
+++ b/app/crm/planering/PlanningClient.tsx
@@ -678,10 +678,19 @@ export default function PlanningClient({
             todayISO={todayISO}
             canWrite={canWrite}
             placing={placing}
+            people={people}
+            jobTypes={jobTypes}
             onDayClick={onMonthDayClick}
             onDayDrop={onMonthDayDrop}
             onSegDragStart={onSegDragStart}
             onSegClick={onSegClick}
+            onSetStatus={onSetStatus}
+            onSetJobType={onSetJobType}
+            onToggleHold={onToggleHold}
+            onOpenConfirm={openConfirm}
+            onResize={onResize}
+            onAddCrew={addCrew}
+            onRemoveCrew={removeCrew}
             dayNotes={dayNotes}
           />
         )}

--- a/app/crm/planering/PlanningClient.tsx
+++ b/app/crm/planering/PlanningClient.tsx
@@ -42,6 +42,7 @@ export default function PlanningClient({
   const [view, setView] = useState<View>('week');
   const [weekOffset, setWeekOffset] = useState(0);
   const [monthOffset, setMonthOffset] = useState(0);
+  const [showWeekend, setShowWeekend] = useState(false);
 
   const [backlog, setBacklog] = useState<SchedulableWorkOrder[]>([]);
   const [trucks, setTrucks] = useState<OpsTruck[]>([]);
@@ -119,6 +120,26 @@ export default function PlanningClient({
       .catch((e) => setError(e?.message || 'Något gick fel'))
       .finally(() => setLoadingBacklog(false));
   }, [loadBacklog]);
+
+  // "Visa helg" preference, persisted across visits (weekends hidden by default for width).
+  useEffect(() => {
+    try {
+      setShowWeekend(localStorage.getItem('crm-planning-show-weekend') === '1');
+    } catch {
+      /* ignore */
+    }
+  }, []);
+  const toggleWeekend = useCallback(() => {
+    setShowWeekend((v) => {
+      const next = !v;
+      try {
+        localStorage.setItem('crm-planning-show-weekend', next ? '1' : '0');
+      } catch {
+        /* ignore */
+      }
+      return next;
+    });
+  }, []);
 
   // Assignable crew (every named employee) — fetched once; a failure just leaves the picker empty.
   useEffect(() => {
@@ -422,6 +443,17 @@ export default function PlanningClient({
               v.{isoWeek(weekMonday)}
             </span>
           )}
+          {view === 'week' && (
+            <button
+              onClick={toggleWeekend}
+              className={cn(
+                'ml-1 rounded-lg border px-2.5 py-1 text-[11px] font-bold transition',
+                showWeekend ? 'border-emerald-300 bg-emerald-50 text-emerald-700' : 'border-[#e0e8dc] bg-white text-slate-500 hover:border-[#c8d4c3]',
+              )}
+            >
+              {showWeekend ? 'Dölj helg' : 'Visa helg'}
+            </button>
+          )}
         </div>
       </div>
 
@@ -518,6 +550,7 @@ export default function PlanningClient({
         {view === 'week' ? (
           <WeekBoard
             weekDays={weekDays}
+            showWeekend={showWeekend}
             trucks={visibleTrucks}
             segments={visibleSegments}
             todayISO={todayISO}

--- a/app/crm/planering/PlanningClient.tsx
+++ b/app/crm/planering/PlanningClient.tsx
@@ -18,6 +18,7 @@ import MonthGrid from './MonthGrid';
 import ConfirmModal from './ConfirmModal';
 import TruckManagerModal from './TruckManagerModal';
 import DepotManagerModal from './DepotManagerModal';
+import DepotStockModal from './DepotStockModal';
 
 type View = 'week' | 'month';
 type DragData =
@@ -59,6 +60,7 @@ export default function PlanningClient({
   const [confirmSeg, setConfirmSeg] = useState<OpsSegment | null>(null);
   const [truckManagerOpen, setTruckManagerOpen] = useState(false);
   const [depotManagerOpen, setDepotManagerOpen] = useState(false);
+  const [stockOpen, setStockOpen] = useState(false);
 
   const dragRef = useRef<DragData | null>(null);
   const todayISO = useMemo(() => fmtISO(new Date()), []);
@@ -475,6 +477,15 @@ export default function PlanningClient({
               Depåer
             </button>
           )}
+          <button
+            onClick={() => setStockOpen(true)}
+            className="inline-flex h-[30px] items-center gap-1.5 rounded-full border border-dashed border-[#c8d4c3] bg-white px-3 text-[12px] font-semibold text-slate-500 transition hover:border-emerald-400 hover:text-emerald-600"
+          >
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M3 7l9-4 9 4-9 4-9-4ZM3 7v10l9 4 9-4V7M12 11v10" />
+            </svg>
+            Lager
+          </button>
         </div>
       </div>
 
@@ -588,6 +599,9 @@ export default function PlanningClient({
           onChanged={() => loadSegments(range.from, range.to).catch(() => {})}
         />
       )}
+
+      {/* Depot stock (balances + deliveries) */}
+      {stockOpen && <DepotStockModal canWrite={canWrite} onClose={() => setStockOpen(false)} />}
     </div>
   );
 }

--- a/app/crm/planering/PlanningClient.tsx
+++ b/app/crm/planering/PlanningClient.tsx
@@ -670,6 +670,22 @@ export default function PlanningClient({
         )}
       </div>
 
+      {/* Legend — job-type colours (dot) + status rail colours, mirroring the card accents. */}
+      <div className="mt-3 flex flex-wrap items-center gap-x-4 gap-y-1.5 px-1 text-[10.5px] text-slate-500">
+        <span className="font-bold text-slate-600">Jobbtyp:</span>
+        {jobTypes.map((t) => (
+          <span key={t.key} className="inline-flex items-center gap-1.5">
+            <span className="h-2 w-2 rounded-full" style={{ backgroundColor: t.color }} />
+            {t.label}
+          </span>
+        ))}
+        <span className="h-3 w-px bg-[#e0e8dc]" />
+        <span className="font-bold text-slate-600">Status:</span>
+        <span className="inline-flex items-center gap-1.5"><span className="h-2 w-2 rounded-full bg-sky-400" />Planerad</span>
+        <span className="inline-flex items-center gap-1.5"><span className="h-2 w-2 rounded-full bg-violet-400" />Pågående</span>
+        <span className="inline-flex items-center gap-1.5"><span className="h-2 w-2 rounded-full bg-emerald-500" />Fakturera</span>
+      </div>
+
       {/* Truck picker (month placement) */}
       {truckPicker && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/40 p-4" onClick={() => setTruckPicker(null)}>

--- a/app/crm/planering/PlanningClient.tsx
+++ b/app/crm/planering/PlanningClient.tsx
@@ -9,6 +9,7 @@ import type { OpsSegment, OpsTruck, SchedulableWorkOrder } from '@/lib/domains/p
 import type { AssignablePerson, CrewMember } from '@/lib/domains/planning/crew';
 import type { DayNote } from '@/lib/domains/planning/dayNotes';
 import type { TruckCrewMember } from '@/lib/domains/planning/truckCrew';
+import { DEFAULT_JOB_TYPES, type JobType, type JobTypeRow } from '@/lib/domains/planning/jobTypes';
 import {
   addDays, addDaysISO, buildMonthWeeks, buildWeekDays, daysBetweenInclusive, fmtISO, isoWeek, startOfWeek, swedishMonthYear,
 } from './planningDates';
@@ -19,6 +20,7 @@ import ConfirmModal from './ConfirmModal';
 import TruckManagerModal from './TruckManagerModal';
 import DepotManagerModal from './DepotManagerModal';
 import DepotStockModal from './DepotStockModal';
+import JobTypeManagerModal from './JobTypeManagerModal';
 
 type View = 'week' | 'month';
 type DragData =
@@ -48,6 +50,7 @@ export default function PlanningClient({
   const [trucks, setTrucks] = useState<OpsTruck[]>([]);
   const [segments, setSegments] = useState<OpsSegment[]>([]);
   const [people, setPeople] = useState<AssignablePerson[]>([]);
+  const [jobTypes, setJobTypes] = useState<JobType[]>(DEFAULT_JOB_TYPES);
   const [dayNotes, setDayNotes] = useState<DayNote[]>([]);
   const [truckCrew, setTruckCrew] = useState<TruckCrewMember[]>([]);
   const [loadingBacklog, setLoadingBacklog] = useState(true);
@@ -63,6 +66,7 @@ export default function PlanningClient({
   const [truckManagerOpen, setTruckManagerOpen] = useState(false);
   const [depotManagerOpen, setDepotManagerOpen] = useState(false);
   const [stockOpen, setStockOpen] = useState(false);
+  const [jobTypeManagerOpen, setJobTypeManagerOpen] = useState(false);
 
   const dragRef = useRef<DragData | null>(null);
   const todayISO = useMemo(() => fmtISO(new Date()), []);
@@ -151,6 +155,19 @@ export default function PlanningClient({
       })
       .catch(() => {});
   }, []);
+
+  // Job types (active ones) for the card chips + picker. Falls back to the built-in defaults before
+  // the list loads (or if the migration hasn't run yet).
+  const loadJobTypes = useCallback(async () => {
+    const r = await fetch(`${API}/job-types`, { cache: 'no-store' });
+    const j = await r.json();
+    if (!j.ok) return;
+    const active = (j.data.jobTypes as JobTypeRow[]).filter((t) => t.active).map((t) => ({ key: t.key, label: t.label, color: t.color }));
+    if (active.length) setJobTypes(active);
+  }, []);
+  useEffect(() => {
+    loadJobTypes().catch(() => {});
+  }, [loadJobTypes]);
 
   useEffect(() => {
     loadSegments(range.from, range.to).catch((e) => setError(e?.message || 'Något gick fel'));
@@ -537,6 +554,17 @@ export default function PlanningClient({
               Depåer
             </button>
           )}
+          {canManageTrucks && (
+            <button
+              onClick={() => setJobTypeManagerOpen(true)}
+              className="inline-flex h-[30px] items-center gap-1.5 rounded-full border border-dashed border-[#c8d4c3] bg-white px-3 text-[12px] font-semibold text-slate-500 transition hover:border-emerald-400 hover:text-emerald-600"
+            >
+              <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M12 2l3 7h7l-5.5 4.5L18 21l-6-4-6 4 1.5-7.5L2 9h7z" />
+              </svg>
+              Jobbtyper
+            </button>
+          )}
           <button
             onClick={() => setStockOpen(true)}
             className="inline-flex h-[30px] items-center gap-1.5 rounded-full border border-dashed border-[#c8d4c3] bg-white px-3 text-[12px] font-semibold text-slate-500 transition hover:border-emerald-400 hover:text-emerald-600"
@@ -585,6 +613,7 @@ export default function PlanningClient({
             canWrite={canWrite}
             placing={placing}
             people={people}
+            jobTypes={jobTypes}
             onCellClick={onWeekCellClick}
             onCellDrop={onCellDrop}
             onSegDragStart={onSegDragStart}
@@ -663,6 +692,11 @@ export default function PlanningClient({
 
       {/* Depot stock (balances + deliveries) */}
       {stockOpen && <DepotStockModal canWrite={canWrite} onClose={() => setStockOpen(false)} />}
+
+      {/* Job-type management */}
+      {jobTypeManagerOpen && (
+        <JobTypeManagerModal onClose={() => setJobTypeManagerOpen(false)} onChanged={() => loadJobTypes().catch(() => {})} />
+      )}
     </div>
   );
 }

--- a/app/crm/planering/PlanningClient.tsx
+++ b/app/crm/planering/PlanningClient.tsx
@@ -55,6 +55,7 @@ export default function PlanningClient({
 
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [search, setSearch] = useState('');
+  const [salesFilter, setSalesFilter] = useState<string | null>(null);
   const [hiddenTrucks, setHiddenTrucks] = useState<Set<string>>(new Set());
   const [backlogDropActive, setBacklogDropActive] = useState(false);
   const [truckPicker, setTruckPicker] = useState<{ dayISO: string; workOrderId: string } | null>(null);
@@ -385,7 +386,20 @@ export default function PlanningClient({
       !q || [j.ref, j.client_name, j.project_name, j.address].some((v) => (v ?? '').toLowerCase().includes(q)),
     [q],
   );
-  const visibleBacklog = useMemo(() => backlog.filter((b) => matchJob(b)), [backlog, matchJob]);
+  // Sales-responsible options for the backlog filter: assignees present in the backlog, named via
+  // the people list (profiles are self-read-only, so we can't join names server-side).
+  const peopleById = useMemo(() => new Map(people.map((p) => [p.id, p.full_name])), [people]);
+  const salesOptions = useMemo(() => {
+    const ids = [...new Set(backlog.map((b) => b.assigned_to).filter((v): v is string => Boolean(v)))];
+    return ids
+      .map((id) => ({ id, name: peopleById.get(id) ?? 'Okänd säljare' }))
+      .sort((a, b) => a.name.localeCompare(b.name, 'sv'));
+  }, [backlog, peopleById]);
+
+  const visibleBacklog = useMemo(
+    () => backlog.filter((b) => matchJob(b) && (!salesFilter || b.assigned_to === salesFilter)),
+    [backlog, matchJob, salesFilter],
+  );
   const visibleSegments = useMemo(
     () => segments.filter((s) => !hiddenTrucks.has(s.truck_id) && (s.job ? matchJob(s.job) : true)),
     [segments, hiddenTrucks, matchJob],
@@ -470,6 +484,20 @@ export default function PlanningClient({
             className="h-9 w-full rounded-lg border border-[#dce4d8] bg-white pl-9 pr-3 text-[13px] text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-2 focus:ring-emerald-500/20"
           />
         </div>
+
+        {salesOptions.length > 0 && (
+          <select
+            value={salesFilter ?? ''}
+            onChange={(e) => setSalesFilter(e.target.value || null)}
+            aria-label="Filtrera på säljare"
+            className="h-9 rounded-lg border border-[#dce4d8] bg-white px-2.5 text-[12.5px] text-slate-600 outline-none transition focus:border-emerald-500"
+          >
+            <option value="">Alla säljare</option>
+            {salesOptions.map((s) => (
+              <option key={s.id} value={s.id}>{s.name}</option>
+            ))}
+          </select>
+        )}
         <div className="flex flex-wrap items-center gap-1.5">
           {trucks.map((t) => {
             const off = hiddenTrucks.has(t.id);

--- a/app/crm/planering/PlanningClient.tsx
+++ b/app/crm/planering/PlanningClient.tsx
@@ -1,81 +1,76 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { cn } from '@/lib/shared/cn';
 import { useToast } from '@/lib/Toast';
 import { crm } from '@/app/crm/lib/crmTokens';
-import type { SchedulableWorkOrder, OpsTruck, OpsSegment } from '@/lib/domains/planning/types';
+import type { OpsSegment, OpsTruck, SchedulableWorkOrder } from '@/lib/domains/planning/types';
+import {
+  addDays, addDaysISO, buildMonthWeeks, buildWeekDays, daysBetweenInclusive, fmtISO, isoWeek, startOfWeek, swedishMonthYear,
+} from './planningDates';
+import Backlog from './Backlog';
+import WeekBoard from './WeekBoard';
+import MonthGrid from './MonthGrid';
 
-// ── small date helpers (UI-local; a richer planning date util comes with the redesign slice) ──
-function startOfWeek(d: Date): Date {
-  const x = new Date(d);
-  const dow = (x.getDay() + 6) % 7; // 0 = Monday
-  x.setDate(x.getDate() - dow);
-  x.setHours(0, 0, 0, 0);
-  return x;
-}
-function addDays(d: Date, n: number): Date {
-  const x = new Date(d);
-  x.setDate(x.getDate() + n);
-  return x;
-}
-function fmtISO(d: Date): string {
-  const y = d.getFullYear();
-  const m = String(d.getMonth() + 1).padStart(2, '0');
-  const day = String(d.getDate()).padStart(2, '0');
-  return `${y}-${m}-${day}`;
-}
-function isoWeek(d: Date): number {
-  const date = new Date(Date.UTC(d.getFullYear(), d.getMonth(), d.getDate()));
-  const dayNum = (date.getUTCDay() + 6) % 7;
-  date.setUTCDate(date.getUTCDate() - dayNum + 3);
-  const firstThursday = new Date(Date.UTC(date.getUTCFullYear(), 0, 4));
-  return 1 + Math.round((date.getTime() - firstThursday.getTime()) / (7 * 24 * 3600 * 1000));
-}
+type View = 'week' | 'month';
+type DragData =
+  | { kind: 'backlog'; id: string }
+  | { kind: 'segment'; id: string; start: string; end: string; truckId: string };
 
-type WeekDay = { date: Date; iso: string; weekday: string; dayLabel: string; isWeekend: boolean; isToday: boolean };
+const API = '/api/crm/planering';
 
 export default function PlanningClient({ canWrite }: { canWrite: boolean }) {
   const toast = useToast();
+  const router = useRouter();
 
+  const [view, setView] = useState<View>('week');
   const [weekOffset, setWeekOffset] = useState(0);
+  const [monthOffset, setMonthOffset] = useState(0);
+
   const [backlog, setBacklog] = useState<SchedulableWorkOrder[]>([]);
   const [trucks, setTrucks] = useState<OpsTruck[]>([]);
   const [segments, setSegments] = useState<OpsSegment[]>([]);
-  const [loading, setLoading] = useState(true);
+  const [loadingBacklog, setLoadingBacklog] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [selectedId, setSelectedId] = useState<string | null>(null);
 
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [search, setSearch] = useState('');
+  const [hiddenTrucks, setHiddenTrucks] = useState<Set<string>>(new Set());
+  const [backlogDropActive, setBacklogDropActive] = useState(false);
+  const [truckPicker, setTruckPicker] = useState<{ dayISO: string; workOrderId: string } | null>(null);
+
+  const dragRef = useRef<DragData | null>(null);
   const todayISO = useMemo(() => fmtISO(new Date()), []);
 
-  const weekDays = useMemo<WeekDay[]>(() => {
-    const monday = addDays(startOfWeek(new Date()), weekOffset * 7);
-    return Array.from({ length: 7 }, (_, i) => {
-      const date = addDays(monday, i);
-      const iso = fmtISO(date);
-      return {
-        date,
-        iso,
-        weekday: date.toLocaleDateString('sv-SE', { weekday: 'short' }),
-        dayLabel: date.toLocaleDateString('sv-SE', { day: 'numeric', month: 'numeric' }),
-        isWeekend: i >= 5,
-        isToday: iso === todayISO,
-      };
-    });
-  }, [weekOffset, todayISO]);
+  // ── visible range (depends on view + offset) ──────────────────────────────
+  const weekMonday = useMemo(() => addDays(startOfWeek(new Date()), weekOffset * 7), [weekOffset]);
+  const weekDays = useMemo(() => buildWeekDays(weekMonday), [weekMonday]);
+  const monthAnchor = useMemo(() => {
+    const b = new Date();
+    b.setHours(0, 0, 0, 0);
+    b.setDate(1);
+    b.setMonth(b.getMonth() + monthOffset);
+    return b;
+  }, [monthOffset]);
+  const monthWeeks = useMemo(() => buildMonthWeeks(monthAnchor), [monthAnchor]);
 
-  const weekNo = useMemo(() => isoWeek(weekDays[0].date), [weekDays]);
-  const fromISO = weekDays[0].iso;
-  const toISO = weekDays[6].iso;
+  const range = useMemo(() => {
+    if (view === 'week') return { from: weekDays[0].iso, to: weekDays[6].iso };
+    const days = monthWeeks.flatMap((w) => w.days);
+    return { from: days[0].iso, to: days[days.length - 1].iso };
+  }, [view, weekDays, monthWeeks]);
 
+  // ── data ──────────────────────────────────────────────────────────────────
   const loadBacklog = useCallback(async () => {
-    const r = await fetch('/api/crm/planering/backlog', { cache: 'no-store' });
+    const r = await fetch(`${API}/backlog`, { cache: 'no-store' });
     const j = await r.json();
     if (!j.ok) throw new Error(j.error || 'Kunde inte hämta arbetsordrar');
     setBacklog(j.data.items as SchedulableWorkOrder[]);
   }, []);
 
-  const loadSchedule = useCallback(async (from: string, to: string) => {
-    const r = await fetch(`/api/crm/planering/segments?from=${from}&to=${to}`, { cache: 'no-store' });
+  const loadSegments = useCallback(async (from: string, to: string) => {
+    const r = await fetch(`${API}/segments?from=${from}&to=${to}`, { cache: 'no-store' });
     const j = await r.json();
     if (!j.ok) throw new Error(j.error || 'Kunde inte hämta schemat');
     setSegments(j.data.segments as OpsSegment[]);
@@ -83,229 +78,322 @@ export default function PlanningClient({ canWrite }: { canWrite: boolean }) {
   }, []);
 
   useEffect(() => {
-    let cancelled = false;
-    setLoading(true);
-    setError(null);
-    Promise.all([loadBacklog(), loadSchedule(fromISO, toISO)])
-      .catch((e) => {
-        if (!cancelled) setError(e?.message || 'Något gick fel');
-      })
-      .finally(() => {
-        if (!cancelled) setLoading(false);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [fromISO, toISO, loadBacklog, loadSchedule]);
+    setLoadingBacklog(true);
+    loadBacklog()
+      .catch((e) => setError(e?.message || 'Något gick fel'))
+      .finally(() => setLoadingBacklog(false));
+  }, [loadBacklog]);
 
-  const segmentsByTruckDay = useMemo(() => {
-    const map = new Map<string, OpsSegment[]>();
-    for (const seg of segments) {
-      for (const wd of weekDays) {
-        if (seg.start_day <= wd.iso && seg.end_day >= wd.iso) {
-          const key = `${seg.truck_id}|${wd.iso}`;
-          const list = map.get(key) ?? [];
-          list.push(seg);
-          map.set(key, list);
-        }
-      }
+  useEffect(() => {
+    loadSegments(range.from, range.to).catch((e) => setError(e?.message || 'Något gick fel'));
+  }, [range.from, range.to, loadSegments]);
+
+  const refresh = useCallback(async () => {
+    try {
+      await Promise.all([loadBacklog(), loadSegments(range.from, range.to)]);
+    } catch {
+      /* a transient refresh error shouldn't undo the action; next nav reloads */
     }
-    return map;
-  }, [segments, weekDays]);
+  }, [loadBacklog, loadSegments, range.from, range.to]);
 
-  const selected = useMemo(() => backlog.find((b) => b.id === selectedId) ?? null, [backlog, selectedId]);
-
+  // ── mutations ───────────────────────────────────────────────────────────────
   const place = useCallback(
-    async (truckId: string, dayISO: string) => {
-      if (!canWrite || !selectedId) return;
-      const r = await fetch('/api/crm/planering/segments', {
+    async (workOrderId: string, truckId: string, startDay: string, endDay: string) => {
+      const r = await fetch(`${API}/segments`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ work_order_id: selectedId, truck_id: truckId, start_day: dayISO, end_day: dayISO }),
+        body: JSON.stringify({ work_order_id: workOrderId, truck_id: truckId, start_day: startDay, end_day: endDay }),
       });
       const j = await r.json();
-      if (!j.ok) {
-        toast.error(j.error || 'Kunde inte placera ordern');
-        return;
-      }
-      toast.success('Order placerad i schemat');
-      setSelectedId(null);
-      try {
-        await Promise.all([loadBacklog(), loadSchedule(fromISO, toISO)]);
-      } catch {
-        /* a transient refresh error shouldn't undo the toast; next nav reloads */
+      if (!j.ok) return toast.error(j.error || 'Kunde inte placera ordern');
+      toast.success('Order placerad');
+      await refresh();
+    },
+    [refresh, toast],
+  );
+
+  const move = useCallback(
+    async (id: string, patch: { truck_id?: string; start_day?: string; end_day?: string }) => {
+      const r = await fetch(`${API}/segments/${id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(patch),
+      });
+      const j = await r.json();
+      if (!j.ok) return toast.error(j.error || 'Kunde inte flytta jobbet');
+      await refresh();
+    },
+    [refresh, toast],
+  );
+
+  const unschedule = useCallback(
+    async (id: string) => {
+      const r = await fetch(`${API}/segments/${id}`, { method: 'DELETE' });
+      const j = await r.json();
+      if (!j.ok) return toast.error(j.error || 'Kunde inte avplanera');
+      toast.success('Jobbet avplanerat');
+      await refresh();
+    },
+    [refresh, toast],
+  );
+
+  // ── drag handlers ───────────────────────────────────────────────────────────
+  const onBacklogDragStart = useCallback((e: React.DragEvent, item: SchedulableWorkOrder) => {
+    dragRef.current = { kind: 'backlog', id: item.id };
+    e.dataTransfer.setData('text/plain', item.id);
+    e.dataTransfer.effectAllowed = 'copyMove';
+  }, []);
+
+  const onSegDragStart = useCallback((e: React.DragEvent, seg: OpsSegment) => {
+    dragRef.current = { kind: 'segment', id: seg.id, start: seg.start_day, end: seg.end_day, truckId: seg.truck_id };
+    e.dataTransfer.setData('text/plain', seg.id);
+    e.dataTransfer.effectAllowed = 'move';
+  }, []);
+
+  const onCellDrop = useCallback(
+    (_e: React.DragEvent, truckId: string, dayISO: string) => {
+      const d = dragRef.current;
+      dragRef.current = null;
+      if (!d) return;
+      if (d.kind === 'backlog') void place(d.id, truckId, dayISO, dayISO);
+      else {
+        const span = daysBetweenInclusive(d.start, d.end);
+        void move(d.id, { truck_id: truckId, start_day: dayISO, end_day: addDaysISO(dayISO, span - 1) });
       }
     },
-    [canWrite, selectedId, fromISO, toISO, loadBacklog, loadSchedule, toast],
+    [place, move],
   );
+
+  const onMonthDayDrop = useCallback(
+    (_e: React.DragEvent, dayISO: string) => {
+      const d = dragRef.current;
+      dragRef.current = null;
+      if (!d) return;
+      if (d.kind === 'backlog') setTruckPicker({ dayISO, workOrderId: d.id });
+      else {
+        const span = daysBetweenInclusive(d.start, d.end);
+        void move(d.id, { start_day: dayISO, end_day: addDaysISO(dayISO, span - 1) });
+      }
+    },
+    [move],
+  );
+
+  const onBacklogDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault();
+      setBacklogDropActive(false);
+      const d = dragRef.current;
+      dragRef.current = null;
+      if (d?.kind === 'segment') void unschedule(d.id);
+    },
+    [unschedule],
+  );
+
+  const onSegClick = useCallback((seg: OpsSegment) => router.push(`/crm/arbetsorder/${seg.work_order_id}`), [router]);
+
+  // ── selection / click-to-place ───────────────────────────────────────────────
+  const onSelect = useCallback((id: string) => setSelectedId((cur) => (cur === id ? null : id)), []);
+  const onWeekCellClick = useCallback(
+    (truckId: string, dayISO: string) => {
+      if (!selectedId) return;
+      void place(selectedId, truckId, dayISO, dayISO);
+      setSelectedId(null);
+    },
+    [selectedId, place],
+  );
+  const onMonthDayClick = useCallback(
+    (dayISO: string) => {
+      if (selectedId) setTruckPicker({ dayISO, workOrderId: selectedId });
+    },
+    [selectedId],
+  );
+  const pickTruck = useCallback(
+    (truckId: string) => {
+      if (!truckPicker) return;
+      void place(truckPicker.workOrderId, truckId, truckPicker.dayISO, truckPicker.dayISO);
+      setTruckPicker(null);
+      setSelectedId(null);
+    },
+    [truckPicker, place],
+  );
+
+  // ── filters ───────────────────────────────────────────────────────────────
+  const q = search.trim().toLowerCase();
+  const matchJob = useCallback(
+    (j: { ref: string; client_name: string; project_name: string; address: string | null }) =>
+      !q || [j.ref, j.client_name, j.project_name, j.address].some((v) => (v ?? '').toLowerCase().includes(q)),
+    [q],
+  );
+  const visibleBacklog = useMemo(() => backlog.filter((b) => matchJob(b)), [backlog, matchJob]);
+  const visibleSegments = useMemo(
+    () => segments.filter((s) => !hiddenTrucks.has(s.truck_id) && (s.job ? matchJob(s.job) : true)),
+    [segments, hiddenTrucks, matchJob],
+  );
+  const visibleTrucks = useMemo(() => trucks.filter((t) => !hiddenTrucks.has(t.id)), [trucks, hiddenTrucks]);
+
+  const toggleTruck = (id: string) =>
+    setHiddenTrucks((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+
+  const goToday = () => (view === 'week' ? setWeekOffset(0) : setMonthOffset(0));
+  const goPrev = () => (view === 'week' ? setWeekOffset((o) => o - 1) : setMonthOffset((o) => o - 1));
+  const goNext = () => (view === 'week' ? setWeekOffset((o) => o + 1) : setMonthOffset((o) => o + 1));
+
+  const navLabel = view === 'week' ? swedishMonthYear(weekMonday) : swedishMonthYear(monthAnchor);
+  const placing = canWrite && !!selectedId;
+  const selected = backlog.find((b) => b.id === selectedId) ?? null;
 
   return (
     <div>
       {/* Header */}
-      <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+      <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
         <div>
           <h1 className={crm.pageTitle}>Planering</h1>
           <p className={crm.pageSubtitle}>Schemalägg arbetsordrar på bilar.</p>
         </div>
+
+        <div className="inline-flex rounded-xl border border-[#e0e8dc] bg-white p-0.5">
+          {(['week', 'month'] as View[]).map((v) => (
+            <button
+              key={v}
+              onClick={() => setView(v)}
+              className={cn(
+                'rounded-lg px-3.5 py-1.5 text-[12.5px] font-semibold transition',
+                view === v ? 'text-white' : 'text-slate-500 hover:text-slate-800',
+              )}
+              style={view === v ? { backgroundColor: 'var(--crm-primary)' } : undefined}
+            >
+              {v === 'week' ? 'Vecka' : 'Månad'}
+            </button>
+          ))}
+        </div>
+
         <div className="flex items-center gap-1.5">
-          <button className={crm.ghostButton} onClick={() => setWeekOffset((o) => o - 1)} aria-label="Föregående vecka">
-            ‹
-          </button>
-          <button className={crm.ghostButton} onClick={() => setWeekOffset(0)}>
-            Idag
-          </button>
-          <button className={crm.ghostButton} onClick={() => setWeekOffset((o) => o + 1)} aria-label="Nästa vecka">
-            ›
-          </button>
-          <span className="ml-1 rounded-lg border border-[#e0e8dc] bg-white px-2.5 py-1 text-[11px] font-semibold text-slate-600">
-            v.{weekNo}
-          </span>
+          <span className="mr-1 text-[13px] font-bold text-slate-700">{navLabel}</span>
+          <button className={crm.ghostButton} onClick={goPrev} aria-label="Bakåt">‹</button>
+          <button className={crm.ghostButton} onClick={goToday}>Idag</button>
+          <button className={crm.ghostButton} onClick={goNext} aria-label="Framåt">›</button>
+          {view === 'week' && (
+            <span className="ml-1 rounded-lg border border-[#e0e8dc] bg-white px-2.5 py-1 text-[11px] font-bold tabular-nums text-slate-600">
+              v.{isoWeek(weekMonday)}
+            </span>
+          )}
         </div>
       </div>
 
-      {/* Skeleton-stage banner */}
-      <div className="mb-3 rounded-xl border border-amber-200 bg-amber-50 px-3 py-2 text-[11px] text-amber-800">
-        Tidig version (Wave 7, skiva 1). Gamla planeringen ligger kvar orörd tills den nya är klar.
+      {/* Filters */}
+      <div className="mb-3 flex flex-wrap items-center gap-2.5">
+        <div className="relative max-w-[280px] flex-1">
+          <svg className="pointer-events-none absolute left-3 top-1/2 h-[15px] w-[15px] -translate-y-1/2 text-slate-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <circle cx="11" cy="11" r="8" /><line x1="21" y1="21" x2="16.65" y2="16.65" />
+          </svg>
+          <input
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Sök Fortnox-nr, kund eller adress…"
+            className="h-9 w-full rounded-lg border border-[#dce4d8] bg-white pl-9 pr-3 text-[13px] text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-2 focus:ring-emerald-500/20"
+          />
+        </div>
+        <div className="flex flex-wrap items-center gap-1.5">
+          {trucks.map((t) => {
+            const off = hiddenTrucks.has(t.id);
+            return (
+              <button
+                key={t.id}
+                onClick={() => toggleTruck(t.id)}
+                className={cn(
+                  'inline-flex h-[30px] items-center gap-2 rounded-full border px-3 text-[12px] font-semibold transition',
+                  off ? 'border-[#e0e8dc] bg-[#f3f6f1] text-slate-400 opacity-60' : 'border-[#e0e8dc] bg-white text-slate-600 hover:border-[#c8d4c3]',
+                )}
+              >
+                <span className="h-2.5 w-2.5 rounded-full" style={{ backgroundColor: t.color || '#94a3b8' }} />
+                {t.name}
+              </button>
+            );
+          })}
+        </div>
       </div>
 
-      {error && (
-        <div className="mb-3 rounded-xl border border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-700">{error}</div>
+      {error && <div className="mb-3 rounded-xl border border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-700">{error}</div>}
+
+      {selected && (
+        <div className="mb-3 rounded-xl border border-emerald-200 bg-emerald-50 px-3 py-2 text-[12px] text-emerald-800">
+          <strong>{selected.project_name}</strong> vald — klicka {view === 'week' ? 'en cell (bil + dag)' : 'en dag'} för att placera, eller dra kortet.
+        </div>
       )}
 
       <div className="grid gap-4 lg:grid-cols-[320px_minmax(0,1fr)]">
-        {/* Backlog */}
-        <section className={`${crm.card} p-3`}>
-          <div className="mb-2 flex items-center justify-between">
-            <h2 className={crm.sectionTitle}>Att planera</h2>
-            <span className="text-[11px] text-slate-400">{backlog.length} st</span>
-          </div>
+        <Backlog
+          items={visibleBacklog}
+          loading={loadingBacklog}
+          canWrite={canWrite}
+          selectedId={selectedId}
+          onSelect={onSelect}
+          onDragStartItem={onBacklogDragStart}
+          onDropUnschedule={onBacklogDrop}
+          onDragOver={(e) => {
+            if (canWrite) {
+              e.preventDefault();
+              if (dragRef.current?.kind === 'segment') setBacklogDropActive(true);
+            }
+          }}
+          dropActive={backlogDropActive}
+        />
 
-          {loading ? (
-            <p className="py-6 text-center text-sm text-slate-400">Laddar…</p>
-          ) : backlog.length === 0 ? (
-            <p className="py-6 text-center text-sm text-slate-400">
-              Inga arbetsordrar att planera. Skapa en order i CRM:et så dyker den upp här.
-            </p>
-          ) : (
-            <ul className="grid gap-1.5">
-              {backlog.map((item) => {
-                const isSelected = item.id === selectedId;
-                return (
-                  <li key={item.id}>
-                    <button
-                      type="button"
-                      disabled={!canWrite}
-                      onClick={() => setSelectedId(isSelected ? null : item.id)}
-                      className={`w-full rounded-xl border p-2.5 text-left transition ${
-                        isSelected
-                          ? 'border-emerald-400 bg-emerald-50 ring-2 ring-emerald-500/20'
-                          : 'border-[#e0e8dc] bg-white hover:border-[#c8d4c3]'
-                      } ${canWrite ? 'cursor-pointer' : 'cursor-default'}`}
-                    >
-                      <div className="flex items-center justify-between gap-2">
-                        <span className="text-[13px] font-bold text-slate-900">{item.project_name}</span>
-                        <span className="shrink-0 text-[10px] font-semibold text-slate-400">{item.order_number}</span>
-                      </div>
-                      <div className="mt-0.5 text-[11px] text-slate-500">{item.client_name}</div>
-                      {item.address && <div className="text-[11px] text-slate-400">{item.address}</div>}
-                      <div className="mt-1 flex flex-wrap items-center gap-1">
-                        {item.total_sacks > 0 && (
-                          <span className={`${crm.badge} border-emerald-200 bg-emerald-50 text-emerald-700`}>
-                            {item.total_sacks} säck
-                          </span>
-                        )}
-                        {item.desired_installation_date && (
-                          <span className={`${crm.badge} border-sky-200 bg-sky-50 text-sky-700`}>
-                            Önskat {item.desired_installation_date}
-                          </span>
-                        )}
-                        {item.segment_count > 0 && (
-                          <span className={`${crm.badge} border-violet-200 bg-violet-50 text-violet-700`}>
-                            {item.segment_count} placerad{item.segment_count === 1 ? '' : 'e'}
-                          </span>
-                        )}
-                      </div>
-                    </button>
-                  </li>
-                );
-              })}
-            </ul>
-          )}
+        {view === 'week' ? (
+          <WeekBoard
+            weekDays={weekDays}
+            trucks={visibleTrucks}
+            segments={visibleSegments}
+            todayISO={todayISO}
+            canWrite={canWrite}
+            placing={placing}
+            onCellClick={onWeekCellClick}
+            onCellDrop={onCellDrop}
+            onSegDragStart={onSegDragStart}
+            onSegClick={onSegClick}
+          />
+        ) : (
+          <MonthGrid
+            weeks={monthWeeks}
+            trucks={trucks}
+            segments={visibleSegments}
+            todayISO={todayISO}
+            canWrite={canWrite}
+            placing={placing}
+            onDayClick={onMonthDayClick}
+            onDayDrop={onMonthDayDrop}
+            onSegDragStart={onSegDragStart}
+            onSegClick={onSegClick}
+          />
+        )}
+      </div>
 
-          {canWrite && selected && (
-            <p className="mt-2 rounded-lg bg-emerald-50 px-2 py-1.5 text-[11px] text-emerald-700">
-              <strong>{selected.project_name}</strong> vald — klicka en cell i schemat för att placera.
-            </p>
-          )}
-        </section>
-
-        {/* Schedule grid */}
-        <section className={`${crm.card} overflow-x-auto p-3`}>
-          <div className="min-w-[760px]">
-            {/* Day header row */}
-            <div className="grid grid-cols-[120px_repeat(7,minmax(96px,1fr))] gap-1">
-              <div />
-              {weekDays.map((wd) => (
-                <div
-                  key={wd.iso}
-                  className={`rounded-lg px-1.5 py-1 text-center text-[11px] font-semibold ${
-                    wd.isToday ? 'bg-emerald-100 text-emerald-800' : wd.isWeekend ? 'text-slate-400' : 'text-slate-600'
-                  }`}
+      {/* Truck picker (month placement) */}
+      {truckPicker && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/40 p-4" onClick={() => setTruckPicker(null)}>
+          <div className="w-full max-w-xs rounded-2xl border border-[#e0e8dc] bg-[#f9fbf7] p-4 shadow-xl" onClick={(e) => e.stopPropagation()}>
+            <h3 className="mb-3 text-[13px] font-bold text-slate-900">Välj bil</h3>
+            <div className="grid gap-1.5">
+              {trucks.map((t) => (
+                <button
+                  key={t.id}
+                  onClick={() => pickTruck(t.id)}
+                  className="flex items-center gap-2.5 rounded-xl border border-[#e0e8dc] bg-white px-3 py-2 text-left text-[13px] font-semibold text-slate-700 transition hover:border-emerald-400 hover:bg-emerald-50"
                 >
-                  <div className="capitalize">{wd.weekday}</div>
-                  <div className="text-[10px] font-normal text-slate-400">{wd.dayLabel}</div>
-                </div>
+                  <span className="h-3 w-3 rounded-full" style={{ backgroundColor: t.color || '#94a3b8' }} />
+                  {t.name}
+                </button>
               ))}
             </div>
-
-            {/* Truck rows */}
-            {trucks.length === 0 ? (
-              <p className="py-6 text-center text-sm text-slate-400">Inga bilar upplagda än.</p>
-            ) : (
-              <div className="mt-1 grid gap-1">
-                {trucks.map((truck) => (
-                  <div key={truck.id} className="grid grid-cols-[120px_repeat(7,minmax(96px,1fr))] gap-1">
-                    <div className="flex items-center gap-1.5 rounded-lg bg-white px-2 py-1.5">
-                      <span
-                        className="inline-block h-2.5 w-2.5 shrink-0 rounded-full"
-                        style={{ backgroundColor: truck.color || '#94a3b8' }}
-                      />
-                      <span className="truncate text-[12px] font-semibold text-slate-700">{truck.name}</span>
-                    </div>
-                    {weekDays.map((wd) => {
-                      const cell = segmentsByTruckDay.get(`${truck.id}|${wd.iso}`) ?? [];
-                      const placeable = canWrite && !!selectedId;
-                      return (
-                        <button
-                          key={wd.iso}
-                          type="button"
-                          disabled={!placeable}
-                          onClick={() => place(truck.id, wd.iso)}
-                          className={`min-h-[52px] rounded-lg border p-1 text-left align-top transition ${
-                            wd.isWeekend ? 'border-slate-100 bg-slate-50/60' : 'border-[#e8efe5] bg-white'
-                          } ${placeable ? 'cursor-pointer hover:border-emerald-400 hover:bg-emerald-50/40' : 'cursor-default'}`}
-                        >
-                          <div className="grid gap-0.5">
-                            {cell.map((seg) => (
-                              <span
-                                key={seg.id}
-                                className="block truncate rounded-md border border-[#dbe7d6] bg-[#f1f7ef] px-1.5 py-0.5 text-[10px] font-semibold text-slate-700"
-                                title={`${seg.work_order?.order_number ?? ''} ${seg.work_order?.project_name ?? ''}`}
-                              >
-                                {seg.work_order?.project_name ?? seg.work_order?.order_number ?? 'Order'}
-                              </span>
-                            ))}
-                          </div>
-                        </button>
-                      );
-                    })}
-                  </div>
-                ))}
-              </div>
-            )}
+            <button onClick={() => setTruckPicker(null)} className={cn(crm.ghostButton, 'mt-3 w-full')}>Avbryt</button>
           </div>
-        </section>
-      </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/app/crm/planering/PlanningClient.tsx
+++ b/app/crm/planering/PlanningClient.tsx
@@ -370,6 +370,28 @@ export default function PlanningClient({
     [toast, truckCrew, loadTruckCrew, range.from, range.to],
   );
 
+  const copyTruckCrew = useCallback(
+    async (truckId: string, sourceFrom: string, sourceTo: string) => {
+      const r = await fetch(`${API}/truck-crew/copy`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          truck_id: truckId,
+          source_start: sourceFrom,
+          source_end: sourceTo,
+          target_start: addDaysISO(sourceFrom, 7),
+          target_end: addDaysISO(sourceTo, 7),
+        }),
+      });
+      const j = await r.json();
+      if (!j.ok) return toast.error(j.error || 'Kunde inte kopiera besättningen');
+      const copied = j.data.copied ?? 0;
+      toast.success(copied > 0 ? `Besättning kopierad till nästa vecka (${copied})` : 'Nästa vecka har redan besättningen');
+      loadTruckCrew(range.from, range.to).catch(() => {});
+    },
+    [toast, loadTruckCrew, range.from, range.to],
+  );
+
   // ── selection / click-to-place ───────────────────────────────────────────────
   const onSelect = useCallback((id: string) => setSelectedId((cur) => (cur === id ? null : id)), []);
   const onWeekCellClick = useCallback(
@@ -629,6 +651,7 @@ export default function PlanningClient({
             truckCrew={truckCrew}
             onAddTruckCrew={addTruckCrew}
             onRemoveTruckCrew={removeTruckCrew}
+            onCopyTruckCrew={copyTruckCrew}
           />
         ) : (
           <MonthGrid

--- a/app/crm/planering/PlanningClient.tsx
+++ b/app/crm/planering/PlanningClient.tsx
@@ -8,6 +8,7 @@ import { crm } from '@/app/crm/lib/crmTokens';
 import type { OpsSegment, OpsTruck, SchedulableWorkOrder } from '@/lib/domains/planning/types';
 import type { AssignablePerson, CrewMember } from '@/lib/domains/planning/crew';
 import type { DayNote } from '@/lib/domains/planning/dayNotes';
+import type { TruckCrewMember } from '@/lib/domains/planning/truckCrew';
 import {
   addDays, addDaysISO, buildMonthWeeks, buildWeekDays, daysBetweenInclusive, fmtISO, isoWeek, startOfWeek, swedishMonthYear,
 } from './planningDates';
@@ -37,6 +38,7 @@ export default function PlanningClient({ canWrite, canManageTrucks }: { canWrite
   const [segments, setSegments] = useState<OpsSegment[]>([]);
   const [people, setPeople] = useState<AssignablePerson[]>([]);
   const [dayNotes, setDayNotes] = useState<DayNote[]>([]);
+  const [truckCrew, setTruckCrew] = useState<TruckCrewMember[]>([]);
   const [loadingBacklog, setLoadingBacklog] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -92,6 +94,13 @@ export default function PlanningClient({ canWrite, canManageTrucks }: { canWrite
     setDayNotes(j.data.notes as DayNote[]);
   }, []);
 
+  const loadTruckCrew = useCallback(async (from: string, to: string) => {
+    const r = await fetch(`${API}/truck-crew?from=${from}&to=${to}`, { cache: 'no-store' });
+    const j = await r.json();
+    if (!j.ok) throw new Error(j.error || 'Kunde inte hämta bilbesättning');
+    setTruckCrew(j.data.crew as TruckCrewMember[]);
+  }, []);
+
   useEffect(() => {
     setLoadingBacklog(true);
     loadBacklog()
@@ -112,7 +121,8 @@ export default function PlanningClient({ canWrite, canManageTrucks }: { canWrite
   useEffect(() => {
     loadSegments(range.from, range.to).catch((e) => setError(e?.message || 'Något gick fel'));
     loadDayNotes(range.from, range.to).catch(() => {});
-  }, [range.from, range.to, loadSegments, loadDayNotes]);
+    loadTruckCrew(range.from, range.to).catch(() => {});
+  }, [range.from, range.to, loadSegments, loadDayNotes, loadTruckCrew]);
 
   const refresh = useCallback(async () => {
     try {
@@ -277,6 +287,36 @@ export default function PlanningClient({ canWrite, canManageTrucks }: { canWrite
       }
     },
     [toast, loadDayNotes, range.from, range.to],
+  );
+
+  // Weekly truck crew: assign for the visible week (startDay/endDay come from the board). Optimistic.
+  const addTruckCrew = useCallback(
+    async (truckId: string, person: AssignablePerson, startDay: string, endDay: string) => {
+      const r = await fetch(`${API}/truck-crew`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ truck_id: truckId, member_id: person.id, member_name: person.full_name, start_day: startDay, end_day: endDay }),
+      });
+      const j = await r.json();
+      if (!j.ok) return toast.error(j.error || 'Kunde inte lägga till i bilbesättningen');
+      setTruckCrew((prev) => [...prev, j.data.item as TruckCrewMember]);
+    },
+    [toast],
+  );
+
+  const removeTruckCrew = useCallback(
+    async (truckId: string, memberId: string) => {
+      const row = truckCrew.find((c) => c.truck_id === truckId && c.member_id === memberId);
+      if (!row) return;
+      setTruckCrew((prev) => prev.filter((c) => c.id !== row.id));
+      const r = await fetch(`${API}/truck-crew/${row.id}`, { method: 'DELETE' });
+      const j = await r.json();
+      if (!j.ok) {
+        toast.error(j.error || 'Kunde inte ta bort ur bilbesättningen');
+        loadTruckCrew(range.from, range.to).catch(() => {});
+      }
+    },
+    [toast, truckCrew, loadTruckCrew, range.from, range.to],
   );
 
   // ── selection / click-to-place ───────────────────────────────────────────────
@@ -464,6 +504,9 @@ export default function PlanningClient({ canWrite, canManageTrucks }: { canWrite
             dayNotes={dayNotes}
             onAddNote={addDayNote}
             onRemoveNote={removeDayNote}
+            truckCrew={truckCrew}
+            onAddTruckCrew={addTruckCrew}
+            onRemoveTruckCrew={removeTruckCrew}
           />
         ) : (
           <MonthGrid

--- a/app/crm/planering/PlanningClient.tsx
+++ b/app/crm/planering/PlanningClient.tsx
@@ -6,6 +6,7 @@ import { cn } from '@/lib/shared/cn';
 import { useToast } from '@/lib/Toast';
 import { crm } from '@/app/crm/lib/crmTokens';
 import type { OpsSegment, OpsTruck, SchedulableWorkOrder } from '@/lib/domains/planning/types';
+import type { AssignablePerson, CrewMember } from '@/lib/domains/planning/crew';
 import {
   addDays, addDaysISO, buildMonthWeeks, buildWeekDays, daysBetweenInclusive, fmtISO, isoWeek, startOfWeek, swedishMonthYear,
 } from './planningDates';
@@ -31,6 +32,7 @@ export default function PlanningClient({ canWrite }: { canWrite: boolean }) {
   const [backlog, setBacklog] = useState<SchedulableWorkOrder[]>([]);
   const [trucks, setTrucks] = useState<OpsTruck[]>([]);
   const [segments, setSegments] = useState<OpsSegment[]>([]);
+  const [people, setPeople] = useState<AssignablePerson[]>([]);
   const [loadingBacklog, setLoadingBacklog] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -84,6 +86,16 @@ export default function PlanningClient({ canWrite }: { canWrite: boolean }) {
       .finally(() => setLoadingBacklog(false));
   }, [loadBacklog]);
 
+  // Assignable crew (every named employee) — fetched once; a failure just leaves the picker empty.
+  useEffect(() => {
+    fetch(`${API}/crew`, { cache: 'no-store' })
+      .then((r) => r.json())
+      .then((j) => {
+        if (j.ok) setPeople(j.data.people as AssignablePerson[]);
+      })
+      .catch(() => {});
+  }, []);
+
   useEffect(() => {
     loadSegments(range.from, range.to).catch((e) => setError(e?.message || 'Något gick fel'));
   }, [range.from, range.to, loadSegments]);
@@ -135,6 +147,37 @@ export default function PlanningClient({ canWrite }: { canWrite: boolean }) {
       await refresh();
     },
     [refresh, toast],
+  );
+
+  // Crew is per-segment, so add/remove patch the one segment's crew locally (snappy) rather than
+  // refetching the whole board. A failed call toasts; the next nav/refresh resyncs from the server.
+  const patchSegCrew = useCallback((segId: string, fn: (crew: CrewMember[]) => CrewMember[]) => {
+    setSegments((prev) => prev.map((s) => (s.id === segId ? { ...s, crew: fn(s.crew) } : s)));
+  }, []);
+
+  const addCrew = useCallback(
+    async (seg: OpsSegment, person: AssignablePerson) => {
+      const r = await fetch(`${API}/segments/${seg.id}/crew`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ member_id: person.id, member_name: person.full_name }),
+      });
+      const j = await r.json();
+      if (!j.ok) return toast.error(j.error || 'Kunde inte lägga till montör');
+      const item = j.data.item as CrewMember;
+      patchSegCrew(seg.id, (crew) => [...crew.filter((c) => c.member_id !== person.id), item]);
+    },
+    [patchSegCrew, toast],
+  );
+
+  const removeCrew = useCallback(
+    async (seg: OpsSegment, memberId: string) => {
+      const r = await fetch(`${API}/segments/${seg.id}/crew?member_id=${memberId}`, { method: 'DELETE' });
+      const j = await r.json();
+      if (!j.ok) return toast.error(j.error || 'Kunde inte ta bort montör');
+      patchSegCrew(seg.id, (crew) => crew.filter((c) => c.member_id !== memberId));
+    },
+    [patchSegCrew, toast],
   );
 
   // ── drag handlers ───────────────────────────────────────────────────────────
@@ -353,11 +396,14 @@ export default function PlanningClient({ canWrite }: { canWrite: boolean }) {
             todayISO={todayISO}
             canWrite={canWrite}
             placing={placing}
+            people={people}
             onCellClick={onWeekCellClick}
             onCellDrop={onCellDrop}
             onSegDragStart={onSegDragStart}
             onSegClick={onSegClick}
             onSetJobType={onSetJobType}
+            onAddCrew={addCrew}
+            onRemoveCrew={removeCrew}
           />
         ) : (
           <MonthGrid

--- a/app/crm/planering/PlanningClient.tsx
+++ b/app/crm/planering/PlanningClient.tsx
@@ -48,6 +48,7 @@ export default function PlanningClient({
   const [weekOffset, setWeekOffset] = useState(0);
   const [monthOffset, setMonthOffset] = useState(0);
   const [showWeekend, setShowWeekend] = useState(false);
+  const [stackWeeks, setStackWeeks] = useState(false);
 
   const [backlog, setBacklog] = useState<SchedulableWorkOrder[]>([]);
   const [trucks, setTrucks] = useState<OpsTruck[]>([]);
@@ -77,6 +78,17 @@ export default function PlanningClient({
   // ── visible range (depends on view + offset) ──────────────────────────────
   const weekMonday = useMemo(() => addDays(startOfWeek(new Date()), weekOffset * 7), [weekOffset]);
   const weekDays = useMemo(() => buildWeekDays(weekMonday), [weekMonday]);
+  // "Hela månaden"-toggle: stack this week + each following week through the month end, each as
+  // its own WeekBoard (otherwise just the single current week).
+  const weekMondays = useMemo(() => {
+    if (view !== 'week' || !stackWeeks) return [weekMonday];
+    const end = new Date(weekMonday);
+    end.setMonth(end.getMonth() + 1, 0); // last day of weekMonday's month
+    const out: Date[] = [];
+    for (let m = weekMonday; m.getTime() <= end.getTime(); m = addDays(m, 7)) out.push(m);
+    return out.length ? out : [weekMonday];
+  }, [view, stackWeeks, weekMonday]);
+  const weekDaysList = useMemo(() => weekMondays.map((m) => buildWeekDays(m)), [weekMondays]);
   const monthAnchor = useMemo(() => {
     const b = new Date();
     b.setHours(0, 0, 0, 0);
@@ -87,10 +99,14 @@ export default function PlanningClient({
   const monthWeeks = useMemo(() => buildMonthWeeks(monthAnchor), [monthAnchor]);
 
   const range = useMemo(() => {
-    if (view === 'week') return { from: weekDays[0].iso, to: weekDays[6].iso };
+    if (view === 'week') {
+      const first = weekDaysList[0];
+      const last = weekDaysList[weekDaysList.length - 1];
+      return { from: first[0].iso, to: last[6].iso };
+    }
     const days = monthWeeks.flatMap((w) => w.days);
     return { from: days[0].iso, to: days[days.length - 1].iso };
-  }, [view, weekDays, monthWeeks]);
+  }, [view, weekDaysList, monthWeeks]);
 
   // ── data ──────────────────────────────────────────────────────────────────
   const loadBacklog = useCallback(async () => {
@@ -133,6 +149,7 @@ export default function PlanningClient({
   useEffect(() => {
     try {
       setShowWeekend(localStorage.getItem('crm-planning-show-weekend') === '1');
+      setStackWeeks(localStorage.getItem('crm-planning-stack-weeks') === '1');
     } catch {
       /* ignore */
     }
@@ -142,6 +159,17 @@ export default function PlanningClient({
       const next = !v;
       try {
         localStorage.setItem('crm-planning-show-weekend', next ? '1' : '0');
+      } catch {
+        /* ignore */
+      }
+      return next;
+    });
+  }, []);
+  const toggleStackWeeks = useCallback(() => {
+    setStackWeeks((v) => {
+      const next = !v;
+      try {
+        localStorage.setItem('crm-planning-stack-weeks', next ? '1' : '0');
       } catch {
         /* ignore */
       }
@@ -594,6 +622,17 @@ export default function PlanningClient({
               {showWeekend ? 'Dölj helg' : 'Visa helg'}
             </button>
           )}
+          {view === 'week' && (
+            <button
+              onClick={toggleStackWeeks}
+              className={cn(
+                'ml-1 rounded-lg border px-2.5 py-1 text-[11px] font-bold transition',
+                stackWeeks ? 'border-emerald-300 bg-emerald-50 text-emerald-700' : 'border-[#e0e8dc] bg-white text-slate-500 hover:border-[#c8d4c3]',
+              )}
+            >
+              {stackWeeks ? 'En vecka' : 'Hela månaden'}
+            </button>
+          )}
         </div>
       </div>
 
@@ -713,29 +752,44 @@ export default function PlanningClient({
         />
 
         {view === 'week' ? (
-          <WeekBoard
-            weekDays={weekDays}
-            showWeekend={showWeekend}
-            trucks={visibleTrucks}
-            segments={visibleSegments}
-            todayISO={todayISO}
-            canWrite={canWrite}
-            placing={placing}
-            people={people}
-            jobTypes={jobTypes}
-            onCellClick={onWeekCellClick}
-            onCellDrop={onCellDrop}
-            onSegDragStart={onSegDragStart}
-            onSegClick={onSegClick}
-            actions={actions}
-            dayNotes={dayNotes}
-            onAddNote={addDayNote}
-            onRemoveNote={removeDayNote}
-            truckCrew={truckCrew}
-            onAddTruckCrew={addTruckCrew}
-            onRemoveTruckCrew={removeTruckCrew}
-            onCopyTruckCrew={copyTruckCrew}
-          />
+          <div className="grid gap-4">
+            {weekMondays.map((m, i) => {
+              const wd = weekDaysList[i];
+              return (
+                <div key={wd[0].iso}>
+                  {weekMondays.length > 1 && (
+                    <div className="mb-1.5 flex items-center gap-2 px-1">
+                      <span className="rounded-lg border border-[#e0e8dc] bg-white px-2 py-0.5 text-[11px] font-bold tabular-nums text-slate-600">v.{isoWeek(m)}</span>
+                      <span className="text-[12px] font-semibold tabular-nums text-slate-500">{wd[0].dayLabel}–{wd[6].dayLabel}</span>
+                    </div>
+                  )}
+                  <WeekBoard
+                    weekDays={wd}
+                    showWeekend={showWeekend}
+                    trucks={visibleTrucks}
+                    segments={visibleSegments}
+                    todayISO={todayISO}
+                    canWrite={canWrite}
+                    placing={placing}
+                    people={people}
+                    jobTypes={jobTypes}
+                    onCellClick={onWeekCellClick}
+                    onCellDrop={onCellDrop}
+                    onSegDragStart={onSegDragStart}
+                    onSegClick={onSegClick}
+                    actions={actions}
+                    dayNotes={dayNotes}
+                    onAddNote={addDayNote}
+                    onRemoveNote={removeDayNote}
+                    truckCrew={truckCrew}
+                    onAddTruckCrew={addTruckCrew}
+                    onRemoveTruckCrew={removeTruckCrew}
+                    onCopyTruckCrew={copyTruckCrew}
+                  />
+                </div>
+              );
+            })}
+          </div>
         ) : (
           <MonthGrid
             weeks={monthWeeks}

--- a/app/crm/planering/PlanningClient.tsx
+++ b/app/crm/planering/PlanningClient.tsx
@@ -113,7 +113,7 @@ export default function PlanningClient({ canWrite }: { canWrite: boolean }) {
   );
 
   const move = useCallback(
-    async (id: string, patch: { truck_id?: string; start_day?: string; end_day?: string }) => {
+    async (id: string, patch: { truck_id?: string; start_day?: string; end_day?: string; job_type?: string | null }) => {
       const r = await fetch(`${API}/segments/${id}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
@@ -190,6 +190,7 @@ export default function PlanningClient({ canWrite }: { canWrite: boolean }) {
   );
 
   const onSegClick = useCallback((seg: OpsSegment) => router.push(`/crm/arbetsorder/${seg.work_order_id}`), [router]);
+  const onSetJobType = useCallback((seg: OpsSegment, jobType: string | null) => void move(seg.id, { job_type: jobType }), [move]);
 
   // ── selection / click-to-place ───────────────────────────────────────────────
   const onSelect = useCallback((id: string) => setSelectedId((cur) => (cur === id ? null : id)), []);
@@ -356,6 +357,7 @@ export default function PlanningClient({ canWrite }: { canWrite: boolean }) {
             onCellDrop={onCellDrop}
             onSegDragStart={onSegDragStart}
             onSegClick={onSegClick}
+            onSetJobType={onSetJobType}
           />
         ) : (
           <MonthGrid

--- a/app/crm/planering/PlanningClient.tsx
+++ b/app/crm/planering/PlanningClient.tsx
@@ -7,6 +7,7 @@ import { useToast } from '@/lib/Toast';
 import { crm } from '@/app/crm/lib/crmTokens';
 import type { OpsSegment, OpsTruck, SchedulableWorkOrder } from '@/lib/domains/planning/types';
 import type { AssignablePerson, CrewMember } from '@/lib/domains/planning/crew';
+import type { DayNote } from '@/lib/domains/planning/dayNotes';
 import {
   addDays, addDaysISO, buildMonthWeeks, buildWeekDays, daysBetweenInclusive, fmtISO, isoWeek, startOfWeek, swedishMonthYear,
 } from './planningDates';
@@ -34,6 +35,7 @@ export default function PlanningClient({ canWrite }: { canWrite: boolean }) {
   const [trucks, setTrucks] = useState<OpsTruck[]>([]);
   const [segments, setSegments] = useState<OpsSegment[]>([]);
   const [people, setPeople] = useState<AssignablePerson[]>([]);
+  const [dayNotes, setDayNotes] = useState<DayNote[]>([]);
   const [loadingBacklog, setLoadingBacklog] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -81,6 +83,13 @@ export default function PlanningClient({ canWrite }: { canWrite: boolean }) {
     setTrucks(j.data.trucks as OpsTruck[]);
   }, []);
 
+  const loadDayNotes = useCallback(async (from: string, to: string) => {
+    const r = await fetch(`${API}/day-notes?from=${from}&to=${to}`, { cache: 'no-store' });
+    const j = await r.json();
+    if (!j.ok) throw new Error(j.error || 'Kunde inte hämta noteringar');
+    setDayNotes(j.data.notes as DayNote[]);
+  }, []);
+
   useEffect(() => {
     setLoadingBacklog(true);
     loadBacklog()
@@ -100,7 +109,8 @@ export default function PlanningClient({ canWrite }: { canWrite: boolean }) {
 
   useEffect(() => {
     loadSegments(range.from, range.to).catch((e) => setError(e?.message || 'Något gick fel'));
-  }, [range.from, range.to, loadSegments]);
+    loadDayNotes(range.from, range.to).catch(() => {});
+  }, [range.from, range.to, loadSegments, loadDayNotes]);
 
   const refresh = useCallback(async () => {
     try {
@@ -238,6 +248,34 @@ export default function PlanningClient({ canWrite }: { canWrite: boolean }) {
   const onSetJobType = useCallback((seg: OpsSegment, jobType: string | null) => void move(seg.id, { job_type: jobType }), [move]);
   const onToggleHold = useCallback((seg: OpsSegment, value: boolean) => void move(seg.id, { on_hold: value }), [move]);
   const openConfirm = useCallback((seg: OpsSegment) => setConfirmSeg(seg), []);
+
+  // Day notes: optimistic local updates (a failed call resyncs from the server on the next nav).
+  const addDayNote = useCallback(
+    async (dayISO: string, body: string) => {
+      const r = await fetch(`${API}/day-notes`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ note_day: dayISO, body }),
+      });
+      const j = await r.json();
+      if (!j.ok) return toast.error(j.error || 'Kunde inte spara noteringen');
+      setDayNotes((prev) => [...prev, j.data.item as DayNote]);
+    },
+    [toast],
+  );
+
+  const removeDayNote = useCallback(
+    async (id: string) => {
+      setDayNotes((cur) => cur.filter((n) => n.id !== id));
+      const r = await fetch(`${API}/day-notes/${id}`, { method: 'DELETE' });
+      const j = await r.json();
+      if (!j.ok) {
+        toast.error(j.error || 'Kunde inte ta bort noteringen');
+        loadDayNotes(range.from, range.to).catch(() => {});
+      }
+    },
+    [toast, loadDayNotes, range.from, range.to],
+  );
 
   // ── selection / click-to-place ───────────────────────────────────────────────
   const onSelect = useCallback((id: string) => setSelectedId((cur) => (cur === id ? null : id)), []);
@@ -410,6 +448,9 @@ export default function PlanningClient({ canWrite }: { canWrite: boolean }) {
             onRemoveCrew={removeCrew}
             onOpenConfirm={openConfirm}
             onToggleHold={onToggleHold}
+            dayNotes={dayNotes}
+            onAddNote={addDayNote}
+            onRemoveNote={removeDayNote}
           />
         ) : (
           <MonthGrid
@@ -423,6 +464,7 @@ export default function PlanningClient({ canWrite }: { canWrite: boolean }) {
             onDayDrop={onMonthDayDrop}
             onSegDragStart={onSegDragStart}
             onSegClick={onSegClick}
+            dayNotes={dayNotes}
           />
         )}
       </div>

--- a/app/crm/planering/PlanningClient.tsx
+++ b/app/crm/planering/PlanningClient.tsx
@@ -310,6 +310,7 @@ export default function PlanningClient({
   const onSegClick = useCallback((seg: OpsSegment) => router.push(`/crm/arbetsorder/${seg.work_order_id}`), [router]);
   const onSetJobType = useCallback((seg: OpsSegment, jobType: string | null) => void move(seg.id, { job_type: jobType }), [move]);
   const onToggleHold = useCallback((seg: OpsSegment, value: boolean) => void move(seg.id, { on_hold: value }), [move]);
+  const onResize = useCallback((seg: OpsSegment, startDay: string, endDay: string) => void move(seg.id, { start_day: startDay, end_day: endDay }), [move]);
   const openConfirm = useCallback((seg: OpsSegment) => setConfirmSeg(seg), []);
 
   // Day notes: optimistic local updates (a failed call resyncs from the server on the next nav).
@@ -652,6 +653,7 @@ export default function PlanningClient({
             onAddTruckCrew={addTruckCrew}
             onRemoveTruckCrew={removeTruckCrew}
             onCopyTruckCrew={copyTruckCrew}
+            onResize={onResize}
           />
         ) : (
           <MonthGrid

--- a/app/crm/planering/PlanningClient.tsx
+++ b/app/crm/planering/PlanningClient.tsx
@@ -16,6 +16,7 @@ import {
 import Backlog from './Backlog';
 import WeekBoard from './WeekBoard';
 import MonthGrid from './MonthGrid';
+import type { SegmentActions } from './jobCard';
 import ConfirmModal from './ConfirmModal';
 import TruckManagerModal from './TruckManagerModal';
 import DepotManagerModal from './DepotManagerModal';
@@ -476,6 +477,11 @@ export default function PlanningClient({
   const placing = canWrite && !!selectedId;
   const selected = backlog.find((b) => b.id === selectedId) ?? null;
 
+  const actions = useMemo<SegmentActions>(
+    () => ({ onSetStatus, onSetJobType, onToggleHold, onOpenConfirm: openConfirm, onResize, onAddCrew: addCrew, onRemoveCrew: removeCrew }),
+    [onSetStatus, onSetJobType, onToggleHold, openConfirm, onResize, addCrew, removeCrew],
+  );
+
   return (
     <div>
       {/* Header */}
@@ -655,11 +661,7 @@ export default function PlanningClient({
             onCellDrop={onCellDrop}
             onSegDragStart={onSegDragStart}
             onSegClick={onSegClick}
-            onSetJobType={onSetJobType}
-            onAddCrew={addCrew}
-            onRemoveCrew={removeCrew}
-            onOpenConfirm={openConfirm}
-            onToggleHold={onToggleHold}
+            actions={actions}
             dayNotes={dayNotes}
             onAddNote={addDayNote}
             onRemoveNote={removeDayNote}
@@ -667,8 +669,6 @@ export default function PlanningClient({
             onAddTruckCrew={addTruckCrew}
             onRemoveTruckCrew={removeTruckCrew}
             onCopyTruckCrew={copyTruckCrew}
-            onResize={onResize}
-            onSetStatus={onSetStatus}
           />
         ) : (
           <MonthGrid
@@ -684,13 +684,7 @@ export default function PlanningClient({
             onDayDrop={onMonthDayDrop}
             onSegDragStart={onSegDragStart}
             onSegClick={onSegClick}
-            onSetStatus={onSetStatus}
-            onSetJobType={onSetJobType}
-            onToggleHold={onToggleHold}
-            onOpenConfirm={openConfirm}
-            onResize={onResize}
-            onAddCrew={addCrew}
-            onRemoveCrew={removeCrew}
+            actions={actions}
             dayNotes={dayNotes}
           />
         )}

--- a/app/crm/planering/PlanningClient.tsx
+++ b/app/crm/planering/PlanningClient.tsx
@@ -127,7 +127,7 @@ export default function PlanningClient({ canWrite }: { canWrite: boolean }) {
   );
 
   const move = useCallback(
-    async (id: string, patch: { truck_id?: string; start_day?: string; end_day?: string; job_type?: string | null }) => {
+    async (id: string, patch: { truck_id?: string; start_day?: string; end_day?: string; job_type?: string | null; on_hold?: boolean }) => {
       const r = await fetch(`${API}/segments/${id}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
@@ -236,6 +236,7 @@ export default function PlanningClient({ canWrite }: { canWrite: boolean }) {
 
   const onSegClick = useCallback((seg: OpsSegment) => router.push(`/crm/arbetsorder/${seg.work_order_id}`), [router]);
   const onSetJobType = useCallback((seg: OpsSegment, jobType: string | null) => void move(seg.id, { job_type: jobType }), [move]);
+  const onToggleHold = useCallback((seg: OpsSegment, value: boolean) => void move(seg.id, { on_hold: value }), [move]);
   const openConfirm = useCallback((seg: OpsSegment) => setConfirmSeg(seg), []);
 
   // ── selection / click-to-place ───────────────────────────────────────────────
@@ -408,6 +409,7 @@ export default function PlanningClient({ canWrite }: { canWrite: boolean }) {
             onAddCrew={addCrew}
             onRemoveCrew={removeCrew}
             onOpenConfirm={openConfirm}
+            onToggleHold={onToggleHold}
           />
         ) : (
           <MonthGrid

--- a/app/crm/planering/PlanningClient.tsx
+++ b/app/crm/planering/PlanningClient.tsx
@@ -13,6 +13,7 @@ import {
 import Backlog from './Backlog';
 import WeekBoard from './WeekBoard';
 import MonthGrid from './MonthGrid';
+import ConfirmModal from './ConfirmModal';
 
 type View = 'week' | 'month';
 type DragData =
@@ -41,6 +42,7 @@ export default function PlanningClient({ canWrite }: { canWrite: boolean }) {
   const [hiddenTrucks, setHiddenTrucks] = useState<Set<string>>(new Set());
   const [backlogDropActive, setBacklogDropActive] = useState(false);
   const [truckPicker, setTruckPicker] = useState<{ dayISO: string; workOrderId: string } | null>(null);
+  const [confirmSeg, setConfirmSeg] = useState<OpsSegment | null>(null);
 
   const dragRef = useRef<DragData | null>(null);
   const todayISO = useMemo(() => fmtISO(new Date()), []);
@@ -234,6 +236,7 @@ export default function PlanningClient({ canWrite }: { canWrite: boolean }) {
 
   const onSegClick = useCallback((seg: OpsSegment) => router.push(`/crm/arbetsorder/${seg.work_order_id}`), [router]);
   const onSetJobType = useCallback((seg: OpsSegment, jobType: string | null) => void move(seg.id, { job_type: jobType }), [move]);
+  const openConfirm = useCallback((seg: OpsSegment) => setConfirmSeg(seg), []);
 
   // ── selection / click-to-place ───────────────────────────────────────────────
   const onSelect = useCallback((id: string) => setSelectedId((cur) => (cur === id ? null : id)), []);
@@ -404,6 +407,7 @@ export default function PlanningClient({ canWrite }: { canWrite: boolean }) {
             onSetJobType={onSetJobType}
             onAddCrew={addCrew}
             onRemoveCrew={removeCrew}
+            onOpenConfirm={openConfirm}
           />
         ) : (
           <MonthGrid
@@ -441,6 +445,11 @@ export default function PlanningClient({ canWrite }: { canWrite: boolean }) {
             <button onClick={() => setTruckPicker(null)} className={cn(crm.ghostButton, 'mt-3 w-full')}>Avbryt</button>
           </div>
         </div>
+      )}
+
+      {/* Order confirmation (SMS/email) */}
+      {confirmSeg && (
+        <ConfirmModal segment={confirmSeg} onClose={() => setConfirmSeg(null)} onSent={refresh} />
       )}
     </div>
   );

--- a/app/crm/planering/PlanningClient.tsx
+++ b/app/crm/planering/PlanningClient.tsx
@@ -17,6 +17,7 @@ import WeekBoard from './WeekBoard';
 import MonthGrid from './MonthGrid';
 import ConfirmModal from './ConfirmModal';
 import TruckManagerModal from './TruckManagerModal';
+import DepotManagerModal from './DepotManagerModal';
 
 type View = 'week' | 'month';
 type DragData =
@@ -25,7 +26,15 @@ type DragData =
 
 const API = '/api/crm/planering';
 
-export default function PlanningClient({ canWrite, canManageTrucks }: { canWrite: boolean; canManageTrucks: boolean }) {
+export default function PlanningClient({
+  canWrite,
+  canManageTrucks,
+  canManageDepots,
+}: {
+  canWrite: boolean;
+  canManageTrucks: boolean;
+  canManageDepots: boolean;
+}) {
   const toast = useToast();
   const router = useRouter();
 
@@ -49,6 +58,7 @@ export default function PlanningClient({ canWrite, canManageTrucks }: { canWrite
   const [truckPicker, setTruckPicker] = useState<{ dayISO: string; workOrderId: string } | null>(null);
   const [confirmSeg, setConfirmSeg] = useState<OpsSegment | null>(null);
   const [truckManagerOpen, setTruckManagerOpen] = useState(false);
+  const [depotManagerOpen, setDepotManagerOpen] = useState(false);
 
   const dragRef = useRef<DragData | null>(null);
   const todayISO = useMemo(() => fmtISO(new Date()), []);
@@ -454,6 +464,17 @@ export default function PlanningClient({ canWrite, canManageTrucks }: { canWrite
               Bilar
             </button>
           )}
+          {canManageDepots && (
+            <button
+              onClick={() => setDepotManagerOpen(true)}
+              className="inline-flex h-[30px] items-center gap-1.5 rounded-full border border-dashed border-[#c8d4c3] bg-white px-3 text-[12px] font-semibold text-slate-500 transition hover:border-emerald-400 hover:text-emerald-600"
+            >
+              <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M3 21V8l9-5 9 5v13M3 21h18M9 21v-6h6v6" />
+              </svg>
+              Depåer
+            </button>
+          )}
         </div>
       </div>
 
@@ -556,6 +577,14 @@ export default function PlanningClient({ canWrite, canManageTrucks }: { canWrite
       {truckManagerOpen && (
         <TruckManagerModal
           onClose={() => setTruckManagerOpen(false)}
+          onChanged={() => loadSegments(range.from, range.to).catch(() => {})}
+        />
+      )}
+
+      {/* Depot management */}
+      {depotManagerOpen && (
+        <DepotManagerModal
+          onClose={() => setDepotManagerOpen(false)}
           onChanged={() => loadSegments(range.from, range.to).catch(() => {})}
         />
       )}

--- a/app/crm/planering/PlanningClient.tsx
+++ b/app/crm/planering/PlanningClient.tsx
@@ -17,6 +17,7 @@ import Backlog from './Backlog';
 import WeekBoard from './WeekBoard';
 import MonthGrid from './MonthGrid';
 import type { SegmentActions } from './jobCard';
+import { dayGroup, reorderWithinGroup } from '@/lib/domains/planning/order';
 import ConfirmModal from './ConfirmModal';
 import TruckManagerModal from './TruckManagerModal';
 import DepotManagerModal from './DepotManagerModal';
@@ -477,9 +478,30 @@ export default function PlanningClient({
   const placing = canWrite && !!selectedId;
   const selected = backlog.find((b) => b.id === selectedId) ?? null;
 
+  // Reorder jobs that share a truck on the same day (sort_index) — nudges one earlier/later and
+  // PATCHes the affected segments, then refreshes.
+  const reorderSegment = useCallback(
+    async (seg: OpsSegment, direction: 'up' | 'down') => {
+      const changes = reorderWithinGroup(dayGroup(segments, seg), seg.id, direction);
+      if (!changes.length) return;
+      const results = await Promise.all(
+        changes.map((ch) =>
+          fetch(`${API}/segments/${ch.id}`, {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ sort_index: ch.sort_index }),
+          }).then((r) => r.json()),
+        ),
+      );
+      if (results.some((j) => !j.ok)) toast.error('Kunde inte ändra ordningen');
+      await refresh();
+    },
+    [segments, refresh, toast],
+  );
+
   const actions = useMemo<SegmentActions>(
-    () => ({ onSetStatus, onSetJobType, onToggleHold, onOpenConfirm: openConfirm, onResize, onAddCrew: addCrew, onRemoveCrew: removeCrew }),
-    [onSetStatus, onSetJobType, onToggleHold, openConfirm, onResize, addCrew, removeCrew],
+    () => ({ onSetStatus, onSetJobType, onToggleHold, onOpenConfirm: openConfirm, onResize, onAddCrew: addCrew, onRemoveCrew: removeCrew, onReorder: reorderSegment }),
+    [onSetStatus, onSetJobType, onToggleHold, openConfirm, onResize, addCrew, removeCrew, reorderSegment],
   );
 
   return (

--- a/app/crm/planering/PlanningClient.tsx
+++ b/app/crm/planering/PlanningClient.tsx
@@ -1,0 +1,311 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useToast } from '@/lib/Toast';
+import { crm } from '@/app/crm/lib/crmTokens';
+import type { SchedulableWorkOrder, OpsTruck, OpsSegment } from '@/lib/domains/planning/types';
+
+// ── small date helpers (UI-local; a richer planning date util comes with the redesign slice) ──
+function startOfWeek(d: Date): Date {
+  const x = new Date(d);
+  const dow = (x.getDay() + 6) % 7; // 0 = Monday
+  x.setDate(x.getDate() - dow);
+  x.setHours(0, 0, 0, 0);
+  return x;
+}
+function addDays(d: Date, n: number): Date {
+  const x = new Date(d);
+  x.setDate(x.getDate() + n);
+  return x;
+}
+function fmtISO(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+function isoWeek(d: Date): number {
+  const date = new Date(Date.UTC(d.getFullYear(), d.getMonth(), d.getDate()));
+  const dayNum = (date.getUTCDay() + 6) % 7;
+  date.setUTCDate(date.getUTCDate() - dayNum + 3);
+  const firstThursday = new Date(Date.UTC(date.getUTCFullYear(), 0, 4));
+  return 1 + Math.round((date.getTime() - firstThursday.getTime()) / (7 * 24 * 3600 * 1000));
+}
+
+type WeekDay = { date: Date; iso: string; weekday: string; dayLabel: string; isWeekend: boolean; isToday: boolean };
+
+export default function PlanningClient({ canWrite }: { canWrite: boolean }) {
+  const toast = useToast();
+
+  const [weekOffset, setWeekOffset] = useState(0);
+  const [backlog, setBacklog] = useState<SchedulableWorkOrder[]>([]);
+  const [trucks, setTrucks] = useState<OpsTruck[]>([]);
+  const [segments, setSegments] = useState<OpsSegment[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  const todayISO = useMemo(() => fmtISO(new Date()), []);
+
+  const weekDays = useMemo<WeekDay[]>(() => {
+    const monday = addDays(startOfWeek(new Date()), weekOffset * 7);
+    return Array.from({ length: 7 }, (_, i) => {
+      const date = addDays(monday, i);
+      const iso = fmtISO(date);
+      return {
+        date,
+        iso,
+        weekday: date.toLocaleDateString('sv-SE', { weekday: 'short' }),
+        dayLabel: date.toLocaleDateString('sv-SE', { day: 'numeric', month: 'numeric' }),
+        isWeekend: i >= 5,
+        isToday: iso === todayISO,
+      };
+    });
+  }, [weekOffset, todayISO]);
+
+  const weekNo = useMemo(() => isoWeek(weekDays[0].date), [weekDays]);
+  const fromISO = weekDays[0].iso;
+  const toISO = weekDays[6].iso;
+
+  const loadBacklog = useCallback(async () => {
+    const r = await fetch('/api/crm/planering/backlog', { cache: 'no-store' });
+    const j = await r.json();
+    if (!j.ok) throw new Error(j.error || 'Kunde inte hämta arbetsordrar');
+    setBacklog(j.data.items as SchedulableWorkOrder[]);
+  }, []);
+
+  const loadSchedule = useCallback(async (from: string, to: string) => {
+    const r = await fetch(`/api/crm/planering/segments?from=${from}&to=${to}`, { cache: 'no-store' });
+    const j = await r.json();
+    if (!j.ok) throw new Error(j.error || 'Kunde inte hämta schemat');
+    setSegments(j.data.segments as OpsSegment[]);
+    setTrucks(j.data.trucks as OpsTruck[]);
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    Promise.all([loadBacklog(), loadSchedule(fromISO, toISO)])
+      .catch((e) => {
+        if (!cancelled) setError(e?.message || 'Något gick fel');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [fromISO, toISO, loadBacklog, loadSchedule]);
+
+  const segmentsByTruckDay = useMemo(() => {
+    const map = new Map<string, OpsSegment[]>();
+    for (const seg of segments) {
+      for (const wd of weekDays) {
+        if (seg.start_day <= wd.iso && seg.end_day >= wd.iso) {
+          const key = `${seg.truck_id}|${wd.iso}`;
+          const list = map.get(key) ?? [];
+          list.push(seg);
+          map.set(key, list);
+        }
+      }
+    }
+    return map;
+  }, [segments, weekDays]);
+
+  const selected = useMemo(() => backlog.find((b) => b.id === selectedId) ?? null, [backlog, selectedId]);
+
+  const place = useCallback(
+    async (truckId: string, dayISO: string) => {
+      if (!canWrite || !selectedId) return;
+      const r = await fetch('/api/crm/planering/segments', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ work_order_id: selectedId, truck_id: truckId, start_day: dayISO, end_day: dayISO }),
+      });
+      const j = await r.json();
+      if (!j.ok) {
+        toast.error(j.error || 'Kunde inte placera ordern');
+        return;
+      }
+      toast.success('Order placerad i schemat');
+      setSelectedId(null);
+      try {
+        await Promise.all([loadBacklog(), loadSchedule(fromISO, toISO)]);
+      } catch {
+        /* a transient refresh error shouldn't undo the toast; next nav reloads */
+      }
+    },
+    [canWrite, selectedId, fromISO, toISO, loadBacklog, loadSchedule, toast],
+  );
+
+  return (
+    <div>
+      {/* Header */}
+      <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+        <div>
+          <h1 className={crm.pageTitle}>Planering</h1>
+          <p className={crm.pageSubtitle}>Schemalägg arbetsordrar på bilar.</p>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <button className={crm.ghostButton} onClick={() => setWeekOffset((o) => o - 1)} aria-label="Föregående vecka">
+            ‹
+          </button>
+          <button className={crm.ghostButton} onClick={() => setWeekOffset(0)}>
+            Idag
+          </button>
+          <button className={crm.ghostButton} onClick={() => setWeekOffset((o) => o + 1)} aria-label="Nästa vecka">
+            ›
+          </button>
+          <span className="ml-1 rounded-lg border border-[#e0e8dc] bg-white px-2.5 py-1 text-[11px] font-semibold text-slate-600">
+            v.{weekNo}
+          </span>
+        </div>
+      </div>
+
+      {/* Skeleton-stage banner */}
+      <div className="mb-3 rounded-xl border border-amber-200 bg-amber-50 px-3 py-2 text-[11px] text-amber-800">
+        Tidig version (Wave 7, skiva 1). Gamla planeringen ligger kvar orörd tills den nya är klar.
+      </div>
+
+      {error && (
+        <div className="mb-3 rounded-xl border border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-700">{error}</div>
+      )}
+
+      <div className="grid gap-4 lg:grid-cols-[320px_minmax(0,1fr)]">
+        {/* Backlog */}
+        <section className={`${crm.card} p-3`}>
+          <div className="mb-2 flex items-center justify-between">
+            <h2 className={crm.sectionTitle}>Att planera</h2>
+            <span className="text-[11px] text-slate-400">{backlog.length} st</span>
+          </div>
+
+          {loading ? (
+            <p className="py-6 text-center text-sm text-slate-400">Laddar…</p>
+          ) : backlog.length === 0 ? (
+            <p className="py-6 text-center text-sm text-slate-400">
+              Inga arbetsordrar att planera. Skapa en order i CRM:et så dyker den upp här.
+            </p>
+          ) : (
+            <ul className="grid gap-1.5">
+              {backlog.map((item) => {
+                const isSelected = item.id === selectedId;
+                return (
+                  <li key={item.id}>
+                    <button
+                      type="button"
+                      disabled={!canWrite}
+                      onClick={() => setSelectedId(isSelected ? null : item.id)}
+                      className={`w-full rounded-xl border p-2.5 text-left transition ${
+                        isSelected
+                          ? 'border-emerald-400 bg-emerald-50 ring-2 ring-emerald-500/20'
+                          : 'border-[#e0e8dc] bg-white hover:border-[#c8d4c3]'
+                      } ${canWrite ? 'cursor-pointer' : 'cursor-default'}`}
+                    >
+                      <div className="flex items-center justify-between gap-2">
+                        <span className="text-[13px] font-bold text-slate-900">{item.project_name}</span>
+                        <span className="shrink-0 text-[10px] font-semibold text-slate-400">{item.order_number}</span>
+                      </div>
+                      <div className="mt-0.5 text-[11px] text-slate-500">{item.client_name}</div>
+                      {item.address && <div className="text-[11px] text-slate-400">{item.address}</div>}
+                      <div className="mt-1 flex flex-wrap items-center gap-1">
+                        {item.total_sacks > 0 && (
+                          <span className={`${crm.badge} border-emerald-200 bg-emerald-50 text-emerald-700`}>
+                            {item.total_sacks} säck
+                          </span>
+                        )}
+                        {item.desired_installation_date && (
+                          <span className={`${crm.badge} border-sky-200 bg-sky-50 text-sky-700`}>
+                            Önskat {item.desired_installation_date}
+                          </span>
+                        )}
+                        {item.segment_count > 0 && (
+                          <span className={`${crm.badge} border-violet-200 bg-violet-50 text-violet-700`}>
+                            {item.segment_count} placerad{item.segment_count === 1 ? '' : 'e'}
+                          </span>
+                        )}
+                      </div>
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+
+          {canWrite && selected && (
+            <p className="mt-2 rounded-lg bg-emerald-50 px-2 py-1.5 text-[11px] text-emerald-700">
+              <strong>{selected.project_name}</strong> vald — klicka en cell i schemat för att placera.
+            </p>
+          )}
+        </section>
+
+        {/* Schedule grid */}
+        <section className={`${crm.card} overflow-x-auto p-3`}>
+          <div className="min-w-[760px]">
+            {/* Day header row */}
+            <div className="grid grid-cols-[120px_repeat(7,minmax(96px,1fr))] gap-1">
+              <div />
+              {weekDays.map((wd) => (
+                <div
+                  key={wd.iso}
+                  className={`rounded-lg px-1.5 py-1 text-center text-[11px] font-semibold ${
+                    wd.isToday ? 'bg-emerald-100 text-emerald-800' : wd.isWeekend ? 'text-slate-400' : 'text-slate-600'
+                  }`}
+                >
+                  <div className="capitalize">{wd.weekday}</div>
+                  <div className="text-[10px] font-normal text-slate-400">{wd.dayLabel}</div>
+                </div>
+              ))}
+            </div>
+
+            {/* Truck rows */}
+            {trucks.length === 0 ? (
+              <p className="py-6 text-center text-sm text-slate-400">Inga bilar upplagda än.</p>
+            ) : (
+              <div className="mt-1 grid gap-1">
+                {trucks.map((truck) => (
+                  <div key={truck.id} className="grid grid-cols-[120px_repeat(7,minmax(96px,1fr))] gap-1">
+                    <div className="flex items-center gap-1.5 rounded-lg bg-white px-2 py-1.5">
+                      <span
+                        className="inline-block h-2.5 w-2.5 shrink-0 rounded-full"
+                        style={{ backgroundColor: truck.color || '#94a3b8' }}
+                      />
+                      <span className="truncate text-[12px] font-semibold text-slate-700">{truck.name}</span>
+                    </div>
+                    {weekDays.map((wd) => {
+                      const cell = segmentsByTruckDay.get(`${truck.id}|${wd.iso}`) ?? [];
+                      const placeable = canWrite && !!selectedId;
+                      return (
+                        <button
+                          key={wd.iso}
+                          type="button"
+                          disabled={!placeable}
+                          onClick={() => place(truck.id, wd.iso)}
+                          className={`min-h-[52px] rounded-lg border p-1 text-left align-top transition ${
+                            wd.isWeekend ? 'border-slate-100 bg-slate-50/60' : 'border-[#e8efe5] bg-white'
+                          } ${placeable ? 'cursor-pointer hover:border-emerald-400 hover:bg-emerald-50/40' : 'cursor-default'}`}
+                        >
+                          <div className="grid gap-0.5">
+                            {cell.map((seg) => (
+                              <span
+                                key={seg.id}
+                                className="block truncate rounded-md border border-[#dbe7d6] bg-[#f1f7ef] px-1.5 py-0.5 text-[10px] font-semibold text-slate-700"
+                                title={`${seg.work_order?.order_number ?? ''} ${seg.work_order?.project_name ?? ''}`}
+                              >
+                                {seg.work_order?.project_name ?? seg.work_order?.order_number ?? 'Order'}
+                              </span>
+                            ))}
+                          </div>
+                        </button>
+                      );
+                    })}
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/app/crm/planering/PlanningClient.tsx
+++ b/app/crm/planering/PlanningClient.tsx
@@ -15,6 +15,7 @@ import Backlog from './Backlog';
 import WeekBoard from './WeekBoard';
 import MonthGrid from './MonthGrid';
 import ConfirmModal from './ConfirmModal';
+import TruckManagerModal from './TruckManagerModal';
 
 type View = 'week' | 'month';
 type DragData =
@@ -23,7 +24,7 @@ type DragData =
 
 const API = '/api/crm/planering';
 
-export default function PlanningClient({ canWrite }: { canWrite: boolean }) {
+export default function PlanningClient({ canWrite, canManageTrucks }: { canWrite: boolean; canManageTrucks: boolean }) {
   const toast = useToast();
   const router = useRouter();
 
@@ -45,6 +46,7 @@ export default function PlanningClient({ canWrite }: { canWrite: boolean }) {
   const [backlogDropActive, setBacklogDropActive] = useState(false);
   const [truckPicker, setTruckPicker] = useState<{ dayISO: string; workOrderId: string } | null>(null);
   const [confirmSeg, setConfirmSeg] = useState<OpsSegment | null>(null);
+  const [truckManagerOpen, setTruckManagerOpen] = useState(false);
 
   const dragRef = useRef<DragData | null>(null);
   const todayISO = useMemo(() => fmtISO(new Date()), []);
@@ -401,6 +403,17 @@ export default function PlanningClient({ canWrite }: { canWrite: boolean }) {
               </button>
             );
           })}
+          {canManageTrucks && (
+            <button
+              onClick={() => setTruckManagerOpen(true)}
+              className="inline-flex h-[30px] items-center gap-1.5 rounded-full border border-dashed border-[#c8d4c3] bg-white px-3 text-[12px] font-semibold text-slate-500 transition hover:border-emerald-400 hover:text-emerald-600"
+            >
+              <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M10 17h4V5H2v12h3M15 17h6v-5l-3-3h-3M5.5 17a1.5 1.5 0 1 0 3 0 1.5 1.5 0 0 0-3 0ZM16.5 17a1.5 1.5 0 1 0 3 0 1.5 1.5 0 0 0-3 0Z" />
+              </svg>
+              Bilar
+            </button>
+          )}
         </div>
       </div>
 
@@ -494,6 +507,14 @@ export default function PlanningClient({ canWrite }: { canWrite: boolean }) {
       {/* Order confirmation (SMS/email) */}
       {confirmSeg && (
         <ConfirmModal segment={confirmSeg} onClose={() => setConfirmSeg(null)} onSent={refresh} />
+      )}
+
+      {/* Fleet management */}
+      {truckManagerOpen && (
+        <TruckManagerModal
+          onClose={() => setTruckManagerOpen(false)}
+          onChanged={() => loadSegments(range.from, range.to).catch(() => {})}
+        />
       )}
     </div>
   );

--- a/app/crm/planering/PlanningClient.tsx
+++ b/app/crm/planering/PlanningClient.tsx
@@ -607,7 +607,7 @@ export default function PlanningClient({
         </div>
       )}
 
-      <div className="grid gap-4 lg:grid-cols-[320px_minmax(0,1fr)]">
+      <div className="grid items-start gap-4 lg:grid-cols-[320px_minmax(0,1fr)]">
         <Backlog
           items={visibleBacklog}
           loading={loadingBacklog}

--- a/app/crm/planering/PlanningClient.tsx
+++ b/app/crm/planering/PlanningClient.tsx
@@ -311,6 +311,20 @@ export default function PlanningClient({
   const onSetJobType = useCallback((seg: OpsSegment, jobType: string | null) => void move(seg.id, { job_type: jobType }), [move]);
   const onToggleHold = useCallback((seg: OpsSegment, value: boolean) => void move(seg.id, { on_hold: value }), [move]);
   const onResize = useCallback((seg: OpsSegment, startDay: string, endDay: string) => void move(seg.id, { start_day: startDay, end_day: endDay }), [move]);
+  const onSetStatus = useCallback(
+    async (seg: OpsSegment, status: string) => {
+      const r = await fetch(`/api/crm/work-orders/${seg.work_order_id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status }),
+      });
+      const j = await r.json();
+      if (!j.ok) return toast.error(j.error || 'Kunde inte ändra status');
+      toast.success('Status uppdaterad');
+      await refresh();
+    },
+    [toast, refresh],
+  );
   const openConfirm = useCallback((seg: OpsSegment) => setConfirmSeg(seg), []);
 
   // Day notes: optimistic local updates (a failed call resyncs from the server on the next nav).
@@ -654,6 +668,7 @@ export default function PlanningClient({
             onRemoveTruckCrew={removeTruckCrew}
             onCopyTruckCrew={copyTruckCrew}
             onResize={onResize}
+            onSetStatus={onSetStatus}
           />
         ) : (
           <MonthGrid

--- a/app/crm/planering/TruckManagerModal.tsx
+++ b/app/crm/planering/TruckManagerModal.tsx
@@ -1,0 +1,154 @@
+'use client';
+
+import { useEffect, useState, type FormEvent } from 'react';
+import { cn } from '@/lib/shared/cn';
+import { useToast } from '@/lib/Toast';
+import { crm } from '@/app/crm/lib/crmTokens';
+import CrmModal from '@/app/crm/components/CrmModal';
+import type { OpsTruck } from '@/lib/domains/planning/types';
+
+const API = '/api/crm/planering/trucks';
+const COLOR_INPUT = 'h-8 w-9 shrink-0 cursor-pointer rounded-lg border border-[#dce4d8] bg-white p-0.5';
+const TEXT_INPUT = 'h-8 flex-1 rounded-lg border border-[#dce4d8] bg-white px-2 text-[13px] text-slate-900 outline-none transition focus:border-emerald-500';
+const PRIMARY = 'inline-flex h-8 shrink-0 items-center rounded-lg px-3 text-[12px] font-semibold text-white transition disabled:cursor-not-allowed disabled:opacity-50';
+
+// Fleet management: list every truck (incl inactive), rename/recolor/(de)activate, add or remove.
+// onChanged lets the board refresh its active-truck lanes after a change.
+export default function TruckManagerModal({ onClose, onChanged }: { onClose: () => void; onChanged: () => void }) {
+  const toast = useToast();
+  const [trucks, setTrucks] = useState<OpsTruck[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState(false);
+  const [newName, setNewName] = useState('');
+  const [newColor, setNewColor] = useState('#3f6f52');
+
+  useEffect(() => {
+    let active = true;
+    fetch(API, { cache: 'no-store' })
+      .then((r) => r.json())
+      .then((j) => {
+        if (active && j.ok) setTrucks(j.data.trucks as OpsTruck[]);
+      })
+      .catch(() => {})
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  function patchLocal(id: string, patch: Partial<OpsTruck>) {
+    setTrucks((prev) => prev.map((t) => (t.id === id ? { ...t, ...patch } : t)));
+  }
+
+  async function saveTruck(t: OpsTruck) {
+    setBusy(true);
+    try {
+      const r = await fetch(`${API}/${t.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: t.name, color: t.color, active: t.active }),
+      });
+      const j = await r.json();
+      if (!j.ok) return toast.error(j.error || 'Kunde inte spara bilen');
+      toast.success('Sparad');
+      onChanged();
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function removeTruck(id: string) {
+    setBusy(true);
+    try {
+      const r = await fetch(`${API}/${id}`, { method: 'DELETE' });
+      const j = await r.json();
+      if (!j.ok) return toast.error(j.error || 'Kunde inte ta bort bilen');
+      setTrucks((prev) => prev.filter((t) => t.id !== id));
+      onChanged();
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function addTruck(e: FormEvent) {
+    e.preventDefault();
+    if (!newName.trim()) return;
+    setBusy(true);
+    try {
+      const r = await fetch(API, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: newName.trim(), color: newColor }),
+      });
+      const j = await r.json();
+      if (!j.ok) return toast.error(j.error || 'Kunde inte lägga till bilen');
+      setTrucks((prev) => [...prev, j.data.item as OpsTruck]);
+      setNewName('');
+      onChanged();
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <CrmModal
+      onClose={onClose}
+      ariaLabel="Hantera bilar"
+      maxWidth="sm:max-w-[560px]"
+      header={
+        <div>
+          <h2 className="text-[15px] font-bold text-slate-900">Hantera bilar</h2>
+          <p className="mt-0.5 text-[12px] text-slate-500">Lägg till, byt namn/färg eller avaktivera bilar i flottan.</p>
+        </div>
+      }
+      footer={
+        <button type="button" onClick={onClose} className={cn(crm.ghostButton, 'ml-auto')}>
+          Stäng
+        </button>
+      }
+    >
+      {loading ? (
+        <p className="py-8 text-center text-sm text-slate-400">Laddar…</p>
+      ) : (
+        <div className="grid gap-2">
+          {trucks.map((t) => (
+            <div key={t.id} className={cn('flex items-center gap-2 rounded-xl border border-[#e0e8dc] bg-white p-2', !t.active && 'opacity-60')}>
+              <input type="color" value={t.color || '#94a3b8'} onChange={(e) => patchLocal(t.id, { color: e.target.value })} className={COLOR_INPUT} aria-label="Färg" />
+              <input value={t.name} onChange={(e) => patchLocal(t.id, { name: e.target.value })} className={TEXT_INPUT} aria-label="Namn" />
+              <label className="flex shrink-0 items-center gap-1 text-[11px] font-semibold text-slate-500">
+                <input type="checkbox" checked={t.active} onChange={(e) => patchLocal(t.id, { active: e.target.checked })} className="h-3.5 w-3.5 accent-emerald-600" />
+                Aktiv
+              </label>
+              <button type="button" onClick={() => saveTruck(t)} disabled={busy} className={PRIMARY} style={{ backgroundColor: 'var(--crm-primary)' }}>
+                Spara
+              </button>
+              <button
+                type="button"
+                onClick={() => removeTruck(t.id)}
+                disabled={busy}
+                aria-label="Ta bort bil"
+                className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-[#e0e8dc] bg-white text-slate-400 transition hover:border-rose-300 hover:text-rose-500 disabled:opacity-50"
+              >
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M3 6h18M8 6V4h8v2M19 6l-1 14H6L5 6" />
+                </svg>
+              </button>
+            </div>
+          ))}
+
+          {trucks.length === 0 && <p className="py-2 text-center text-[12px] text-slate-400">Inga bilar upplagda än.</p>}
+
+          <form onSubmit={addTruck} className="mt-1 flex items-center gap-2 rounded-xl border border-dashed border-[#c8d4c3] bg-[#f9fbf7] p-2">
+            <input type="color" value={newColor} onChange={(e) => setNewColor(e.target.value)} className={COLOR_INPUT} aria-label="Färg" />
+            <input value={newName} onChange={(e) => setNewName(e.target.value)} placeholder="Ny bil…" className={TEXT_INPUT} aria-label="Namn på ny bil" />
+            <button type="submit" disabled={busy || !newName.trim()} className={PRIMARY} style={{ backgroundColor: 'var(--crm-primary)' }}>
+              Lägg till
+            </button>
+          </form>
+        </div>
+      )}
+    </CrmModal>
+  );
+}

--- a/app/crm/planering/TruckManagerModal.tsx
+++ b/app/crm/planering/TruckManagerModal.tsx
@@ -2,98 +2,54 @@
 
 import { useEffect, useState, type FormEvent } from 'react';
 import { cn } from '@/lib/shared/cn';
-import { useToast } from '@/lib/Toast';
 import { crm } from '@/app/crm/lib/crmTokens';
 import CrmModal from '@/app/crm/components/CrmModal';
+import { useEntityCrud } from './useEntityCrud';
+import { TrashIcon } from './managerModalUi';
 import type { OpsTruck, OpsDepot } from '@/lib/domains/planning/types';
 
 const API = '/api/crm/planering/trucks';
 const DEPOTS_API = '/api/crm/planering/depots';
-const COLOR_INPUT = 'h-9 w-full cursor-pointer rounded-lg border border-[#dce4d8] bg-white p-1';
-const TEXT_INPUT = 'h-9 w-full rounded-lg border border-[#dce4d8] bg-white px-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-2 focus:ring-emerald-500/15';
-const SELECT_INPUT = 'h-9 w-full rounded-lg border border-[#dce4d8] bg-white px-2.5 text-sm text-slate-700 outline-none transition focus:border-emerald-500';
-const PRIMARY = 'inline-flex h-9 shrink-0 items-center justify-center rounded-lg px-4 text-[13px] font-semibold text-white transition disabled:cursor-not-allowed disabled:opacity-50';
-const DANGER = 'inline-flex h-9 shrink-0 items-center gap-1.5 rounded-lg border border-[#e0e8dc] bg-white px-3 text-[13px] font-semibold text-slate-500 transition hover:border-rose-300 hover:text-rose-600 disabled:cursor-not-allowed disabled:opacity-50';
 
-// Fleet management: list every truck (incl inactive), rename/recolor/(de)activate, add or remove.
-// onChanged lets the board refresh its active-truck lanes after a change.
+// Fleet management: rename/recolor/(de)activate/assign-depot, add or remove. onChanged refreshes the
+// board's active-truck lanes after a change.
 export default function TruckManagerModal({ onClose, onChanged }: { onClose: () => void; onChanged: () => void }) {
-  const toast = useToast();
-  const [trucks, setTrucks] = useState<OpsTruck[]>([]);
+  const { items: trucks, loading, busy, patchLocal, save, remove, add } = useEntityCrud<OpsTruck>({
+    api: API,
+    listKey: 'trucks',
+    toPayload: (t) => ({ name: t.name, color: t.color, active: t.active, depot_id: t.depot_id }),
+    labels: { saveFail: 'Kunde inte spara bilen', removeFail: 'Kunde inte ta bort bilen', addFail: 'Kunde inte lägga till bilen' },
+  });
   const [depots, setDepots] = useState<OpsDepot[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [busy, setBusy] = useState(false);
   const [newName, setNewName] = useState('');
   const [newColor, setNewColor] = useState('#3f6f52');
 
+  // Active depots for the per-truck depot picker (separate collection from trucks).
   useEffect(() => {
     let active = true;
-    Promise.all([fetch(API, { cache: 'no-store' }).then((r) => r.json()), fetch(DEPOTS_API, { cache: 'no-store' }).then((r) => r.json())])
-      .then(([truckRes, depotRes]) => {
-        if (!active) return;
-        if (truckRes.ok) setTrucks(truckRes.data.trucks as OpsTruck[]);
-        if (depotRes.ok) setDepots((depotRes.data.depots as OpsDepot[]).filter((d) => d.active));
+    fetch(DEPOTS_API, { cache: 'no-store' })
+      .then((r) => r.json())
+      .then((j) => {
+        if (active && j.ok) setDepots((j.data.depots as OpsDepot[]).filter((d) => d.active));
       })
-      .catch(() => {})
-      .finally(() => {
-        if (active) setLoading(false);
-      });
+      .catch(() => {});
     return () => {
       active = false;
     };
   }, []);
 
-  function patchLocal(id: string, patch: Partial<OpsTruck>) {
-    setTrucks((prev) => prev.map((t) => (t.id === id ? { ...t, ...patch } : t)));
+  async function onSave(t: OpsTruck) {
+    if (await save(t)) onChanged();
   }
-
-  async function saveTruck(t: OpsTruck) {
-    setBusy(true);
-    try {
-      const r = await fetch(`${API}/${t.id}`, {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name: t.name, color: t.color, active: t.active, depot_id: t.depot_id }),
-      });
-      const j = await r.json();
-      if (!j.ok) return toast.error(j.error || 'Kunde inte spara bilen');
-      toast.success('Sparad');
-      onChanged();
-    } finally {
-      setBusy(false);
-    }
+  async function onRemove(id: string) {
+    if (await remove(id)) onChanged();
   }
-
-  async function removeTruck(id: string) {
-    setBusy(true);
-    try {
-      const r = await fetch(`${API}/${id}`, { method: 'DELETE' });
-      const j = await r.json();
-      if (!j.ok) return toast.error(j.error || 'Kunde inte ta bort bilen');
-      setTrucks((prev) => prev.filter((t) => t.id !== id));
-      onChanged();
-    } finally {
-      setBusy(false);
-    }
-  }
-
-  async function addTruck(e: FormEvent) {
+  async function onAdd(e: FormEvent) {
     e.preventDefault();
     if (!newName.trim()) return;
-    setBusy(true);
-    try {
-      const r = await fetch(API, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name: newName.trim(), color: newColor }),
-      });
-      const j = await r.json();
-      if (!j.ok) return toast.error(j.error || 'Kunde inte lägga till bilen');
-      setTrucks((prev) => [...prev, j.data.item as OpsTruck]);
+    if (await add({ name: newName.trim(), color: newColor })) {
       setNewName('');
       onChanged();
-    } finally {
-      setBusy(false);
     }
   }
 
@@ -121,8 +77,8 @@ export default function TruckManagerModal({ onClose, onChanged }: { onClose: () 
           {trucks.map((t) => (
             <div key={t.id} className={cn('rounded-xl border border-[#e0e8dc] bg-white p-3', !t.active && 'opacity-60')}>
               <div className="grid grid-cols-[2.5rem_1fr] items-center gap-2.5">
-                <input type="color" value={t.color || '#94a3b8'} onChange={(e) => patchLocal(t.id, { color: e.target.value })} className={COLOR_INPUT} aria-label="Färg" />
-                <input value={t.name} onChange={(e) => patchLocal(t.id, { name: e.target.value })} className={TEXT_INPUT} placeholder="Bilens namn" aria-label="Namn" />
+                <input type="color" value={t.color || '#94a3b8'} onChange={(e) => patchLocal(t.id, { color: e.target.value })} className={crm.colorInput} aria-label="Färg" />
+                <input value={t.name} onChange={(e) => patchLocal(t.id, { name: e.target.value })} className={crm.input} placeholder="Bilens namn" aria-label="Namn" />
               </div>
               <div className="mt-2.5 flex flex-wrap items-end gap-3">
                 <div className="flex min-w-[180px] flex-1 flex-col gap-1">
@@ -131,7 +87,7 @@ export default function TruckManagerModal({ onClose, onChanged }: { onClose: () 
                     value={t.depot_id ?? ''}
                     onChange={(e) => patchLocal(t.id, { depot_id: e.target.value || null })}
                     aria-label="Depå"
-                    className={SELECT_INPUT}
+                    className={crm.select}
                   >
                     <option value="">Ingen depå</option>
                     {depots.map((d) => (
@@ -145,13 +101,11 @@ export default function TruckManagerModal({ onClose, onChanged }: { onClose: () 
                 </label>
               </div>
               <div className="mt-3 flex items-center justify-end gap-2 border-t border-[#eef3eb] pt-2.5">
-                <button type="button" onClick={() => removeTruck(t.id)} disabled={busy} className={DANGER}>
-                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                    <path d="M3 6h18M8 6V4h8v2M19 6l-1 14H6L5 6" />
-                  </svg>
+                <button type="button" onClick={() => onRemove(t.id)} disabled={busy} className={crm.dangerButton}>
+                  <TrashIcon />
                   Ta bort
                 </button>
-                <button type="button" onClick={() => saveTruck(t)} disabled={busy} className={PRIMARY} style={{ backgroundColor: 'var(--crm-primary)' }}>
+                <button type="button" onClick={() => onSave(t)} disabled={busy} className={crm.formButton} style={{ backgroundColor: 'var(--crm-primary)' }}>
                   Spara
                 </button>
               </div>
@@ -160,12 +114,12 @@ export default function TruckManagerModal({ onClose, onChanged }: { onClose: () 
 
           {trucks.length === 0 && <p className="py-2 text-center text-[13px] text-slate-400">Inga bilar upplagda än.</p>}
 
-          <form onSubmit={addTruck} className="rounded-xl border border-dashed border-[#c8d4c3] bg-[#f9fbf7] p-3">
+          <form onSubmit={onAdd} className="rounded-xl border border-dashed border-[#c8d4c3] bg-[#f9fbf7] p-3">
             <p className="mb-2 px-0.5 text-[11px] font-bold uppercase tracking-wide text-slate-400">Lägg till ny bil</p>
             <div className="grid grid-cols-[2.5rem_1fr_auto] items-center gap-2.5">
-              <input type="color" value={newColor} onChange={(e) => setNewColor(e.target.value)} className={COLOR_INPUT} aria-label="Färg" />
-              <input value={newName} onChange={(e) => setNewName(e.target.value)} placeholder="Bilens namn…" className={TEXT_INPUT} aria-label="Namn på ny bil" />
-              <button type="submit" disabled={busy || !newName.trim()} className={PRIMARY} style={{ backgroundColor: 'var(--crm-primary)' }}>
+              <input type="color" value={newColor} onChange={(e) => setNewColor(e.target.value)} className={crm.colorInput} aria-label="Färg" />
+              <input value={newName} onChange={(e) => setNewName(e.target.value)} placeholder="Bilens namn…" className={crm.input} aria-label="Namn på ny bil" />
+              <button type="submit" disabled={busy || !newName.trim()} className={crm.formButton} style={{ backgroundColor: 'var(--crm-primary)' }}>
                 Lägg till
               </button>
             </div>

--- a/app/crm/planering/TruckManagerModal.tsx
+++ b/app/crm/planering/TruckManagerModal.tsx
@@ -5,9 +5,10 @@ import { cn } from '@/lib/shared/cn';
 import { useToast } from '@/lib/Toast';
 import { crm } from '@/app/crm/lib/crmTokens';
 import CrmModal from '@/app/crm/components/CrmModal';
-import type { OpsTruck } from '@/lib/domains/planning/types';
+import type { OpsTruck, OpsDepot } from '@/lib/domains/planning/types';
 
 const API = '/api/crm/planering/trucks';
+const DEPOTS_API = '/api/crm/planering/depots';
 const COLOR_INPUT = 'h-8 w-9 shrink-0 cursor-pointer rounded-lg border border-[#dce4d8] bg-white p-0.5';
 const TEXT_INPUT = 'h-8 flex-1 rounded-lg border border-[#dce4d8] bg-white px-2 text-[13px] text-slate-900 outline-none transition focus:border-emerald-500';
 const PRIMARY = 'inline-flex h-8 shrink-0 items-center rounded-lg px-3 text-[12px] font-semibold text-white transition disabled:cursor-not-allowed disabled:opacity-50';
@@ -17,6 +18,7 @@ const PRIMARY = 'inline-flex h-8 shrink-0 items-center rounded-lg px-3 text-[12p
 export default function TruckManagerModal({ onClose, onChanged }: { onClose: () => void; onChanged: () => void }) {
   const toast = useToast();
   const [trucks, setTrucks] = useState<OpsTruck[]>([]);
+  const [depots, setDepots] = useState<OpsDepot[]>([]);
   const [loading, setLoading] = useState(true);
   const [busy, setBusy] = useState(false);
   const [newName, setNewName] = useState('');
@@ -24,10 +26,11 @@ export default function TruckManagerModal({ onClose, onChanged }: { onClose: () 
 
   useEffect(() => {
     let active = true;
-    fetch(API, { cache: 'no-store' })
-      .then((r) => r.json())
-      .then((j) => {
-        if (active && j.ok) setTrucks(j.data.trucks as OpsTruck[]);
+    Promise.all([fetch(API, { cache: 'no-store' }).then((r) => r.json()), fetch(DEPOTS_API, { cache: 'no-store' }).then((r) => r.json())])
+      .then(([truckRes, depotRes]) => {
+        if (!active) return;
+        if (truckRes.ok) setTrucks(truckRes.data.trucks as OpsTruck[]);
+        if (depotRes.ok) setDepots((depotRes.data.depots as OpsDepot[]).filter((d) => d.active));
       })
       .catch(() => {})
       .finally(() => {
@@ -48,7 +51,7 @@ export default function TruckManagerModal({ onClose, onChanged }: { onClose: () 
       const r = await fetch(`${API}/${t.id}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name: t.name, color: t.color, active: t.active }),
+        body: JSON.stringify({ name: t.name, color: t.color, active: t.active, depot_id: t.depot_id }),
       });
       const j = await r.json();
       if (!j.ok) return toast.error(j.error || 'Kunde inte spara bilen');
@@ -117,6 +120,17 @@ export default function TruckManagerModal({ onClose, onChanged }: { onClose: () 
             <div key={t.id} className={cn('flex items-center gap-2 rounded-xl border border-[#e0e8dc] bg-white p-2', !t.active && 'opacity-60')}>
               <input type="color" value={t.color || '#94a3b8'} onChange={(e) => patchLocal(t.id, { color: e.target.value })} className={COLOR_INPUT} aria-label="Färg" />
               <input value={t.name} onChange={(e) => patchLocal(t.id, { name: e.target.value })} className={TEXT_INPUT} aria-label="Namn" />
+              <select
+                value={t.depot_id ?? ''}
+                onChange={(e) => patchLocal(t.id, { depot_id: e.target.value || null })}
+                aria-label="Depå"
+                className="h-8 w-[120px] shrink-0 rounded-lg border border-[#dce4d8] bg-white px-1.5 text-[12px] text-slate-700 outline-none transition focus:border-emerald-500"
+              >
+                <option value="">Ingen depå</option>
+                {depots.map((d) => (
+                  <option key={d.id} value={d.id}>{d.name}</option>
+                ))}
+              </select>
               <label className="flex shrink-0 items-center gap-1 text-[11px] font-semibold text-slate-500">
                 <input type="checkbox" checked={t.active} onChange={(e) => patchLocal(t.id, { active: e.target.checked })} className="h-3.5 w-3.5 accent-emerald-600" />
                 Aktiv

--- a/app/crm/planering/TruckManagerModal.tsx
+++ b/app/crm/planering/TruckManagerModal.tsx
@@ -9,9 +9,11 @@ import type { OpsTruck, OpsDepot } from '@/lib/domains/planning/types';
 
 const API = '/api/crm/planering/trucks';
 const DEPOTS_API = '/api/crm/planering/depots';
-const COLOR_INPUT = 'h-8 w-9 shrink-0 cursor-pointer rounded-lg border border-[#dce4d8] bg-white p-0.5';
-const TEXT_INPUT = 'h-8 flex-1 rounded-lg border border-[#dce4d8] bg-white px-2 text-[13px] text-slate-900 outline-none transition focus:border-emerald-500';
-const PRIMARY = 'inline-flex h-8 shrink-0 items-center rounded-lg px-3 text-[12px] font-semibold text-white transition disabled:cursor-not-allowed disabled:opacity-50';
+const COLOR_INPUT = 'h-9 w-full cursor-pointer rounded-lg border border-[#dce4d8] bg-white p-1';
+const TEXT_INPUT = 'h-9 w-full rounded-lg border border-[#dce4d8] bg-white px-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-2 focus:ring-emerald-500/15';
+const SELECT_INPUT = 'h-9 w-full rounded-lg border border-[#dce4d8] bg-white px-2.5 text-sm text-slate-700 outline-none transition focus:border-emerald-500';
+const PRIMARY = 'inline-flex h-9 shrink-0 items-center justify-center rounded-lg px-4 text-[13px] font-semibold text-white transition disabled:cursor-not-allowed disabled:opacity-50';
+const DANGER = 'inline-flex h-9 shrink-0 items-center gap-1.5 rounded-lg border border-[#e0e8dc] bg-white px-3 text-[13px] font-semibold text-slate-500 transition hover:border-rose-300 hover:text-rose-600 disabled:cursor-not-allowed disabled:opacity-50';
 
 // Fleet management: list every truck (incl inactive), rename/recolor/(de)activate, add or remove.
 // onChanged lets the board refresh its active-truck lanes after a change.
@@ -115,51 +117,58 @@ export default function TruckManagerModal({ onClose, onChanged }: { onClose: () 
       {loading ? (
         <p className="py-8 text-center text-sm text-slate-400">Laddar…</p>
       ) : (
-        <div className="grid gap-2">
+        <div className="grid gap-3">
           {trucks.map((t) => (
-            <div key={t.id} className={cn('flex items-center gap-2 rounded-xl border border-[#e0e8dc] bg-white p-2', !t.active && 'opacity-60')}>
-              <input type="color" value={t.color || '#94a3b8'} onChange={(e) => patchLocal(t.id, { color: e.target.value })} className={COLOR_INPUT} aria-label="Färg" />
-              <input value={t.name} onChange={(e) => patchLocal(t.id, { name: e.target.value })} className={TEXT_INPUT} aria-label="Namn" />
-              <select
-                value={t.depot_id ?? ''}
-                onChange={(e) => patchLocal(t.id, { depot_id: e.target.value || null })}
-                aria-label="Depå"
-                className="h-8 w-[120px] shrink-0 rounded-lg border border-[#dce4d8] bg-white px-1.5 text-[12px] text-slate-700 outline-none transition focus:border-emerald-500"
-              >
-                <option value="">Ingen depå</option>
-                {depots.map((d) => (
-                  <option key={d.id} value={d.id}>{d.name}</option>
-                ))}
-              </select>
-              <label className="flex shrink-0 items-center gap-1 text-[11px] font-semibold text-slate-500">
-                <input type="checkbox" checked={t.active} onChange={(e) => patchLocal(t.id, { active: e.target.checked })} className="h-3.5 w-3.5 accent-emerald-600" />
-                Aktiv
-              </label>
-              <button type="button" onClick={() => saveTruck(t)} disabled={busy} className={PRIMARY} style={{ backgroundColor: 'var(--crm-primary)' }}>
-                Spara
-              </button>
-              <button
-                type="button"
-                onClick={() => removeTruck(t.id)}
-                disabled={busy}
-                aria-label="Ta bort bil"
-                className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-[#e0e8dc] bg-white text-slate-400 transition hover:border-rose-300 hover:text-rose-500 disabled:opacity-50"
-              >
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                  <path d="M3 6h18M8 6V4h8v2M19 6l-1 14H6L5 6" />
-                </svg>
-              </button>
+            <div key={t.id} className={cn('rounded-xl border border-[#e0e8dc] bg-white p-3', !t.active && 'opacity-60')}>
+              <div className="grid grid-cols-[2.5rem_1fr] items-center gap-2.5">
+                <input type="color" value={t.color || '#94a3b8'} onChange={(e) => patchLocal(t.id, { color: e.target.value })} className={COLOR_INPUT} aria-label="Färg" />
+                <input value={t.name} onChange={(e) => patchLocal(t.id, { name: e.target.value })} className={TEXT_INPUT} placeholder="Bilens namn" aria-label="Namn" />
+              </div>
+              <div className="mt-2.5 flex flex-wrap items-end gap-3">
+                <div className="flex min-w-[180px] flex-1 flex-col gap-1">
+                  <label className="px-0.5 text-[11px] font-semibold text-slate-500">Depå</label>
+                  <select
+                    value={t.depot_id ?? ''}
+                    onChange={(e) => patchLocal(t.id, { depot_id: e.target.value || null })}
+                    aria-label="Depå"
+                    className={SELECT_INPUT}
+                  >
+                    <option value="">Ingen depå</option>
+                    {depots.map((d) => (
+                      <option key={d.id} value={d.id}>{d.name}</option>
+                    ))}
+                  </select>
+                </div>
+                <label className="flex h-9 cursor-pointer select-none items-center gap-2 rounded-lg border border-[#e0e8dc] bg-[#f9fbf7] px-3 text-[13px] font-semibold text-slate-600">
+                  <input type="checkbox" checked={t.active} onChange={(e) => patchLocal(t.id, { active: e.target.checked })} className="h-4 w-4 accent-emerald-600" />
+                  Aktiv
+                </label>
+              </div>
+              <div className="mt-3 flex items-center justify-end gap-2 border-t border-[#eef3eb] pt-2.5">
+                <button type="button" onClick={() => removeTruck(t.id)} disabled={busy} className={DANGER}>
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                    <path d="M3 6h18M8 6V4h8v2M19 6l-1 14H6L5 6" />
+                  </svg>
+                  Ta bort
+                </button>
+                <button type="button" onClick={() => saveTruck(t)} disabled={busy} className={PRIMARY} style={{ backgroundColor: 'var(--crm-primary)' }}>
+                  Spara
+                </button>
+              </div>
             </div>
           ))}
 
-          {trucks.length === 0 && <p className="py-2 text-center text-[12px] text-slate-400">Inga bilar upplagda än.</p>}
+          {trucks.length === 0 && <p className="py-2 text-center text-[13px] text-slate-400">Inga bilar upplagda än.</p>}
 
-          <form onSubmit={addTruck} className="mt-1 flex items-center gap-2 rounded-xl border border-dashed border-[#c8d4c3] bg-[#f9fbf7] p-2">
-            <input type="color" value={newColor} onChange={(e) => setNewColor(e.target.value)} className={COLOR_INPUT} aria-label="Färg" />
-            <input value={newName} onChange={(e) => setNewName(e.target.value)} placeholder="Ny bil…" className={TEXT_INPUT} aria-label="Namn på ny bil" />
-            <button type="submit" disabled={busy || !newName.trim()} className={PRIMARY} style={{ backgroundColor: 'var(--crm-primary)' }}>
-              Lägg till
-            </button>
+          <form onSubmit={addTruck} className="rounded-xl border border-dashed border-[#c8d4c3] bg-[#f9fbf7] p-3">
+            <p className="mb-2 px-0.5 text-[11px] font-bold uppercase tracking-wide text-slate-400">Lägg till ny bil</p>
+            <div className="grid grid-cols-[2.5rem_1fr_auto] items-center gap-2.5">
+              <input type="color" value={newColor} onChange={(e) => setNewColor(e.target.value)} className={COLOR_INPUT} aria-label="Färg" />
+              <input value={newName} onChange={(e) => setNewName(e.target.value)} placeholder="Bilens namn…" className={TEXT_INPUT} aria-label="Namn på ny bil" />
+              <button type="submit" disabled={busy || !newName.trim()} className={PRIMARY} style={{ backgroundColor: 'var(--crm-primary)' }}>
+                Lägg till
+              </button>
+            </div>
           </form>
         </div>
       )}

--- a/app/crm/planering/WeekBoard.tsx
+++ b/app/crm/planering/WeekBoard.tsx
@@ -5,7 +5,7 @@ import type { OpsSegment, OpsTruck } from '@/lib/domains/planning/types';
 import { parseISO, type WeekDay } from './planningDates';
 import { JOB_TYPES } from '@/lib/domains/planning/jobTypes';
 import type { AssignablePerson } from '@/lib/domains/planning/crew';
-import { statusMeta, StatusPill, SackProgress, JobTypeOrMaterial, JobRef, CrewEditor, CrewAvatars, ConfirmationBadge } from './jobCard';
+import { statusMeta, StatusPill, SackProgress, JobTypeOrMaterial, JobRef, CrewEditor, CrewAvatars, ConfirmationBadge, HoldBadge } from './jobCard';
 
 type WeekBoardProps = {
   weekDays: WeekDay[];
@@ -23,6 +23,7 @@ type WeekBoardProps = {
   onAddCrew: (seg: OpsSegment, person: AssignablePerson) => void;
   onRemoveCrew: (seg: OpsSegment, memberId: string) => void;
   onOpenConfirm: (seg: OpsSegment) => void;
+  onToggleHold: (seg: OpsSegment, value: boolean) => void;
 };
 
 // Which day column (0–6) a pointer x lands in, within a 7-column lane.
@@ -34,7 +35,7 @@ function dayIndexFromX(e: React.MouseEvent | React.DragEvent): number {
 
 export default function WeekBoard({
   weekDays, trucks, segments, todayISO, canWrite, placing, people,
-  onCellClick, onCellDrop, onSegDragStart, onSegClick, onSetJobType, onAddCrew, onRemoveCrew, onOpenConfirm,
+  onCellClick, onCellDrop, onSegDragStart, onSegClick, onSetJobType, onAddCrew, onRemoveCrew, onOpenConfirm, onToggleHold,
 }: WeekBoardProps) {
   const weekStart = weekDays[0].iso;
   const weekEnd = weekDays[6].iso;
@@ -126,6 +127,7 @@ export default function WeekBoard({
                           className={cn(
                             'relative overflow-hidden rounded-xl border border-[#e0e8dc] bg-white p-2.5 pl-3.5 shadow-[0_1px_2px_rgba(20,44,27,0.06)] transition hover:-translate-y-px hover:shadow-[0_3px_10px_rgba(20,44,27,0.12)]',
                             canWrite ? 'cursor-grab active:cursor-grabbing' : 'cursor-pointer',
+                            seg.on_hold && 'opacity-60 ring-1 ring-amber-200',
                           )}
                         >
                           <span className={cn('absolute inset-y-0 left-0 w-1', statusMeta(seg.job?.status ?? '').rail)} />
@@ -139,6 +141,7 @@ export default function WeekBoard({
                               <div className="text-[11px] text-slate-500">{job.client_name}</div>
                               {job.address && <div className="mt-0.5 text-[10.5px] text-slate-400">{job.address}</div>}
                               <div className="mt-2 flex flex-wrap items-center gap-1.5">
+                                {seg.on_hold && <HoldBadge />}
                                 <JobTypeOrMaterial jobType={seg.job_type} material={job.material} />
                                 <SackProgress planned={job.total_sacks} reported={seg.sacks_reported} />
                                 <ConfirmationBadge confirmation={seg.confirmation} />
@@ -173,21 +176,39 @@ export default function WeekBoard({
                                 </select>
                               )}
                               {canWrite && (
-                                <button
-                                  type="button"
-                                  onMouseDown={(ev) => ev.stopPropagation()}
-                                  onClick={(ev) => {
-                                    ev.stopPropagation();
-                                    onOpenConfirm(seg);
-                                  }}
-                                  className="mt-1.5 inline-flex h-6 w-full items-center justify-center gap-1 rounded-lg border border-[#e0e8dc] bg-white text-[10px] font-semibold text-slate-500 transition hover:border-emerald-400 hover:text-emerald-600"
-                                >
-                                  <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                                    <rect x="2" y="4" width="20" height="16" rx="2" />
-                                    <path d="M22 7l-10 6L2 7" />
-                                  </svg>
-                                  Skicka bekräftelse
-                                </button>
+                                <div className="mt-1.5 flex gap-1.5">
+                                  <button
+                                    type="button"
+                                    onMouseDown={(ev) => ev.stopPropagation()}
+                                    onClick={(ev) => {
+                                      ev.stopPropagation();
+                                      onToggleHold(seg, !seg.on_hold);
+                                    }}
+                                    className={cn(
+                                      'inline-flex h-6 flex-1 items-center justify-center gap-1 rounded-lg border text-[10px] font-semibold transition',
+                                      seg.on_hold
+                                        ? 'border-emerald-200 bg-emerald-50 text-emerald-700 hover:border-emerald-400'
+                                        : 'border-[#e0e8dc] bg-white text-slate-500 hover:border-amber-400 hover:text-amber-600',
+                                    )}
+                                  >
+                                    {seg.on_hold ? 'Återuppta' : 'Pausa'}
+                                  </button>
+                                  <button
+                                    type="button"
+                                    onMouseDown={(ev) => ev.stopPropagation()}
+                                    onClick={(ev) => {
+                                      ev.stopPropagation();
+                                      onOpenConfirm(seg);
+                                    }}
+                                    className="inline-flex h-6 flex-1 items-center justify-center gap-1 rounded-lg border border-[#e0e8dc] bg-white text-[10px] font-semibold text-slate-500 transition hover:border-emerald-400 hover:text-emerald-600"
+                                  >
+                                    <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                                      <rect x="2" y="4" width="20" height="16" rx="2" />
+                                      <path d="M22 7l-10 6L2 7" />
+                                    </svg>
+                                    Bekräftelse
+                                  </button>
+                                </div>
                               )}
                             </>
                           ) : (

--- a/app/crm/planering/WeekBoard.tsx
+++ b/app/crm/planering/WeekBoard.tsx
@@ -4,12 +4,12 @@ import { cn } from '@/lib/shared/cn';
 import { crm } from '@/app/crm/lib/crmTokens';
 import type { OpsSegment, OpsTruck } from '@/lib/domains/planning/types';
 import { type WeekDay, addDaysISO, daysBetweenInclusive } from './planningDates';
-import { resolveJobTypeFrom, type JobType } from '@/lib/domains/planning/jobTypes';
+import type { JobType } from '@/lib/domains/planning/jobTypes';
 import type { AssignablePerson } from '@/lib/domains/planning/crew';
 import { crewForTruckInRange, type TruckCrewMember } from '@/lib/domains/planning/truckCrew';
 import { groupNotesByDay, type DayNote } from '@/lib/domains/planning/dayNotes';
 import { swedishHoliday } from '@/lib/domains/planning/holidays';
-import { statusMeta, StatusPill, SackProgress, JobTypeOrMaterial, JobRef, CrewEditor, CrewAvatars, ConfirmationBadge, HoldBadge, MapLink, SegmentMenu } from './jobCard';
+import { CrewEditor, CrewAvatars, SegmentCardBody, type SegmentActions } from './jobCard';
 import DayNotesCell from './DayNotesCell';
 
 type WeekBoardProps = {
@@ -26,11 +26,7 @@ type WeekBoardProps = {
   onCellDrop: (e: React.DragEvent, truckId: string, dayISO: string) => void;
   onSegDragStart: (e: React.DragEvent, seg: OpsSegment) => void;
   onSegClick: (seg: OpsSegment) => void;
-  onSetJobType: (seg: OpsSegment, jobType: string | null) => void;
-  onAddCrew: (seg: OpsSegment, person: AssignablePerson) => void;
-  onRemoveCrew: (seg: OpsSegment, memberId: string) => void;
-  onOpenConfirm: (seg: OpsSegment) => void;
-  onToggleHold: (seg: OpsSegment, value: boolean) => void;
+  actions: SegmentActions;
   dayNotes: DayNote[];
   onAddNote: (dayISO: string, body: string) => void;
   onRemoveNote: (id: string) => void;
@@ -38,8 +34,6 @@ type WeekBoardProps = {
   onAddTruckCrew: (truckId: string, person: AssignablePerson, startDay: string, endDay: string) => void;
   onRemoveTruckCrew: (truckId: string, memberId: string) => void;
   onCopyTruckCrew: (truckId: string, sourceFrom: string, sourceTo: string) => void;
-  onResize: (seg: OpsSegment, startDay: string, endDay: string) => void;
-  onSetStatus: (seg: OpsSegment, status: string) => void;
 };
 
 // Which visible-day column (0…count-1) a pointer x lands in, within a `count`-column lane.
@@ -51,8 +45,8 @@ function dayIndexFromX(e: React.MouseEvent | React.DragEvent, count: number): nu
 
 export default function WeekBoard({
   weekDays, showWeekend, trucks, segments, todayISO, canWrite, placing, people, jobTypes,
-  onCellClick, onCellDrop, onSegDragStart, onSegClick, onSetJobType, onAddCrew, onRemoveCrew, onOpenConfirm, onToggleHold,
-  dayNotes, onAddNote, onRemoveNote, truckCrew, onAddTruckCrew, onRemoveTruckCrew, onCopyTruckCrew, onResize, onSetStatus,
+  onCellClick, onCellDrop, onSegDragStart, onSegClick, actions,
+  dayNotes, onAddNote, onRemoveNote, truckCrew, onAddTruckCrew, onRemoveTruckCrew, onCopyTruckCrew,
 }: WeekBoardProps) {
   // The visible day columns: all seven, or weekdays only when weekends are hidden.
   const days = showWeekend ? weekDays : weekDays.filter((d) => !d.isWeekend);
@@ -101,7 +95,7 @@ export default function WeekBoard({
       setResize(null);
       suppressClickRef.current = true;
       setTimeout(() => { suppressClickRef.current = false; }, 0);
-      if (endIso && endIso !== seg.end_day) onResize(seg, seg.start_day, endIso);
+      if (endIso && endIso !== seg.end_day) actions.onResize(seg, seg.start_day, endIso);
     };
     window.addEventListener('mousemove', onMove);
     window.addEventListener('mouseup', onUp);
@@ -233,7 +227,6 @@ export default function WeekBoard({
                     {laneSegs.map((seg) => {
                       const col = segColumns(seg);
                       if (!col) return null;
-                      const job = seg.job;
                       const previewEnd = resize?.segId === seg.id ? days.findIndex((d) => d.iso === resize.endIso) : -1;
                       const endIdx = previewEnd >= col.s ? previewEnd : col.e;
                       return (
@@ -253,7 +246,6 @@ export default function WeekBoard({
                             seg.on_hold && 'opacity-60 ring-1 ring-amber-200',
                           )}
                         >
-                          <span className={cn('absolute inset-y-0 left-0 w-1', statusMeta(seg.job?.status ?? '').rail)} />
                           {canWrite && (
                             <span
                               onMouseDown={(e) => startResize(e, seg)}
@@ -264,55 +256,13 @@ export default function WeekBoard({
                               <svg width="4" height="13" viewBox="0 0 4 14" fill="currentColor"><rect width="1.2" height="14" rx="0.6" /><rect x="2.8" width="1.2" height="14" rx="0.6" /></svg>
                             </span>
                           )}
-                          {job ? (
-                            <>
-                              <div className="flex items-center gap-2">
-                                <JobRef job={job} />
-                                <StatusPill status={job.status} className="ml-auto" />
-                                {canWrite && (
-                                  <span className="relative z-20 inline-flex">
-                                  <SegmentMenu
-                                    status={job.status}
-                                    jobType={seg.job_type}
-                                    jobTypes={jobTypes}
-                                    onHold={seg.on_hold}
-                                    lengthDays={daysBetweenInclusive(seg.start_day, seg.end_day)}
-                                    crew={seg.crew}
-                                    people={people}
-                                    onSetStatus={(st) => onSetStatus(seg, st)}
-                                    onSetJobType={(key) => onSetJobType(seg, key)}
-                                    onToggleHold={() => onToggleHold(seg, !seg.on_hold)}
-                                    onOpenConfirm={() => onOpenConfirm(seg)}
-                                    onSetLength={(d) => onResize(seg, seg.start_day, addDaysISO(seg.start_day, d - 1))}
-                                    onAddCrew={(p) => onAddCrew(seg, p)}
-                                    onRemoveCrew={(mid) => onRemoveCrew(seg, mid)}
-                                  />
-                                  </span>
-                                )}
-                              </div>
-                              <div className="mt-1.5 text-[13px] font-bold leading-tight text-slate-900">{job.project_name}</div>
-                              <div className="text-[11px] text-slate-500">{job.client_name}</div>
-                              {job.address && (
-                                <div className="mt-0.5 flex items-center gap-1 text-[10.5px] text-slate-400">
-                                  <span className="truncate">{job.address}</span>
-                                  <MapLink address={job.address} />
-                                </div>
-                              )}
-                              <div className="mt-2 flex flex-wrap items-center gap-1.5">
-                                {seg.on_hold && <HoldBadge />}
-                                <JobTypeOrMaterial jobType={resolveJobTypeFrom(jobTypes, seg.job_type)} material={job.material} />
-                              </div>
-                              <div className="mt-2 flex flex-wrap items-center gap-2">
-                                <SackProgress planned={job.total_sacks} reported={seg.sacks_reported} />
-                                <ConfirmationBadge confirmation={seg.confirmation} />
-                                <div className="ml-auto">
-                                  <CrewAvatars crew={seg.crew} />
-                                </div>
-                              </div>
-                            </>
-                          ) : (
-                            <div className="text-[11px] text-slate-400">Order saknas</div>
-                          )}
+                          <SegmentCardBody
+                            seg={seg}
+                            canWrite={canWrite}
+                            jobTypes={jobTypes}
+                            people={people}
+                            actions={actions}
+                          />
                         </div>
                       );
                     })}

--- a/app/crm/planering/WeekBoard.tsx
+++ b/app/crm/planering/WeekBoard.tsx
@@ -5,7 +5,9 @@ import type { OpsSegment, OpsTruck } from '@/lib/domains/planning/types';
 import { parseISO, type WeekDay } from './planningDates';
 import { JOB_TYPES } from '@/lib/domains/planning/jobTypes';
 import type { AssignablePerson } from '@/lib/domains/planning/crew';
+import { groupNotesByDay, type DayNote } from '@/lib/domains/planning/dayNotes';
 import { statusMeta, StatusPill, SackProgress, JobTypeOrMaterial, JobRef, CrewEditor, CrewAvatars, ConfirmationBadge, HoldBadge } from './jobCard';
+import DayNotesCell from './DayNotesCell';
 
 type WeekBoardProps = {
   weekDays: WeekDay[];
@@ -24,6 +26,9 @@ type WeekBoardProps = {
   onRemoveCrew: (seg: OpsSegment, memberId: string) => void;
   onOpenConfirm: (seg: OpsSegment) => void;
   onToggleHold: (seg: OpsSegment, value: boolean) => void;
+  dayNotes: DayNote[];
+  onAddNote: (dayISO: string, body: string) => void;
+  onRemoveNote: (id: string) => void;
 };
 
 // Which day column (0–6) a pointer x lands in, within a 7-column lane.
@@ -36,11 +41,13 @@ function dayIndexFromX(e: React.MouseEvent | React.DragEvent): number {
 export default function WeekBoard({
   weekDays, trucks, segments, todayISO, canWrite, placing, people,
   onCellClick, onCellDrop, onSegDragStart, onSegClick, onSetJobType, onAddCrew, onRemoveCrew, onOpenConfirm, onToggleHold,
+  dayNotes, onAddNote, onRemoveNote,
 }: WeekBoardProps) {
   const weekStart = weekDays[0].iso;
   const weekEnd = weekDays[6].iso;
   const startMs = parseISO(weekStart).getTime();
   const dayIndexOf = (iso: string) => Math.round((parseISO(iso).getTime() - startMs) / 86_400_000);
+  const notesByDay = groupNotesByDay(dayNotes);
 
   return (
     <section className={cn(crm.card, 'overflow-x-auto p-3')}>
@@ -62,6 +69,23 @@ export default function WeekBoard({
               </div>
             );
           })}
+        </div>
+
+        {/* Day notes strip (dagsanteckningar) */}
+        <div className="grid grid-cols-[112px_repeat(7,minmax(132px,1fr))] border-t border-[#eef3eb]">
+          <div className="flex items-center justify-end pr-2 text-[9.5px] font-semibold uppercase tracking-wide text-slate-300">Noteringar</div>
+          {weekDays.map((wd) => (
+            <DayNotesCell
+              key={wd.iso}
+              dayISO={wd.iso}
+              notes={notesByDay.get(wd.iso) ?? []}
+              canWrite={canWrite}
+              isWeekend={wd.isWeekend}
+              isToday={wd.iso === todayISO}
+              onAdd={onAddNote}
+              onRemove={onRemoveNote}
+            />
+          ))}
         </div>
 
         {/* Truck lanes */}

--- a/app/crm/planering/WeekBoard.tsx
+++ b/app/crm/planering/WeekBoard.tsx
@@ -1,8 +1,9 @@
 import type React from 'react';
+import { useRef, useState } from 'react';
 import { cn } from '@/lib/shared/cn';
 import { crm } from '@/app/crm/lib/crmTokens';
 import type { OpsSegment, OpsTruck } from '@/lib/domains/planning/types';
-import { type WeekDay } from './planningDates';
+import { type WeekDay, addDaysISO, daysBetweenInclusive } from './planningDates';
 import { resolveJobTypeFrom, type JobType } from '@/lib/domains/planning/jobTypes';
 import type { AssignablePerson } from '@/lib/domains/planning/crew';
 import { crewForTruckInRange, type TruckCrewMember } from '@/lib/domains/planning/truckCrew';
@@ -37,6 +38,7 @@ type WeekBoardProps = {
   onAddTruckCrew: (truckId: string, person: AssignablePerson, startDay: string, endDay: string) => void;
   onRemoveTruckCrew: (truckId: string, memberId: string) => void;
   onCopyTruckCrew: (truckId: string, sourceFrom: string, sourceTo: string) => void;
+  onResize: (seg: OpsSegment, startDay: string, endDay: string) => void;
 };
 
 // Which visible-day column (0…count-1) a pointer x lands in, within a `count`-column lane.
@@ -49,7 +51,7 @@ function dayIndexFromX(e: React.MouseEvent | React.DragEvent, count: number): nu
 export default function WeekBoard({
   weekDays, showWeekend, trucks, segments, todayISO, canWrite, placing, people, jobTypes,
   onCellClick, onCellDrop, onSegDragStart, onSegClick, onSetJobType, onAddCrew, onRemoveCrew, onOpenConfirm, onToggleHold,
-  dayNotes, onAddNote, onRemoveNote, truckCrew, onAddTruckCrew, onRemoveTruckCrew, onCopyTruckCrew,
+  dayNotes, onAddNote, onRemoveNote, truckCrew, onAddTruckCrew, onRemoveTruckCrew, onCopyTruckCrew, onResize,
 }: WeekBoardProps) {
   // The visible day columns: all seven, or weekdays only when weekends are hidden.
   const days = showWeekend ? weekDays : weekDays.filter((d) => !d.isWeekend);
@@ -73,17 +75,48 @@ export default function WeekBoard({
     return s === -1 ? null : { s, e };
   };
 
+  const [resize, setResize] = useState<{ segId: string; endIso: string } | null>(null);
+  const resizeEndRef = useRef<string | null>(null);
+  const suppressClickRef = useRef(false);
+
+  // Pointer-drag a card's right edge to change how many days it spans (live preview via `resize`).
+  const startResize = (e: React.MouseEvent, seg: OpsSegment) => {
+    e.stopPropagation();
+    e.preventDefault();
+    const dayArea = (e.currentTarget as HTMLElement).closest('[data-dayarea]') as HTMLElement | null;
+    if (!dayArea) return;
+    const rect = dayArea.getBoundingClientRect();
+    resizeEndRef.current = seg.end_day;
+    const onMove = (me: MouseEvent) => {
+      const idx = Math.max(0, Math.min(n - 1, Math.floor(((me.clientX - rect.left) / rect.width) * n)));
+      const endIso = days[idx].iso < seg.start_day ? seg.start_day : days[idx].iso;
+      resizeEndRef.current = endIso;
+      setResize({ segId: seg.id, endIso });
+    };
+    const onUp = () => {
+      window.removeEventListener('mousemove', onMove);
+      window.removeEventListener('mouseup', onUp);
+      const endIso = resizeEndRef.current;
+      setResize(null);
+      suppressClickRef.current = true;
+      setTimeout(() => { suppressClickRef.current = false; }, 0);
+      if (endIso && endIso !== seg.end_day) onResize(seg, seg.start_day, endIso);
+    };
+    window.addEventListener('mousemove', onMove);
+    window.addEventListener('mouseup', onUp);
+  };
+
   return (
-    <section className={cn(crm.card, 'overflow-x-auto p-3')}>
+    <section className={cn(crm.card, 'wk-board overflow-x-auto p-3')}>
       <div style={{ minWidth: 112 + n * 132 }}>
         {/* Day header */}
-        <div className="grid" style={{ gridTemplateColumns: laneCols }}>
+        <div className="mb-1.5 grid" style={{ gridTemplateColumns: laneCols }}>
           <div />
           {days.map((wd) => {
             const isToday = wd.iso === todayISO;
             const hol = swedishHoliday(wd.iso);
             return (
-              <div key={wd.iso} className={cn('border-l border-[#d3ddcb] px-1.5 py-1.5 text-center last:border-r', isToday ? 'bg-emerald-50' : hol && 'bg-rose-50')}>
+              <div key={wd.iso} className={cn('px-1.5 py-1.5 text-center', isToday ? 'bg-emerald-50' : hol && 'bg-rose-50')}>
                 <div className={cn('text-[11.5px] font-bold capitalize', isToday ? 'text-emerald-700' : hol ? 'text-rose-600' : wd.isWeekend ? 'text-slate-400' : 'text-slate-600')}>
                   {wd.weekday}
                 </div>
@@ -95,7 +128,7 @@ export default function WeekBoard({
         </div>
 
         {/* Day notes strip (dagsanteckningar) */}
-        <div className="grid border-t border-[#eef3eb]" style={{ gridTemplateColumns: laneCols }}>
+        <div className="grid" style={{ gridTemplateColumns: laneCols }}>
           <div className="flex items-center justify-end pr-2 text-[9.5px] font-semibold uppercase tracking-wide text-slate-300">Noteringar</div>
           {days.map((wd) => (
             <DayNotesCell
@@ -123,15 +156,15 @@ export default function WeekBoard({
             return (
               <div
                 key={truck.id}
-                className={cn('grid border-t border-[#d3ddcb]', ti === trucks.length - 1 && 'border-b')}
+                className={cn('grid border-t border-solid border-[#e8efe5]', ti === trucks.length - 1 && 'border-b')}
                 style={{ gridTemplateColumns: laneCols }}
               >
-                <div className="flex flex-col gap-1.5 py-3 pl-1 pr-2">
+                <div className="flex flex-col gap-1 py-2 pl-1 pr-2">
                   <div className="flex items-center gap-2">
                     <span className="h-2.5 w-2.5 shrink-0 rounded-full ring-2 ring-black/[0.03]" style={{ backgroundColor: truck.color || '#94a3b8' }} />
                     <span className="truncate text-[12.5px] font-bold text-slate-700">{truck.name}</span>
                   </div>
-                  <div className="pl-[18px]">
+                  <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1 pl-[18px]">
                     {canWrite ? (
                       <CrewEditor
                         crew={laneCrew}
@@ -147,7 +180,7 @@ export default function WeekBoard({
                         type="button"
                         onClick={() => onCopyTruckCrew(truck.id, weekStart, weekEnd)}
                         title="Kopiera besättningen till nästa vecka"
-                        className="mt-1 inline-flex items-center gap-0.5 text-[9px] font-semibold text-slate-400 transition hover:text-emerald-600"
+                        className="inline-flex items-center gap-0.5 text-[9px] font-semibold text-slate-400 transition hover:text-emerald-600"
                       >
                         <svg width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round">
                           <path d="M5 12h14M13 6l6 6-6 6" />
@@ -160,6 +193,7 @@ export default function WeekBoard({
 
                 {/* Day-area: one drop zone; the target day is derived from the pointer x. */}
                 <div
+                  data-dayarea
                   className="relative"
                   style={{ gridColumn: '2 / -1' }}
                   onDragOver={(e) => {
@@ -180,7 +214,7 @@ export default function WeekBoard({
                       <div
                         key={wd.iso}
                         className={cn(
-                          'border-l border-[#d3ddcb] last:border-r',
+                          'border-solid border-[#e8efe5] border-l',
                           wd.iso === todayISO
                             ? 'bg-emerald-500/5'
                             : swedishHoliday(wd.iso)
@@ -194,11 +228,13 @@ export default function WeekBoard({
                   </div>
 
                   {/* segments */}
-                  <div className={cn('relative grid content-start gap-1.5 p-1.5', placing && 'cursor-copy')} style={{ gridTemplateColumns: dayCols, minHeight: 118 }}>
+                  <div className={cn('relative grid h-full content-start gap-1.5 px-1.5 py-1.5', placing && 'cursor-copy')} style={{ gridTemplateColumns: dayCols, minHeight: 72 }}>
                     {laneSegs.map((seg) => {
                       const col = segColumns(seg);
                       if (!col) return null;
                       const job = seg.job;
+                      const previewEnd = resize?.segId === seg.id ? days.findIndex((d) => d.iso === resize.endIso) : -1;
+                      const endIdx = previewEnd >= col.s ? previewEnd : col.e;
                       return (
                         <div
                           key={seg.id}
@@ -206,9 +242,10 @@ export default function WeekBoard({
                           onDragStart={(ev) => onSegDragStart(ev, seg)}
                           onClick={(ev) => {
                             ev.stopPropagation();
+                            if (suppressClickRef.current) return;
                             onSegClick(seg);
                           }}
-                          style={{ gridColumn: `${col.s + 1} / ${col.e + 2}` }}
+                          style={{ gridColumn: `${col.s + 1} / ${endIdx + 2}` }}
                           className={cn(
                             'relative overflow-hidden rounded-xl border border-[#e0e8dc] bg-white p-2.5 pl-3.5 shadow-[0_1px_2px_rgba(20,44,27,0.06)] transition hover:-translate-y-px hover:shadow-[0_3px_10px_rgba(20,44,27,0.12)]',
                             canWrite ? 'cursor-grab active:cursor-grabbing' : 'cursor-pointer',
@@ -216,6 +253,16 @@ export default function WeekBoard({
                           )}
                         >
                           <span className={cn('absolute inset-y-0 left-0 w-1', statusMeta(seg.job?.status ?? '').rail)} />
+                          {canWrite && (
+                            <span
+                              onMouseDown={(e) => startResize(e, seg)}
+                              onClick={(e) => e.stopPropagation()}
+                              title="Dra för att ändra antal dagar"
+                              className="absolute inset-y-1 right-0 z-10 flex w-2.5 cursor-ew-resize items-center justify-center rounded-r-xl text-slate-300 transition hover:bg-emerald-50 hover:text-emerald-500"
+                            >
+                              <svg width="4" height="13" viewBox="0 0 4 14" fill="currentColor"><rect width="1.2" height="14" rx="0.6" /><rect x="2.8" width="1.2" height="14" rx="0.6" /></svg>
+                            </span>
+                          )}
                           {job ? (
                             <>
                               <div className="flex items-center gap-2">
@@ -226,9 +273,11 @@ export default function WeekBoard({
                                     jobType={seg.job_type}
                                     jobTypes={jobTypes}
                                     onHold={seg.on_hold}
+                                    lengthDays={daysBetweenInclusive(seg.start_day, seg.end_day)}
                                     onSetJobType={(key) => onSetJobType(seg, key)}
                                     onToggleHold={() => onToggleHold(seg, !seg.on_hold)}
                                     onOpenConfirm={() => onOpenConfirm(seg)}
+                                    onSetLength={(d) => onResize(seg, seg.start_day, addDaysISO(seg.start_day, d - 1))}
                                   />
                                 )}
                               </div>

--- a/app/crm/planering/WeekBoard.tsx
+++ b/app/crm/planering/WeekBoard.tsx
@@ -3,7 +3,7 @@ import { cn } from '@/lib/shared/cn';
 import { crm } from '@/app/crm/lib/crmTokens';
 import type { OpsSegment, OpsTruck } from '@/lib/domains/planning/types';
 import { type WeekDay } from './planningDates';
-import { JOB_TYPES } from '@/lib/domains/planning/jobTypes';
+import { resolveJobTypeFrom, type JobType } from '@/lib/domains/planning/jobTypes';
 import type { AssignablePerson } from '@/lib/domains/planning/crew';
 import { crewForTruckInRange, type TruckCrewMember } from '@/lib/domains/planning/truckCrew';
 import { groupNotesByDay, type DayNote } from '@/lib/domains/planning/dayNotes';
@@ -20,6 +20,7 @@ type WeekBoardProps = {
   canWrite: boolean;
   placing: boolean; // a backlog item is selected → cells are placement targets
   people: AssignablePerson[];
+  jobTypes: JobType[];
   onCellClick: (truckId: string, dayISO: string) => void;
   onCellDrop: (e: React.DragEvent, truckId: string, dayISO: string) => void;
   onSegDragStart: (e: React.DragEvent, seg: OpsSegment) => void;
@@ -45,7 +46,7 @@ function dayIndexFromX(e: React.MouseEvent | React.DragEvent, count: number): nu
 }
 
 export default function WeekBoard({
-  weekDays, showWeekend, trucks, segments, todayISO, canWrite, placing, people,
+  weekDays, showWeekend, trucks, segments, todayISO, canWrite, placing, people, jobTypes,
   onCellClick, onCellDrop, onSegDragStart, onSegClick, onSetJobType, onAddCrew, onRemoveCrew, onOpenConfirm, onToggleHold,
   dayNotes, onAddNote, onRemoveNote, truckCrew, onAddTruckCrew, onRemoveTruckCrew,
 }: WeekBoardProps) {
@@ -213,7 +214,7 @@ export default function WeekBoard({
                               )}
                               <div className="mt-2 flex flex-wrap items-center gap-1.5">
                                 {seg.on_hold && <HoldBadge />}
-                                <JobTypeOrMaterial jobType={seg.job_type} material={job.material} />
+                                <JobTypeOrMaterial jobType={resolveJobTypeFrom(jobTypes, seg.job_type)} material={job.material} />
                                 <SackProgress planned={job.total_sacks} reported={seg.sacks_reported} />
                                 <ConfirmationBadge confirmation={seg.confirmation} />
                               </div>
@@ -241,7 +242,7 @@ export default function WeekBoard({
                                   className="mt-2 h-6 w-full rounded-lg border border-[#e0e8dc] bg-white px-1.5 text-[10px] font-semibold text-slate-500 outline-none focus:border-emerald-400"
                                 >
                                   <option value="">Jobbtyp…</option>
-                                  {JOB_TYPES.map((t) => (
+                                  {jobTypes.map((t) => (
                                     <option key={t.key} value={t.key}>{t.label}</option>
                                   ))}
                                 </select>

--- a/app/crm/planering/WeekBoard.tsx
+++ b/app/crm/planering/WeekBoard.tsx
@@ -7,6 +7,7 @@ import { JOB_TYPES } from '@/lib/domains/planning/jobTypes';
 import type { AssignablePerson } from '@/lib/domains/planning/crew';
 import { crewForTruckInRange, type TruckCrewMember } from '@/lib/domains/planning/truckCrew';
 import { groupNotesByDay, type DayNote } from '@/lib/domains/planning/dayNotes';
+import { swedishHoliday } from '@/lib/domains/planning/holidays';
 import { statusMeta, StatusPill, SackProgress, JobTypeOrMaterial, JobRef, CrewEditor, CrewAvatars, ConfirmationBadge, HoldBadge } from './jobCard';
 import DayNotesCell from './DayNotesCell';
 
@@ -78,12 +79,14 @@ export default function WeekBoard({
           <div />
           {days.map((wd) => {
             const isToday = wd.iso === todayISO;
+            const hol = swedishHoliday(wd.iso);
             return (
-              <div key={wd.iso} className={cn('rounded-lg px-1.5 py-1.5 text-center', isToday && 'bg-emerald-50')}>
-                <div className={cn('text-[11.5px] font-bold capitalize', isToday ? 'text-emerald-700' : wd.isWeekend ? 'text-slate-400' : 'text-slate-600')}>
+              <div key={wd.iso} className={cn('rounded-lg px-1.5 py-1.5 text-center', isToday ? 'bg-emerald-50' : hol && 'bg-rose-50')}>
+                <div className={cn('text-[11.5px] font-bold capitalize', isToday ? 'text-emerald-700' : hol ? 'text-rose-600' : wd.isWeekend ? 'text-slate-400' : 'text-slate-600')}>
                   {wd.weekday}
                 </div>
-                <div className={cn('text-[10px] tabular-nums', isToday ? 'text-emerald-600' : 'text-slate-400')}>{wd.dayLabel}</div>
+                <div className={cn('text-[10px] tabular-nums', isToday ? 'text-emerald-600' : hol ? 'text-rose-400' : 'text-slate-400')}>{wd.dayLabel}</div>
+                {hol && <div className="truncate text-[8px] font-semibold leading-tight text-rose-500" title={hol}>{hol}</div>}
               </div>
             );
           })}
@@ -159,7 +162,13 @@ export default function WeekBoard({
                         key={wd.iso}
                         className={cn(
                           'border-l border-[#e8efe5] last:border-r',
-                          wd.iso === todayISO ? 'bg-emerald-500/5' : wd.isWeekend ? 'bg-slate-400/[0.06]' : '',
+                          wd.iso === todayISO
+                            ? 'bg-emerald-500/5'
+                            : swedishHoliday(wd.iso)
+                              ? 'bg-rose-400/[0.07]'
+                              : wd.isWeekend
+                                ? 'bg-slate-400/[0.06]'
+                                : '',
                         )}
                       />
                     ))}

--- a/app/crm/planering/WeekBoard.tsx
+++ b/app/crm/planering/WeekBoard.tsx
@@ -83,7 +83,7 @@ export default function WeekBoard({
             const isToday = wd.iso === todayISO;
             const hol = swedishHoliday(wd.iso);
             return (
-              <div key={wd.iso} className={cn('rounded-lg px-1.5 py-1.5 text-center', isToday ? 'bg-emerald-50' : hol && 'bg-rose-50')}>
+              <div key={wd.iso} className={cn('border-l border-[#d3ddcb] px-1.5 py-1.5 text-center last:border-r', isToday ? 'bg-emerald-50' : hol && 'bg-rose-50')}>
                 <div className={cn('text-[11.5px] font-bold capitalize', isToday ? 'text-emerald-700' : hol ? 'text-rose-600' : wd.isWeekend ? 'text-slate-400' : 'text-slate-600')}>
                   {wd.weekday}
                 </div>
@@ -115,13 +115,17 @@ export default function WeekBoard({
         {trucks.length === 0 ? (
           <p className="py-8 text-center text-sm text-slate-400">Inga bilar upplagda än.</p>
         ) : (
-          trucks.map((truck) => {
+          trucks.map((truck, ti) => {
             const laneSegs = segments.filter(
               (s) => s.truck_id === truck.id && s.end_day >= weekStart && s.start_day <= weekEnd,
             );
             const laneCrew = crewForTruckInRange(truckCrew, truck.id, weekStart, weekEnd);
             return (
-              <div key={truck.id} className="grid border-t border-[#e0e8dc]" style={{ gridTemplateColumns: laneCols }}>
+              <div
+                key={truck.id}
+                className={cn('grid border-t border-[#d3ddcb]', ti === trucks.length - 1 && 'border-b')}
+                style={{ gridTemplateColumns: laneCols }}
+              >
                 <div className="flex flex-col gap-1.5 py-3 pl-1 pr-2">
                   <div className="flex items-center gap-2">
                     <span className="h-2.5 w-2.5 shrink-0 rounded-full ring-2 ring-black/[0.03]" style={{ backgroundColor: truck.color || '#94a3b8' }} />
@@ -176,7 +180,7 @@ export default function WeekBoard({
                       <div
                         key={wd.iso}
                         className={cn(
-                          'border-l border-[#e6ede1] last:border-r',
+                          'border-l border-[#d3ddcb] last:border-r',
                           wd.iso === todayISO
                             ? 'bg-emerald-500/5'
                             : swedishHoliday(wd.iso)

--- a/app/crm/planering/WeekBoard.tsx
+++ b/app/crm/planering/WeekBoard.tsx
@@ -102,7 +102,7 @@ export default function WeekBoard({
   };
 
   return (
-    <section className={cn(crm.card, 'wk-board overflow-x-auto p-3')}>
+    <section className={cn(crm.card, 'planning-board overflow-x-auto p-3')}>
       <div style={{ minWidth: 112 + n * 132 }}>
         {/* Day header */}
         <div className="mb-1.5 grid" style={{ gridTemplateColumns: laneCols }}>

--- a/app/crm/planering/WeekBoard.tsx
+++ b/app/crm/planering/WeekBoard.tsx
@@ -4,7 +4,8 @@ import { crm } from '@/app/crm/lib/crmTokens';
 import type { OpsSegment, OpsTruck } from '@/lib/domains/planning/types';
 import { parseISO, type WeekDay } from './planningDates';
 import { JOB_TYPES } from '@/lib/domains/planning/jobTypes';
-import { statusMeta, StatusPill, SackProgress, JobTypeOrMaterial, JobRef } from './jobCard';
+import type { AssignablePerson } from '@/lib/domains/planning/crew';
+import { statusMeta, StatusPill, SackProgress, JobTypeOrMaterial, JobRef, CrewEditor, CrewAvatars } from './jobCard';
 
 type WeekBoardProps = {
   weekDays: WeekDay[];
@@ -13,11 +14,14 @@ type WeekBoardProps = {
   todayISO: string;
   canWrite: boolean;
   placing: boolean; // a backlog item is selected → cells are placement targets
+  people: AssignablePerson[];
   onCellClick: (truckId: string, dayISO: string) => void;
   onCellDrop: (e: React.DragEvent, truckId: string, dayISO: string) => void;
   onSegDragStart: (e: React.DragEvent, seg: OpsSegment) => void;
   onSegClick: (seg: OpsSegment) => void;
   onSetJobType: (seg: OpsSegment, jobType: string | null) => void;
+  onAddCrew: (seg: OpsSegment, person: AssignablePerson) => void;
+  onRemoveCrew: (seg: OpsSegment, memberId: string) => void;
 };
 
 // Which day column (0–6) a pointer x lands in, within a 7-column lane.
@@ -28,7 +32,8 @@ function dayIndexFromX(e: React.MouseEvent | React.DragEvent): number {
 }
 
 export default function WeekBoard({
-  weekDays, trucks, segments, todayISO, canWrite, placing, onCellClick, onCellDrop, onSegDragStart, onSegClick, onSetJobType,
+  weekDays, trucks, segments, todayISO, canWrite, placing, people,
+  onCellClick, onCellDrop, onSegDragStart, onSegClick, onSetJobType, onAddCrew, onRemoveCrew,
 }: WeekBoardProps) {
   const weekStart = weekDays[0].iso;
   const weekEnd = weekDays[6].iso;
@@ -135,6 +140,18 @@ export default function WeekBoard({
                               <div className="mt-2 flex flex-wrap items-center gap-1.5">
                                 <JobTypeOrMaterial jobType={seg.job_type} material={job.material} />
                                 <SackProgress planned={job.total_sacks} reported={seg.sacks_reported} />
+                              </div>
+                              <div className="mt-2">
+                                {canWrite ? (
+                                  <CrewEditor
+                                    crew={seg.crew}
+                                    people={people}
+                                    onAdd={(p) => onAddCrew(seg, p)}
+                                    onRemove={(mid) => onRemoveCrew(seg, mid)}
+                                  />
+                                ) : (
+                                  <CrewAvatars crew={seg.crew} />
+                                )}
                               </div>
                               {canWrite && (
                                 <select

--- a/app/crm/planering/WeekBoard.tsx
+++ b/app/crm/planering/WeekBoard.tsx
@@ -121,7 +121,7 @@ export default function WeekBoard({
             );
             const laneCrew = crewForTruckInRange(truckCrew, truck.id, weekStart, weekEnd);
             return (
-              <div key={truck.id} className="grid border-t border-[#e8efe5]" style={{ gridTemplateColumns: laneCols }}>
+              <div key={truck.id} className="grid border-t border-[#e0e8dc]" style={{ gridTemplateColumns: laneCols }}>
                 <div className="flex flex-col gap-1.5 py-3 pl-1 pr-2">
                   <div className="flex items-center gap-2">
                     <span className="h-2.5 w-2.5 shrink-0 rounded-full ring-2 ring-black/[0.03]" style={{ backgroundColor: truck.color || '#94a3b8' }} />
@@ -176,7 +176,7 @@ export default function WeekBoard({
                       <div
                         key={wd.iso}
                         className={cn(
-                          'border-l border-[#e8efe5] last:border-r',
+                          'border-l border-[#e6ede1] last:border-r',
                           wd.iso === todayISO
                             ? 'bg-emerald-500/5'
                             : swedishHoliday(wd.iso)

--- a/app/crm/planering/WeekBoard.tsx
+++ b/app/crm/planering/WeekBoard.tsx
@@ -3,7 +3,7 @@ import { cn } from '@/lib/shared/cn';
 import { crm } from '@/app/crm/lib/crmTokens';
 import type { OpsSegment, OpsTruck } from '@/lib/domains/planning/types';
 import { parseISO, type WeekDay } from './planningDates';
-import { statusMeta, StatusPill, SackBadge, MaterialChip, JobRef } from './jobCard';
+import { statusMeta, StatusPill, SackProgress, MaterialChip, JobRef } from './jobCard';
 
 type WeekBoardProps = {
   weekDays: WeekDay[];
@@ -132,7 +132,7 @@ export default function WeekBoard({
                               {job.address && <div className="mt-0.5 text-[10.5px] text-slate-400">{job.address}</div>}
                               <div className="mt-2 flex flex-wrap items-center gap-1.5">
                                 <MaterialChip material={job.material} />
-                                <SackBadge sacks={job.total_sacks} />
+                                <SackProgress planned={job.total_sacks} reported={seg.sacks_reported} />
                               </div>
                             </>
                           ) : (

--- a/app/crm/planering/WeekBoard.tsx
+++ b/app/crm/planering/WeekBoard.tsx
@@ -5,6 +5,7 @@ import type { OpsSegment, OpsTruck } from '@/lib/domains/planning/types';
 import { parseISO, type WeekDay } from './planningDates';
 import { JOB_TYPES } from '@/lib/domains/planning/jobTypes';
 import type { AssignablePerson } from '@/lib/domains/planning/crew';
+import { crewForTruckInRange, type TruckCrewMember } from '@/lib/domains/planning/truckCrew';
 import { groupNotesByDay, type DayNote } from '@/lib/domains/planning/dayNotes';
 import { statusMeta, StatusPill, SackProgress, JobTypeOrMaterial, JobRef, CrewEditor, CrewAvatars, ConfirmationBadge, HoldBadge } from './jobCard';
 import DayNotesCell from './DayNotesCell';
@@ -29,6 +30,9 @@ type WeekBoardProps = {
   dayNotes: DayNote[];
   onAddNote: (dayISO: string, body: string) => void;
   onRemoveNote: (id: string) => void;
+  truckCrew: TruckCrewMember[];
+  onAddTruckCrew: (truckId: string, person: AssignablePerson, startDay: string, endDay: string) => void;
+  onRemoveTruckCrew: (truckId: string, memberId: string) => void;
 };
 
 // Which day column (0–6) a pointer x lands in, within a 7-column lane.
@@ -41,7 +45,7 @@ function dayIndexFromX(e: React.MouseEvent | React.DragEvent): number {
 export default function WeekBoard({
   weekDays, trucks, segments, todayISO, canWrite, placing, people,
   onCellClick, onCellDrop, onSegDragStart, onSegClick, onSetJobType, onAddCrew, onRemoveCrew, onOpenConfirm, onToggleHold,
-  dayNotes, onAddNote, onRemoveNote,
+  dayNotes, onAddNote, onRemoveNote, truckCrew, onAddTruckCrew, onRemoveTruckCrew,
 }: WeekBoardProps) {
   const weekStart = weekDays[0].iso;
   const weekEnd = weekDays[6].iso;
@@ -96,11 +100,26 @@ export default function WeekBoard({
             const laneSegs = segments.filter(
               (s) => s.truck_id === truck.id && s.end_day >= weekStart && s.start_day <= weekEnd,
             );
+            const laneCrew = crewForTruckInRange(truckCrew, truck.id, weekStart, weekEnd);
             return (
               <div key={truck.id} className="grid grid-cols-[112px_repeat(7,minmax(132px,1fr))] border-t border-[#e8efe5]">
-                <div className="flex items-start gap-2 py-3 pl-1 pr-2">
-                  <span className="mt-[3px] h-2.5 w-2.5 shrink-0 rounded-full ring-2 ring-black/[0.03]" style={{ backgroundColor: truck.color || '#94a3b8' }} />
-                  <span className="truncate text-[12.5px] font-bold text-slate-700">{truck.name}</span>
+                <div className="flex flex-col gap-1.5 py-3 pl-1 pr-2">
+                  <div className="flex items-center gap-2">
+                    <span className="h-2.5 w-2.5 shrink-0 rounded-full ring-2 ring-black/[0.03]" style={{ backgroundColor: truck.color || '#94a3b8' }} />
+                    <span className="truncate text-[12.5px] font-bold text-slate-700">{truck.name}</span>
+                  </div>
+                  <div className="pl-[18px]">
+                    {canWrite ? (
+                      <CrewEditor
+                        crew={laneCrew}
+                        people={people}
+                        onAdd={(p) => onAddTruckCrew(truck.id, p, weekStart, weekEnd)}
+                        onRemove={(mid) => onRemoveTruckCrew(truck.id, mid)}
+                      />
+                    ) : (
+                      <CrewAvatars crew={laneCrew} />
+                    )}
+                  </div>
                 </div>
 
                 {/* Day-area: one drop zone; the target day is derived from the pointer x. */}

--- a/app/crm/planering/WeekBoard.tsx
+++ b/app/crm/planering/WeekBoard.tsx
@@ -2,7 +2,7 @@ import type React from 'react';
 import { cn } from '@/lib/shared/cn';
 import { crm } from '@/app/crm/lib/crmTokens';
 import type { OpsSegment, OpsTruck } from '@/lib/domains/planning/types';
-import { parseISO, type WeekDay } from './planningDates';
+import { type WeekDay } from './planningDates';
 import { JOB_TYPES } from '@/lib/domains/planning/jobTypes';
 import type { AssignablePerson } from '@/lib/domains/planning/crew';
 import { crewForTruckInRange, type TruckCrewMember } from '@/lib/domains/planning/truckCrew';
@@ -12,6 +12,7 @@ import DayNotesCell from './DayNotesCell';
 
 type WeekBoardProps = {
   weekDays: WeekDay[];
+  showWeekend: boolean;
   trucks: OpsTruck[];
   segments: OpsSegment[];
   todayISO: string;
@@ -35,37 +36,50 @@ type WeekBoardProps = {
   onRemoveTruckCrew: (truckId: string, memberId: string) => void;
 };
 
-// Which day column (0–6) a pointer x lands in, within a 7-column lane.
-function dayIndexFromX(e: React.MouseEvent | React.DragEvent): number {
+// Which visible-day column (0…count-1) a pointer x lands in, within a `count`-column lane.
+function dayIndexFromX(e: React.MouseEvent | React.DragEvent, count: number): number {
   const rect = e.currentTarget.getBoundingClientRect();
-  const idx = Math.floor(((e.clientX - rect.left) / rect.width) * 7);
-  return Math.max(0, Math.min(6, idx));
+  const idx = Math.floor(((e.clientX - rect.left) / rect.width) * count);
+  return Math.max(0, Math.min(count - 1, idx));
 }
 
 export default function WeekBoard({
-  weekDays, trucks, segments, todayISO, canWrite, placing, people,
+  weekDays, showWeekend, trucks, segments, todayISO, canWrite, placing, people,
   onCellClick, onCellDrop, onSegDragStart, onSegClick, onSetJobType, onAddCrew, onRemoveCrew, onOpenConfirm, onToggleHold,
   dayNotes, onAddNote, onRemoveNote, truckCrew, onAddTruckCrew, onRemoveTruckCrew,
 }: WeekBoardProps) {
+  // The visible day columns: all seven, or weekdays only when weekends are hidden.
+  const days = showWeekend ? weekDays : weekDays.filter((d) => !d.isWeekend);
+  const n = days.length;
   const weekStart = weekDays[0].iso;
   const weekEnd = weekDays[6].iso;
-  const startMs = parseISO(weekStart).getTime();
-  const dayIndexOf = (iso: string) => Math.round((parseISO(iso).getTime() - startMs) / 86_400_000);
+  const laneCols = `112px repeat(${n}, minmax(132px,1fr))`;
+  const dayCols = `repeat(${n}, minmax(0,1fr))`;
   const notesByDay = groupNotesByDay(dayNotes);
+
+  // First/last visible-day column a segment occupies (null when it falls entirely on hidden days).
+  const segColumns = (seg: OpsSegment): { s: number; e: number } | null => {
+    let s = -1;
+    let e = -1;
+    for (let i = 0; i < n; i++) {
+      if (days[i].iso >= seg.start_day && days[i].iso <= seg.end_day) {
+        if (s === -1) s = i;
+        e = i;
+      }
+    }
+    return s === -1 ? null : { s, e };
+  };
 
   return (
     <section className={cn(crm.card, 'overflow-x-auto p-3')}>
-      <div className="min-w-[1040px]">
+      <div style={{ minWidth: 112 + n * 132 }}>
         {/* Day header */}
-        <div className="grid grid-cols-[112px_repeat(7,minmax(132px,1fr))]">
+        <div className="grid" style={{ gridTemplateColumns: laneCols }}>
           <div />
-          {weekDays.map((wd) => {
+          {days.map((wd) => {
             const isToday = wd.iso === todayISO;
             return (
-              <div
-                key={wd.iso}
-                className={cn('rounded-lg px-1.5 py-1.5 text-center', isToday && 'bg-emerald-50')}
-              >
+              <div key={wd.iso} className={cn('rounded-lg px-1.5 py-1.5 text-center', isToday && 'bg-emerald-50')}>
                 <div className={cn('text-[11.5px] font-bold capitalize', isToday ? 'text-emerald-700' : wd.isWeekend ? 'text-slate-400' : 'text-slate-600')}>
                   {wd.weekday}
                 </div>
@@ -76,9 +90,9 @@ export default function WeekBoard({
         </div>
 
         {/* Day notes strip (dagsanteckningar) */}
-        <div className="grid grid-cols-[112px_repeat(7,minmax(132px,1fr))] border-t border-[#eef3eb]">
+        <div className="grid border-t border-[#eef3eb]" style={{ gridTemplateColumns: laneCols }}>
           <div className="flex items-center justify-end pr-2 text-[9.5px] font-semibold uppercase tracking-wide text-slate-300">Noteringar</div>
-          {weekDays.map((wd) => (
+          {days.map((wd) => (
             <DayNotesCell
               key={wd.iso}
               dayISO={wd.iso}
@@ -102,7 +116,7 @@ export default function WeekBoard({
             );
             const laneCrew = crewForTruckInRange(truckCrew, truck.id, weekStart, weekEnd);
             return (
-              <div key={truck.id} className="grid grid-cols-[112px_repeat(7,minmax(132px,1fr))] border-t border-[#e8efe5]">
+              <div key={truck.id} className="grid border-t border-[#e8efe5]" style={{ gridTemplateColumns: laneCols }}>
                 <div className="flex flex-col gap-1.5 py-3 pl-1 pr-2">
                   <div className="flex items-center gap-2">
                     <span className="h-2.5 w-2.5 shrink-0 rounded-full ring-2 ring-black/[0.03]" style={{ backgroundColor: truck.color || '#94a3b8' }} />
@@ -132,15 +146,15 @@ export default function WeekBoard({
                   onDrop={(e) => {
                     if (!canWrite) return;
                     e.preventDefault();
-                    onCellDrop(e, truck.id, weekDays[dayIndexFromX(e)].iso);
+                    onCellDrop(e, truck.id, days[dayIndexFromX(e, n)].iso);
                   }}
                   onClick={(e) => {
-                    if (placing) onCellClick(truck.id, weekDays[dayIndexFromX(e)].iso);
+                    if (placing) onCellClick(truck.id, days[dayIndexFromX(e, n)].iso);
                   }}
                 >
                   {/* gridline / weekend / today background */}
-                  <div className="pointer-events-none absolute inset-0 grid grid-cols-7">
-                    {weekDays.map((wd) => (
+                  <div className="pointer-events-none absolute inset-0 grid" style={{ gridTemplateColumns: dayCols }}>
+                    {days.map((wd) => (
                       <div
                         key={wd.iso}
                         className={cn(
@@ -152,10 +166,10 @@ export default function WeekBoard({
                   </div>
 
                   {/* segments */}
-                  <div className={cn('relative grid grid-cols-7 content-start gap-1.5 p-1.5', placing && 'cursor-copy')} style={{ minHeight: 118 }}>
+                  <div className={cn('relative grid content-start gap-1.5 p-1.5', placing && 'cursor-copy')} style={{ gridTemplateColumns: dayCols, minHeight: 118 }}>
                     {laneSegs.map((seg) => {
-                      const s = Math.max(0, dayIndexOf(seg.start_day));
-                      const e = Math.min(6, dayIndexOf(seg.end_day));
+                      const col = segColumns(seg);
+                      if (!col) return null;
                       const job = seg.job;
                       return (
                         <div
@@ -166,7 +180,7 @@ export default function WeekBoard({
                             ev.stopPropagation();
                             onSegClick(seg);
                           }}
-                          style={{ gridColumn: `${s + 1} / ${e + 2}` }}
+                          style={{ gridColumn: `${col.s + 1} / ${col.e + 2}` }}
                           className={cn(
                             'relative overflow-hidden rounded-xl border border-[#e0e8dc] bg-white p-2.5 pl-3.5 shadow-[0_1px_2px_rgba(20,44,27,0.06)] transition hover:-translate-y-px hover:shadow-[0_3px_10px_rgba(20,44,27,0.12)]',
                             canWrite ? 'cursor-grab active:cursor-grabbing' : 'cursor-pointer',

--- a/app/crm/planering/WeekBoard.tsx
+++ b/app/crm/planering/WeekBoard.tsx
@@ -36,6 +36,7 @@ type WeekBoardProps = {
   truckCrew: TruckCrewMember[];
   onAddTruckCrew: (truckId: string, person: AssignablePerson, startDay: string, endDay: string) => void;
   onRemoveTruckCrew: (truckId: string, memberId: string) => void;
+  onCopyTruckCrew: (truckId: string, sourceFrom: string, sourceTo: string) => void;
 };
 
 // Which visible-day column (0…count-1) a pointer x lands in, within a `count`-column lane.
@@ -48,7 +49,7 @@ function dayIndexFromX(e: React.MouseEvent | React.DragEvent, count: number): nu
 export default function WeekBoard({
   weekDays, showWeekend, trucks, segments, todayISO, canWrite, placing, people, jobTypes,
   onCellClick, onCellDrop, onSegDragStart, onSegClick, onSetJobType, onAddCrew, onRemoveCrew, onOpenConfirm, onToggleHold,
-  dayNotes, onAddNote, onRemoveNote, truckCrew, onAddTruckCrew, onRemoveTruckCrew,
+  dayNotes, onAddNote, onRemoveNote, truckCrew, onAddTruckCrew, onRemoveTruckCrew, onCopyTruckCrew,
 }: WeekBoardProps) {
   // The visible day columns: all seven, or weekdays only when weekends are hidden.
   const days = showWeekend ? weekDays : weekDays.filter((d) => !d.isWeekend);
@@ -136,6 +137,19 @@ export default function WeekBoard({
                       />
                     ) : (
                       <CrewAvatars crew={laneCrew} />
+                    )}
+                    {canWrite && laneCrew.length > 0 && (
+                      <button
+                        type="button"
+                        onClick={() => onCopyTruckCrew(truck.id, weekStart, weekEnd)}
+                        title="Kopiera besättningen till nästa vecka"
+                        className="mt-1 inline-flex items-center gap-0.5 text-[9px] font-semibold text-slate-400 transition hover:text-emerald-600"
+                      >
+                        <svg width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round">
+                          <path d="M5 12h14M13 6l6 6-6 6" />
+                        </svg>
+                        nästa v.
+                      </button>
                     )}
                   </div>
                 </div>

--- a/app/crm/planering/WeekBoard.tsx
+++ b/app/crm/planering/WeekBoard.tsx
@@ -8,7 +8,7 @@ import type { AssignablePerson } from '@/lib/domains/planning/crew';
 import { crewForTruckInRange, type TruckCrewMember } from '@/lib/domains/planning/truckCrew';
 import { groupNotesByDay, type DayNote } from '@/lib/domains/planning/dayNotes';
 import { swedishHoliday } from '@/lib/domains/planning/holidays';
-import { statusMeta, StatusPill, SackProgress, JobTypeOrMaterial, JobRef, CrewEditor, CrewAvatars, ConfirmationBadge, HoldBadge, MapLink } from './jobCard';
+import { statusMeta, StatusPill, SackProgress, JobTypeOrMaterial, JobRef, CrewEditor, CrewAvatars, ConfirmationBadge, HoldBadge, MapLink, SegmentMenu } from './jobCard';
 import DayNotesCell from './DayNotesCell';
 
 type WeekBoardProps = {
@@ -217,6 +217,16 @@ export default function WeekBoard({
                               <div className="flex items-center gap-2">
                                 <JobRef job={job} />
                                 <StatusPill status={job.status} className="ml-auto" />
+                                {canWrite && (
+                                  <SegmentMenu
+                                    jobType={seg.job_type}
+                                    jobTypes={jobTypes}
+                                    onHold={seg.on_hold}
+                                    onSetJobType={(key) => onSetJobType(seg, key)}
+                                    onToggleHold={() => onToggleHold(seg, !seg.on_hold)}
+                                    onOpenConfirm={() => onOpenConfirm(seg)}
+                                  />
+                                )}
                               </div>
                               <div className="mt-1.5 text-[13px] font-bold leading-tight text-slate-900">{job.project_name}</div>
                               <div className="text-[11px] text-slate-500">{job.client_name}</div>
@@ -229,73 +239,23 @@ export default function WeekBoard({
                               <div className="mt-2 flex flex-wrap items-center gap-1.5">
                                 {seg.on_hold && <HoldBadge />}
                                 <JobTypeOrMaterial jobType={resolveJobTypeFrom(jobTypes, seg.job_type)} material={job.material} />
+                              </div>
+                              <div className="mt-2 flex flex-wrap items-center gap-2">
                                 <SackProgress planned={job.total_sacks} reported={seg.sacks_reported} />
                                 <ConfirmationBadge confirmation={seg.confirmation} />
-                              </div>
-                              <div className="mt-2">
-                                {canWrite ? (
-                                  <CrewEditor
-                                    crew={seg.crew}
-                                    people={people}
-                                    onAdd={(p) => onAddCrew(seg, p)}
-                                    onRemove={(mid) => onRemoveCrew(seg, mid)}
-                                  />
-                                ) : (
-                                  <CrewAvatars crew={seg.crew} />
-                                )}
-                              </div>
-                              {canWrite && (
-                                <select
-                                  value={seg.job_type ?? ''}
-                                  onClick={(ev) => ev.stopPropagation()}
-                                  onMouseDown={(ev) => ev.stopPropagation()}
-                                  onChange={(ev) => {
-                                    ev.stopPropagation();
-                                    onSetJobType(seg, ev.target.value || null);
-                                  }}
-                                  className="mt-2 h-6 w-full rounded-lg border border-[#e0e8dc] bg-white px-1.5 text-[10px] font-semibold text-slate-500 outline-none focus:border-emerald-400"
-                                >
-                                  <option value="">Jobbtyp…</option>
-                                  {jobTypes.map((t) => (
-                                    <option key={t.key} value={t.key}>{t.label}</option>
-                                  ))}
-                                </select>
-                              )}
-                              {canWrite && (
-                                <div className="mt-1.5 flex gap-1.5">
-                                  <button
-                                    type="button"
-                                    onMouseDown={(ev) => ev.stopPropagation()}
-                                    onClick={(ev) => {
-                                      ev.stopPropagation();
-                                      onToggleHold(seg, !seg.on_hold);
-                                    }}
-                                    className={cn(
-                                      'inline-flex h-6 flex-1 items-center justify-center gap-1 rounded-lg border text-[10px] font-semibold transition',
-                                      seg.on_hold
-                                        ? 'border-emerald-200 bg-emerald-50 text-emerald-700 hover:border-emerald-400'
-                                        : 'border-[#e0e8dc] bg-white text-slate-500 hover:border-amber-400 hover:text-amber-600',
-                                    )}
-                                  >
-                                    {seg.on_hold ? 'Återuppta' : 'Pausa'}
-                                  </button>
-                                  <button
-                                    type="button"
-                                    onMouseDown={(ev) => ev.stopPropagation()}
-                                    onClick={(ev) => {
-                                      ev.stopPropagation();
-                                      onOpenConfirm(seg);
-                                    }}
-                                    className="inline-flex h-6 flex-1 items-center justify-center gap-1 rounded-lg border border-[#e0e8dc] bg-white text-[10px] font-semibold text-slate-500 transition hover:border-emerald-400 hover:text-emerald-600"
-                                  >
-                                    <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                                      <rect x="2" y="4" width="20" height="16" rx="2" />
-                                      <path d="M22 7l-10 6L2 7" />
-                                    </svg>
-                                    Bekräftelse
-                                  </button>
+                                <div className="ml-auto">
+                                  {canWrite ? (
+                                    <CrewEditor
+                                      crew={seg.crew}
+                                      people={people}
+                                      onAdd={(p) => onAddCrew(seg, p)}
+                                      onRemove={(mid) => onRemoveCrew(seg, mid)}
+                                    />
+                                  ) : (
+                                    <CrewAvatars crew={seg.crew} />
+                                  )}
                                 </div>
-                              )}
+                              </div>
                             </>
                           ) : (
                             <div className="text-[11px] text-slate-400">Order saknas</div>

--- a/app/crm/planering/WeekBoard.tsx
+++ b/app/crm/planering/WeekBoard.tsx
@@ -1,5 +1,5 @@
 import type React from 'react';
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { cn } from '@/lib/shared/cn';
 import { crm } from '@/app/crm/lib/crmTokens';
 import type { OpsSegment, OpsTruck } from '@/lib/domains/planning/types';
@@ -74,6 +74,13 @@ export default function WeekBoard({
   const [resize, setResize] = useState<{ segId: string; endIso: string } | null>(null);
   const resizeEndRef = useRef<string | null>(null);
   const suppressClickRef = useRef(false);
+  const [dragCell, setDragCell] = useState<{ truckId: string; idx: number } | null>(null);
+  // Clear the drag-target highlight whenever a drag ends (drop, Esc, or leaving the window).
+  useEffect(() => {
+    const clear = () => setDragCell(null);
+    window.addEventListener('dragend', clear);
+    return () => window.removeEventListener('dragend', clear);
+  }, []);
 
   // Pointer-drag a card's right edge to change how many days it spans (live preview via `resize`).
   const startResize = (e: React.MouseEvent, seg: OpsSegment) => {
@@ -193,11 +200,15 @@ export default function WeekBoard({
                   className="relative"
                   style={{ gridColumn: '2 / -1' }}
                   onDragOver={(e) => {
-                    if (canWrite) e.preventDefault();
+                    if (!canWrite) return;
+                    e.preventDefault();
+                    const idx = dayIndexFromX(e, n);
+                    setDragCell((cur) => (cur && cur.truckId === truck.id && cur.idx === idx ? cur : { truckId: truck.id, idx }));
                   }}
                   onDrop={(e) => {
                     if (!canWrite) return;
                     e.preventDefault();
+                    setDragCell(null);
                     onCellDrop(e, truck.id, days[dayIndexFromX(e, n)].iso);
                   }}
                   onClick={(e) => {
@@ -206,18 +217,20 @@ export default function WeekBoard({
                 >
                   {/* gridline / weekend / today background */}
                   <div className="pointer-events-none absolute inset-0 grid" style={{ gridTemplateColumns: dayCols }}>
-                    {days.map((wd) => (
+                    {days.map((wd, di) => (
                       <div
                         key={wd.iso}
                         className={cn(
                           'border-solid border-[#e8efe5] border-l',
-                          wd.iso === todayISO
-                            ? 'bg-emerald-500/5'
-                            : swedishHoliday(wd.iso)
-                              ? 'bg-rose-400/[0.07]'
-                              : wd.isWeekend
-                                ? 'bg-slate-400/[0.06]'
-                                : '',
+                          dragCell?.truckId === truck.id && dragCell.idx === di
+                            ? 'bg-emerald-400/20 ring-2 ring-inset ring-emerald-400'
+                            : wd.iso === todayISO
+                              ? 'bg-emerald-500/5'
+                              : swedishHoliday(wd.iso)
+                                ? 'bg-rose-400/[0.07]'
+                                : wd.isWeekend
+                                  ? 'bg-slate-400/[0.06]'
+                                  : '',
                         )}
                       />
                     ))}

--- a/app/crm/planering/WeekBoard.tsx
+++ b/app/crm/planering/WeekBoard.tsx
@@ -3,7 +3,8 @@ import { cn } from '@/lib/shared/cn';
 import { crm } from '@/app/crm/lib/crmTokens';
 import type { OpsSegment, OpsTruck } from '@/lib/domains/planning/types';
 import { parseISO, type WeekDay } from './planningDates';
-import { statusMeta, StatusPill, SackProgress, MaterialChip, JobRef } from './jobCard';
+import { JOB_TYPES } from '@/lib/domains/planning/jobTypes';
+import { statusMeta, StatusPill, SackProgress, JobTypeOrMaterial, JobRef } from './jobCard';
 
 type WeekBoardProps = {
   weekDays: WeekDay[];
@@ -16,6 +17,7 @@ type WeekBoardProps = {
   onCellDrop: (e: React.DragEvent, truckId: string, dayISO: string) => void;
   onSegDragStart: (e: React.DragEvent, seg: OpsSegment) => void;
   onSegClick: (seg: OpsSegment) => void;
+  onSetJobType: (seg: OpsSegment, jobType: string | null) => void;
 };
 
 // Which day column (0–6) a pointer x lands in, within a 7-column lane.
@@ -26,7 +28,7 @@ function dayIndexFromX(e: React.MouseEvent | React.DragEvent): number {
 }
 
 export default function WeekBoard({
-  weekDays, trucks, segments, todayISO, canWrite, placing, onCellClick, onCellDrop, onSegDragStart, onSegClick,
+  weekDays, trucks, segments, todayISO, canWrite, placing, onCellClick, onCellDrop, onSegDragStart, onSegClick, onSetJobType,
 }: WeekBoardProps) {
   const weekStart = weekDays[0].iso;
   const weekEnd = weekDays[6].iso;
@@ -131,9 +133,26 @@ export default function WeekBoard({
                               <div className="text-[11px] text-slate-500">{job.client_name}</div>
                               {job.address && <div className="mt-0.5 text-[10.5px] text-slate-400">{job.address}</div>}
                               <div className="mt-2 flex flex-wrap items-center gap-1.5">
-                                <MaterialChip material={job.material} />
+                                <JobTypeOrMaterial jobType={seg.job_type} material={job.material} />
                                 <SackProgress planned={job.total_sacks} reported={seg.sacks_reported} />
                               </div>
+                              {canWrite && (
+                                <select
+                                  value={seg.job_type ?? ''}
+                                  onClick={(ev) => ev.stopPropagation()}
+                                  onMouseDown={(ev) => ev.stopPropagation()}
+                                  onChange={(ev) => {
+                                    ev.stopPropagation();
+                                    onSetJobType(seg, ev.target.value || null);
+                                  }}
+                                  className="mt-2 h-6 w-full rounded-lg border border-[#e0e8dc] bg-white px-1.5 text-[10px] font-semibold text-slate-500 outline-none focus:border-emerald-400"
+                                >
+                                  <option value="">Jobbtyp…</option>
+                                  {JOB_TYPES.map((t) => (
+                                    <option key={t.key} value={t.key}>{t.label}</option>
+                                  ))}
+                                </select>
+                              )}
                             </>
                           ) : (
                             <div className="text-[11px] text-slate-400">Order saknas</div>

--- a/app/crm/planering/WeekBoard.tsx
+++ b/app/crm/planering/WeekBoard.tsx
@@ -39,6 +39,7 @@ type WeekBoardProps = {
   onRemoveTruckCrew: (truckId: string, memberId: string) => void;
   onCopyTruckCrew: (truckId: string, sourceFrom: string, sourceTo: string) => void;
   onResize: (seg: OpsSegment, startDay: string, endDay: string) => void;
+  onSetStatus: (seg: OpsSegment, status: string) => void;
 };
 
 // Which visible-day column (0…count-1) a pointer x lands in, within a `count`-column lane.
@@ -51,7 +52,7 @@ function dayIndexFromX(e: React.MouseEvent | React.DragEvent, count: number): nu
 export default function WeekBoard({
   weekDays, showWeekend, trucks, segments, todayISO, canWrite, placing, people, jobTypes,
   onCellClick, onCellDrop, onSegDragStart, onSegClick, onSetJobType, onAddCrew, onRemoveCrew, onOpenConfirm, onToggleHold,
-  dayNotes, onAddNote, onRemoveNote, truckCrew, onAddTruckCrew, onRemoveTruckCrew, onCopyTruckCrew, onResize,
+  dayNotes, onAddNote, onRemoveNote, truckCrew, onAddTruckCrew, onRemoveTruckCrew, onCopyTruckCrew, onResize, onSetStatus,
 }: WeekBoardProps) {
   // The visible day columns: all seven, or weekdays only when weekends are hidden.
   const days = showWeekend ? weekDays : weekDays.filter((d) => !d.isWeekend);
@@ -247,7 +248,7 @@ export default function WeekBoard({
                           }}
                           style={{ gridColumn: `${col.s + 1} / ${endIdx + 2}` }}
                           className={cn(
-                            'relative overflow-hidden rounded-xl border border-[#e0e8dc] bg-white p-2.5 pl-3.5 shadow-[0_1px_2px_rgba(20,44,27,0.06)] transition hover:-translate-y-px hover:shadow-[0_3px_10px_rgba(20,44,27,0.12)]',
+                            'relative overflow-hidden rounded-xl border border-[#e0e8dc] bg-white p-2.5 pl-3.5 shadow-[0_1px_2px_rgba(20,44,27,0.06)] transition hover:shadow-[0_3px_10px_rgba(20,44,27,0.12)]',
                             canWrite ? 'cursor-grab active:cursor-grabbing' : 'cursor-pointer',
                             seg.on_hold && 'opacity-60 ring-1 ring-amber-200',
                           )}
@@ -258,7 +259,7 @@ export default function WeekBoard({
                               onMouseDown={(e) => startResize(e, seg)}
                               onClick={(e) => e.stopPropagation()}
                               title="Dra för att ändra antal dagar"
-                              className="absolute inset-y-1 right-0 z-10 flex w-2.5 cursor-ew-resize items-center justify-center rounded-r-xl text-slate-300 transition hover:bg-emerald-50 hover:text-emerald-500"
+                              className="absolute inset-y-2 right-0 z-10 flex w-2 cursor-ew-resize items-center justify-center text-slate-300 transition hover:text-emerald-500"
                             >
                               <svg width="4" height="13" viewBox="0 0 4 14" fill="currentColor"><rect width="1.2" height="14" rx="0.6" /><rect x="2.8" width="1.2" height="14" rx="0.6" /></svg>
                             </span>
@@ -269,16 +270,24 @@ export default function WeekBoard({
                                 <JobRef job={job} />
                                 <StatusPill status={job.status} className="ml-auto" />
                                 {canWrite && (
+                                  <span className="relative z-20 inline-flex">
                                   <SegmentMenu
+                                    status={job.status}
                                     jobType={seg.job_type}
                                     jobTypes={jobTypes}
                                     onHold={seg.on_hold}
                                     lengthDays={daysBetweenInclusive(seg.start_day, seg.end_day)}
+                                    crew={seg.crew}
+                                    people={people}
+                                    onSetStatus={(st) => onSetStatus(seg, st)}
                                     onSetJobType={(key) => onSetJobType(seg, key)}
                                     onToggleHold={() => onToggleHold(seg, !seg.on_hold)}
                                     onOpenConfirm={() => onOpenConfirm(seg)}
                                     onSetLength={(d) => onResize(seg, seg.start_day, addDaysISO(seg.start_day, d - 1))}
+                                    onAddCrew={(p) => onAddCrew(seg, p)}
+                                    onRemoveCrew={(mid) => onRemoveCrew(seg, mid)}
                                   />
+                                  </span>
                                 )}
                               </div>
                               <div className="mt-1.5 text-[13px] font-bold leading-tight text-slate-900">{job.project_name}</div>
@@ -297,16 +306,7 @@ export default function WeekBoard({
                                 <SackProgress planned={job.total_sacks} reported={seg.sacks_reported} />
                                 <ConfirmationBadge confirmation={seg.confirmation} />
                                 <div className="ml-auto">
-                                  {canWrite ? (
-                                    <CrewEditor
-                                      crew={seg.crew}
-                                      people={people}
-                                      onAdd={(p) => onAddCrew(seg, p)}
-                                      onRemove={(mid) => onRemoveCrew(seg, mid)}
-                                    />
-                                  ) : (
-                                    <CrewAvatars crew={seg.crew} />
-                                  )}
+                                  <CrewAvatars crew={seg.crew} />
                                 </div>
                               </div>
                             </>

--- a/app/crm/planering/WeekBoard.tsx
+++ b/app/crm/planering/WeekBoard.tsx
@@ -10,6 +10,7 @@ import { crewForTruckInRange, type TruckCrewMember } from '@/lib/domains/plannin
 import { groupNotesByDay, type DayNote } from '@/lib/domains/planning/dayNotes';
 import { swedishHoliday } from '@/lib/domains/planning/holidays';
 import { CrewEditor, CrewAvatars, SegmentCardBody, type SegmentActions } from './jobCard';
+import { orderInfo } from '@/lib/domains/planning/order';
 import DayNotesCell from './DayNotesCell';
 
 type WeekBoardProps = {
@@ -262,6 +263,7 @@ export default function WeekBoard({
                             jobTypes={jobTypes}
                             people={people}
                             actions={actions}
+                            order={orderInfo(segments, seg)}
                           />
                         </div>
                       );

--- a/app/crm/planering/WeekBoard.tsx
+++ b/app/crm/planering/WeekBoard.tsx
@@ -8,7 +8,7 @@ import type { AssignablePerson } from '@/lib/domains/planning/crew';
 import { crewForTruckInRange, type TruckCrewMember } from '@/lib/domains/planning/truckCrew';
 import { groupNotesByDay, type DayNote } from '@/lib/domains/planning/dayNotes';
 import { swedishHoliday } from '@/lib/domains/planning/holidays';
-import { statusMeta, StatusPill, SackProgress, JobTypeOrMaterial, JobRef, CrewEditor, CrewAvatars, ConfirmationBadge, HoldBadge } from './jobCard';
+import { statusMeta, StatusPill, SackProgress, JobTypeOrMaterial, JobRef, CrewEditor, CrewAvatars, ConfirmationBadge, HoldBadge, MapLink } from './jobCard';
 import DayNotesCell from './DayNotesCell';
 
 type WeekBoardProps = {
@@ -205,7 +205,12 @@ export default function WeekBoard({
                               </div>
                               <div className="mt-1.5 text-[13px] font-bold leading-tight text-slate-900">{job.project_name}</div>
                               <div className="text-[11px] text-slate-500">{job.client_name}</div>
-                              {job.address && <div className="mt-0.5 text-[10.5px] text-slate-400">{job.address}</div>}
+                              {job.address && (
+                                <div className="mt-0.5 flex items-center gap-1 text-[10.5px] text-slate-400">
+                                  <span className="truncate">{job.address}</span>
+                                  <MapLink address={job.address} />
+                                </div>
+                              )}
                               <div className="mt-2 flex flex-wrap items-center gap-1.5">
                                 {seg.on_hold && <HoldBadge />}
                                 <JobTypeOrMaterial jobType={seg.job_type} material={job.material} />

--- a/app/crm/planering/WeekBoard.tsx
+++ b/app/crm/planering/WeekBoard.tsx
@@ -75,6 +75,7 @@ export default function WeekBoard({
   const resizeEndRef = useRef<string | null>(null);
   const suppressClickRef = useRef(false);
   const [dragCell, setDragCell] = useState<{ truckId: string; idx: number } | null>(null);
+  const [hoverCell, setHoverCell] = useState<{ truckId: string; idx: number } | null>(null);
   // Clear the drag-target highlight whenever a drag ends (drop, Esc, or leaving the window).
   useEffect(() => {
     const clear = () => setDragCell(null);
@@ -211,6 +212,12 @@ export default function WeekBoard({
                     setDragCell(null);
                     onCellDrop(e, truck.id, days[dayIndexFromX(e, n)].iso);
                   }}
+                  onMouseMove={(e) => {
+                    if (!placing) return;
+                    const idx = dayIndexFromX(e, n);
+                    setHoverCell((cur) => (cur && cur.truckId === truck.id && cur.idx === idx ? cur : { truckId: truck.id, idx }));
+                  }}
+                  onMouseLeave={() => placing && setHoverCell(null)}
                   onClick={(e) => {
                     if (placing) onCellClick(truck.id, days[dayIndexFromX(e, n)].iso);
                   }}
@@ -224,13 +231,17 @@ export default function WeekBoard({
                           'border-solid border-[#e8efe5] border-l',
                           dragCell?.truckId === truck.id && dragCell.idx === di
                             ? 'bg-emerald-400/20 ring-2 ring-inset ring-emerald-400'
-                            : wd.iso === todayISO
-                              ? 'bg-emerald-500/5'
-                              : swedishHoliday(wd.iso)
-                                ? 'bg-rose-400/[0.07]'
-                                : wd.isWeekend
-                                  ? 'bg-slate-400/[0.06]'
-                                  : '',
+                            : placing && hoverCell?.truckId === truck.id && hoverCell.idx === di
+                              ? 'bg-emerald-400/10 outline-dashed outline-2 -outline-offset-2 outline-emerald-400/70'
+                              : placing
+                                ? 'bg-emerald-400/[0.05]'
+                                : wd.iso === todayISO
+                                  ? 'bg-emerald-500/5'
+                                  : swedishHoliday(wd.iso)
+                                    ? 'bg-rose-400/[0.07]'
+                                    : wd.isWeekend
+                                      ? 'bg-slate-400/[0.06]'
+                                      : '',
                         )}
                       />
                     ))}

--- a/app/crm/planering/WeekBoard.tsx
+++ b/app/crm/planering/WeekBoard.tsx
@@ -1,0 +1,153 @@
+import type React from 'react';
+import { cn } from '@/lib/shared/cn';
+import { crm } from '@/app/crm/lib/crmTokens';
+import type { OpsSegment, OpsTruck } from '@/lib/domains/planning/types';
+import { parseISO, type WeekDay } from './planningDates';
+import { statusMeta, StatusPill, SackBadge, MaterialChip, JobRef } from './jobCard';
+
+type WeekBoardProps = {
+  weekDays: WeekDay[];
+  trucks: OpsTruck[];
+  segments: OpsSegment[];
+  todayISO: string;
+  canWrite: boolean;
+  placing: boolean; // a backlog item is selected → cells are placement targets
+  onCellClick: (truckId: string, dayISO: string) => void;
+  onCellDrop: (e: React.DragEvent, truckId: string, dayISO: string) => void;
+  onSegDragStart: (e: React.DragEvent, seg: OpsSegment) => void;
+  onSegClick: (seg: OpsSegment) => void;
+};
+
+// Which day column (0–6) a pointer x lands in, within a 7-column lane.
+function dayIndexFromX(e: React.MouseEvent | React.DragEvent): number {
+  const rect = e.currentTarget.getBoundingClientRect();
+  const idx = Math.floor(((e.clientX - rect.left) / rect.width) * 7);
+  return Math.max(0, Math.min(6, idx));
+}
+
+export default function WeekBoard({
+  weekDays, trucks, segments, todayISO, canWrite, placing, onCellClick, onCellDrop, onSegDragStart, onSegClick,
+}: WeekBoardProps) {
+  const weekStart = weekDays[0].iso;
+  const weekEnd = weekDays[6].iso;
+  const startMs = parseISO(weekStart).getTime();
+  const dayIndexOf = (iso: string) => Math.round((parseISO(iso).getTime() - startMs) / 86_400_000);
+
+  return (
+    <section className={cn(crm.card, 'overflow-x-auto p-3')}>
+      <div className="min-w-[1040px]">
+        {/* Day header */}
+        <div className="grid grid-cols-[112px_repeat(7,minmax(132px,1fr))]">
+          <div />
+          {weekDays.map((wd) => {
+            const isToday = wd.iso === todayISO;
+            return (
+              <div
+                key={wd.iso}
+                className={cn('rounded-lg px-1.5 py-1.5 text-center', isToday && 'bg-emerald-50')}
+              >
+                <div className={cn('text-[11.5px] font-bold capitalize', isToday ? 'text-emerald-700' : wd.isWeekend ? 'text-slate-400' : 'text-slate-600')}>
+                  {wd.weekday}
+                </div>
+                <div className={cn('text-[10px] tabular-nums', isToday ? 'text-emerald-600' : 'text-slate-400')}>{wd.dayLabel}</div>
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Truck lanes */}
+        {trucks.length === 0 ? (
+          <p className="py-8 text-center text-sm text-slate-400">Inga bilar upplagda än.</p>
+        ) : (
+          trucks.map((truck) => {
+            const laneSegs = segments.filter(
+              (s) => s.truck_id === truck.id && s.end_day >= weekStart && s.start_day <= weekEnd,
+            );
+            return (
+              <div key={truck.id} className="grid grid-cols-[112px_repeat(7,minmax(132px,1fr))] border-t border-[#e8efe5]">
+                <div className="flex items-start gap-2 py-3 pl-1 pr-2">
+                  <span className="mt-[3px] h-2.5 w-2.5 shrink-0 rounded-full ring-2 ring-black/[0.03]" style={{ backgroundColor: truck.color || '#94a3b8' }} />
+                  <span className="truncate text-[12.5px] font-bold text-slate-700">{truck.name}</span>
+                </div>
+
+                {/* Day-area: one drop zone; the target day is derived from the pointer x. */}
+                <div
+                  className="relative"
+                  style={{ gridColumn: '2 / -1' }}
+                  onDragOver={(e) => {
+                    if (canWrite) e.preventDefault();
+                  }}
+                  onDrop={(e) => {
+                    if (!canWrite) return;
+                    e.preventDefault();
+                    onCellDrop(e, truck.id, weekDays[dayIndexFromX(e)].iso);
+                  }}
+                  onClick={(e) => {
+                    if (placing) onCellClick(truck.id, weekDays[dayIndexFromX(e)].iso);
+                  }}
+                >
+                  {/* gridline / weekend / today background */}
+                  <div className="pointer-events-none absolute inset-0 grid grid-cols-7">
+                    {weekDays.map((wd) => (
+                      <div
+                        key={wd.iso}
+                        className={cn(
+                          'border-l border-[#e8efe5] last:border-r',
+                          wd.iso === todayISO ? 'bg-emerald-500/5' : wd.isWeekend ? 'bg-slate-400/[0.06]' : '',
+                        )}
+                      />
+                    ))}
+                  </div>
+
+                  {/* segments */}
+                  <div className={cn('relative grid grid-cols-7 content-start gap-1.5 p-1.5', placing && 'cursor-copy')} style={{ minHeight: 118 }}>
+                    {laneSegs.map((seg) => {
+                      const s = Math.max(0, dayIndexOf(seg.start_day));
+                      const e = Math.min(6, dayIndexOf(seg.end_day));
+                      const job = seg.job;
+                      return (
+                        <div
+                          key={seg.id}
+                          draggable={canWrite}
+                          onDragStart={(ev) => onSegDragStart(ev, seg)}
+                          onClick={(ev) => {
+                            ev.stopPropagation();
+                            onSegClick(seg);
+                          }}
+                          style={{ gridColumn: `${s + 1} / ${e + 2}` }}
+                          className={cn(
+                            'relative overflow-hidden rounded-xl border border-[#e0e8dc] bg-white p-2.5 pl-3.5 shadow-[0_1px_2px_rgba(20,44,27,0.06)] transition hover:-translate-y-px hover:shadow-[0_3px_10px_rgba(20,44,27,0.12)]',
+                            canWrite ? 'cursor-grab active:cursor-grabbing' : 'cursor-pointer',
+                          )}
+                        >
+                          <span className={cn('absolute inset-y-0 left-0 w-1', statusMeta(seg.job?.status ?? '').rail)} />
+                          {job ? (
+                            <>
+                              <div className="flex items-center gap-2">
+                                <JobRef job={job} />
+                                <StatusPill status={job.status} className="ml-auto" />
+                              </div>
+                              <div className="mt-1.5 text-[13px] font-bold leading-tight text-slate-900">{job.project_name}</div>
+                              <div className="text-[11px] text-slate-500">{job.client_name}</div>
+                              {job.address && <div className="mt-0.5 text-[10.5px] text-slate-400">{job.address}</div>}
+                              <div className="mt-2 flex flex-wrap items-center gap-1.5">
+                                <MaterialChip material={job.material} />
+                                <SackBadge sacks={job.total_sacks} />
+                              </div>
+                            </>
+                          ) : (
+                            <div className="text-[11px] text-slate-400">Order saknas</div>
+                          )}
+                        </div>
+                      );
+                    })}
+                  </div>
+                </div>
+              </div>
+            );
+          })
+        )}
+      </div>
+    </section>
+  );
+}

--- a/app/crm/planering/WeekBoard.tsx
+++ b/app/crm/planering/WeekBoard.tsx
@@ -5,7 +5,7 @@ import type { OpsSegment, OpsTruck } from '@/lib/domains/planning/types';
 import { parseISO, type WeekDay } from './planningDates';
 import { JOB_TYPES } from '@/lib/domains/planning/jobTypes';
 import type { AssignablePerson } from '@/lib/domains/planning/crew';
-import { statusMeta, StatusPill, SackProgress, JobTypeOrMaterial, JobRef, CrewEditor, CrewAvatars } from './jobCard';
+import { statusMeta, StatusPill, SackProgress, JobTypeOrMaterial, JobRef, CrewEditor, CrewAvatars, ConfirmationBadge } from './jobCard';
 
 type WeekBoardProps = {
   weekDays: WeekDay[];
@@ -22,6 +22,7 @@ type WeekBoardProps = {
   onSetJobType: (seg: OpsSegment, jobType: string | null) => void;
   onAddCrew: (seg: OpsSegment, person: AssignablePerson) => void;
   onRemoveCrew: (seg: OpsSegment, memberId: string) => void;
+  onOpenConfirm: (seg: OpsSegment) => void;
 };
 
 // Which day column (0–6) a pointer x lands in, within a 7-column lane.
@@ -33,7 +34,7 @@ function dayIndexFromX(e: React.MouseEvent | React.DragEvent): number {
 
 export default function WeekBoard({
   weekDays, trucks, segments, todayISO, canWrite, placing, people,
-  onCellClick, onCellDrop, onSegDragStart, onSegClick, onSetJobType, onAddCrew, onRemoveCrew,
+  onCellClick, onCellDrop, onSegDragStart, onSegClick, onSetJobType, onAddCrew, onRemoveCrew, onOpenConfirm,
 }: WeekBoardProps) {
   const weekStart = weekDays[0].iso;
   const weekEnd = weekDays[6].iso;
@@ -140,6 +141,7 @@ export default function WeekBoard({
                               <div className="mt-2 flex flex-wrap items-center gap-1.5">
                                 <JobTypeOrMaterial jobType={seg.job_type} material={job.material} />
                                 <SackProgress planned={job.total_sacks} reported={seg.sacks_reported} />
+                                <ConfirmationBadge confirmation={seg.confirmation} />
                               </div>
                               <div className="mt-2">
                                 {canWrite ? (
@@ -169,6 +171,23 @@ export default function WeekBoard({
                                     <option key={t.key} value={t.key}>{t.label}</option>
                                   ))}
                                 </select>
+                              )}
+                              {canWrite && (
+                                <button
+                                  type="button"
+                                  onMouseDown={(ev) => ev.stopPropagation()}
+                                  onClick={(ev) => {
+                                    ev.stopPropagation();
+                                    onOpenConfirm(seg);
+                                  }}
+                                  className="mt-1.5 inline-flex h-6 w-full items-center justify-center gap-1 rounded-lg border border-[#e0e8dc] bg-white text-[10px] font-semibold text-slate-500 transition hover:border-emerald-400 hover:text-emerald-600"
+                                >
+                                  <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                                    <rect x="2" y="4" width="20" height="16" rx="2" />
+                                    <path d="M22 7l-10 6L2 7" />
+                                  </svg>
+                                  Skicka bekräftelse
+                                </button>
                               )}
                             </>
                           ) : (

--- a/app/crm/planering/jobCard.tsx
+++ b/app/crm/planering/jobCard.tsx
@@ -249,6 +249,29 @@ export function CrewEditor({
   );
 }
 
+// A small pin link opening the job-site address in Google Maps. Stops propagation so it doesn't
+// trigger the card's select/open handler.
+export function MapLink({ address }: { address: string | null }) {
+  if (!address) return null;
+  const href = `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(address)}`;
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      onClick={(e) => e.stopPropagation()}
+      title="Öppna i Kartor"
+      aria-label="Öppna adressen i Kartor"
+      className="inline-flex shrink-0 text-slate-400 transition hover:text-emerald-600"
+    >
+      <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M21 10c0 6-9 12-9 12s-9-6-9-12a9 9 0 0 1 18 0Z" />
+        <circle cx="12" cy="10" r="3" />
+      </svg>
+    </a>
+  );
+}
+
 // The reference shown on cards (Fortnox number, or internal AO when not synced yet).
 export function JobRef({ job, className }: { job: Pick<JobDisplay, 'ref' | 'is_fortnox_ref'>; className?: string }) {
   return (

--- a/app/crm/planering/jobCard.tsx
+++ b/app/crm/planering/jobCard.tsx
@@ -1,0 +1,64 @@
+import { cn } from '@/lib/shared/cn';
+import {
+  workOrderStatusLabel,
+  workOrderStatusClass,
+  workOrderStatusAccent,
+  type WorkOrderStatus,
+} from '@/app/crm/lib/crmTokens';
+import type { JobDisplay } from '@/lib/domains/planning/display';
+
+// Status label + colors for a job, reusing the CRM work-order tokens so the planning board reads
+// identically to the rest of the CRM.
+export function statusMeta(status: string) {
+  const s = status as WorkOrderStatus;
+  return {
+    label: workOrderStatusLabel[s] ?? status,
+    pill: workOrderStatusClass[s] ?? 'border-slate-200 bg-slate-50 text-slate-600',
+    rail: workOrderStatusAccent[s] ?? 'bg-slate-300',
+  };
+}
+
+export function StatusPill({ status, className }: { status: string; className?: string }) {
+  const m = statusMeta(status);
+  return (
+    <span className={cn('whitespace-nowrap rounded-full border px-2 py-px text-[9px] font-bold', m.pill, className)}>
+      {m.label}
+    </span>
+  );
+}
+
+// Sack badge — amber "kvar X/Y" form is for a later per-day-reporting slice; for now it's the
+// planned sack total computed from the work order's line items.
+export function SackBadge({ sacks }: { sacks: number }) {
+  if (!(sacks > 0)) return null;
+  return (
+    <span className="whitespace-nowrap rounded-full border border-emerald-200 bg-emerald-50 px-2 py-px text-[10px] font-bold tabular-nums text-emerald-700">
+      {sacks} säck
+    </span>
+  );
+}
+
+export function MaterialChip({ material }: { material: string | null }) {
+  if (!material) return null;
+  return (
+    <span className="inline-flex items-center gap-1.5 whitespace-nowrap rounded-full border border-[#e0e8dc] bg-[#f3f6f1] px-2 py-px text-[10px] font-semibold text-slate-600">
+      <span className="h-1.5 w-1.5 rounded-full bg-emerald-500" />
+      {material}
+    </span>
+  );
+}
+
+// The reference shown on cards (Fortnox number, or internal AO when not synced yet).
+export function JobRef({ job, className }: { job: Pick<JobDisplay, 'ref' | 'is_fortnox_ref'>; className?: string }) {
+  return (
+    <span
+      className={cn(
+        'whitespace-nowrap text-[12px] font-extrabold tabular-nums tracking-tight',
+        job.is_fortnox_ref ? 'text-[#1f4a2e]' : 'font-bold text-slate-400',
+        className,
+      )}
+    >
+      {job.ref}
+    </span>
+  );
+}

--- a/app/crm/planering/jobCard.tsx
+++ b/app/crm/planering/jobCard.tsx
@@ -12,7 +12,9 @@ import type { JobDisplay } from '@/lib/domains/planning/display';
 import { sacksRemaining, sacksOverrun } from '@/lib/domains/planning/reports';
 import { crewInitials, crewColor, type CrewMember, type AssignablePerson } from '@/lib/domains/planning/crew';
 import { describeSmsStatus, type ConfirmationSummary } from '@/lib/domains/planning/confirmations';
-import type { JobType } from '@/lib/domains/planning/jobTypes';
+import { resolveJobTypeFrom, type JobType } from '@/lib/domains/planning/jobTypes';
+import type { OpsSegment } from '@/lib/domains/planning/types';
+import { addDaysISO, daysBetweenInclusive } from './planningDates';
 
 // Status label + colors for a job, reusing the CRM work-order tokens so the planning board reads
 // identically to the rest of the CRM.
@@ -582,6 +584,102 @@ export function SegmentMenu({
           </>,
           document.body,
         )}
+    </>
+  );
+}
+
+
+// The per-segment mutation handlers (each takes the segment), shared by both board views.
+export type SegmentActions = {
+  onSetStatus: (seg: OpsSegment, status: string) => void;
+  onSetJobType: (seg: OpsSegment, jobType: string | null) => void;
+  onToggleHold: (seg: OpsSegment, value: boolean) => void;
+  onOpenConfirm: (seg: OpsSegment) => void;
+  onResize: (seg: OpsSegment, startDay: string, endDay: string) => void;
+  onAddCrew: (seg: OpsSegment, person: AssignablePerson) => void;
+  onRemoveCrew: (seg: OpsSegment, memberId: string) => void;
+};
+
+// The shared inner content of a scheduled-job card (status rail, header with kebab, project/client/
+// address, job-type + sack/confirmation/crew). Used by BOTH the week and month boards so the card
+// reads identically everywhere; each board owns only the outer wrapper (drag, positioning, the
+// week-only resize handle). Pass truckColor/truckName to show the truck (the month board needs it;
+// the week board groups by truck rows so it omits them). The caller's wrapper must be `relative`.
+export function SegmentCardBody({
+  seg,
+  canWrite,
+  jobTypes,
+  people,
+  actions,
+  truckColor,
+  truckName,
+}: {
+  seg: OpsSegment;
+  canWrite: boolean;
+  jobTypes: JobType[];
+  people: AssignablePerson[];
+  actions: SegmentActions;
+  truckColor?: string;
+  truckName?: string;
+}) {
+  const job = seg.job;
+  return (
+    <>
+      <span className={cn('absolute inset-y-0 left-0 w-1', statusMeta(job?.status ?? '').rail)} />
+      {job ? (
+        <>
+          <div className="flex items-center gap-2">
+            {truckColor && <span className="h-2 w-2 shrink-0 rounded-full" style={{ backgroundColor: truckColor }} />}
+            <JobRef job={job} />
+            <StatusPill status={job.status} className="ml-auto" />
+            {canWrite && (
+              <span className="relative z-20 inline-flex">
+              <SegmentMenu
+                status={job.status}
+                jobType={seg.job_type}
+                jobTypes={jobTypes}
+                onHold={seg.on_hold}
+                lengthDays={daysBetweenInclusive(seg.start_day, seg.end_day)}
+                crew={seg.crew}
+                people={people}
+                onSetStatus={(st) => actions.onSetStatus(seg, st)}
+                onSetJobType={(key) => actions.onSetJobType(seg, key)}
+                onToggleHold={() => actions.onToggleHold(seg, !seg.on_hold)}
+                onOpenConfirm={() => actions.onOpenConfirm(seg)}
+                onSetLength={(d) => actions.onResize(seg, seg.start_day, addDaysISO(seg.start_day, d - 1))}
+                onAddCrew={(person) => actions.onAddCrew(seg, person)}
+                onRemoveCrew={(mid) => actions.onRemoveCrew(seg, mid)}
+              />
+              </span>
+            )}
+          </div>
+          <div className="mt-1.5 truncate text-[13px] font-bold leading-tight text-slate-900">{job.project_name}</div>
+          <div className="truncate text-[11px] text-slate-500">{job.client_name}</div>
+          {job.address && (
+            <div className="mt-0.5 flex items-center gap-1 text-[10.5px] text-slate-400">
+              <span className="truncate">{job.address}</span>
+              <MapLink address={job.address} />
+            </div>
+          )}
+          <div className="mt-2 flex flex-wrap items-center gap-1.5">
+            {seg.on_hold && <HoldBadge />}
+            <JobTypeOrMaterial jobType={resolveJobTypeFrom(jobTypes, seg.job_type)} material={job.material} />
+          </div>
+          <div className="mt-2 flex flex-wrap items-center gap-2">
+            <SackProgress planned={job.total_sacks} reported={seg.sacks_reported} />
+            <ConfirmationBadge confirmation={seg.confirmation} />
+            <div className="ml-auto flex items-center gap-1">
+              {truckName && <span className="truncate text-[9px] font-semibold text-slate-400">{truckName}</span>}
+              <CrewAvatars crew={seg.crew} />
+            </div>
+          </div>
+        </>
+      ) : (
+        <div className="flex items-center gap-1.5">
+          {truckColor && <span className="h-2 w-2 shrink-0 rounded-full" style={{ backgroundColor: truckColor }} />}
+          <span className="text-[11px] text-slate-400">Order saknas</span>
+        </div>
+      )}
     </>
   );
 }

--- a/app/crm/planering/jobCard.tsx
+++ b/app/crm/planering/jobCard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type SyntheticEvent } from 'react';
+import { useEffect, useLayoutEffect, useRef, useState, type SyntheticEvent } from 'react';
 import { createPortal } from 'react-dom';
 import { cn } from '@/lib/shared/cn';
 import {
@@ -364,6 +364,7 @@ export function SegmentMenu({
   const [pos, setPos] = useState<{ top: number; left: number } | null>(null);
   const btnRef = useRef<HTMLButtonElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
+  const anchorRef = useRef<{ top: number; bottom: number } | null>(null);
   const available = people.filter((p) => !crew.some((c) => c.member_id === p.id));
 
   useEffect(() => {
@@ -381,6 +382,19 @@ export function SegmentMenu({
     };
   }, [open]);
 
+  useLayoutEffect(() => {
+    if (!open || !menuRef.current || !anchorRef.current) return;
+    const h = menuRef.current.offsetHeight;
+    const vh = window.innerHeight;
+    const a = anchorRef.current;
+    let top = a.bottom + 4;
+    if (top + h > vh - 8) {
+      const above = a.top - 4 - h;
+      top = above >= 8 ? above : Math.max(8, vh - 8 - h);
+    }
+    setPos((prev) => (prev && prev.top !== top ? { ...prev, top } : prev));
+  }, [open]);
+
   const toggle = (e: SyntheticEvent) => {
     e.stopPropagation();
     if (open) {
@@ -389,7 +403,8 @@ export function SegmentMenu({
     }
     const r = btnRef.current?.getBoundingClientRect();
     if (!r) return;
-    setPos({ top: r.bottom + 4, left: Math.max(8, Math.min(r.right - 380, window.innerWidth - 388)) });
+    anchorRef.current = { top: r.top, bottom: r.bottom };
+    setPos({ top: r.bottom + 4, left: Math.max(8, Math.min(r.right - 540, window.innerWidth - 548)) });
     setOpen(true);
   };
 
@@ -421,13 +436,13 @@ export function SegmentMenu({
             <div className="fixed inset-0 z-[60]" onMouseDown={(e) => { e.stopPropagation(); setOpen(false); }} />
             <div
               ref={menuRef}
-              className="fixed z-[61] max-h-[82vh] w-[380px] overflow-auto overscroll-contain rounded-2xl border border-[#e0e8dc] bg-white p-3 shadow-[0_16px_40px_rgba(20,44,27,0.22)]"
+              className="fixed z-[61] max-h-[82vh] w-[540px] overflow-auto overscroll-contain rounded-2xl border border-[#e0e8dc] bg-white p-3 shadow-[0_16px_40px_rgba(20,44,27,0.22)]"
               style={{ top: pos.top, left: pos.left }}
               onMouseDown={(e) => e.stopPropagation()}
               onClick={(e) => e.stopPropagation()}
             >
-              <div className="grid grid-cols-2 gap-x-3">
-                {/* Left column - work-order attributes */}
+              <div className="grid grid-cols-3 gap-x-3">
+                {/* Status */}
                 <div>
                   <p className="mb-1 px-0.5 text-[9px] font-bold uppercase tracking-[0.07em] text-slate-400">Status</p>
                   <div className="space-y-0.5">
@@ -453,8 +468,11 @@ export function SegmentMenu({
                       );
                     })}
                   </div>
+                </div>
 
-                  <p className="mb-1 mt-3 px-0.5 text-[9px] font-bold uppercase tracking-[0.07em] text-slate-400">Jobbtyp</p>
+                {/* Jobbtyp */}
+                <div className="border-l border-[#eef3eb] pl-3">
+                  <p className="mb-1 px-0.5 text-[9px] font-bold uppercase tracking-[0.07em] text-slate-400">Jobbtyp</p>
                   <div className="space-y-0.5">
                     {jobTypes.map((t) => {
                       const active = t.key === jobType;
@@ -479,7 +497,7 @@ export function SegmentMenu({
                   </div>
                 </div>
 
-                {/* Right column - timing + crew */}
+                {/* Längd + Besättning */}
                 <div className="border-l border-[#eef3eb] pl-3">
                   <p className="mb-1 px-0.5 text-[9px] font-bold uppercase tracking-[0.07em] text-slate-400">
                     Längd <span className="font-semibold normal-case tracking-normal text-slate-300">dagar</span>
@@ -525,7 +543,7 @@ export function SegmentMenu({
                       ))}
                     </div>
                   )}
-                  <div className="max-h-[200px] overflow-auto overscroll-contain rounded-lg border border-[#eef3eb] bg-[#f9fbf7] p-0.5">
+                  <div className="max-h-[160px] overflow-auto overscroll-contain rounded-lg border border-[#eef3eb] bg-[#f9fbf7] p-0.5">
                     {available.length === 0 ? (
                       <p className="px-1.5 py-1.5 text-[10px] text-slate-400">{crew.length ? 'Alla tillagda' : 'Inga personer'}</p>
                     ) : (

--- a/app/crm/planering/jobCard.tsx
+++ b/app/crm/planering/jobCard.tsx
@@ -8,7 +8,6 @@ import {
 } from '@/app/crm/lib/crmTokens';
 import type { JobDisplay } from '@/lib/domains/planning/display';
 import { sacksRemaining, sacksOverrun } from '@/lib/domains/planning/reports';
-import { resolveJobType } from '@/lib/domains/planning/jobTypes';
 import { crewInitials, crewColor, type CrewMember, type AssignablePerson } from '@/lib/domains/planning/crew';
 import { describeSmsStatus, type ConfirmationSummary } from '@/lib/domains/planning/confirmations';
 
@@ -79,15 +78,14 @@ export function MaterialChip({ material }: { material: string | null }) {
   );
 }
 
-// The explicit planner-set job type (with its colour) when present; otherwise the material
-// inferred from the work order.
-export function JobTypeOrMaterial({ jobType, material }: { jobType: string | null; material: string | null }) {
-  const jt = resolveJobType(jobType);
-  if (!jt) return <MaterialChip material={material} />;
+// The explicit planner-set job type (with its colour, already resolved by the caller) when present;
+// otherwise the material inferred from the work order.
+export function JobTypeOrMaterial({ jobType, material }: { jobType: { label: string; color: string } | null; material: string | null }) {
+  if (!jobType) return <MaterialChip material={material} />;
   return (
     <span className="inline-flex items-center gap-1.5 whitespace-nowrap rounded-full border border-[#e0e8dc] bg-[#f3f6f1] px-2 py-px text-[10px] font-semibold text-slate-600">
-      <span className="h-1.5 w-1.5 rounded-full" style={{ backgroundColor: jt.color }} />
-      {jt.label}
+      <span className="h-1.5 w-1.5 rounded-full" style={{ backgroundColor: jobType.color }} />
+      {jobType.label}
     </span>
   );
 }

--- a/app/crm/planering/jobCard.tsx
+++ b/app/crm/planering/jobCard.tsx
@@ -7,7 +7,7 @@ import {
   type WorkOrderStatus,
 } from '@/app/crm/lib/crmTokens';
 import type { JobDisplay } from '@/lib/domains/planning/display';
-import { sacksRemaining } from '@/lib/domains/planning/reports';
+import { sacksRemaining, sacksOverrun } from '@/lib/domains/planning/reports';
 import { resolveJobType } from '@/lib/domains/planning/jobTypes';
 import { crewInitials, crewColor, type CrewMember, type AssignablePerson } from '@/lib/domains/planning/crew';
 import { describeSmsStatus, type ConfirmationSummary } from '@/lib/domains/planning/confirmations';
@@ -47,11 +47,21 @@ export function SackBadge({ sacks }: { sacks: number }) {
 export function SackProgress({ planned, reported }: { planned: number; reported: number }) {
   if (!(planned > 0) && !(reported > 0)) return null;
   if (reported > 0) {
+    const over = sacksOverrun(planned, reported);
     return (
       <span className="inline-flex items-center gap-1.5">
-        <span className="whitespace-nowrap rounded-full border border-amber-200 bg-amber-50 px-2 py-px text-[10px] font-bold tabular-nums text-amber-700">
-          kvar {sacksRemaining(planned, reported)} / {planned}
-        </span>
+        {over > 0 ? (
+          <span
+            title="Fler säckar blåsta än planerat"
+            className="whitespace-nowrap rounded-full border border-rose-200 bg-rose-50 px-2 py-px text-[10px] font-bold tabular-nums text-rose-700"
+          >
+            över {over} / {planned}
+          </span>
+        ) : (
+          <span className="whitespace-nowrap rounded-full border border-amber-200 bg-amber-50 px-2 py-px text-[10px] font-bold tabular-nums text-amber-700">
+            kvar {sacksRemaining(planned, reported)} / {planned}
+          </span>
+        )}
         <span className="text-[9.5px] font-semibold tabular-nums text-slate-400">blåsta {reported}</span>
       </span>
     );

--- a/app/crm/planering/jobCard.tsx
+++ b/app/crm/planering/jobCard.tsx
@@ -10,6 +10,7 @@ import type { JobDisplay } from '@/lib/domains/planning/display';
 import { sacksRemaining } from '@/lib/domains/planning/reports';
 import { resolveJobType } from '@/lib/domains/planning/jobTypes';
 import { crewInitials, crewColor, type CrewMember, type AssignablePerson } from '@/lib/domains/planning/crew';
+import type { ConfirmationSummary } from '@/lib/domains/planning/confirmations';
 
 // Status label + colors for a job, reusing the CRM work-order tokens so the planning board reads
 // identically to the rest of the CRM.
@@ -77,6 +78,31 @@ export function JobTypeOrMaterial({ jobType, material }: { jobType: string | nul
     <span className="inline-flex items-center gap-1.5 whitespace-nowrap rounded-full border border-[#e0e8dc] bg-[#f3f6f1] px-2 py-px text-[10px] font-semibold text-slate-600">
       <span className="h-1.5 w-1.5 rounded-full" style={{ backgroundColor: jt.color }} />
       {jt.label}
+    </span>
+  );
+}
+
+// Confirmation state: a green "bekräftad" pill once an email and/or SMS has gone out to the
+// customer, with the channels + dates + recipients in the tooltip. Renders nothing until sent.
+export function ConfirmationBadge({ confirmation }: { confirmation: ConfirmationSummary }) {
+  const { email_sent_at, sms_sent_at, email_to, sms_to } = confirmation;
+  if (!email_sent_at && !sms_sent_at) return null;
+  const channels = [email_sent_at ? 'Mejl' : null, sms_sent_at ? 'SMS' : null].filter(Boolean).join(' + ');
+  const title = [
+    email_sent_at && `Mejl ${email_sent_at.slice(0, 10)}${email_to ? ` → ${email_to}` : ''}`,
+    sms_sent_at && `SMS ${sms_sent_at.slice(0, 10)}${sms_to ? ` → ${sms_to}` : ''}`,
+  ]
+    .filter(Boolean)
+    .join(' · ');
+  return (
+    <span
+      title={title}
+      className="inline-flex items-center gap-1 whitespace-nowrap rounded-full border border-emerald-200 bg-emerald-50 px-2 py-px text-[9px] font-bold text-emerald-700"
+    >
+      <svg width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3.2" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M20 6L9 17l-5-5" />
+      </svg>
+      {channels}
     </span>
   );
 }

--- a/app/crm/planering/jobCard.tsx
+++ b/app/crm/planering/jobCard.tsx
@@ -47,21 +47,23 @@ export function SackProgress({ planned, reported }: { planned: number; reported:
   if (!(planned > 0) && !(reported > 0)) return null;
   if (reported > 0) {
     const over = sacksOverrun(planned, reported);
+    const title = `Blåsta ${reported} av ${planned} planerade säckar`;
+    if (over > 0) {
+      return (
+        <span
+          title={title}
+          className="whitespace-nowrap rounded-full border border-rose-200 bg-rose-50 px-2 py-px text-[10px] font-bold tabular-nums text-rose-700"
+        >
+          över {over} / {planned}
+        </span>
+      );
+    }
     return (
-      <span className="inline-flex items-center gap-1.5">
-        {over > 0 ? (
-          <span
-            title="Fler säckar blåsta än planerat"
-            className="whitespace-nowrap rounded-full border border-rose-200 bg-rose-50 px-2 py-px text-[10px] font-bold tabular-nums text-rose-700"
-          >
-            över {over} / {planned}
-          </span>
-        ) : (
-          <span className="whitespace-nowrap rounded-full border border-amber-200 bg-amber-50 px-2 py-px text-[10px] font-bold tabular-nums text-amber-700">
-            kvar {sacksRemaining(planned, reported)} / {planned}
-          </span>
-        )}
-        <span className="text-[9.5px] font-semibold tabular-nums text-slate-400">blåsta {reported}</span>
+      <span
+        title={title}
+        className="whitespace-nowrap rounded-full border border-amber-200 bg-amber-50 px-2 py-px text-[10px] font-bold tabular-nums text-amber-700"
+      >
+        kvar {sacksRemaining(planned, reported)} / {planned}
       </span>
     );
   }

--- a/app/crm/planering/jobCard.tsx
+++ b/app/crm/planering/jobCard.tsx
@@ -82,6 +82,19 @@ export function JobTypeOrMaterial({ jobType, material }: { jobType: string | nul
   );
 }
 
+// Paused-placement marker. Amber so it reads as "needs attention / not active".
+export function HoldBadge() {
+  return (
+    <span className="inline-flex items-center gap-1 whitespace-nowrap rounded-full border border-amber-300 bg-amber-50 px-2 py-px text-[9px] font-bold text-amber-700">
+      <svg width="8" height="8" viewBox="0 0 24 24" fill="currentColor">
+        <rect x="6" y="5" width="4" height="14" rx="1" />
+        <rect x="14" y="5" width="4" height="14" rx="1" />
+      </svg>
+      Pausad
+    </span>
+  );
+}
+
 // Confirmation state: a green "bekräftad" pill once an email and/or SMS has gone out to the
 // customer, with the channels + dates + recipients in the tooltip. When Twilio reports the SMS as
 // failed/undelivered the pill turns rose so the planner sees the customer wasn't reached. Renders

--- a/app/crm/planering/jobCard.tsx
+++ b/app/crm/planering/jobCard.tsx
@@ -6,6 +6,7 @@ import {
   type WorkOrderStatus,
 } from '@/app/crm/lib/crmTokens';
 import type { JobDisplay } from '@/lib/domains/planning/display';
+import { sacksRemaining } from '@/lib/domains/planning/reports';
 
 // Status label + colors for a job, reusing the CRM work-order tokens so the planning board reads
 // identically to the rest of the CRM.
@@ -27,8 +28,7 @@ export function StatusPill({ status, className }: { status: string; className?: 
   );
 }
 
-// Sack badge — amber "kvar X/Y" form is for a later per-day-reporting slice; for now it's the
-// planned sack total computed from the work order's line items.
+// Planned sack total computed from the work order's line items.
 export function SackBadge({ sacks }: { sacks: number }) {
   if (!(sacks > 0)) return null;
   return (
@@ -36,6 +36,23 @@ export function SackBadge({ sacks }: { sacks: number }) {
       {sacks} säck
     </span>
   );
+}
+
+// Sack progress: once any sacks are reported as blown it switches to an amber "kvar X / Y" plus
+// the blown count; otherwise it shows the planned total.
+export function SackProgress({ planned, reported }: { planned: number; reported: number }) {
+  if (!(planned > 0) && !(reported > 0)) return null;
+  if (reported > 0) {
+    return (
+      <span className="inline-flex items-center gap-1.5">
+        <span className="whitespace-nowrap rounded-full border border-amber-200 bg-amber-50 px-2 py-px text-[10px] font-bold tabular-nums text-amber-700">
+          kvar {sacksRemaining(planned, reported)} / {planned}
+        </span>
+        <span className="text-[9.5px] font-semibold tabular-nums text-slate-400">blåsta {reported}</span>
+      </span>
+    );
+  }
+  return <SackBadge sacks={planned} />;
 }
 
 export function MaterialChip({ material }: { material: string | null }) {

--- a/app/crm/planering/jobCard.tsx
+++ b/app/crm/planering/jobCard.tsx
@@ -1,4 +1,5 @@
-import { useState, type SyntheticEvent } from 'react';
+import { useEffect, useRef, useState, type SyntheticEvent } from 'react';
+import { createPortal } from 'react-dom';
 import { cn } from '@/lib/shared/cn';
 import {
   workOrderStatusLabel,
@@ -10,6 +11,7 @@ import type { JobDisplay } from '@/lib/domains/planning/display';
 import { sacksRemaining, sacksOverrun } from '@/lib/domains/planning/reports';
 import { crewInitials, crewColor, type CrewMember, type AssignablePerson } from '@/lib/domains/planning/crew';
 import { describeSmsStatus, type ConfirmationSummary } from '@/lib/domains/planning/confirmations';
+import type { JobType } from '@/lib/domains/planning/jobTypes';
 
 // Status label + colors for a job, reusing the CRM work-order tokens so the planning board reads
 // identically to the rest of the CRM.
@@ -284,5 +286,146 @@ export function JobRef({ job, className }: { job: Pick<JobDisplay, 'ref' | 'is_f
     >
       {job.ref}
     </span>
+  );
+}
+
+// Per-segment actions, tucked behind a kebab so the card itself stays calm (matching the mockup):
+// set/clear the job type, pause/resume, and send an order confirmation. The popover is portalled to
+// <body> so it escapes the card's overflow-hidden / transform clipping; it closes on outside click,
+// scroll, or resize.
+export function SegmentMenu({
+  jobType,
+  jobTypes,
+  onHold,
+  onSetJobType,
+  onToggleHold,
+  onOpenConfirm,
+}: {
+  jobType: string | null;
+  jobTypes: JobType[];
+  onHold: boolean;
+  onSetJobType: (key: string | null) => void;
+  onToggleHold: () => void;
+  onOpenConfirm: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [pos, setPos] = useState<{ top: number; left: number } | null>(null);
+  const btnRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const close = () => setOpen(false);
+    window.addEventListener('scroll', close, true);
+    window.addEventListener('resize', close);
+    return () => {
+      window.removeEventListener('scroll', close, true);
+      window.removeEventListener('resize', close);
+    };
+  }, [open]);
+
+  const toggle = (e: SyntheticEvent) => {
+    e.stopPropagation();
+    if (open) {
+      setOpen(false);
+      return;
+    }
+    const r = btnRef.current?.getBoundingClientRect();
+    if (!r) return;
+    setPos({ top: r.bottom + 4, left: Math.max(8, Math.min(r.right - 204, window.innerWidth - 212)) });
+    setOpen(true);
+  };
+
+  return (
+    <>
+      <button
+        ref={btnRef}
+        type="button"
+        onMouseDown={(e) => e.stopPropagation()}
+        onClick={toggle}
+        title="Åtgärder"
+        aria-label="Åtgärder"
+        className={cn(
+          'inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-lg transition',
+          open ? 'bg-slate-100 text-slate-600' : 'text-slate-300 hover:bg-slate-100 hover:text-slate-600',
+        )}
+      >
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor">
+          <circle cx="12" cy="5" r="1.7" />
+          <circle cx="12" cy="12" r="1.7" />
+          <circle cx="12" cy="19" r="1.7" />
+        </svg>
+      </button>
+
+      {open &&
+        pos &&
+        createPortal(
+          <>
+            <div className="fixed inset-0 z-[60]" onMouseDown={(e) => { e.stopPropagation(); setOpen(false); }} />
+            <div
+              className="fixed z-[61] w-[204px] rounded-xl border border-[#e0e8dc] bg-white p-1.5 shadow-[0_10px_30px_rgba(20,44,27,0.2)]"
+              style={{ top: pos.top, left: pos.left }}
+              onMouseDown={(e) => e.stopPropagation()}
+              onClick={(e) => e.stopPropagation()}
+            >
+              <p className="px-1.5 pb-1 pt-0.5 text-[9px] font-bold uppercase tracking-wide text-slate-400">Jobbtyp</p>
+              <div className="grid grid-cols-2 gap-1">
+                {jobTypes.map((t) => {
+                  const active = t.key === jobType;
+                  return (
+                    <button
+                      key={t.key}
+                      type="button"
+                      onClick={() => {
+                        onSetJobType(active ? null : t.key);
+                        setOpen(false);
+                      }}
+                      className={cn(
+                        'flex items-center gap-1.5 rounded-lg px-1.5 py-1 text-left text-[10.5px] font-semibold transition',
+                        active ? 'bg-emerald-50 text-emerald-700 ring-1 ring-emerald-200' : 'text-slate-600 hover:bg-slate-50',
+                      )}
+                    >
+                      <span className="h-2 w-2 shrink-0 rounded-full" style={{ backgroundColor: t.color }} />
+                      <span className="truncate">{t.label}</span>
+                    </button>
+                  );
+                })}
+              </div>
+
+              <div className="my-1.5 h-px bg-[#eef3eb]" />
+
+              <button
+                type="button"
+                onClick={() => {
+                  onToggleHold();
+                  setOpen(false);
+                }}
+                className="flex w-full items-center gap-2 rounded-lg px-1.5 py-1.5 text-left text-[11px] font-semibold text-slate-600 transition hover:bg-slate-50"
+              >
+                {onHold ? (
+                  <svg width="13" height="13" viewBox="0 0 24 24" fill="currentColor"><path d="M8 5v14l11-7z" /></svg>
+                ) : (
+                  <svg width="13" height="13" viewBox="0 0 24 24" fill="currentColor"><rect x="6" y="5" width="4" height="14" rx="1" /><rect x="14" y="5" width="4" height="14" rx="1" /></svg>
+                )}
+                {onHold ? 'Återuppta' : 'Pausa'}
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  onOpenConfirm();
+                  setOpen(false);
+                }}
+                className="flex w-full items-center gap-2 rounded-lg px-1.5 py-1.5 text-left text-[11px] font-semibold text-slate-600 transition hover:bg-emerald-50 hover:text-emerald-700"
+              >
+                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <rect x="2" y="4" width="20" height="16" rx="2" />
+                  <path d="M22 7l-10 6L2 7" />
+                </svg>
+                Skicka bekräftelse
+              </button>
+            </div>
+          </>,
+          document.body,
+        )}
+    </>
   );
 }

--- a/app/crm/planering/jobCard.tsx
+++ b/app/crm/planering/jobCard.tsx
@@ -15,6 +15,7 @@ import { describeSmsStatus, type ConfirmationSummary } from '@/lib/domains/plann
 import { resolveJobTypeFrom, type JobType } from '@/lib/domains/planning/jobTypes';
 import type { OpsSegment } from '@/lib/domains/planning/types';
 import { addDaysISO, daysBetweenInclusive } from './planningDates';
+import type { OrderInfo } from '@/lib/domains/planning/order';
 
 // Status label + colors for a job, reusing the CRM work-order tokens so the planning board reads
 // identically to the rest of the CRM.
@@ -344,6 +345,7 @@ export function SegmentMenu({
   onSetLength,
   onAddCrew,
   onRemoveCrew,
+  order,
 }: {
   status: string;
   jobType: string | null;
@@ -359,6 +361,7 @@ export function SegmentMenu({
   onSetLength: (days: number) => void;
   onAddCrew: (person: AssignablePerson) => void;
   onRemoveCrew: (memberId: string) => void;
+  order?: { index: number; total: number; onMove: (dir: 'up' | 'down') => void };
 }) {
   const [open, setOpen] = useState(false);
   const [pos, setPos] = useState<{ top: number; left: number } | null>(null);
@@ -497,8 +500,40 @@ export function SegmentMenu({
                   </div>
                 </div>
 
-                {/* Längd + Besättning */}
+                {/* Ordning + Längd + Besättning */}
                 <div className="border-l border-[#eef3eb] pl-3">
+                  {order && order.total > 1 && (
+                    <div className="mb-3">
+                      <p className="mb-1 px-0.5 text-[9px] font-bold uppercase tracking-[0.07em] text-slate-400">Ordning på dagen</p>
+                      <div className="flex items-center gap-1">
+                        <button
+                          type="button"
+                          disabled={order.index === 0}
+                          onClick={() => {
+                            order.onMove('up');
+                            setOpen(false);
+                          }}
+                          title="Tidigare"
+                          className="inline-flex h-7 w-7 items-center justify-center rounded-md bg-slate-50 p-0 text-slate-600 transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-40"
+                        >
+                          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round"><path d="M18 15l-6-6-6 6" /></svg>
+                        </button>
+                        <span className="min-w-[42px] text-center text-[11px] font-bold tabular-nums text-slate-500">{order.index + 1} / {order.total}</span>
+                        <button
+                          type="button"
+                          disabled={order.index === order.total - 1}
+                          onClick={() => {
+                            order.onMove('down');
+                            setOpen(false);
+                          }}
+                          title="Senare"
+                          className="inline-flex h-7 w-7 items-center justify-center rounded-md bg-slate-50 p-0 text-slate-600 transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-40"
+                        >
+                          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round"><path d="M6 9l6 6 6-6" /></svg>
+                        </button>
+                      </div>
+                    </div>
+                  )}
                   <p className="mb-1 px-0.5 text-[9px] font-bold uppercase tracking-[0.07em] text-slate-400">
                     Längd <span className="font-semibold normal-case tracking-normal text-slate-300">dagar</span>
                   </p>
@@ -616,6 +651,7 @@ export type SegmentActions = {
   onResize: (seg: OpsSegment, startDay: string, endDay: string) => void;
   onAddCrew: (seg: OpsSegment, person: AssignablePerson) => void;
   onRemoveCrew: (seg: OpsSegment, memberId: string) => void;
+  onReorder: (seg: OpsSegment, direction: 'up' | 'down') => void;
 };
 
 // The shared inner content of a scheduled-job card (status rail, header with kebab, project/client/
@@ -631,6 +667,7 @@ export function SegmentCardBody({
   actions,
   truckColor,
   truckName,
+  order,
 }: {
   seg: OpsSegment;
   canWrite: boolean;
@@ -639,6 +676,7 @@ export function SegmentCardBody({
   actions: SegmentActions;
   truckColor?: string;
   truckName?: string;
+  order?: OrderInfo;
 }) {
   const job = seg.job;
   return (
@@ -648,11 +686,20 @@ export function SegmentCardBody({
         <>
           <div className="flex items-center gap-2">
             {truckColor && <span className="h-2 w-2 shrink-0 rounded-full" style={{ backgroundColor: truckColor }} />}
+            {order && order.total > 1 && (
+              <span
+                title={`Ordning ${order.index + 1} av ${order.total} på dagen`}
+                className="inline-flex h-4 min-w-[16px] shrink-0 items-center justify-center rounded-full bg-slate-100 px-1 text-[9px] font-bold tabular-nums text-slate-500"
+              >
+                {order.index + 1}
+              </span>
+            )}
             <JobRef job={job} />
             <StatusPill status={job.status} className="ml-auto" />
             {canWrite && (
               <span className="relative z-20 inline-flex">
               <SegmentMenu
+                order={order && order.total > 1 ? { index: order.index, total: order.total, onMove: (dir) => actions.onReorder(seg, dir) } : undefined}
                 status={job.status}
                 jobType={seg.job_type}
                 jobTypes={jobTypes}

--- a/app/crm/planering/jobCard.tsx
+++ b/app/crm/planering/jobCard.tsx
@@ -297,16 +297,20 @@ export function SegmentMenu({
   jobType,
   jobTypes,
   onHold,
+  lengthDays,
   onSetJobType,
   onToggleHold,
   onOpenConfirm,
+  onSetLength,
 }: {
   jobType: string | null;
   jobTypes: JobType[];
   onHold: boolean;
+  lengthDays: number;
   onSetJobType: (key: string | null) => void;
   onToggleHold: () => void;
   onOpenConfirm: () => void;
+  onSetLength: (days: number) => void;
 }) {
   const [open, setOpen] = useState(false);
   const [pos, setPos] = useState<{ top: number; left: number } | null>(null);
@@ -345,8 +349,8 @@ export function SegmentMenu({
         title="Åtgärder"
         aria-label="Åtgärder"
         className={cn(
-          'inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-lg transition',
-          open ? 'bg-slate-100 text-slate-600' : 'text-slate-300 hover:bg-slate-100 hover:text-slate-600',
+          'inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-lg p-0 transition',
+          open ? 'bg-slate-100 text-slate-600' : 'text-slate-500 hover:bg-slate-100 hover:text-slate-600',
         )}
       >
         <svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor">
@@ -389,6 +393,28 @@ export function SegmentMenu({
                     </button>
                   );
                 })}
+              </div>
+
+              <div className="my-1.5 h-px bg-[#eef3eb]" />
+
+              <p className="px-1.5 pb-1 pt-0.5 text-[9px] font-bold uppercase tracking-wide text-slate-400">Längd (dagar)</p>
+              <div className="flex gap-1 px-0.5">
+                {[1, 2, 3, 4, 5, 6, 7].map((d) => (
+                  <button
+                    key={d}
+                    type="button"
+                    onClick={() => {
+                      onSetLength(d);
+                      setOpen(false);
+                    }}
+                    className={cn(
+                      'h-6 flex-1 rounded-lg p-0 text-[11px] font-bold tabular-nums transition',
+                      d === lengthDays ? 'bg-emerald-600 text-white' : 'bg-slate-50 text-slate-600 hover:bg-slate-100',
+                    )}
+                  >
+                    {d}
+                  </button>
+                ))}
               </div>
 
               <div className="my-1.5 h-px bg-[#eef3eb]" />

--- a/app/crm/planering/jobCard.tsx
+++ b/app/crm/planering/jobCard.tsx
@@ -10,7 +10,7 @@ import type { JobDisplay } from '@/lib/domains/planning/display';
 import { sacksRemaining } from '@/lib/domains/planning/reports';
 import { resolveJobType } from '@/lib/domains/planning/jobTypes';
 import { crewInitials, crewColor, type CrewMember, type AssignablePerson } from '@/lib/domains/planning/crew';
-import type { ConfirmationSummary } from '@/lib/domains/planning/confirmations';
+import { describeSmsStatus, type ConfirmationSummary } from '@/lib/domains/planning/confirmations';
 
 // Status label + colors for a job, reusing the CRM work-order tokens so the planning board reads
 // identically to the rest of the CRM.
@@ -83,26 +83,41 @@ export function JobTypeOrMaterial({ jobType, material }: { jobType: string | nul
 }
 
 // Confirmation state: a green "bekräftad" pill once an email and/or SMS has gone out to the
-// customer, with the channels + dates + recipients in the tooltip. Renders nothing until sent.
+// customer, with the channels + dates + recipients in the tooltip. When Twilio reports the SMS as
+// failed/undelivered the pill turns rose so the planner sees the customer wasn't reached. Renders
+// nothing until something is sent.
 export function ConfirmationBadge({ confirmation }: { confirmation: ConfirmationSummary }) {
-  const { email_sent_at, sms_sent_at, email_to, sms_to } = confirmation;
+  const { email_sent_at, sms_sent_at, email_to, sms_to, sms_status } = confirmation;
   if (!email_sent_at && !sms_sent_at) return null;
+
+  const sms = sms_sent_at ? describeSmsStatus(sms_status) : null;
+  const failed = sms?.tone === 'fail';
   const channels = [email_sent_at ? 'Mejl' : null, sms_sent_at ? 'SMS' : null].filter(Boolean).join(' + ');
   const title = [
     email_sent_at && `Mejl ${email_sent_at.slice(0, 10)}${email_to ? ` → ${email_to}` : ''}`,
-    sms_sent_at && `SMS ${sms_sent_at.slice(0, 10)}${sms_to ? ` → ${sms_to}` : ''}`,
+    sms_sent_at && `SMS ${sms_sent_at.slice(0, 10)}${sms_to ? ` → ${sms_to}` : ''}${sms ? ` (${sms.label})` : ''}`,
   ]
     .filter(Boolean)
     .join(' · ');
+
   return (
     <span
       title={title}
-      className="inline-flex items-center gap-1 whitespace-nowrap rounded-full border border-emerald-200 bg-emerald-50 px-2 py-px text-[9px] font-bold text-emerald-700"
+      className={cn(
+        'inline-flex items-center gap-1 whitespace-nowrap rounded-full border px-2 py-px text-[9px] font-bold',
+        failed ? 'border-rose-200 bg-rose-50 text-rose-700' : 'border-emerald-200 bg-emerald-50 text-emerald-700',
+      )}
     >
-      <svg width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3.2" strokeLinecap="round" strokeLinejoin="round">
-        <path d="M20 6L9 17l-5-5" />
-      </svg>
-      {channels}
+      {failed ? (
+        <svg width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M12 9v4M12 17h.01M10.3 3.9 1.8 18a2 2 0 0 0 1.7 3h17a2 2 0 0 0 1.7-3L13.7 3.9a2 2 0 0 0-3.4 0Z" />
+        </svg>
+      ) : (
+        <svg width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3.2" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M20 6L9 17l-5-5" />
+        </svg>
+      )}
+      {failed ? `${channels} · ej levererat` : channels}
     </span>
   );
 }

--- a/app/crm/planering/jobCard.tsx
+++ b/app/crm/planering/jobCard.tsx
@@ -1,3 +1,4 @@
+import { useState, type SyntheticEvent } from 'react';
 import { cn } from '@/lib/shared/cn';
 import {
   workOrderStatusLabel,
@@ -8,6 +9,7 @@ import {
 import type { JobDisplay } from '@/lib/domains/planning/display';
 import { sacksRemaining } from '@/lib/domains/planning/reports';
 import { resolveJobType } from '@/lib/domains/planning/jobTypes';
+import { crewInitials, crewColor, type CrewMember, type AssignablePerson } from '@/lib/domains/planning/crew';
 
 // Status label + colors for a job, reusing the CRM work-order tokens so the planning board reads
 // identically to the rest of the CRM.
@@ -76,6 +78,110 @@ export function JobTypeOrMaterial({ jobType, material }: { jobType: string | nul
       <span className="h-1.5 w-1.5 rounded-full" style={{ backgroundColor: jt.color }} />
       {jt.label}
     </span>
+  );
+}
+
+// A single crew avatar: initials on the person's deterministic colour.
+function Avatar({ name, seed, size = 20 }: { name: string; seed: string; size?: number }) {
+  return (
+    <span
+      title={name}
+      className="inline-flex items-center justify-center rounded-full font-bold text-white ring-1 ring-black/5"
+      style={{ width: size, height: size, fontSize: size <= 16 ? 7 : 8.5, backgroundColor: crewColor(seed) }}
+    >
+      {crewInitials(name)}
+    </span>
+  );
+}
+
+// Read-only crew cluster (overlapping avatars) — used where the board isn't editable.
+export function CrewAvatars({ crew, size }: { crew: CrewMember[]; size?: number }) {
+  if (crew.length === 0) return null;
+  return (
+    <div className="flex items-center -space-x-1.5">
+      {crew.map((c) => (
+        <Avatar key={c.id} name={c.member_name} seed={c.member_id ?? c.member_name} size={size} />
+      ))}
+    </div>
+  );
+}
+
+// Editable crew row: removable avatars + a "+ team" dropdown of assignable people. All clicks are
+// stopped so they don't bubble to the card's open-work-order handler.
+export function CrewEditor({
+  crew,
+  people,
+  onAdd,
+  onRemove,
+}: {
+  crew: CrewMember[];
+  people: AssignablePerson[];
+  onAdd: (person: AssignablePerson) => void;
+  onRemove: (memberId: string) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const stop = (e: SyntheticEvent) => e.stopPropagation();
+  const assigned = new Set(crew.map((c) => c.member_id));
+  const available = people.filter((p) => !assigned.has(p.id));
+
+  return (
+    <div className="flex flex-wrap items-center gap-1" onClick={stop} onMouseDown={stop}>
+      {crew.map((c) => (
+        <button
+          key={c.id}
+          type="button"
+          onClick={(e) => {
+            stop(e);
+            if (c.member_id) onRemove(c.member_id);
+          }}
+          title={`${c.member_name} — klicka för att ta bort`}
+          className="group/av relative inline-flex h-5 w-5 items-center justify-center rounded-full text-[8.5px] font-bold text-white ring-1 ring-black/5"
+          style={{ backgroundColor: crewColor(c.member_id ?? c.member_name) }}
+        >
+          <span className="group-hover/av:opacity-0">{crewInitials(c.member_name)}</span>
+          <span className="absolute inset-0 hidden items-center justify-center rounded-full bg-rose-500 text-[11px] leading-none group-hover/av:flex">×</span>
+        </button>
+      ))}
+
+      <div className="relative">
+        <button
+          type="button"
+          onClick={(e) => {
+            stop(e);
+            setOpen((o) => !o);
+          }}
+          className="inline-flex h-5 items-center rounded-full border border-dashed border-[#c8d4c3] bg-white px-1.5 text-[9px] font-bold text-slate-400 transition hover:border-emerald-400 hover:text-emerald-600"
+        >
+          + team
+        </button>
+        {open && (
+          <>
+            <span className="fixed inset-0 z-10" onClick={(e) => { stop(e); setOpen(false); }} />
+            <div className="absolute left-0 top-6 z-20 max-h-52 w-44 overflow-auto rounded-xl border border-[#e0e8dc] bg-white p-1 shadow-lg">
+              {available.length === 0 ? (
+                <p className="px-2 py-1.5 text-[10px] text-slate-400">Alla tillagda</p>
+              ) : (
+                available.map((p) => (
+                  <button
+                    key={p.id}
+                    type="button"
+                    onClick={(e) => {
+                      stop(e);
+                      onAdd(p);
+                      setOpen(false);
+                    }}
+                    className="flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left text-[11px] text-slate-700 transition hover:bg-emerald-50"
+                  >
+                    <Avatar name={p.full_name} seed={p.id} size={18} />
+                    <span className="truncate">{p.full_name}</span>
+                  </button>
+                ))
+              )}
+            </div>
+          </>
+        )}
+      </div>
+    </div>
   );
 }
 

--- a/app/crm/planering/jobCard.tsx
+++ b/app/crm/planering/jobCard.tsx
@@ -5,6 +5,7 @@ import {
   workOrderStatusLabel,
   workOrderStatusClass,
   workOrderStatusAccent,
+  WORK_ORDER_STATUS_OPTIONS,
   type WorkOrderStatus,
 } from '@/app/crm/lib/crmTokens';
 import type { JobDisplay } from '@/lib/domains/planning/display';
@@ -186,9 +187,40 @@ export function CrewEditor({
   onRemove: (memberId: string) => void;
 }) {
   const [open, setOpen] = useState(false);
+  const [pos, setPos] = useState<{ top: number; left: number } | null>(null);
+  const btnRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
   const stop = (e: SyntheticEvent) => e.stopPropagation();
   const assigned = new Set(crew.map((c) => c.member_id));
   const available = people.filter((p) => !assigned.has(p.id));
+
+  useEffect(() => {
+    if (!open) return;
+    const onScroll = (e: Event) => {
+      // Scrolling inside the (portaled) list shouldn't close it — only a page/board scroll should.
+      if (menuRef.current && e.target instanceof Node && menuRef.current.contains(e.target)) return;
+      setOpen(false);
+    };
+    const onResize = () => setOpen(false);
+    window.addEventListener('scroll', onScroll, true);
+    window.addEventListener('resize', onResize);
+    return () => {
+      window.removeEventListener('scroll', onScroll, true);
+      window.removeEventListener('resize', onResize);
+    };
+  }, [open]);
+
+  const toggle = (e: SyntheticEvent) => {
+    stop(e);
+    if (open) {
+      setOpen(false);
+      return;
+    }
+    const r = btnRef.current?.getBoundingClientRect();
+    if (!r) return;
+    setPos({ top: r.bottom + 4, left: Math.max(8, Math.min(r.left, window.innerWidth - 184)) });
+    setOpen(true);
+  };
 
   return (
     <div className="flex flex-wrap items-center gap-1" onClick={stop} onMouseDown={stop}>
@@ -209,21 +241,26 @@ export function CrewEditor({
         </button>
       ))}
 
-      <div className="relative">
-        <button
-          type="button"
-          onClick={(e) => {
-            stop(e);
-            setOpen((o) => !o);
-          }}
-          className="inline-flex h-5 items-center rounded-full border border-dashed border-[#c8d4c3] bg-white px-1.5 text-[9px] font-bold text-slate-400 transition hover:border-emerald-400 hover:text-emerald-600"
-        >
-          + team
-        </button>
-        {open && (
+      <button
+        ref={btnRef}
+        type="button"
+        onClick={toggle}
+        className="inline-flex h-5 items-center rounded-full border border-dashed border-[#c8d4c3] bg-white px-1.5 text-[9px] font-bold text-slate-400 transition hover:border-emerald-400 hover:text-emerald-600"
+      >
+        + team
+      </button>
+      {open &&
+        pos &&
+        createPortal(
           <>
-            <span className="fixed inset-0 z-10" onClick={(e) => { stop(e); setOpen(false); }} />
-            <div className="absolute left-0 top-6 z-20 max-h-52 w-44 overflow-auto rounded-xl border border-[#e0e8dc] bg-white p-1 shadow-lg">
+            <div className="fixed inset-0 z-[60]" onMouseDown={(e) => { stop(e); setOpen(false); }} />
+            <div
+              ref={menuRef}
+              className="fixed z-[61] max-h-52 w-44 overflow-auto overscroll-contain rounded-xl border border-[#e0e8dc] bg-white p-1 shadow-[0_10px_30px_rgba(20,44,27,0.2)]"
+              style={{ top: pos.top, left: pos.left }}
+              onMouseDown={(e) => stop(e)}
+              onClick={(e) => stop(e)}
+            >
               {available.length === 0 ? (
                 <p className="px-2 py-1.5 text-[10px] text-slate-400">Alla tillagda</p>
               ) : (
@@ -244,15 +281,14 @@ export function CrewEditor({
                 ))
               )}
             </div>
-          </>
+          </>,
+          document.body,
         )}
-      </div>
     </div>
   );
 }
 
-// A small pin link opening the job-site address in Google Maps. Stops propagation so it doesn't
-// trigger the card's select/open handler.
+// A small Google Maps pin link next to an address.
 export function MapLink({ address }: { address: string | null }) {
   if (!address) return null;
   const href = `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(address)}`;
@@ -289,41 +325,57 @@ export function JobRef({ job, className }: { job: Pick<JobDisplay, 'ref' | 'is_f
   );
 }
 
-// Per-segment actions, tucked behind a kebab so the card itself stays calm (matching the mockup):
-// set/clear the job type, pause/resume, and send an order confirmation. The popover is portalled to
-// <body> so it escapes the card's overflow-hidden / transform clipping; it closes on outside click,
-// scroll, or resize.
+// Per-segment actions behind a kebab. Portalled to <body> so it escapes the card's overflow-hidden /
+// transform clipping; closes on outside click, scroll, or resize. Two-column layout to stay compact.
 export function SegmentMenu({
+  status,
   jobType,
   jobTypes,
   onHold,
   lengthDays,
+  crew,
+  people,
+  onSetStatus,
   onSetJobType,
   onToggleHold,
   onOpenConfirm,
   onSetLength,
+  onAddCrew,
+  onRemoveCrew,
 }: {
+  status: string;
   jobType: string | null;
   jobTypes: JobType[];
   onHold: boolean;
   lengthDays: number;
+  crew: CrewMember[];
+  people: AssignablePerson[];
+  onSetStatus: (status: string) => void;
   onSetJobType: (key: string | null) => void;
   onToggleHold: () => void;
   onOpenConfirm: () => void;
   onSetLength: (days: number) => void;
+  onAddCrew: (person: AssignablePerson) => void;
+  onRemoveCrew: (memberId: string) => void;
 }) {
   const [open, setOpen] = useState(false);
   const [pos, setPos] = useState<{ top: number; left: number } | null>(null);
   const btnRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const available = people.filter((p) => !crew.some((c) => c.member_id === p.id));
 
   useEffect(() => {
     if (!open) return;
-    const close = () => setOpen(false);
-    window.addEventListener('scroll', close, true);
-    window.addEventListener('resize', close);
+    const onScroll = (e: Event) => {
+      if (menuRef.current && e.target instanceof Node && menuRef.current.contains(e.target)) return;
+      setOpen(false);
+    };
+    const onResize = () => setOpen(false);
+    window.addEventListener('scroll', onScroll, true);
+    window.addEventListener('resize', onResize);
     return () => {
-      window.removeEventListener('scroll', close, true);
-      window.removeEventListener('resize', close);
+      window.removeEventListener('scroll', onScroll, true);
+      window.removeEventListener('resize', onResize);
     };
   }, [open]);
 
@@ -335,7 +387,7 @@ export function SegmentMenu({
     }
     const r = btnRef.current?.getBoundingClientRect();
     if (!r) return;
-    setPos({ top: r.bottom + 4, left: Math.max(8, Math.min(r.right - 204, window.innerWidth - 212)) });
+    setPos({ top: r.bottom + 4, left: Math.max(8, Math.min(r.right - 380, window.innerWidth - 388)) });
     setOpen(true);
   };
 
@@ -366,88 +418,166 @@ export function SegmentMenu({
           <>
             <div className="fixed inset-0 z-[60]" onMouseDown={(e) => { e.stopPropagation(); setOpen(false); }} />
             <div
-              className="fixed z-[61] w-[204px] rounded-xl border border-[#e0e8dc] bg-white p-1.5 shadow-[0_10px_30px_rgba(20,44,27,0.2)]"
+              ref={menuRef}
+              className="fixed z-[61] max-h-[82vh] w-[380px] overflow-auto overscroll-contain rounded-2xl border border-[#e0e8dc] bg-white p-3 shadow-[0_16px_40px_rgba(20,44,27,0.22)]"
               style={{ top: pos.top, left: pos.left }}
               onMouseDown={(e) => e.stopPropagation()}
               onClick={(e) => e.stopPropagation()}
             >
-              <p className="px-1.5 pb-1 pt-0.5 text-[9px] font-bold uppercase tracking-wide text-slate-400">Jobbtyp</p>
-              <div className="grid grid-cols-2 gap-1">
-                {jobTypes.map((t) => {
-                  const active = t.key === jobType;
-                  return (
-                    <button
-                      key={t.key}
-                      type="button"
-                      onClick={() => {
-                        onSetJobType(active ? null : t.key);
-                        setOpen(false);
-                      }}
-                      className={cn(
-                        'flex items-center gap-1.5 rounded-lg px-1.5 py-1 text-left text-[10.5px] font-semibold transition',
-                        active ? 'bg-emerald-50 text-emerald-700 ring-1 ring-emerald-200' : 'text-slate-600 hover:bg-slate-50',
-                      )}
-                    >
-                      <span className="h-2 w-2 shrink-0 rounded-full" style={{ backgroundColor: t.color }} />
-                      <span className="truncate">{t.label}</span>
-                    </button>
-                  );
-                })}
-              </div>
+              <div className="grid grid-cols-2 gap-x-3">
+                {/* Left column - work-order attributes */}
+                <div>
+                  <p className="mb-1 px-0.5 text-[9px] font-bold uppercase tracking-[0.07em] text-slate-400">Status</p>
+                  <div className="space-y-0.5">
+                    {WORK_ORDER_STATUS_OPTIONS.map((st) => {
+                      const active = st === status;
+                      const m = statusMeta(st);
+                      return (
+                        <button
+                          key={st}
+                          type="button"
+                          onClick={() => {
+                            onSetStatus(st);
+                            setOpen(false);
+                          }}
+                          className={cn(
+                            'flex w-full items-center gap-2 rounded-lg border px-2 py-1 text-left text-[11px] font-semibold transition',
+                            active ? m.pill : 'border-transparent text-slate-600 hover:bg-slate-50',
+                          )}
+                        >
+                          <span className={cn('h-2 w-2 shrink-0 rounded-full', m.rail)} />
+                          <span className="truncate">{workOrderStatusLabel[st]}</span>
+                        </button>
+                      );
+                    })}
+                  </div>
 
-              <div className="my-1.5 h-px bg-[#eef3eb]" />
+                  <p className="mb-1 mt-3 px-0.5 text-[9px] font-bold uppercase tracking-[0.07em] text-slate-400">Jobbtyp</p>
+                  <div className="space-y-0.5">
+                    {jobTypes.map((t) => {
+                      const active = t.key === jobType;
+                      return (
+                        <button
+                          key={t.key}
+                          type="button"
+                          onClick={() => {
+                            onSetJobType(active ? null : t.key);
+                            setOpen(false);
+                          }}
+                          className={cn(
+                            'flex w-full items-center gap-2 rounded-lg border px-2 py-1 text-left text-[11px] font-semibold transition',
+                            active ? 'border-emerald-200 bg-emerald-50 text-emerald-700' : 'border-transparent text-slate-600 hover:bg-slate-50',
+                          )}
+                        >
+                          <span className="h-2 w-2 shrink-0 rounded-full" style={{ backgroundColor: t.color }} />
+                          <span className="truncate">{t.label}</span>
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
 
-              <p className="px-1.5 pb-1 pt-0.5 text-[9px] font-bold uppercase tracking-wide text-slate-400">Längd (dagar)</p>
-              <div className="flex gap-1 px-0.5">
-                {[1, 2, 3, 4, 5, 6, 7].map((d) => (
-                  <button
-                    key={d}
-                    type="button"
-                    onClick={() => {
-                      onSetLength(d);
-                      setOpen(false);
-                    }}
-                    className={cn(
-                      'h-6 flex-1 rounded-lg p-0 text-[11px] font-bold tabular-nums transition',
-                      d === lengthDays ? 'bg-emerald-600 text-white' : 'bg-slate-50 text-slate-600 hover:bg-slate-100',
+                {/* Right column - timing + crew */}
+                <div className="border-l border-[#eef3eb] pl-3">
+                  <p className="mb-1 px-0.5 text-[9px] font-bold uppercase tracking-[0.07em] text-slate-400">
+                    Längd <span className="font-semibold normal-case tracking-normal text-slate-300">dagar</span>
+                  </p>
+                  <div className="flex gap-1">
+                    {[1, 2, 3, 4, 5, 6, 7].map((d) => (
+                      <button
+                        key={d}
+                        type="button"
+                        onClick={() => {
+                          onSetLength(d);
+                          setOpen(false);
+                        }}
+                        className={cn(
+                          'h-7 flex-1 rounded-md p-0 text-[11px] font-bold tabular-nums transition',
+                          d === lengthDays ? 'bg-emerald-600 text-white shadow-sm' : 'bg-slate-50 text-slate-600 hover:bg-slate-100',
+                        )}
+                      >
+                        {d}
+                      </button>
+                    ))}
+                  </div>
+
+                  <p className="mb-1 mt-3 px-0.5 text-[9px] font-bold uppercase tracking-[0.07em] text-slate-400">Besättning</p>
+                  {crew.length > 0 && (
+                    <div className="mb-1 flex flex-wrap gap-1">
+                      {crew.map((c) => (
+                        <button
+                          key={c.id}
+                          type="button"
+                          onClick={() => c.member_id && onRemoveCrew(c.member_id)}
+                          title={`${c.member_name} - ta bort`}
+                          className="inline-flex items-center gap-1 rounded-full bg-slate-50 py-0.5 pl-0.5 pr-2 text-[10px] font-semibold text-slate-600 transition hover:bg-rose-50 hover:text-rose-600"
+                        >
+                          <span
+                            className="inline-flex h-4 w-4 items-center justify-center rounded-full text-[7.5px] font-bold text-white"
+                            style={{ backgroundColor: crewColor(c.member_id ?? c.member_name) }}
+                          >
+                            {crewInitials(c.member_name)}
+                          </span>
+                          <span className="max-w-[100px] truncate">{c.member_name}</span>
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                  <div className="max-h-[200px] overflow-auto overscroll-contain rounded-lg border border-[#eef3eb] bg-[#f9fbf7] p-0.5">
+                    {available.length === 0 ? (
+                      <p className="px-1.5 py-1.5 text-[10px] text-slate-400">{crew.length ? 'Alla tillagda' : 'Inga personer'}</p>
+                    ) : (
+                      available.map((p) => (
+                        <button
+                          key={p.id}
+                          type="button"
+                          onClick={() => onAddCrew(p)}
+                          className="flex w-full items-center gap-2 rounded-md px-1.5 py-1 text-left text-[11px] text-slate-700 transition hover:bg-emerald-50"
+                        >
+                          <Avatar name={p.full_name} seed={p.id} size={16} />
+                          <span className="truncate">{p.full_name}</span>
+                        </button>
+                      ))
                     )}
-                  >
-                    {d}
-                  </button>
-                ))}
+                  </div>
+                </div>
               </div>
 
-              <div className="my-1.5 h-px bg-[#eef3eb]" />
-
-              <button
-                type="button"
-                onClick={() => {
-                  onToggleHold();
-                  setOpen(false);
-                }}
-                className="flex w-full items-center gap-2 rounded-lg px-1.5 py-1.5 text-left text-[11px] font-semibold text-slate-600 transition hover:bg-slate-50"
-              >
-                {onHold ? (
-                  <svg width="13" height="13" viewBox="0 0 24 24" fill="currentColor"><path d="M8 5v14l11-7z" /></svg>
-                ) : (
-                  <svg width="13" height="13" viewBox="0 0 24 24" fill="currentColor"><rect x="6" y="5" width="4" height="14" rx="1" /><rect x="14" y="5" width="4" height="14" rx="1" /></svg>
-                )}
-                {onHold ? 'Återuppta' : 'Pausa'}
-              </button>
-              <button
-                type="button"
-                onClick={() => {
-                  onOpenConfirm();
-                  setOpen(false);
-                }}
-                className="flex w-full items-center gap-2 rounded-lg px-1.5 py-1.5 text-left text-[11px] font-semibold text-slate-600 transition hover:bg-emerald-50 hover:text-emerald-700"
-              >
-                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                  <rect x="2" y="4" width="20" height="16" rx="2" />
-                  <path d="M22 7l-10 6L2 7" />
-                </svg>
-                Skicka bekräftelse
-              </button>
+              {/* Footer actions */}
+              <div className="mt-3 grid grid-cols-2 gap-2 border-t border-[#eef3eb] pt-3">
+                <button
+                  type="button"
+                  onClick={() => {
+                    onToggleHold();
+                    setOpen(false);
+                  }}
+                  className={cn(
+                    'flex items-center justify-center gap-1.5 rounded-lg border px-2 py-1.5 text-[11px] font-semibold transition',
+                    onHold ? 'border-amber-200 bg-amber-50 text-amber-700 hover:bg-amber-100' : 'border-[#e0e8dc] bg-white text-slate-600 hover:bg-slate-50',
+                  )}
+                >
+                  {onHold ? (
+                    <svg width="13" height="13" viewBox="0 0 24 24" fill="currentColor"><path d="M8 5v14l11-7z" /></svg>
+                  ) : (
+                    <svg width="13" height="13" viewBox="0 0 24 24" fill="currentColor"><rect x="6" y="5" width="4" height="14" rx="1" /><rect x="14" y="5" width="4" height="14" rx="1" /></svg>
+                  )}
+                  {onHold ? 'Återuppta' : 'Pausa'}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    onOpenConfirm();
+                    setOpen(false);
+                  }}
+                  className="flex items-center justify-center gap-1.5 rounded-lg border border-emerald-200 bg-emerald-50 px-2 py-1.5 text-[11px] font-semibold text-emerald-700 transition hover:bg-emerald-100"
+                >
+                  <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                    <rect x="2" y="4" width="20" height="16" rx="2" />
+                    <path d="M22 7l-10 6L2 7" />
+                  </svg>
+                  Bekräftelse
+                </button>
+              </div>
             </div>
           </>,
           document.body,

--- a/app/crm/planering/jobCard.tsx
+++ b/app/crm/planering/jobCard.tsx
@@ -7,6 +7,7 @@ import {
 } from '@/app/crm/lib/crmTokens';
 import type { JobDisplay } from '@/lib/domains/planning/display';
 import { sacksRemaining } from '@/lib/domains/planning/reports';
+import { resolveJobType } from '@/lib/domains/planning/jobTypes';
 
 // Status label + colors for a job, reusing the CRM work-order tokens so the planning board reads
 // identically to the rest of the CRM.
@@ -61,6 +62,19 @@ export function MaterialChip({ material }: { material: string | null }) {
     <span className="inline-flex items-center gap-1.5 whitespace-nowrap rounded-full border border-[#e0e8dc] bg-[#f3f6f1] px-2 py-px text-[10px] font-semibold text-slate-600">
       <span className="h-1.5 w-1.5 rounded-full bg-emerald-500" />
       {material}
+    </span>
+  );
+}
+
+// The explicit planner-set job type (with its colour) when present; otherwise the material
+// inferred from the work order.
+export function JobTypeOrMaterial({ jobType, material }: { jobType: string | null; material: string | null }) {
+  const jt = resolveJobType(jobType);
+  if (!jt) return <MaterialChip material={material} />;
+  return (
+    <span className="inline-flex items-center gap-1.5 whitespace-nowrap rounded-full border border-[#e0e8dc] bg-[#f3f6f1] px-2 py-px text-[10px] font-semibold text-slate-600">
+      <span className="h-1.5 w-1.5 rounded-full" style={{ backgroundColor: jt.color }} />
+      {jt.label}
     </span>
   );
 }

--- a/app/crm/planering/managerModalUi.tsx
+++ b/app/crm/planering/managerModalUi.tsx
@@ -1,0 +1,9 @@
+// Small shared bits for the planning management modals (bilar/jobbtyper/depåer).
+
+export function TrashIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M3 6h18M8 6V4h8v2M19 6l-1 14H6L5 6" />
+    </svg>
+  );
+}

--- a/app/crm/planering/page.tsx
+++ b/app/crm/planering/page.tsx
@@ -1,0 +1,13 @@
+import { getCurrentUser } from '@/lib/auth/route';
+import PlanningClient from './PlanningClient';
+
+export const dynamic = 'force-dynamic';
+
+// NEW CRM-first planning (Wave 7), as a CRM surface under the CRM layout (sidebar + auth gate).
+// The CRM layout already restricts access to sales/admin (konsult passes as read-only). The API
+// enforces the real planning.* permissions; konsult cannot write.
+export default async function CrmPlaneringPage() {
+  const user = await getCurrentUser().catch(() => null);
+  const canWrite = user?.role === 'admin' || user?.role === 'sales';
+  return <PlanningClient canWrite={canWrite} />;
+}

--- a/app/crm/planering/page.tsx
+++ b/app/crm/planering/page.tsx
@@ -9,5 +9,8 @@ export const dynamic = 'force-dynamic';
 export default async function CrmPlaneringPage() {
   const user = await getCurrentUser().catch(() => null);
   const canWrite = user?.role === 'admin' || user?.role === 'sales';
-  return <PlanningClient canWrite={canWrite} />;
+  // Fleet management is seeded to admins (planning.truck.manage). The API enforces the real
+  // permission; this is just the UI affordance.
+  const canManageTrucks = user?.role === 'admin';
+  return <PlanningClient canWrite={canWrite} canManageTrucks={canManageTrucks} />;
 }

--- a/app/crm/planering/page.tsx
+++ b/app/crm/planering/page.tsx
@@ -9,8 +9,9 @@ export const dynamic = 'force-dynamic';
 export default async function CrmPlaneringPage() {
   const user = await getCurrentUser().catch(() => null);
   const canWrite = user?.role === 'admin' || user?.role === 'sales';
-  // Fleet management is seeded to admins (planning.truck.manage). The API enforces the real
-  // permission; this is just the UI affordance.
+  // Fleet + depot management are seeded to admins (planning.truck.manage / planning.depot.manage).
+  // The API enforces the real permissions; these are just the UI affordances.
   const canManageTrucks = user?.role === 'admin';
-  return <PlanningClient canWrite={canWrite} canManageTrucks={canManageTrucks} />;
+  const canManageDepots = user?.role === 'admin';
+  return <PlanningClient canWrite={canWrite} canManageTrucks={canManageTrucks} canManageDepots={canManageDepots} />;
 }

--- a/app/crm/planering/planningDates.ts
+++ b/app/crm/planering/planningDates.ts
@@ -1,0 +1,96 @@
+// Pure date helpers for the planning board (week + month). No Date.now() inside — callers pass
+// the reference date — so the building functions are deterministic and unit-testable.
+
+export const WEEKDAYS_SHORT = ['mån', 'tis', 'ons', 'tor', 'fre', 'lör', 'sön'] as const;
+
+export function fmtISO(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+export function parseISO(iso: string): Date {
+  const [y, m, d] = iso.split('-').map(Number);
+  return new Date(y, m - 1, d);
+}
+
+export function addDays(d: Date, n: number): Date {
+  const x = new Date(d);
+  x.setDate(x.getDate() + n);
+  x.setHours(0, 0, 0, 0);
+  return x;
+}
+
+export function addDaysISO(iso: string, n: number): string {
+  return fmtISO(addDays(parseISO(iso), n));
+}
+
+// Inclusive day span between two ISO dates (same day = 1).
+export function daysBetweenInclusive(startISO: string, endISO: string): number {
+  const ms = parseISO(endISO).getTime() - parseISO(startISO).getTime();
+  return Math.round(ms / 86_400_000) + 1;
+}
+
+// Monday of the week containing d.
+export function startOfWeek(d: Date): Date {
+  const x = new Date(d);
+  const dow = (x.getDay() + 6) % 7; // 0 = Monday
+  x.setDate(x.getDate() - dow);
+  x.setHours(0, 0, 0, 0);
+  return x;
+}
+
+// ISO-8601 week number.
+export function isoWeek(d: Date): number {
+  const date = new Date(Date.UTC(d.getFullYear(), d.getMonth(), d.getDate()));
+  const dayNum = (date.getUTCDay() + 6) % 7;
+  date.setUTCDate(date.getUTCDate() - dayNum + 3);
+  const firstThursday = new Date(Date.UTC(date.getUTCFullYear(), 0, 4));
+  return 1 + Math.round((date.getTime() - firstThursday.getTime()) / (7 * 24 * 3600 * 1000));
+}
+
+export type WeekDay = { iso: string; date: Date; weekday: string; dayLabel: string; isWeekend: boolean };
+
+export function buildWeekDays(monday: Date): WeekDay[] {
+  return Array.from({ length: 7 }, (_, i) => {
+    const date = addDays(monday, i);
+    return {
+      iso: fmtISO(date),
+      date,
+      weekday: WEEKDAYS_SHORT[i],
+      dayLabel: `${date.getDate()}/${date.getMonth() + 1}`,
+      isWeekend: i >= 5,
+    };
+  });
+}
+
+export type MonthDayCell = { iso: string; day: number; inMonth: boolean; isWeekend: boolean };
+export type MonthWeek = { weekNo: number; days: MonthDayCell[] };
+
+// Calendar weeks (Mon-start) covering the month that `ref` falls in, including spill-over days
+// from the adjacent months to fill the grid.
+export function buildMonthWeeks(ref: Date): MonthWeek[] {
+  const year = ref.getFullYear();
+  const month = ref.getMonth();
+  const lastOfMonth = new Date(year, month + 1, 0);
+  let cur = startOfWeek(new Date(year, month, 1));
+  const weeks: MonthWeek[] = [];
+
+  while (true) {
+    const weekStart = cur;
+    const days: MonthDayCell[] = Array.from({ length: 7 }, (_, i) => {
+      const d = addDays(weekStart, i);
+      return { iso: fmtISO(d), day: d.getDate(), inMonth: d.getMonth() === month, isWeekend: i >= 5 };
+    });
+    weeks.push({ weekNo: isoWeek(weekStart), days });
+    cur = addDays(cur, 7);
+    if (cur > lastOfMonth) break;
+  }
+  return weeks;
+}
+
+export function swedishMonthYear(d: Date): string {
+  const s = d.toLocaleDateString('sv-SE', { month: 'long', year: 'numeric' });
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}

--- a/app/crm/planering/useEntityCrud.ts
+++ b/app/crm/planering/useEntityCrud.ts
@@ -1,0 +1,106 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useToast } from '@/lib/Toast';
+
+type WithId = { id: string };
+
+// Shared CRUD-over-a-REST-collection for the planning management modals (bilar/jobbtyper/depåer).
+// Each modal owns its field-row JSX + "add new" form; this owns the duplicated machine:
+// load(no-store) → list state, optimistic patchLocal, save (PATCH /{id}), remove (DELETE /{id}),
+// add (POST), plus loading/busy and the {ok,data,error} envelope handling + toasts.
+//
+// save/remove/add resolve to a success signal so the caller can fire its own onChanged() refresh.
+export function useEntityCrud<T extends WithId>(opts: {
+  api: string; // collection endpoint, e.g. /api/crm/planering/trucks
+  listKey: string; // key under {data} holding the array, e.g. 'trucks'
+  itemKey?: string; // key under {data} for a created row (default 'item')
+  toPayload: (item: T) => unknown; // PATCH body built from an edited row
+  labels?: { saved?: string; saveFail?: string; removeFail?: string; addFail?: string };
+}) {
+  const toast = useToast();
+  const itemKey = opts.itemKey ?? 'item';
+  const [items, setItems] = useState<T[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    fetch(opts.api, { cache: 'no-store' })
+      .then((r) => r.json())
+      .then((j) => {
+        if (active && j.ok) setItems(j.data[opts.listKey] as T[]);
+      })
+      .catch(() => {})
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [opts.api]);
+
+  function patchLocal(id: string, patch: Partial<T>) {
+    setItems((prev) => prev.map((it) => (it.id === id ? { ...it, ...patch } : it)));
+  }
+
+  async function save(item: T): Promise<boolean> {
+    setBusy(true);
+    try {
+      const r = await fetch(`${opts.api}/${item.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(opts.toPayload(item)),
+      });
+      const j = await r.json();
+      if (!j.ok) {
+        toast.error(j.error || opts.labels?.saveFail || 'Kunde inte spara');
+        return false;
+      }
+      toast.success(opts.labels?.saved || 'Sparad');
+      return true;
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function remove(id: string): Promise<boolean> {
+    setBusy(true);
+    try {
+      const r = await fetch(`${opts.api}/${id}`, { method: 'DELETE' });
+      const j = await r.json();
+      if (!j.ok) {
+        toast.error(j.error || opts.labels?.removeFail || 'Kunde inte ta bort');
+        return false;
+      }
+      setItems((prev) => prev.filter((it) => it.id !== id));
+      return true;
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function add(payload: unknown): Promise<T | null> {
+    setBusy(true);
+    try {
+      const r = await fetch(opts.api, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      const j = await r.json();
+      if (!j.ok) {
+        toast.error(j.error || opts.labels?.addFail || 'Kunde inte lägga till');
+        return null;
+      }
+      const created = j.data[itemKey] as T;
+      setItems((prev) => [...prev, created]);
+      return created;
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return { items, setItems, loading, busy, patchLocal, save, remove, add };
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -2,6 +2,20 @@
 @tailwind components;
 @tailwind utilities;
 
+/* Tailwind preflight is disabled project-wide (see tailwind.config.js → corePlugins.preflight:false),
+   so there is no global `border-width: 0` reset. Any element with a border *style* (e.g. the
+   `border-solid` utility) but no explicit width on a given side falls back to the CSS-initial
+   `medium` (~3px) border on that side — phantom borders that eat layout space. The planning week
+   board uses `border-solid` for its grid lines, so restore the reset *scoped to that board only*
+   (in @layer base so real width utilities like `border-l`/`border-b` still win). */
+@layer base {
+  .wk-board *,
+  .wk-board *::before,
+  .wk-board *::after {
+    border-width: 0;
+  }
+}
+
 /* Melodic Frost — CRM-specific design tokens */
 .crm-shell {
   --crm-sidebar-bg: #0d2117;

--- a/app/globals.css
+++ b/app/globals.css
@@ -5,13 +5,15 @@
 /* Tailwind preflight is disabled project-wide (see tailwind.config.js → corePlugins.preflight:false),
    so there is no global `border-width: 0` reset. Any element with a border *style* (e.g. the
    `border-solid` utility) but no explicit width on a given side falls back to the CSS-initial
-   `medium` (~3px) border on that side — phantom borders that eat layout space. The planning week
-   board uses `border-solid` for its grid lines, so restore the reset *scoped to that board only*
-   (in @layer base so real width utilities like `border-l`/`border-b` still win). */
+   `medium` (~3px) border on that side — phantom borders that eat layout space. The planning boards
+   (week + month) use `border-solid` for their grid lines, so restore the reset *scoped to those
+   boards only* (in @layer base so real width utilities like `border-l`/`border-b` still win).
+   The proper app-wide fix (re-enable preflight / a global reset) is deferred: it would make
+   currently-hidden Tailwind div-borders appear across the not-yet-rebuilt non-CRM surfaces. */
 @layer base {
-  .wk-board *,
-  .wk-board *::before,
-  .wk-board *::after {
+  .planning-board *,
+  .planning-board *::before,
+  .planning-board *::after {
     border-width: 0;
   }
 }

--- a/lib/auth/permissions.ts
+++ b/lib/auth/permissions.ts
@@ -36,6 +36,9 @@ export const PERMISSION_KEYS = [
   // Fortnox actions
   'fortnox.offer.push', 'fortnox.workorder.push', 'fortnox.invoice.create',
   'fortnox.customer.sync', 'fortnox.read',
+  // Planning (Wave 7 — new CRM-first scheduling surface; seeded in 20260611_planning_permissions.sql)
+  'planning.schedule.read', 'planning.schedule.write',
+  'planning.truck.manage', 'planning.depot.manage',
   // Coarse meta keys backing the legacy requireCrmUser/Writer/Admin guards 1:1
   'crm.access', 'crm.write', 'crm.admin',
 ] as const;

--- a/lib/domains/crm/materials.ts
+++ b/lib/domains/crm/materials.ts
@@ -33,6 +33,21 @@ export function inferMaterialFromArticle(articleName: string | null | undefined)
   return null;
 }
 
+// The canonical material short labels (EKOVILLA, KNAUF SUPAFIL, …), in catalogue order. The single
+// material identity used by depot deliveries + consumption so stock reconciles.
+export const MATERIAL_SHORTS: string[] = [...new Set(Object.values(MATERIALS).map((m) => m.short))];
+
+// The material `short` of the first line item whose article resolves to a known material, else null.
+// Attributes a work order's blown sacks to a depot material (depot stock consumption).
+export function materialShortFromLineItems(lineItems: unknown[] | null | undefined): string | null {
+  if (!Array.isArray(lineItems)) return null;
+  for (const it of lineItems) {
+    const m = inferMaterialFromArticle((it as { article_name?: string | null })?.article_name);
+    if (m) return m.short;
+  }
+  return null;
+}
+
 // Whole sacks needed: mass (volume × density) / bag weight, rounded UP – you order
 // whole sacks. Returns 0 when any input is non-positive.
 export function sacksFor(volumeM3: number, densityKgPerM3: number, bagWeightKg: number): number {

--- a/lib/domains/crm/materials.ts
+++ b/lib/domains/crm/materials.ts
@@ -1,3 +1,6 @@
+import { parseDecimal } from '@/lib/shared/number';
+import { lineItemQuantity, type LineItemQuantitySource } from '@/lib/domains/crm/lineItems';
+
 // Lösull materials: bag weight (kg/säck) and lambdavärde (W/m²K).
 // Single source of truth shared by egenkontroll (manual select) and the quote form's
 // sack calculation (material inferred from the article).
@@ -35,4 +38,28 @@ export function inferMaterialFromArticle(articleName: string | null | undefined)
 export function sacksFor(volumeM3: number, densityKgPerM3: number, bagWeightKg: number): number {
   if (!(volumeM3 > 0) || !(densityKgPerM3 > 0) || !(bagWeightKg > 0)) return 0;
   return Math.ceil((volumeM3 * densityKgPerM3) / bagWeightKg);
+}
+
+// A quote/work-order line carrying enough to compute its sack count: the quantity inputs
+// (pricing_mode / m2 / thickness_mm / quantity) plus the article name (→ material & bag weight)
+// and the entered density.
+export type SackLineItem = LineItemQuantitySource & {
+  article_name?: string | null;
+  density?: string | null;
+};
+
+// Whole sacks for one line. 0 unless the material resolves from the article AND a positive
+// density is set. Single source of truth so the quote work-description, the Fortnox push, and
+// the planning backlog all agree on the sack count for the same line.
+export function lineItemSacks(item: SackLineItem): number {
+  const material = inferMaterialFromArticle(item.article_name);
+  const density = parseDecimal(item.density);
+  if (!material || !(density > 0)) return 0;
+  return sacksFor(lineItemQuantity(item), density, material.bagWeight);
+}
+
+// Total whole sacks across a quote/work-order's line items.
+export function totalSacks(items: SackLineItem[] | null | undefined): number {
+  if (!Array.isArray(items)) return 0;
+  return items.reduce((sum, it) => sum + lineItemSacks(it), 0);
 }

--- a/lib/domains/planning/backlog.ts
+++ b/lib/domains/planning/backlog.ts
@@ -1,70 +1,39 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
-import { totalSacks } from '@/lib/domains/crm/materials';
+import { mapWorkOrderJob, type WorkOrderJobRow } from './display';
 import type { SchedulableWorkOrder } from './types';
 
-// Work-order statuses that still want scheduling. 'ready' is retired; 'completed',
-// 'partially_invoiced', 'invoiced' and 'cancelled' are past the install and excluded.
+// resolveJobAddress is the single source for the job-site address; re-exported under its old name
+// so existing tests/imports keep working.
+export { resolveJobAddress as resolveBacklogAddress } from './display';
+
+// Work-order statuses that still want scheduling. 'completed', 'partially_invoiced', 'invoiced'
+// and 'cancelled' are past the install and excluded.
 export const SCHEDULABLE_WORK_ORDER_STATUSES = ['draft', 'scheduled', 'in_progress'] as const;
 
-// The crm_work_orders columns the backlog reads.
-type WorkOrderRow = {
+type WorkOrderRow = WorkOrderJobRow & {
   id: string;
-  order_number: string;
-  project_name: string;
-  client_name: string;
-  status: string;
   desired_installation_date: string | null;
-  work_address: Record<string, unknown> | null;
-  customer_snapshot: Record<string, unknown> | null;
-  line_items: unknown[] | null;
 };
 
 function str(value: unknown): string {
   return value == null ? '' : String(value).trim();
 }
 
-function joinAddress(parts: unknown[]): string | null {
-  const cleaned = parts.map(str).filter(Boolean);
-  return cleaned.length ? cleaned.join(', ') : null;
-}
-
-// The job-site address: the separate work address when one is stored (it's only persisted when
-// it differs from the customer address), else a separate delivery address on the snapshot, else
-// the customer's card address. Mirrors how the order itself resolves the work address.
-export function resolveBacklogAddress(
-  workAddress: Record<string, unknown> | null,
-  snapshot: Record<string, unknown> | null,
-): string | null {
-  const wa = workAddress ?? {};
-  if (str(wa.street_address)) return joinAddress([wa.street_address, wa.postal_code, wa.city]);
-
-  const snap = snapshot ?? {};
-  if (str(snap.delivery_address)) {
-    return joinAddress([snap.delivery_address, snap.delivery_postal_code, snap.delivery_city]);
-  }
-  return joinAddress([snap.street_address, snap.postal_code, snap.city]);
-}
-
 // Pure mapper: a crm_work_orders row (+ how many segments already cover it) → backlog item.
 export function mapWorkOrderToBacklogItem(row: WorkOrderRow, segmentCount: number): SchedulableWorkOrder {
-  const snap = row.customer_snapshot ?? {};
+  const snap = (row.customer_snapshot ?? {}) as Record<string, unknown>;
   return {
     id: row.id,
-    order_number: row.order_number,
-    project_name: row.project_name,
-    client_name: row.client_name,
-    status: row.status,
+    ...mapWorkOrderJob(row),
     desired_installation_date: row.desired_installation_date ?? null,
-    address: resolveBacklogAddress(row.work_address, row.customer_snapshot),
     contact_email: str(snap.email) || null,
     contact_phone: str(snap.phone) || null,
-    total_sacks: totalSacks(row.line_items as never),
     segment_count: segmentCount,
   };
 }
 
 const WORK_ORDER_BACKLOG_SELECT =
-  'id, order_number, project_name, client_name, status, desired_installation_date, work_address, customer_snapshot, line_items';
+  'id, order_number, fortnox_order_number, project_name, client_name, status, desired_installation_date, work_address, customer_snapshot, line_items';
 
 // List CRM work orders eligible for scheduling, annotated with how many ops_segments already
 // cover them. RLS applies to both reads (planner needs crm.workorder.read + planning.schedule.read).
@@ -82,7 +51,6 @@ export async function listSchedulableWorkOrders(
   const rows = (orders ?? []) as WorkOrderRow[];
   if (rows.length === 0) return { data: [], error: null };
 
-  // Count existing placements per work order in one query, merged client-side.
   const ids = rows.map((r) => r.id);
   const { data: segs, error: segErr } = await supabase
     .from('ops_segments')

--- a/lib/domains/planning/backlog.ts
+++ b/lib/domains/planning/backlog.ts
@@ -13,6 +13,7 @@ export const SCHEDULABLE_WORK_ORDER_STATUSES = ['draft', 'scheduled', 'in_progre
 type WorkOrderRow = WorkOrderJobRow & {
   id: string;
   desired_installation_date: string | null;
+  assigned_to: string | null;
 };
 
 function str(value: unknown): string {
@@ -28,12 +29,13 @@ export function mapWorkOrderToBacklogItem(row: WorkOrderRow, segmentCount: numbe
     desired_installation_date: row.desired_installation_date ?? null,
     contact_email: str(snap.email) || null,
     contact_phone: str(snap.phone) || null,
+    assigned_to: row.assigned_to ?? null,
     segment_count: segmentCount,
   };
 }
 
 const WORK_ORDER_BACKLOG_SELECT =
-  'id, order_number, fortnox_order_number, project_name, client_name, status, desired_installation_date, work_address, customer_snapshot, line_items';
+  'id, order_number, fortnox_order_number, project_name, client_name, status, desired_installation_date, assigned_to, work_address, customer_snapshot, line_items';
 
 // List CRM work orders eligible for scheduling, annotated with how many ops_segments already
 // cover them. RLS applies to both reads (planner needs crm.workorder.read + planning.schedule.read).

--- a/lib/domains/planning/backlog.ts
+++ b/lib/domains/planning/backlog.ts
@@ -1,0 +1,100 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { totalSacks } from '@/lib/domains/crm/materials';
+import type { SchedulableWorkOrder } from './types';
+
+// Work-order statuses that still want scheduling. 'ready' is retired; 'completed',
+// 'partially_invoiced', 'invoiced' and 'cancelled' are past the install and excluded.
+export const SCHEDULABLE_WORK_ORDER_STATUSES = ['draft', 'scheduled', 'in_progress'] as const;
+
+// The crm_work_orders columns the backlog reads.
+type WorkOrderRow = {
+  id: string;
+  order_number: string;
+  project_name: string;
+  client_name: string;
+  status: string;
+  desired_installation_date: string | null;
+  work_address: Record<string, unknown> | null;
+  customer_snapshot: Record<string, unknown> | null;
+  line_items: unknown[] | null;
+};
+
+function str(value: unknown): string {
+  return value == null ? '' : String(value).trim();
+}
+
+function joinAddress(parts: unknown[]): string | null {
+  const cleaned = parts.map(str).filter(Boolean);
+  return cleaned.length ? cleaned.join(', ') : null;
+}
+
+// The job-site address: the separate work address when one is stored (it's only persisted when
+// it differs from the customer address), else a separate delivery address on the snapshot, else
+// the customer's card address. Mirrors how the order itself resolves the work address.
+export function resolveBacklogAddress(
+  workAddress: Record<string, unknown> | null,
+  snapshot: Record<string, unknown> | null,
+): string | null {
+  const wa = workAddress ?? {};
+  if (str(wa.street_address)) return joinAddress([wa.street_address, wa.postal_code, wa.city]);
+
+  const snap = snapshot ?? {};
+  if (str(snap.delivery_address)) {
+    return joinAddress([snap.delivery_address, snap.delivery_postal_code, snap.delivery_city]);
+  }
+  return joinAddress([snap.street_address, snap.postal_code, snap.city]);
+}
+
+// Pure mapper: a crm_work_orders row (+ how many segments already cover it) → backlog item.
+export function mapWorkOrderToBacklogItem(row: WorkOrderRow, segmentCount: number): SchedulableWorkOrder {
+  const snap = row.customer_snapshot ?? {};
+  return {
+    id: row.id,
+    order_number: row.order_number,
+    project_name: row.project_name,
+    client_name: row.client_name,
+    status: row.status,
+    desired_installation_date: row.desired_installation_date ?? null,
+    address: resolveBacklogAddress(row.work_address, row.customer_snapshot),
+    contact_email: str(snap.email) || null,
+    contact_phone: str(snap.phone) || null,
+    total_sacks: totalSacks(row.line_items as never),
+    segment_count: segmentCount,
+  };
+}
+
+const WORK_ORDER_BACKLOG_SELECT =
+  'id, order_number, project_name, client_name, status, desired_installation_date, work_address, customer_snapshot, line_items';
+
+// List CRM work orders eligible for scheduling, annotated with how many ops_segments already
+// cover them. RLS applies to both reads (planner needs crm.workorder.read + planning.schedule.read).
+export async function listSchedulableWorkOrders(
+  supabase: SupabaseClient,
+): Promise<{ data: SchedulableWorkOrder[]; error: { message: string } | null }> {
+  const { data: orders, error } = await supabase
+    .from('crm_work_orders')
+    .select(WORK_ORDER_BACKLOG_SELECT)
+    .in('status', SCHEDULABLE_WORK_ORDER_STATUSES as unknown as string[])
+    .order('desired_installation_date', { ascending: true, nullsFirst: false });
+
+  if (error) return { data: [], error };
+
+  const rows = (orders ?? []) as WorkOrderRow[];
+  if (rows.length === 0) return { data: [], error: null };
+
+  // Count existing placements per work order in one query, merged client-side.
+  const ids = rows.map((r) => r.id);
+  const { data: segs, error: segErr } = await supabase
+    .from('ops_segments')
+    .select('work_order_id')
+    .in('work_order_id', ids);
+
+  if (segErr) return { data: [], error: segErr };
+
+  const counts = new Map<string, number>();
+  for (const s of (segs ?? []) as Array<{ work_order_id: string }>) {
+    counts.set(s.work_order_id, (counts.get(s.work_order_id) ?? 0) + 1);
+  }
+
+  return { data: rows.map((r) => mapWorkOrderToBacklogItem(r, counts.get(r.id) ?? 0)), error: null };
+}

--- a/lib/domains/planning/confirmations.ts
+++ b/lib/domains/planning/confirmations.ts
@@ -1,0 +1,230 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { sendEmail } from '@/lib/email';
+import { sendSms } from '@/lib/sms';
+import { buildPlanningNotificationEmail } from '@/lib/planningNotificationEmail';
+import { buildPlanningNotificationSms } from '@/lib/planningNotificationSms';
+
+// Order confirmations (orderbekräftelse) for a scheduled job. The recipient comes from the CRM
+// customer; the message templates are reused from the existing planning notification builders and
+// the senders from lib/email (Resend) + lib/sms (Twilio). Each send is recorded in
+// ops_work_order_confirmations; the board reads a per-work-order summary for the "bekräftad" badge.
+
+export type ConfirmationChannel = 'email' | 'sms';
+
+// Per-work-order confirmation state shown as a badge on every one of the job's cards.
+export type ConfirmationSummary = {
+  email_sent_at: string | null;
+  email_to: string | null;
+  sms_sent_at: string | null;
+  sms_to: string | null;
+};
+
+export const EMPTY_CONFIRMATION: ConfirmationSummary = {
+  email_sent_at: null,
+  email_to: null,
+  sms_sent_at: null,
+  sms_to: null,
+};
+
+type RawConfirmation = { work_order_id: string; channel: string; recipient: string; created_at: string };
+
+// Pure: reduce confirmation rows into a per-work-order summary (the latest email + latest sms).
+// Order-independent — keeps whichever row has the newest created_at per channel.
+export function summarizeConfirmations(rows: RawConfirmation[]): Map<string, ConfirmationSummary> {
+  const map = new Map<string, ConfirmationSummary>();
+  for (const r of rows) {
+    const cur = map.get(r.work_order_id) ?? { ...EMPTY_CONFIRMATION };
+    if (r.channel === 'email' && (!cur.email_sent_at || r.created_at > cur.email_sent_at)) {
+      cur.email_sent_at = r.created_at;
+      cur.email_to = r.recipient;
+    }
+    if (r.channel === 'sms' && (!cur.sms_sent_at || r.created_at > cur.sms_sent_at)) {
+      cur.sms_sent_at = r.created_at;
+      cur.sms_to = r.recipient;
+    }
+    map.set(r.work_order_id, cur);
+  }
+  return map;
+}
+
+export async function confirmationsByWorkOrder(
+  supabase: SupabaseClient,
+  workOrderIds: string[],
+): Promise<Map<string, ConfirmationSummary>> {
+  if (workOrderIds.length === 0) return new Map();
+  const { data } = await supabase
+    .from('ops_work_order_confirmations')
+    .select('work_order_id, channel, recipient, created_at')
+    .in('work_order_id', workOrderIds);
+  return summarizeConfirmations((data ?? []) as RawConfirmation[]);
+}
+
+// The job fields needed to compose a confirmation, loaded from a segment + its work order + truck.
+type SegmentConfirmContext = {
+  work_order_id: string;
+  project_name: string;
+  client_name: string;
+  order_number: string;
+  fortnox_order_number: string | null;
+  start_day: string;
+  end_day: string;
+  truck_name: string | null;
+};
+
+async function loadSegmentContext(
+  supabase: SupabaseClient,
+  segmentId: string,
+): Promise<{ data: SegmentConfirmContext | null; error: { message: string } | null }> {
+  const { data, error } = await supabase
+    .from('ops_segments')
+    .select(
+      'work_order_id, start_day, end_day, ' +
+        'work_order:crm_work_orders(project_name, client_name, order_number, fortnox_order_number), ' +
+        'truck:ops_trucks(name)',
+    )
+    .eq('id', segmentId)
+    .single();
+  if (error || !data) return { data: null, error: error ?? { message: 'Segmentet kunde inte hittas' } };
+
+  const row = data as Record<string, any>;
+  const wo = Array.isArray(row.work_order) ? row.work_order[0] : row.work_order;
+  const truck = Array.isArray(row.truck) ? row.truck[0] : row.truck;
+  return {
+    data: {
+      work_order_id: row.work_order_id,
+      project_name: wo?.project_name ?? '',
+      client_name: wo?.client_name ?? '',
+      order_number: wo?.order_number ?? '',
+      fortnox_order_number: wo?.fortnox_order_number ?? null,
+      start_day: row.start_day,
+      end_day: row.end_day,
+      truck_name: truck?.name ?? null,
+    },
+    error: null,
+  };
+}
+
+type RecordConfirmationInput = {
+  workOrderId: string;
+  segmentId: string;
+  channel: ConfirmationChannel;
+  recipient: string;
+  startDay: string;
+  endDay: string;
+  providerMessageId: string | null;
+  status: string | null;
+  actorUserId: string;
+};
+
+async function recordConfirmation(supabase: SupabaseClient, input: RecordConfirmationInput): Promise<void> {
+  await supabase.from('ops_work_order_confirmations').insert({
+    work_order_id: input.workOrderId,
+    segment_id: input.segmentId,
+    channel: input.channel,
+    recipient: input.recipient,
+    start_day: input.startDay,
+    end_day: input.endDay,
+    provider_message_id: input.providerMessageId,
+    status: input.status,
+    created_by: input.actorUserId,
+  });
+}
+
+export type SendConfirmationInput = {
+  segmentId: string;
+  sendEmail: boolean;
+  recipientEmail: string | null;
+  sendSms: boolean;
+  recipientPhone: string | null;
+  customMessage: string | null;
+  actorUserId: string;
+  actorName: string | null;
+};
+
+export type SendConfirmationResult = {
+  email: { sent: boolean; error: string | null };
+  sms: { sent: boolean; status: string | null; error: string | null };
+};
+
+// Build + send the requested channels, recording each successful send. Channels are independent: a
+// failure in one (e.g. SMS not configured) is returned as an error and never blocks the other.
+// Note: sendEmail is a no-op in non-production when Resend isn't configured (it logs and resolves),
+// so a dev "sent" reflects the app-wide email stub — production really sends.
+export async function sendOrderConfirmation(
+  supabase: SupabaseClient,
+  input: SendConfirmationInput,
+): Promise<{ data: SendConfirmationResult | null; error: { message: string } | null }> {
+  const { data: ctx, error: ctxErr } = await loadSegmentContext(supabase, input.segmentId);
+  if (ctxErr || !ctx) return { data: null, error: ctxErr };
+
+  // The reference the business follows: the Fortnox order number when synced, else the internal AO.
+  const orderNumber = ctx.fortnox_order_number || ctx.order_number || null;
+  const customerName = ctx.client_name || null;
+  const result: SendConfirmationResult = {
+    email: { sent: false, error: null },
+    sms: { sent: false, status: null, error: null },
+  };
+
+  if (input.sendEmail && input.recipientEmail) {
+    try {
+      const { subject, html, text } = buildPlanningNotificationEmail({
+        recipientEmail: input.recipientEmail,
+        projectName: ctx.project_name,
+        customerName,
+        orderNumber,
+        startDay: ctx.start_day,
+        endDay: ctx.end_day,
+        truck: ctx.truck_name,
+        salesResponsible: input.actorName,
+        customMessage: input.customMessage,
+      });
+      await sendEmail({ to: input.recipientEmail, subject, html, text });
+      await recordConfirmation(supabase, {
+        workOrderId: ctx.work_order_id,
+        segmentId: input.segmentId,
+        channel: 'email',
+        recipient: input.recipientEmail,
+        startDay: ctx.start_day,
+        endDay: ctx.end_day,
+        providerMessageId: null,
+        status: null,
+        actorUserId: input.actorUserId,
+      });
+      result.email.sent = true;
+    } catch (e: any) {
+      result.email.error = e?.message || 'Mejlet kunde inte skickas';
+    }
+  }
+
+  if (input.sendSms && input.recipientPhone) {
+    try {
+      const body = buildPlanningNotificationSms({
+        projectName: ctx.project_name,
+        orderNumber,
+        customerName,
+        startDay: ctx.start_day,
+        endDay: ctx.end_day,
+        truck: ctx.truck_name,
+        salesResponsible: input.actorName,
+      });
+      const res = await sendSms({ to: input.recipientPhone, body });
+      await recordConfirmation(supabase, {
+        workOrderId: ctx.work_order_id,
+        segmentId: input.segmentId,
+        channel: 'sms',
+        recipient: input.recipientPhone,
+        startDay: ctx.start_day,
+        endDay: ctx.end_day,
+        providerMessageId: res.sid,
+        status: res.status,
+        actorUserId: input.actorUserId,
+      });
+      result.sms.sent = true;
+      result.sms.status = res.status;
+    } catch (e: any) {
+      result.sms.error = e?.message || 'SMS kunde inte skickas';
+    }
+  }
+
+  return { data: result, error: null };
+}

--- a/lib/domains/planning/confirmations.ts
+++ b/lib/domains/planning/confirmations.ts
@@ -1,13 +1,9 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
-import { sendEmail } from '@/lib/email';
-import { sendSms } from '@/lib/sms';
-import { buildPlanningNotificationEmail } from '@/lib/planningNotificationEmail';
-import { buildPlanningNotificationSms } from '@/lib/planningNotificationSms';
 
-// Order confirmations (orderbekräftelse) for a scheduled job. The recipient comes from the CRM
-// customer; the message templates are reused from the existing planning notification builders and
-// the senders from lib/email (Resend) + lib/sms (Twilio). Each send is recorded in
-// ops_work_order_confirmations; the board reads a per-work-order summary for the "bekräftad" badge.
+// Order confirmations (orderbekräftelse) for a scheduled job — the CLIENT-SAFE, pure half: types,
+// the per-work-order summary read, and presentation helpers. The actual sending (Twilio/Resend,
+// server-only) lives in ./confirmationsSend so this module can be imported by board cards without
+// pulling Node-only transports into the browser bundle.
 
 export type ConfirmationChannel = 'email' | 'sms';
 
@@ -17,6 +13,9 @@ export type ConfirmationSummary = {
   email_to: string | null;
   sms_sent_at: string | null;
   sms_to: string | null;
+  // Latest SMS delivery status from Twilio (queued/sent/delivered/failed/undelivered), updated by
+  // the status callback. Null when no SMS was sent or no status has arrived yet.
+  sms_status: string | null;
 };
 
 export const EMPTY_CONFIRMATION: ConfirmationSummary = {
@@ -24,9 +23,16 @@ export const EMPTY_CONFIRMATION: ConfirmationSummary = {
   email_to: null,
   sms_sent_at: null,
   sms_to: null,
+  sms_status: null,
 };
 
-type RawConfirmation = { work_order_id: string; channel: string; recipient: string; created_at: string };
+type RawConfirmation = {
+  work_order_id: string;
+  channel: string;
+  recipient: string;
+  created_at: string;
+  status?: string | null;
+};
 
 // Pure: reduce confirmation rows into a per-work-order summary (the latest email + latest sms).
 // Order-independent — keeps whichever row has the newest created_at per channel.
@@ -41,10 +47,23 @@ export function summarizeConfirmations(rows: RawConfirmation[]): Map<string, Con
     if (r.channel === 'sms' && (!cur.sms_sent_at || r.created_at > cur.sms_sent_at)) {
       cur.sms_sent_at = r.created_at;
       cur.sms_to = r.recipient;
+      cur.sms_status = r.status ?? null;
     }
     map.set(r.work_order_id, cur);
   }
   return map;
+}
+
+export type SmsStatusTone = 'ok' | 'fail' | 'pending';
+
+// Pure: map a Twilio SMS status to a Swedish label + tone for the badge. Returns null when there is
+// no status to show (so the card falls back to a plain "sent" badge).
+export function describeSmsStatus(status: string | null | undefined): { label: string; tone: SmsStatusTone } | null {
+  if (!status) return null;
+  const s = status.toLowerCase();
+  if (s === 'delivered') return { label: 'Levererat', tone: 'ok' };
+  if (s === 'failed' || s === 'undelivered') return { label: 'Ej levererat', tone: 'fail' };
+  return { label: 'Skickat', tone: 'pending' };
 }
 
 export async function confirmationsByWorkOrder(
@@ -54,177 +73,7 @@ export async function confirmationsByWorkOrder(
   if (workOrderIds.length === 0) return new Map();
   const { data } = await supabase
     .from('ops_work_order_confirmations')
-    .select('work_order_id, channel, recipient, created_at')
+    .select('work_order_id, channel, recipient, created_at, status')
     .in('work_order_id', workOrderIds);
   return summarizeConfirmations((data ?? []) as RawConfirmation[]);
-}
-
-// The job fields needed to compose a confirmation, loaded from a segment + its work order + truck.
-type SegmentConfirmContext = {
-  work_order_id: string;
-  project_name: string;
-  client_name: string;
-  order_number: string;
-  fortnox_order_number: string | null;
-  start_day: string;
-  end_day: string;
-  truck_name: string | null;
-};
-
-async function loadSegmentContext(
-  supabase: SupabaseClient,
-  segmentId: string,
-): Promise<{ data: SegmentConfirmContext | null; error: { message: string } | null }> {
-  const { data, error } = await supabase
-    .from('ops_segments')
-    .select(
-      'work_order_id, start_day, end_day, ' +
-        'work_order:crm_work_orders(project_name, client_name, order_number, fortnox_order_number), ' +
-        'truck:ops_trucks(name)',
-    )
-    .eq('id', segmentId)
-    .single();
-  if (error || !data) return { data: null, error: error ?? { message: 'Segmentet kunde inte hittas' } };
-
-  const row = data as Record<string, any>;
-  const wo = Array.isArray(row.work_order) ? row.work_order[0] : row.work_order;
-  const truck = Array.isArray(row.truck) ? row.truck[0] : row.truck;
-  return {
-    data: {
-      work_order_id: row.work_order_id,
-      project_name: wo?.project_name ?? '',
-      client_name: wo?.client_name ?? '',
-      order_number: wo?.order_number ?? '',
-      fortnox_order_number: wo?.fortnox_order_number ?? null,
-      start_day: row.start_day,
-      end_day: row.end_day,
-      truck_name: truck?.name ?? null,
-    },
-    error: null,
-  };
-}
-
-type RecordConfirmationInput = {
-  workOrderId: string;
-  segmentId: string;
-  channel: ConfirmationChannel;
-  recipient: string;
-  startDay: string;
-  endDay: string;
-  providerMessageId: string | null;
-  status: string | null;
-  actorUserId: string;
-};
-
-async function recordConfirmation(supabase: SupabaseClient, input: RecordConfirmationInput): Promise<void> {
-  await supabase.from('ops_work_order_confirmations').insert({
-    work_order_id: input.workOrderId,
-    segment_id: input.segmentId,
-    channel: input.channel,
-    recipient: input.recipient,
-    start_day: input.startDay,
-    end_day: input.endDay,
-    provider_message_id: input.providerMessageId,
-    status: input.status,
-    created_by: input.actorUserId,
-  });
-}
-
-export type SendConfirmationInput = {
-  segmentId: string;
-  sendEmail: boolean;
-  recipientEmail: string | null;
-  sendSms: boolean;
-  recipientPhone: string | null;
-  customMessage: string | null;
-  actorUserId: string;
-  actorName: string | null;
-};
-
-export type SendConfirmationResult = {
-  email: { sent: boolean; error: string | null };
-  sms: { sent: boolean; status: string | null; error: string | null };
-};
-
-// Build + send the requested channels, recording each successful send. Channels are independent: a
-// failure in one (e.g. SMS not configured) is returned as an error and never blocks the other.
-// Note: sendEmail is a no-op in non-production when Resend isn't configured (it logs and resolves),
-// so a dev "sent" reflects the app-wide email stub — production really sends.
-export async function sendOrderConfirmation(
-  supabase: SupabaseClient,
-  input: SendConfirmationInput,
-): Promise<{ data: SendConfirmationResult | null; error: { message: string } | null }> {
-  const { data: ctx, error: ctxErr } = await loadSegmentContext(supabase, input.segmentId);
-  if (ctxErr || !ctx) return { data: null, error: ctxErr };
-
-  // The reference the business follows: the Fortnox order number when synced, else the internal AO.
-  const orderNumber = ctx.fortnox_order_number || ctx.order_number || null;
-  const customerName = ctx.client_name || null;
-  const result: SendConfirmationResult = {
-    email: { sent: false, error: null },
-    sms: { sent: false, status: null, error: null },
-  };
-
-  if (input.sendEmail && input.recipientEmail) {
-    try {
-      const { subject, html, text } = buildPlanningNotificationEmail({
-        recipientEmail: input.recipientEmail,
-        projectName: ctx.project_name,
-        customerName,
-        orderNumber,
-        startDay: ctx.start_day,
-        endDay: ctx.end_day,
-        truck: ctx.truck_name,
-        salesResponsible: input.actorName,
-        customMessage: input.customMessage,
-      });
-      await sendEmail({ to: input.recipientEmail, subject, html, text });
-      await recordConfirmation(supabase, {
-        workOrderId: ctx.work_order_id,
-        segmentId: input.segmentId,
-        channel: 'email',
-        recipient: input.recipientEmail,
-        startDay: ctx.start_day,
-        endDay: ctx.end_day,
-        providerMessageId: null,
-        status: null,
-        actorUserId: input.actorUserId,
-      });
-      result.email.sent = true;
-    } catch (e: any) {
-      result.email.error = e?.message || 'Mejlet kunde inte skickas';
-    }
-  }
-
-  if (input.sendSms && input.recipientPhone) {
-    try {
-      const body = buildPlanningNotificationSms({
-        projectName: ctx.project_name,
-        orderNumber,
-        customerName,
-        startDay: ctx.start_day,
-        endDay: ctx.end_day,
-        truck: ctx.truck_name,
-        salesResponsible: input.actorName,
-      });
-      const res = await sendSms({ to: input.recipientPhone, body });
-      await recordConfirmation(supabase, {
-        workOrderId: ctx.work_order_id,
-        segmentId: input.segmentId,
-        channel: 'sms',
-        recipient: input.recipientPhone,
-        startDay: ctx.start_day,
-        endDay: ctx.end_day,
-        providerMessageId: res.sid,
-        status: res.status,
-        actorUserId: input.actorUserId,
-      });
-      result.sms.sent = true;
-      result.sms.status = res.status;
-    } catch (e: any) {
-      result.sms.error = e?.message || 'SMS kunde inte skickas';
-    }
-  }
-
-  return { data: result, error: null };
 }

--- a/lib/domains/planning/confirmationsSend.ts
+++ b/lib/domains/planning/confirmationsSend.ts
@@ -66,8 +66,11 @@ type RecordConfirmationInput = {
   actorUserId: string;
 };
 
-async function recordConfirmation(supabase: SupabaseClient, input: RecordConfirmationInput): Promise<void> {
-  await supabase.from('ops_work_order_confirmations').insert({
+async function recordConfirmation(
+  supabase: SupabaseClient,
+  input: RecordConfirmationInput,
+): Promise<{ error: { message: string } | null }> {
+  const { error } = await supabase.from('ops_work_order_confirmations').insert({
     work_order_id: input.workOrderId,
     segment_id: input.segmentId,
     channel: input.channel,
@@ -78,6 +81,7 @@ async function recordConfirmation(supabase: SupabaseClient, input: RecordConfirm
     status: input.status,
     created_by: input.actorUserId,
   });
+  return { error: error ?? null };
 }
 
 export type SendConfirmationInput = {
@@ -92,8 +96,10 @@ export type SendConfirmationInput = {
 };
 
 export type SendConfirmationResult = {
-  email: { sent: boolean; error: string | null };
-  sms: { sent: boolean; status: string | null; error: string | null };
+  // `recorded` is false when the message was sent but its audit row failed to persist — the caller
+  // must warn the planner NOT to re-send (the customer was already contacted, just not logged).
+  email: { sent: boolean; recorded: boolean; error: string | null };
+  sms: { sent: boolean; recorded: boolean; status: string | null; error: string | null };
 };
 
 // Build + send the requested channels, recording each successful send. Channels are independent: a
@@ -111,8 +117,8 @@ export async function sendOrderConfirmation(
   const orderNumber = ctx.fortnox_order_number || ctx.order_number || null;
   const customerName = ctx.client_name || null;
   const result: SendConfirmationResult = {
-    email: { sent: false, error: null },
-    sms: { sent: false, status: null, error: null },
+    email: { sent: false, recorded: false, error: null },
+    sms: { sent: false, recorded: false, status: null, error: null },
   };
 
   if (input.sendEmail && input.recipientEmail) {
@@ -129,7 +135,8 @@ export async function sendOrderConfirmation(
         customMessage: input.customMessage,
       });
       await sendEmail({ to: input.recipientEmail, subject, html, text });
-      await recordConfirmation(supabase, {
+      result.email.sent = true;
+      const rec = await recordConfirmation(supabase, {
         workOrderId: ctx.work_order_id,
         segmentId: input.segmentId,
         channel: 'email',
@@ -140,7 +147,11 @@ export async function sendOrderConfirmation(
         status: null,
         actorUserId: input.actorUserId,
       });
-      result.email.sent = true;
+      result.email.recorded = !rec.error;
+      if (rec.error) {
+        console.error('[planning] confirmation email sent but not recorded:', rec.error.message);
+        result.email.error = 'Skickat, men kunde inte loggas — skicka inte igen.';
+      }
     } catch (e: any) {
       result.email.error = e?.message || 'Mejlet kunde inte skickas';
     }
@@ -158,7 +169,9 @@ export async function sendOrderConfirmation(
         salesResponsible: input.actorName,
       });
       const res = await sendSms({ to: input.recipientPhone, body });
-      await recordConfirmation(supabase, {
+      result.sms.sent = true;
+      result.sms.status = res.status;
+      const rec = await recordConfirmation(supabase, {
         workOrderId: ctx.work_order_id,
         segmentId: input.segmentId,
         channel: 'sms',
@@ -169,8 +182,11 @@ export async function sendOrderConfirmation(
         status: res.status,
         actorUserId: input.actorUserId,
       });
-      result.sms.sent = true;
-      result.sms.status = res.status;
+      result.sms.recorded = !rec.error;
+      if (rec.error) {
+        console.error('[planning] confirmation SMS sent but not recorded:', rec.error.message);
+        result.sms.error = 'Skickat, men kunde inte loggas — skicka inte igen.';
+      }
     } catch (e: any) {
       result.sms.error = e?.message || 'SMS kunde inte skickas';
     }

--- a/lib/domains/planning/confirmationsSend.ts
+++ b/lib/domains/planning/confirmationsSend.ts
@@ -1,0 +1,180 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { sendEmail } from '@/lib/email';
+import { sendSms } from '@/lib/sms';
+import { buildPlanningNotificationEmail } from '@/lib/planningNotificationEmail';
+import { buildPlanningNotificationSms } from '@/lib/planningNotificationSms';
+import type { ConfirmationChannel } from './confirmations';
+
+// Server-only half of order confirmations: build the message from a scheduled job + send it via
+// Resend/Twilio + record each successful send. Kept apart from ./confirmations (the client-safe
+// summary/presentation half) so the Node-only transports never reach the browser bundle.
+
+// The job fields needed to compose a confirmation, loaded from a segment + its work order + truck.
+type SegmentConfirmContext = {
+  work_order_id: string;
+  project_name: string;
+  client_name: string;
+  order_number: string;
+  fortnox_order_number: string | null;
+  start_day: string;
+  end_day: string;
+  truck_name: string | null;
+};
+
+async function loadSegmentContext(
+  supabase: SupabaseClient,
+  segmentId: string,
+): Promise<{ data: SegmentConfirmContext | null; error: { message: string } | null }> {
+  const { data, error } = await supabase
+    .from('ops_segments')
+    .select(
+      'work_order_id, start_day, end_day, ' +
+        'work_order:crm_work_orders(project_name, client_name, order_number, fortnox_order_number), ' +
+        'truck:ops_trucks(name)',
+    )
+    .eq('id', segmentId)
+    .single();
+  if (error || !data) return { data: null, error: error ?? { message: 'Segmentet kunde inte hittas' } };
+
+  const row = data as Record<string, any>;
+  const wo = Array.isArray(row.work_order) ? row.work_order[0] : row.work_order;
+  const truck = Array.isArray(row.truck) ? row.truck[0] : row.truck;
+  return {
+    data: {
+      work_order_id: row.work_order_id,
+      project_name: wo?.project_name ?? '',
+      client_name: wo?.client_name ?? '',
+      order_number: wo?.order_number ?? '',
+      fortnox_order_number: wo?.fortnox_order_number ?? null,
+      start_day: row.start_day,
+      end_day: row.end_day,
+      truck_name: truck?.name ?? null,
+    },
+    error: null,
+  };
+}
+
+type RecordConfirmationInput = {
+  workOrderId: string;
+  segmentId: string;
+  channel: ConfirmationChannel;
+  recipient: string;
+  startDay: string;
+  endDay: string;
+  providerMessageId: string | null;
+  status: string | null;
+  actorUserId: string;
+};
+
+async function recordConfirmation(supabase: SupabaseClient, input: RecordConfirmationInput): Promise<void> {
+  await supabase.from('ops_work_order_confirmations').insert({
+    work_order_id: input.workOrderId,
+    segment_id: input.segmentId,
+    channel: input.channel,
+    recipient: input.recipient,
+    start_day: input.startDay,
+    end_day: input.endDay,
+    provider_message_id: input.providerMessageId,
+    status: input.status,
+    created_by: input.actorUserId,
+  });
+}
+
+export type SendConfirmationInput = {
+  segmentId: string;
+  sendEmail: boolean;
+  recipientEmail: string | null;
+  sendSms: boolean;
+  recipientPhone: string | null;
+  customMessage: string | null;
+  actorUserId: string;
+  actorName: string | null;
+};
+
+export type SendConfirmationResult = {
+  email: { sent: boolean; error: string | null };
+  sms: { sent: boolean; status: string | null; error: string | null };
+};
+
+// Build + send the requested channels, recording each successful send. Channels are independent: a
+// failure in one (e.g. SMS not configured) is returned as an error and never blocks the other.
+// Note: sendEmail is a no-op in non-production when Resend isn't configured (it logs and resolves),
+// so a dev "sent" reflects the app-wide email stub — production really sends.
+export async function sendOrderConfirmation(
+  supabase: SupabaseClient,
+  input: SendConfirmationInput,
+): Promise<{ data: SendConfirmationResult | null; error: { message: string } | null }> {
+  const { data: ctx, error: ctxErr } = await loadSegmentContext(supabase, input.segmentId);
+  if (ctxErr || !ctx) return { data: null, error: ctxErr };
+
+  // The reference the business follows: the Fortnox order number when synced, else the internal AO.
+  const orderNumber = ctx.fortnox_order_number || ctx.order_number || null;
+  const customerName = ctx.client_name || null;
+  const result: SendConfirmationResult = {
+    email: { sent: false, error: null },
+    sms: { sent: false, status: null, error: null },
+  };
+
+  if (input.sendEmail && input.recipientEmail) {
+    try {
+      const { subject, html, text } = buildPlanningNotificationEmail({
+        recipientEmail: input.recipientEmail,
+        projectName: ctx.project_name,
+        customerName,
+        orderNumber,
+        startDay: ctx.start_day,
+        endDay: ctx.end_day,
+        truck: ctx.truck_name,
+        salesResponsible: input.actorName,
+        customMessage: input.customMessage,
+      });
+      await sendEmail({ to: input.recipientEmail, subject, html, text });
+      await recordConfirmation(supabase, {
+        workOrderId: ctx.work_order_id,
+        segmentId: input.segmentId,
+        channel: 'email',
+        recipient: input.recipientEmail,
+        startDay: ctx.start_day,
+        endDay: ctx.end_day,
+        providerMessageId: null,
+        status: null,
+        actorUserId: input.actorUserId,
+      });
+      result.email.sent = true;
+    } catch (e: any) {
+      result.email.error = e?.message || 'Mejlet kunde inte skickas';
+    }
+  }
+
+  if (input.sendSms && input.recipientPhone) {
+    try {
+      const body = buildPlanningNotificationSms({
+        projectName: ctx.project_name,
+        orderNumber,
+        customerName,
+        startDay: ctx.start_day,
+        endDay: ctx.end_day,
+        truck: ctx.truck_name,
+        salesResponsible: input.actorName,
+      });
+      const res = await sendSms({ to: input.recipientPhone, body });
+      await recordConfirmation(supabase, {
+        workOrderId: ctx.work_order_id,
+        segmentId: input.segmentId,
+        channel: 'sms',
+        recipient: input.recipientPhone,
+        startDay: ctx.start_day,
+        endDay: ctx.end_day,
+        providerMessageId: res.sid,
+        status: res.status,
+        actorUserId: input.actorUserId,
+      });
+      result.sms.sent = true;
+      result.sms.status = res.status;
+    } catch (e: any) {
+      result.sms.error = e?.message || 'SMS kunde inte skickas';
+    }
+  }
+
+  return { data: result, error: null };
+}

--- a/lib/domains/planning/crew.ts
+++ b/lib/domains/planning/crew.ts
@@ -1,0 +1,102 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+// Per-segment crew (besättning) for the CRM-first planning. A crew member's display name is
+// denormalised onto the row (member_name) because profiles SELECT RLS is self-only — the planner
+// can't read other people's profile rows, so the board renders entirely from ops_segment_crew
+// without ever joining profiles. member_id is kept (nullable) for future installer / "my jobs"
+// linking. Pure helpers here are unit-tested; the DB functions are thin RLS-scoped queries.
+
+// A crew member as rendered on a job card.
+export type CrewMember = {
+  id: string; // ops_segment_crew row id
+  member_id: string | null;
+  member_name: string;
+};
+
+// A person the planner can pick from (any employee with a name — installers included). Sourced via
+// the admin client because session RLS hides other profiles.
+export type AssignablePerson = {
+  id: string;
+  full_name: string;
+};
+
+// Initials for an avatar chip: first letter of the first + last name token; a single token gives
+// its first two letters; empty falls back to '?'.
+export function crewInitials(name: string): string {
+  const parts = name.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return '?';
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+}
+
+// Muted avatar palette that sits inside the sage/paper CRM system.
+const CREW_COLORS = ['#3f6f52', '#5a7d9a', '#9a6f4e', '#7a6a9c', '#a05c6b', '#4f8a82', '#8a7a4e', '#6b7280'];
+
+// Deterministic colour for a crew member, keyed by their id/name so a person reads the same colour
+// everywhere on the board (no Math.random — must be stable across renders/runs).
+export function crewColor(seed: string): string {
+  let hash = 0;
+  for (let i = 0; i < seed.length; i++) hash = (hash * 31 + seed.charCodeAt(i)) | 0;
+  return CREW_COLORS[Math.abs(hash) % CREW_COLORS.length];
+}
+
+// Pure validation for a crew assignment. A name is always required (it's the durable display value).
+export function validateCrewAssignment(memberName: string): 'invalid_name' | null {
+  return memberName.trim().length > 0 ? null : 'invalid_name';
+}
+
+type RawCrew = { id: string; segment_id: string; member_id: string | null; member_name: string };
+
+// Crew rows grouped by segment id, for a set of segments. RLS (planning.schedule.read) applies.
+export async function listCrewBySegment(
+  supabase: SupabaseClient,
+  segmentIds: string[],
+): Promise<Map<string, CrewMember[]>> {
+  const map = new Map<string, CrewMember[]>();
+  if (segmentIds.length === 0) return map;
+  const { data } = await supabase
+    .from('ops_segment_crew')
+    .select('id, segment_id, member_id, member_name')
+    .in('segment_id', segmentIds)
+    .order('member_name', { ascending: true });
+  for (const r of (data ?? []) as RawCrew[]) {
+    const list = map.get(r.segment_id) ?? [];
+    list.push({ id: r.id, member_id: r.member_id, member_name: r.member_name });
+    map.set(r.segment_id, list);
+  }
+  return map;
+}
+
+export type AssignCrewInput = {
+  segmentId: string;
+  memberId: string | null;
+  memberName: string;
+  actorUserId: string;
+};
+
+// created_by must equal the caller (RLS insert policy checks created_by = auth.uid()).
+export async function assignCrew(
+  supabase: SupabaseClient,
+  input: AssignCrewInput,
+): Promise<{ data: CrewMember | null; error: { message: string } | null }> {
+  const { data, error } = await supabase
+    .from('ops_segment_crew')
+    .insert({
+      segment_id: input.segmentId,
+      member_id: input.memberId,
+      member_name: input.memberName,
+      created_by: input.actorUserId,
+    })
+    .select('id, segment_id, member_id, member_name')
+    .single();
+  const row = data as RawCrew | null;
+  return {
+    data: row ? { id: row.id, member_id: row.member_id, member_name: row.member_name } : null,
+    error,
+  };
+}
+
+// Remove a crew member from a segment (by the person, since (segment_id, member_id) is unique).
+export async function unassignCrew(supabase: SupabaseClient, segmentId: string, memberId: string) {
+  return supabase.from('ops_segment_crew').delete().eq('segment_id', segmentId).eq('member_id', memberId);
+}

--- a/lib/domains/planning/dayNotes.ts
+++ b/lib/domains/planning/dayNotes.ts
@@ -1,0 +1,72 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+// Day notes (dagsanteckningar): free-text notes pinned to a calendar day on the board. Pure helpers
+// here are unit-tested; the DB functions are thin RLS-scoped queries (planning.schedule.*).
+
+export type DayNote = {
+  id: string;
+  note_day: string; // 'YYYY-MM-DD'
+  body: string;
+  created_by: string | null;
+};
+
+export const MAX_NOTE_LENGTH = 500;
+
+// Pure validation for a note body.
+export function validateNoteBody(body: string): 'empty' | 'too_long' | null {
+  const trimmed = body.trim();
+  if (!trimmed) return 'empty';
+  if (trimmed.length > MAX_NOTE_LENGTH) return 'too_long';
+  return null;
+}
+
+// Pure: group notes by their day (oldest first within a day, matching insert order).
+export function groupNotesByDay(notes: DayNote[]): Map<string, DayNote[]> {
+  const map = new Map<string, DayNote[]>();
+  for (const n of notes) {
+    const list = map.get(n.note_day) ?? [];
+    list.push(n);
+    map.set(n.note_day, list);
+  }
+  return map;
+}
+
+const NOTE_SELECT = 'id, note_day, body, created_by';
+
+// Notes whose day falls in [from, to]. RLS (planning.schedule.read) applies.
+export async function listDayNotes(
+  supabase: SupabaseClient,
+  range: { from: string; to: string },
+): Promise<{ data: DayNote[]; error: { message: string } | null }> {
+  const { data, error } = await supabase
+    .from('ops_day_notes')
+    .select(NOTE_SELECT)
+    .gte('note_day', range.from)
+    .lte('note_day', range.to)
+    .order('note_day', { ascending: true })
+    .order('created_at', { ascending: true });
+  return { data: (data ?? []) as DayNote[], error };
+}
+
+export type CreateDayNoteInput = {
+  noteDay: string;
+  body: string;
+  actorUserId: string;
+};
+
+// created_by must equal the caller (RLS insert policy checks created_by = auth.uid()).
+export async function createDayNote(
+  supabase: SupabaseClient,
+  input: CreateDayNoteInput,
+): Promise<{ data: DayNote | null; error: { message: string } | null }> {
+  const { data, error } = await supabase
+    .from('ops_day_notes')
+    .insert({ note_day: input.noteDay, body: input.body.trim(), created_by: input.actorUserId })
+    .select(NOTE_SELECT)
+    .single();
+  return { data: (data as DayNote) ?? null, error };
+}
+
+export async function deleteDayNote(supabase: SupabaseClient, id: string) {
+  return supabase.from('ops_day_notes').delete().eq('id', id);
+}

--- a/lib/domains/planning/depotStock.ts
+++ b/lib/domains/planning/depotStock.ts
@@ -1,0 +1,139 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { materialShortFromLineItems } from '@/lib/domains/crm/materials';
+
+// Depot stock (slice 12b): per-material balance per depot = sum(deliveries) − consumption, where
+// consumption is derived from ops_segment_reports (a job's blown sacks → its segment's truck → that
+// truck's depot, attributed to the work order's material). Pure computeDepotBalances is unit-tested;
+// the DB functions are thin RLS-scoped reads/writes.
+
+export type StockRow = { depot_id: string; material: string; sacks: number };
+
+export type DepotMaterialBalance = {
+  material: string;
+  delivered: number;
+  consumed: number;
+  balance: number;
+};
+
+export type DepotBalance = {
+  depot_id: string;
+  depot_name: string;
+  rows: DepotMaterialBalance[];
+  total_balance: number;
+};
+
+// Pure: combine delivered + consumed rows into a per-depot, per-material balance. A material appears
+// for a depot if it has any delivery or any consumption there. Depots are returned in input order;
+// material rows are sorted alphabetically.
+export function computeDepotBalances(
+  depots: { id: string; name: string }[],
+  delivered: StockRow[],
+  consumed: StockRow[],
+): DepotBalance[] {
+  // depot_id -> material -> { delivered, consumed }
+  const acc = new Map<string, Map<string, { delivered: number; consumed: number }>>();
+  const ensure = (depotId: string, material: string) => {
+    let byMat = acc.get(depotId);
+    if (!byMat) {
+      byMat = new Map();
+      acc.set(depotId, byMat);
+    }
+    let cell = byMat.get(material);
+    if (!cell) {
+      cell = { delivered: 0, consumed: 0 };
+      byMat.set(material, cell);
+    }
+    return cell;
+  };
+  for (const r of delivered) ensure(r.depot_id, r.material).delivered += r.sacks;
+  for (const r of consumed) ensure(r.depot_id, r.material).consumed += r.sacks;
+
+  return depots.map((d) => {
+    const byMat = acc.get(d.id);
+    const rows: DepotMaterialBalance[] = byMat
+      ? [...byMat.entries()]
+          .map(([material, cell]) => ({
+            material,
+            delivered: cell.delivered,
+            consumed: cell.consumed,
+            balance: cell.delivered - cell.consumed,
+          }))
+          .sort((a, b) => a.material.localeCompare(b.material, 'sv'))
+      : [];
+    return {
+      depot_id: d.id,
+      depot_name: d.name,
+      rows,
+      total_balance: rows.reduce((sum, r) => sum + r.balance, 0),
+    };
+  });
+}
+
+// Raw delivery stock rows (one per delivery; computeDepotBalances aggregates).
+async function listDeliveryRows(supabase: SupabaseClient): Promise<StockRow[]> {
+  const { data } = await supabase.from('ops_depot_deliveries').select('depot_id, material, sacks');
+  return ((data ?? []) as Array<{ depot_id: string; material: string; sacks: number | string }>).map((r) => ({
+    depot_id: r.depot_id,
+    material: r.material,
+    sacks: Number(r.sacks),
+  }));
+}
+
+// Consumption stock rows derived from sack reports: blown sacks → segment's truck → truck's depot,
+// attributed to the work order's material. Empty until the installer reporting flow populates
+// ops_segment_reports.
+async function deriveConsumptionRows(supabase: SupabaseClient): Promise<StockRow[]> {
+  const { data: trucks } = await supabase.from('ops_trucks').select('id, depot_id');
+  const truckDepot = new Map((trucks ?? []).map((t: any) => [t.id as string, (t.depot_id as string | null) ?? null]));
+
+  const { data: reports } = await supabase
+    .from('ops_segment_reports')
+    .select('sacks_blown, segment:ops_segments(truck_id), work_order:crm_work_orders(line_items)');
+
+  const rows: StockRow[] = [];
+  for (const r of (reports ?? []) as Array<Record<string, any>>) {
+    const seg = Array.isArray(r.segment) ? r.segment[0] : r.segment;
+    const wo = Array.isArray(r.work_order) ? r.work_order[0] : r.work_order;
+    const depotId = seg ? truckDepot.get(seg.truck_id) : null;
+    const material = materialShortFromLineItems(wo?.line_items);
+    if (depotId && material) rows.push({ depot_id: depotId, material, sacks: Number(r.sacks_blown) });
+  }
+  return rows;
+}
+
+// Per-depot, per-material balances for the stock view. RLS (planning.schedule.read) applies.
+export async function getDepotStock(supabase: SupabaseClient): Promise<{ data: DepotBalance[]; error: { message: string } | null }> {
+  const { data: depots, error } = await supabase.from('ops_depots').select('id, name').order('name', { ascending: true });
+  if (error) return { data: [], error };
+
+  const [delivered, consumed] = await Promise.all([listDeliveryRows(supabase), deriveConsumptionRows(supabase)]);
+  return {
+    data: computeDepotBalances((depots ?? []) as { id: string; name: string }[], delivered, consumed),
+    error: null,
+  };
+}
+
+export type CreateDeliveryInput = {
+  depotId: string;
+  material: string;
+  sacks: number;
+  deliveredOn: string;
+  note: string | null;
+  actorUserId: string;
+};
+
+// created_by must equal the caller (RLS insert policy checks created_by = auth.uid()).
+export async function createDelivery(supabase: SupabaseClient, input: CreateDeliveryInput) {
+  return supabase
+    .from('ops_depot_deliveries')
+    .insert({
+      depot_id: input.depotId,
+      material: input.material,
+      sacks: input.sacks,
+      delivered_on: input.deliveredOn,
+      note: input.note,
+      created_by: input.actorUserId,
+    })
+    .select('id, depot_id, material, sacks, delivered_on, note')
+    .single();
+}

--- a/lib/domains/planning/depotStock.ts
+++ b/lib/domains/planning/depotStock.ts
@@ -82,6 +82,15 @@ async function listDeliveryRows(supabase: SupabaseClient): Promise<StockRow[]> {
 // Consumption stock rows derived from sack reports: blown sacks → segment's truck → truck's depot,
 // attributed to the work order's material. Empty until the installer reporting flow populates
 // ops_segment_reports.
+//
+// ⚠️ KNOWN LIMITATIONS — revisit when wiring the installer sack-reporting flow (currently dormant
+// because there are no reports yet):
+//   1. materialShortFromLineItems returns only the FIRST recognised material, so a work order with
+//      two materials debits all its blown sacks from that one material. A faithful split needs the
+//      report (or line items) to carry sacks-per-material, which the reporting model must define.
+//   2. A segment whose truck has depot_id = null is silently skipped (`if (depotId && material)`),
+//      so those blown sacks are never subtracted from any depot. Decide where un-depoted consumption
+//      lands (a default depot? surfaced as a warning?) once trucks-without-depots is a real case.
 async function deriveConsumptionRows(supabase: SupabaseClient): Promise<StockRow[]> {
   const { data: trucks } = await supabase.from('ops_trucks').select('id, depot_id');
   const truckDepot = new Map((trucks ?? []).map((t: any) => [t.id as string, (t.depot_id as string | null) ?? null]));

--- a/lib/domains/planning/depots.ts
+++ b/lib/domains/planning/depots.ts
@@ -1,0 +1,63 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { OpsDepot } from './types';
+
+// Depot (depå) administration. A depot is a physical store of insulation sacks; each truck belongs
+// to one (ops_trucks.depot_id). Reading is board-level (planning.schedule.read); managing is
+// planning.depot.manage. Deliveries + per-material balances live in ./depotStock (slice 12b).
+
+// Pure validation for a depot.
+export function validateDepot(name: string): 'name_required' | 'name_too_long' | null {
+  const n = name.trim();
+  if (!n) return 'name_required';
+  if (n.length > 80) return 'name_too_long';
+  return null;
+}
+
+const DEPOT_SELECT = 'id, name, location, active';
+
+// All depots (incl inactive) for the manage panel + truck depot pickers.
+export async function listAllDepots(supabase: SupabaseClient) {
+  return supabase.from('ops_depots').select(DEPOT_SELECT).order('name', { ascending: true });
+}
+
+export async function createDepot(
+  supabase: SupabaseClient,
+  input: { name: string; location: string | null },
+): Promise<{ data: OpsDepot | null; error: { message: string } | null }> {
+  const { data, error } = await supabase
+    .from('ops_depots')
+    .insert({ name: input.name.trim(), location: input.location })
+    .select(DEPOT_SELECT)
+    .single();
+  return { data: (data as OpsDepot) ?? null, error };
+}
+
+export type UpdateDepotInput = {
+  name?: string;
+  location?: string | null;
+  active?: boolean;
+};
+
+export async function updateDepot(
+  supabase: SupabaseClient,
+  id: string,
+  patch: UpdateDepotInput,
+): Promise<{ data: OpsDepot | null; error: { message: string } | null }> {
+  const update: Record<string, unknown> = {};
+  if (patch.name !== undefined) update.name = patch.name.trim();
+  if (patch.location !== undefined) update.location = patch.location;
+  if (patch.active !== undefined) update.active = patch.active;
+
+  const { data, error } = await supabase
+    .from('ops_depots')
+    .update(update)
+    .eq('id', id)
+    .select(DEPOT_SELECT)
+    .single();
+  return { data: (data as OpsDepot) ?? null, error };
+}
+
+// Delete a depot. Trucks referencing it are ON DELETE SET NULL, so they simply lose their depot.
+export async function deleteDepot(supabase: SupabaseClient, id: string) {
+  return supabase.from('ops_depots').delete().eq('id', id);
+}

--- a/lib/domains/planning/display.ts
+++ b/lib/domains/planning/display.ts
@@ -1,0 +1,88 @@
+import { inferMaterialFromArticle, totalSacks } from '@/lib/domains/crm/materials';
+
+// Shared, pure display mapping for a CRM work order shown in the planning board — used by both
+// the backlog read model and the scheduled-segment read model so a job looks identical wherever
+// it appears (same reference, address, sacks, material).
+
+// The raw crm_work_orders columns the planning board reads.
+export type WorkOrderJobRow = {
+  order_number: string;
+  fortnox_order_number?: string | null;
+  project_name: string;
+  client_name: string;
+  status: string;
+  customer_snapshot?: Record<string, unknown> | null;
+  work_address?: Record<string, unknown> | null;
+  line_items?: unknown[] | null;
+};
+
+export type JobDisplay = {
+  // Reference shown on cards: the Fortnox order number when synced (e.g. "#5418"), else the
+  // internal order number. The number the business follows is the Fortnox one.
+  ref: string;
+  is_fortnox_ref: boolean;
+  project_name: string;
+  client_name: string;
+  status: string;
+  address: string | null;
+  total_sacks: number;
+  material: string | null;
+};
+
+function str(value: unknown): string {
+  return value == null ? '' : String(value).trim();
+}
+
+function joinAddress(parts: unknown[]): string | null {
+  const cleaned = parts.map(str).filter(Boolean);
+  return cleaned.length ? cleaned.join(', ') : null;
+}
+
+// Lead with the Fortnox order number when present (the reference the business follows), else fall
+// back to the internal order number. Mirrors documentRef used across the CRM.
+export function workOrderRef(fortnoxOrderNumber: string | null | undefined, orderNumber: string): { ref: string; isFortnox: boolean } {
+  const fx = str(fortnoxOrderNumber);
+  return fx ? { ref: `#${fx}`, isFortnox: true } : { ref: orderNumber, isFortnox: false };
+}
+
+// The job-site address: a separate work address when stored (only persisted when it differs from
+// the customer address), else a separate delivery address on the snapshot, else the customer's
+// card address. Mirrors how the order itself resolves the work address.
+export function resolveJobAddress(
+  workAddress: Record<string, unknown> | null | undefined,
+  snapshot: Record<string, unknown> | null | undefined,
+): string | null {
+  const wa = workAddress ?? {};
+  if (str(wa.street_address)) return joinAddress([wa.street_address, wa.postal_code, wa.city]);
+  const snap = snapshot ?? {};
+  if (str(snap.delivery_address)) return joinAddress([snap.delivery_address, snap.delivery_postal_code, snap.delivery_city]);
+  return joinAddress([snap.street_address, snap.postal_code, snap.city]);
+}
+
+// Best-effort material label from the line items (the insulation the job uses, e.g. "Ekovilla"),
+// derived from the article names. Returns null when no known material is recognised. An explicit
+// per-segment job type (Leverans/Utsugning/…) is a later slice.
+export function materialLabelFromLineItems(lineItems: unknown[] | null | undefined): string | null {
+  if (!Array.isArray(lineItems)) return null;
+  for (const it of lineItems) {
+    const name = (it as { article_name?: string | null })?.article_name;
+    const m = inferMaterialFromArticle(name);
+    if (m) return m.short.toLowerCase().replace(/\b\w/g, (c) => c.toUpperCase());
+  }
+  return null;
+}
+
+// Map a crm_work_orders row to the shared display fields shown on a planning card.
+export function mapWorkOrderJob(row: WorkOrderJobRow): JobDisplay {
+  const { ref, isFortnox } = workOrderRef(row.fortnox_order_number, row.order_number);
+  return {
+    ref,
+    is_fortnox_ref: isFortnox,
+    project_name: row.project_name,
+    client_name: row.client_name,
+    status: row.status,
+    address: resolveJobAddress(row.work_address, row.customer_snapshot),
+    total_sacks: totalSacks((row.line_items ?? []) as never),
+    material: materialLabelFromLineItems(row.line_items),
+  };
+}

--- a/lib/domains/planning/holidays.ts
+++ b/lib/domains/planning/holidays.ts
@@ -1,0 +1,90 @@
+// Swedish public holidays (röda dagar) — pure, no deps. Used to shade holiday columns/cells on the
+// board. Fixed-date holidays + Easter-derived moving ones (Computus) + the big de-facto eves
+// (Julafton / Midsommarafton / Nyårsafton) which are non-working in practice.
+
+function pad(n: number): string {
+  return n < 10 ? `0${n}` : `${n}`;
+}
+
+// Anonymous Gregorian algorithm — Easter Sunday for a (Gregorian) year.
+function easterSunday(year: number): { month: number; day: number } {
+  const a = year % 19;
+  const b = Math.floor(year / 100);
+  const c = year % 100;
+  const d = Math.floor(b / 4);
+  const e = b % 4;
+  const f = Math.floor((b + 8) / 25);
+  const g = Math.floor((b - f + 1) / 3);
+  const h = (19 * a + b - d - g + 15) % 30;
+  const i = Math.floor(c / 4);
+  const k = c % 4;
+  const l = (32 + 2 * e + 2 * i - h - k) % 7;
+  const m = Math.floor((a + 11 * h + 22 * l) / 451);
+  const month = Math.floor((h + l - 7 * m + 114) / 31);
+  const day = ((h + l - 7 * m + 114) % 31) + 1;
+  return { month, day };
+}
+
+// Shift an ISO date by whole days (UTC-safe).
+function addDays(iso: string, days: number): string {
+  const d = new Date(`${iso}T00:00:00Z`);
+  d.setUTCDate(d.getUTCDate() + days);
+  return d.toISOString().slice(0, 10);
+}
+
+// The first date with the given weekday (0=Sun…6=Sat) within [startISO, endISO].
+function weekdayInRange(startISO: string, endISO: string, weekday: number): string {
+  let cur = startISO;
+  while (cur <= endISO) {
+    if (new Date(`${cur}T00:00:00Z`).getUTCDay() === weekday) return cur;
+    cur = addDays(cur, 1);
+  }
+  return startISO;
+}
+
+const cache = new Map<number, Map<string, string>>();
+
+function buildYear(year: number): Map<string, string> {
+  const map = new Map<string, string>();
+  const md = (m: number, day: number) => `${year}-${pad(m)}-${pad(day)}`;
+  const set = (iso: string, name: string) => map.set(iso, name);
+
+  // Fixed-date red days (+ de-facto eves).
+  set(md(1, 1), 'Nyårsdagen');
+  set(md(1, 6), 'Trettondedag jul');
+  set(md(5, 1), 'Första maj');
+  set(md(6, 6), 'Sveriges nationaldag');
+  set(md(12, 24), 'Julafton');
+  set(md(12, 25), 'Juldagen');
+  set(md(12, 26), 'Annandag jul');
+  set(md(12, 31), 'Nyårsafton');
+
+  // Easter-derived.
+  const e = easterSunday(year);
+  const easter = md(e.month, e.day);
+  set(addDays(easter, -2), 'Långfredagen');
+  set(easter, 'Påskdagen');
+  set(addDays(easter, 1), 'Annandag påsk');
+  set(addDays(easter, 39), 'Kristi himmelsfärds dag');
+  set(addDays(easter, 49), 'Pingstdagen');
+
+  // Midsummer (Sat 20–26 Jun, eve the Fri before) + All Saints' (Sat 31 Oct–6 Nov).
+  const midsummer = weekdayInRange(md(6, 20), md(6, 26), 6);
+  set(midsummer, 'Midsommardagen');
+  set(addDays(midsummer, -1), 'Midsommarafton');
+  set(weekdayInRange(md(10, 31), md(11, 6), 6), 'Alla helgons dag');
+
+  return map;
+}
+
+// The Swedish holiday name for an ISO date ('YYYY-MM-DD'), or null on an ordinary day.
+export function swedishHoliday(iso: string): string | null {
+  const year = Number(iso.slice(0, 4));
+  if (!Number.isInteger(year)) return null;
+  let y = cache.get(year);
+  if (!y) {
+    y = buildYear(year);
+    cache.set(year, y);
+  }
+  return y.get(iso) ?? null;
+}

--- a/lib/domains/planning/jobTypes.ts
+++ b/lib/domains/planning/jobTypes.ts
@@ -1,0 +1,23 @@
+// Fixed planning job types and their card colour. Stored as ops_segments.job_type (free text;
+// the app offers this set). `color` is a CSS colour used for the card's job-type dot/chip.
+
+export type JobType = { key: string; label: string; color: string };
+
+export const JOB_TYPES: JobType[] = [
+  { key: 'ekovilla', label: 'Ekovilla', color: '#059669' }, // emerald
+  { key: 'vitull', label: 'Vitull', color: '#0284c7' }, // sky
+  { key: 'leverans', label: 'Leverans', color: '#0d9488' }, // teal
+  { key: 'utsugning', label: 'Utsugning', color: '#d97706' }, // amber
+  { key: 'snickerier', label: 'Snickerier', color: '#7c3aed' }, // violet
+  { key: 'ovrigt', label: 'Övrigt', color: '#64748b' }, // slate
+];
+
+const BY_KEY = new Map(JOB_TYPES.map((t) => [t.key, t]));
+
+// Resolve a stored job_type to its label + colour. Empty → null (the caller falls back to the
+// material inferred from the work order). An unknown key still renders, in a neutral colour.
+export function resolveJobType(jobType: string | null | undefined): JobType | null {
+  const key = (jobType ?? '').trim().toLowerCase();
+  if (!key) return null;
+  return BY_KEY.get(key) ?? { key, label: (jobType ?? '').trim(), color: '#64748b' };
+}

--- a/lib/domains/planning/jobTypes.ts
+++ b/lib/domains/planning/jobTypes.ts
@@ -1,9 +1,13 @@
-// Fixed planning job types and their card colour. Stored as ops_segments.job_type (free text;
-// the app offers this set). `color` is a CSS colour used for the card's job-type dot/chip.
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+// Planning job types + their card colour. Admin-editable (ops_job_types); ops_segments.job_type
+// stores the stable `key`. The runtime list is fetched from the DB; DEFAULT_JOB_TYPES is both the
+// seed set and the fallback before the list loads. Pure helpers are unit-tested.
 
 export type JobType = { key: string; label: string; color: string };
+export type JobTypeRow = JobType & { id: string; sort_index: number; active: boolean };
 
-export const JOB_TYPES: JobType[] = [
+export const DEFAULT_JOB_TYPES: JobType[] = [
   { key: 'ekovilla', label: 'Ekovilla', color: '#059669' }, // emerald
   { key: 'vitull', label: 'Vitull', color: '#0284c7' }, // sky
   { key: 'leverans', label: 'Leverans', color: '#0d9488' }, // teal
@@ -12,12 +16,84 @@ export const JOB_TYPES: JobType[] = [
   { key: 'ovrigt', label: 'Övrigt', color: '#64748b' }, // slate
 ];
 
-const BY_KEY = new Map(JOB_TYPES.map((t) => [t.key, t]));
+// Resolve a stored job_type key against a list. Empty → null (the caller falls back to the material
+// inferred from the work order). An unknown key still renders, in a neutral colour, labelled by the
+// raw key (e.g. a type that was later deleted).
+export function resolveJobTypeFrom(types: JobType[], jobType: string | null | undefined): JobType | null {
+  const raw = (jobType ?? '').trim();
+  if (!raw) return null;
+  const key = raw.toLowerCase();
+  return types.find((t) => t.key.toLowerCase() === key) ?? { key, label: raw, color: '#64748b' };
+}
 
-// Resolve a stored job_type to its label + colour. Empty → null (the caller falls back to the
-// material inferred from the work order). An unknown key still renders, in a neutral colour.
-export function resolveJobType(jobType: string | null | undefined): JobType | null {
-  const key = (jobType ?? '').trim().toLowerCase();
-  if (!key) return null;
-  return BY_KEY.get(key) ?? { key, label: (jobType ?? '').trim(), color: '#64748b' };
+const HEX_RE = /^#[0-9a-fA-F]{6}$/;
+
+// Pure validation for a job type.
+export function validateJobType(label: string, color: string): 'label_required' | 'label_too_long' | 'bad_color' | null {
+  const l = label.trim();
+  if (!l) return 'label_required';
+  if (l.length > 40) return 'label_too_long';
+  if (!HEX_RE.test(color)) return 'bad_color';
+  return null;
+}
+
+// A stable key derived from a label (lowercase ascii slug). Used when creating a new type; the key
+// is never edited afterwards so existing ops_segments keep resolving.
+export function slugifyJobType(label: string): string {
+  const slug = label
+    .trim()
+    .toLowerCase()
+    .replace(/[åä]/g, 'a')
+    .replace(/ö/g, 'o')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 40);
+  return slug || 'typ';
+}
+
+const SELECT = 'id, key, label, color, sort_index, active';
+
+// All job types (incl inactive) ordered for the picker + admin panel. RLS (schedule.read) applies.
+export async function listJobTypes(supabase: SupabaseClient) {
+  return supabase.from('ops_job_types').select(SELECT).order('sort_index', { ascending: true }).order('label', { ascending: true });
+}
+
+export async function createJobType(
+  supabase: SupabaseClient,
+  input: { label: string; color: string },
+): Promise<{ data: JobTypeRow | null; error: { message: string } | null }> {
+  const { data, error } = await supabase
+    .from('ops_job_types')
+    .insert({ key: slugifyJobType(input.label), label: input.label.trim(), color: input.color })
+    .select(SELECT)
+    .single();
+  return { data: (data as JobTypeRow) ?? null, error };
+}
+
+export type UpdateJobTypeInput = {
+  label?: string;
+  color?: string;
+  active?: boolean;
+  sortIndex?: number;
+};
+
+// key is never updated (stable identity for ops_segments.job_type).
+export async function updateJobType(
+  supabase: SupabaseClient,
+  id: string,
+  patch: UpdateJobTypeInput,
+): Promise<{ data: JobTypeRow | null; error: { message: string } | null }> {
+  const update: Record<string, unknown> = {};
+  if (patch.label !== undefined) update.label = patch.label.trim();
+  if (patch.color !== undefined) update.color = patch.color;
+  if (patch.active !== undefined) update.active = patch.active;
+  if (patch.sortIndex !== undefined) update.sort_index = patch.sortIndex;
+
+  const { data, error } = await supabase.from('ops_job_types').update(update).eq('id', id).select(SELECT).single();
+  return { data: (data as JobTypeRow) ?? null, error };
+}
+
+// Delete a job type. Segments still carrying its key keep the key and resolve to a neutral chip.
+export async function deleteJobType(supabase: SupabaseClient, id: string) {
+  return supabase.from('ops_job_types').delete().eq('id', id);
 }

--- a/lib/domains/planning/order.ts
+++ b/lib/domains/planning/order.ts
@@ -1,0 +1,39 @@
+// Ordering of jobs that share a truck on the same day ("which job is done first"). The order is
+// carried by ops_segments.sort_index; these pure helpers compute a segment's position in its
+// truck+day group and the sort_index changes needed to nudge it earlier/later. Unit-tested.
+
+type Orderable = { id: string; truck_id: string; start_day: string; sort_index: number };
+
+// Segments sharing the same truck AND start day, ordered as shown on the board
+// (sort_index, then id as a stable tiebreak).
+export function dayGroup<T extends Orderable>(segments: T[], seg: Pick<Orderable, 'truck_id' | 'start_day'>): T[] {
+  return segments
+    .filter((s) => s.truck_id === seg.truck_id && s.start_day === seg.start_day)
+    .sort((a, b) => a.sort_index - b.sort_index || a.id.localeCompare(b.id));
+}
+
+export type OrderInfo = { index: number; total: number };
+
+// A segment's 1-based-friendly position (0-based index) within its truck+day group.
+export function orderInfo<T extends Orderable>(segments: T[], seg: T): OrderInfo {
+  const group = dayGroup(segments, seg);
+  return { index: group.findIndex((s) => s.id === seg.id), total: group.length };
+}
+
+// The sort_index updates needed to move `segId` one step earlier ('up') or later ('down') within
+// its group. Renumbers the affected members to 0..n so positions are always distinct (the seeded
+// default of 0 everywhere would otherwise make a swap a no-op). Returns only the rows that change.
+export function reorderWithinGroup<T extends Orderable>(
+  group: T[],
+  segId: string,
+  direction: 'up' | 'down',
+): { id: string; sort_index: number }[] {
+  const idx = group.findIndex((s) => s.id === segId);
+  const target = direction === 'up' ? idx - 1 : idx + 1;
+  if (idx < 0 || target < 0 || target >= group.length) return [];
+  const ids = group.map((s) => s.id);
+  [ids[idx], ids[target]] = [ids[target], ids[idx]];
+  return ids
+    .map((id, i) => ({ id, sort_index: i }))
+    .filter((next) => group.find((s) => s.id === next.id)!.sort_index !== next.sort_index);
+}

--- a/lib/domains/planning/reports.ts
+++ b/lib/domains/planning/reports.ts
@@ -14,6 +14,12 @@ export function sacksRemaining(planned: number, blown: number): number {
   return Math.max(0, planned - blown);
 }
 
+// Sacks blown beyond plan (overrun), floored at 0. Drives the "över N" warning when installers
+// report more sacks than the quote planned.
+export function sacksOverrun(planned: number, blown: number): number {
+  return Math.max(0, blown - planned);
+}
+
 export type CreateReportInput = {
   segmentId: string;
   reportDay: string;

--- a/lib/domains/planning/reports.ts
+++ b/lib/domains/planning/reports.ts
@@ -1,0 +1,63 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+// Pure validation for a sack report.
+export function validateReport(reportDay: string, sacksBlown: number): 'invalid_date' | 'invalid_amount' | null {
+  if (!ISO_DATE_RE.test(reportDay)) return 'invalid_date';
+  if (!Number.isFinite(sacksBlown) || sacksBlown < 0) return 'invalid_amount';
+  return null;
+}
+
+// Sacks remaining for a job: planned (from line items) minus blown, floored at 0.
+export function sacksRemaining(planned: number, blown: number): number {
+  return Math.max(0, planned - blown);
+}
+
+export type CreateReportInput = {
+  segmentId: string;
+  reportDay: string;
+  sacksBlown: number;
+  note?: string | null;
+  actorUserId: string;
+};
+
+// work_order_id is derived server-side from the segment — never trusted from the client.
+export async function createSegmentReport(supabase: SupabaseClient, input: CreateReportInput) {
+  const { data: seg, error: segErr } = await supabase
+    .from('ops_segments')
+    .select('work_order_id')
+    .eq('id', input.segmentId)
+    .single();
+  if (segErr || !seg) return { data: null, error: segErr ?? { message: 'Segmentet kunde inte hittas' } };
+
+  return supabase
+    .from('ops_segment_reports')
+    .insert({
+      segment_id: input.segmentId,
+      work_order_id: (seg as { work_order_id: string }).work_order_id,
+      report_day: input.reportDay,
+      sacks_blown: input.sacksBlown,
+      note: input.note ?? null,
+      created_by: input.actorUserId,
+    })
+    .select('id, segment_id, work_order_id, report_day, sacks_blown, note, created_at')
+    .single();
+}
+
+// Sum of blown sacks per work order, across all its segments' reports.
+export async function reportedSacksByWorkOrder(
+  supabase: SupabaseClient,
+  workOrderIds: string[],
+): Promise<Map<string, number>> {
+  const map = new Map<string, number>();
+  if (workOrderIds.length === 0) return map;
+  const { data } = await supabase
+    .from('ops_segment_reports')
+    .select('work_order_id, sacks_blown')
+    .in('work_order_id', workOrderIds);
+  for (const r of (data ?? []) as Array<{ work_order_id: string; sacks_blown: number | string }>) {
+    map.set(r.work_order_id, (map.get(r.work_order_id) ?? 0) + Number(r.sacks_blown));
+  }
+  return map;
+}

--- a/lib/domains/planning/schedule.ts
+++ b/lib/domains/planning/schedule.ts
@@ -14,7 +14,7 @@ export function validateSegmentDates(startDay: string, endDay: string): 'invalid
 }
 
 const SEGMENT_SELECT =
-  'id, work_order_id, truck_id, start_day, end_day, sort_index, created_by, created_at, updated_at, ' +
+  'id, work_order_id, truck_id, start_day, end_day, sort_index, job_type, created_by, created_at, updated_at, ' +
   'work_order:crm_work_orders(order_number, fortnox_order_number, project_name, client_name, status, customer_snapshot, work_address, line_items)';
 
 type RawSegment = {
@@ -24,6 +24,7 @@ type RawSegment = {
   start_day: string;
   end_day: string;
   sort_index: number;
+  job_type: string | null;
   created_by: string | null;
   created_at: string;
   updated_at: string;
@@ -42,6 +43,7 @@ export function mapSegment(row: RawSegment): OpsSegment {
     start_day: row.start_day,
     end_day: row.end_day,
     sort_index: row.sort_index,
+    job_type: row.job_type,
     created_by: row.created_by,
     created_at: row.created_at,
     updated_at: row.updated_at,
@@ -88,6 +90,7 @@ export type PlaceSegmentInput = {
   startDay: string;
   endDay: string;
   sortIndex?: number;
+  jobType?: string | null;
   actorUserId: string;
 };
 
@@ -104,6 +107,7 @@ export async function placeSegment(
       start_day: input.startDay,
       end_day: input.endDay,
       sort_index: input.sortIndex ?? 0,
+      job_type: input.jobType ?? null,
       created_by: input.actorUserId,
     })
     .select(SEGMENT_SELECT)
@@ -117,9 +121,10 @@ export type MoveSegmentInput = {
   startDay?: string;
   endDay?: string;
   sortIndex?: number;
+  jobType?: string | null;
 };
 
-// Patch a placement (drag to another truck/day, reorder). Only sent fields are written.
+// Patch a placement (drag to another truck/day, reorder, set job type). Only sent fields written.
 export async function moveSegment(
   supabase: SupabaseClient,
   id: string,
@@ -130,6 +135,7 @@ export async function moveSegment(
   if (patch.startDay !== undefined) update.start_day = patch.startDay;
   if (patch.endDay !== undefined) update.end_day = patch.endDay;
   if (patch.sortIndex !== undefined) update.sort_index = patch.sortIndex;
+  if (patch.jobType !== undefined) update.job_type = patch.jobType;
 
   const { data, error } = await supabase.from('ops_segments').update(update).eq('id', id).select(SEGMENT_SELECT).single();
   return { data: data ? mapSegment(data as unknown as RawSegment) : null, error };

--- a/lib/domains/planning/schedule.ts
+++ b/lib/domains/planning/schedule.ts
@@ -94,7 +94,7 @@ export async function listSegments(
 export async function listTrucks(supabase: SupabaseClient) {
   return supabase
     .from('ops_trucks')
-    .select('id, name, color, active')
+    .select('id, name, color, active, depot_id')
     .eq('active', true)
     .order('name', { ascending: true });
 }

--- a/lib/domains/planning/schedule.ts
+++ b/lib/domains/planning/schedule.ts
@@ -1,0 +1,77 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+// Pure validation for a placement/move. Returns an error code or null when valid. ISO dates
+// sort lexicographically, so a string compare is a correct range check.
+export function validateSegmentDates(startDay: string, endDay: string): 'invalid_date' | 'end_before_start' | null {
+  if (!ISO_DATE_RE.test(startDay) || !ISO_DATE_RE.test(endDay)) return 'invalid_date';
+  if (endDay < startDay) return 'end_before_start';
+  return null;
+}
+
+const SEGMENT_SELECT =
+  'id, work_order_id, truck_id, start_day, end_day, sort_index, created_by, created_at, updated_at, ' +
+  'work_order:crm_work_orders(order_number, project_name, client_name, status)';
+
+// Segments overlapping the [from, to] window: anything that starts on/before `to` and ends
+// on/after `from`. RLS (planning.schedule.read) applies.
+export async function listSegments(supabase: SupabaseClient, range: { from: string; to: string }) {
+  return supabase
+    .from('ops_segments')
+    .select(SEGMENT_SELECT)
+    .lte('start_day', range.to)
+    .gte('end_day', range.from)
+    .order('start_day', { ascending: true })
+    .order('sort_index', { ascending: true });
+}
+
+export async function listTrucks(supabase: SupabaseClient) {
+  return supabase
+    .from('ops_trucks')
+    .select('id, name, color, active')
+    .eq('active', true)
+    .order('name', { ascending: true });
+}
+
+export type PlaceSegmentInput = {
+  workOrderId: string;
+  truckId: string;
+  startDay: string;
+  endDay: string;
+  sortIndex?: number;
+  actorUserId: string;
+};
+
+// created_by must equal the caller (RLS insert policy checks created_by = auth.uid()).
+export async function placeSegment(supabase: SupabaseClient, input: PlaceSegmentInput) {
+  return supabase
+    .from('ops_segments')
+    .insert({
+      work_order_id: input.workOrderId,
+      truck_id: input.truckId,
+      start_day: input.startDay,
+      end_day: input.endDay,
+      sort_index: input.sortIndex ?? 0,
+      created_by: input.actorUserId,
+    })
+    .select(SEGMENT_SELECT)
+    .single();
+}
+
+export type MoveSegmentInput = {
+  truckId?: string;
+  startDay?: string;
+  endDay?: string;
+  sortIndex?: number;
+};
+
+// Patch a placement (drag to another truck/day, reorder). Only sent fields are written.
+export async function moveSegment(supabase: SupabaseClient, id: string, patch: MoveSegmentInput) {
+  const update: Record<string, unknown> = {};
+  if (patch.truckId !== undefined) update.truck_id = patch.truckId;
+  if (patch.startDay !== undefined) update.start_day = patch.startDay;
+  if (patch.endDay !== undefined) update.end_day = patch.endDay;
+  if (patch.sortIndex !== undefined) update.sort_index = patch.sortIndex;
+  return supabase.from('ops_segments').update(update).eq('id', id).select(SEGMENT_SELECT).single();
+}

--- a/lib/domains/planning/schedule.ts
+++ b/lib/domains/planning/schedule.ts
@@ -1,5 +1,6 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { mapWorkOrderJob, type WorkOrderJobRow } from './display';
+import { reportedSacksByWorkOrder } from './reports';
 import type { OpsSegment } from './types';
 
 const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
@@ -45,6 +46,7 @@ export function mapSegment(row: RawSegment): OpsSegment {
     created_at: row.created_at,
     updated_at: row.updated_at,
     job: wo ? mapWorkOrderJob(wo) : null,
+    sacks_reported: 0,
   };
 }
 
@@ -63,7 +65,13 @@ export async function listSegments(
     .order('sort_index', { ascending: true });
 
   if (error) return { data: [], error };
-  return { data: ((data ?? []) as unknown as RawSegment[]).map(mapSegment), error: null };
+
+  const segs = ((data ?? []) as unknown as RawSegment[]).map(mapSegment);
+  // Attach each job's blown-sack total (summed across the job's segments) for the "kvar X/Y" card.
+  const ids = [...new Set(segs.map((s) => s.work_order_id))];
+  const reported = await reportedSacksByWorkOrder(supabase, ids);
+  for (const s of segs) s.sacks_reported = reported.get(s.work_order_id) ?? 0;
+  return { data: segs, error: null };
 }
 
 export async function listTrucks(supabase: SupabaseClient) {

--- a/lib/domains/planning/schedule.ts
+++ b/lib/domains/planning/schedule.ts
@@ -2,6 +2,7 @@ import type { SupabaseClient } from '@supabase/supabase-js';
 import { mapWorkOrderJob, type WorkOrderJobRow } from './display';
 import { reportedSacksByWorkOrder } from './reports';
 import { listCrewBySegment } from './crew';
+import { confirmationsByWorkOrder, EMPTY_CONFIRMATION } from './confirmations';
 import type { OpsSegment } from './types';
 
 const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
@@ -51,6 +52,7 @@ export function mapSegment(row: RawSegment): OpsSegment {
     job: wo ? mapWorkOrderJob(wo) : null,
     sacks_reported: 0,
     crew: [],
+    confirmation: { ...EMPTY_CONFIRMATION },
   };
 }
 
@@ -71,16 +73,18 @@ export async function listSegments(
   if (error) return { data: [], error };
 
   const segs = ((data ?? []) as unknown as RawSegment[]).map(mapSegment);
-  // Attach each job's blown-sack total (summed across the job's segments) for the "kvar X/Y" card,
-  // and the crew assigned to each individual placement (keyed by segment id).
+  // Attach each job's blown-sack total + confirmation state (both summed/keyed by work order), and
+  // the crew assigned to each individual placement (keyed by segment id).
   const workOrderIds = [...new Set(segs.map((s) => s.work_order_id))];
-  const [reported, crewBySegment] = await Promise.all([
+  const [reported, crewBySegment, confirmations] = await Promise.all([
     reportedSacksByWorkOrder(supabase, workOrderIds),
     listCrewBySegment(supabase, segs.map((s) => s.id)),
+    confirmationsByWorkOrder(supabase, workOrderIds),
   ]);
   for (const s of segs) {
     s.sacks_reported = reported.get(s.work_order_id) ?? 0;
     s.crew = crewBySegment.get(s.id) ?? [];
+    s.confirmation = confirmations.get(s.work_order_id) ?? { ...EMPTY_CONFIRMATION };
   }
   return { data: segs, error: null };
 }

--- a/lib/domains/planning/schedule.ts
+++ b/lib/domains/planning/schedule.ts
@@ -1,6 +1,7 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { mapWorkOrderJob, type WorkOrderJobRow } from './display';
 import { reportedSacksByWorkOrder } from './reports';
+import { listCrewBySegment } from './crew';
 import type { OpsSegment } from './types';
 
 const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
@@ -49,6 +50,7 @@ export function mapSegment(row: RawSegment): OpsSegment {
     updated_at: row.updated_at,
     job: wo ? mapWorkOrderJob(wo) : null,
     sacks_reported: 0,
+    crew: [],
   };
 }
 
@@ -69,10 +71,17 @@ export async function listSegments(
   if (error) return { data: [], error };
 
   const segs = ((data ?? []) as unknown as RawSegment[]).map(mapSegment);
-  // Attach each job's blown-sack total (summed across the job's segments) for the "kvar X/Y" card.
-  const ids = [...new Set(segs.map((s) => s.work_order_id))];
-  const reported = await reportedSacksByWorkOrder(supabase, ids);
-  for (const s of segs) s.sacks_reported = reported.get(s.work_order_id) ?? 0;
+  // Attach each job's blown-sack total (summed across the job's segments) for the "kvar X/Y" card,
+  // and the crew assigned to each individual placement (keyed by segment id).
+  const workOrderIds = [...new Set(segs.map((s) => s.work_order_id))];
+  const [reported, crewBySegment] = await Promise.all([
+    reportedSacksByWorkOrder(supabase, workOrderIds),
+    listCrewBySegment(supabase, segs.map((s) => s.id)),
+  ]);
+  for (const s of segs) {
+    s.sacks_reported = reported.get(s.work_order_id) ?? 0;
+    s.crew = crewBySegment.get(s.id) ?? [];
+  }
   return { data: segs, error: null };
 }
 

--- a/lib/domains/planning/schedule.ts
+++ b/lib/domains/planning/schedule.ts
@@ -1,9 +1,11 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
+import { mapWorkOrderJob, type WorkOrderJobRow } from './display';
+import type { OpsSegment } from './types';
 
 const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 
-// Pure validation for a placement/move. Returns an error code or null when valid. ISO dates
-// sort lexicographically, so a string compare is a correct range check.
+// Pure validation for a placement/move. Returns an error code or null when valid. ISO dates sort
+// lexicographically, so a string compare is a correct range check.
 export function validateSegmentDates(startDay: string, endDay: string): 'invalid_date' | 'end_before_start' | null {
   if (!ISO_DATE_RE.test(startDay) || !ISO_DATE_RE.test(endDay)) return 'invalid_date';
   if (endDay < startDay) return 'end_before_start';
@@ -12,18 +14,56 @@ export function validateSegmentDates(startDay: string, endDay: string): 'invalid
 
 const SEGMENT_SELECT =
   'id, work_order_id, truck_id, start_day, end_day, sort_index, created_by, created_at, updated_at, ' +
-  'work_order:crm_work_orders(order_number, project_name, client_name, status)';
+  'work_order:crm_work_orders(order_number, fortnox_order_number, project_name, client_name, status, customer_snapshot, work_address, line_items)';
+
+type RawSegment = {
+  id: string;
+  work_order_id: string;
+  truck_id: string;
+  start_day: string;
+  end_day: string;
+  sort_index: number;
+  created_by: string | null;
+  created_at: string;
+  updated_at: string;
+  work_order: WorkOrderJobRow | WorkOrderJobRow[] | null;
+};
+
+// Map a raw ops_segments row (with the embedded work order) to the OpsSegment the UI renders.
+// Supabase returns a to-one embed as an object, but the generated typing can be an array —
+// normalise either way.
+export function mapSegment(row: RawSegment): OpsSegment {
+  const wo = Array.isArray(row.work_order) ? row.work_order[0] : row.work_order;
+  return {
+    id: row.id,
+    work_order_id: row.work_order_id,
+    truck_id: row.truck_id,
+    start_day: row.start_day,
+    end_day: row.end_day,
+    sort_index: row.sort_index,
+    created_by: row.created_by,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+    job: wo ? mapWorkOrderJob(wo) : null,
+  };
+}
 
 // Segments overlapping the [from, to] window: anything that starts on/before `to` and ends
 // on/after `from`. RLS (planning.schedule.read) applies.
-export async function listSegments(supabase: SupabaseClient, range: { from: string; to: string }) {
-  return supabase
+export async function listSegments(
+  supabase: SupabaseClient,
+  range: { from: string; to: string },
+): Promise<{ data: OpsSegment[]; error: { message: string } | null }> {
+  const { data, error } = await supabase
     .from('ops_segments')
     .select(SEGMENT_SELECT)
     .lte('start_day', range.to)
     .gte('end_day', range.from)
     .order('start_day', { ascending: true })
     .order('sort_index', { ascending: true });
+
+  if (error) return { data: [], error };
+  return { data: ((data ?? []) as unknown as RawSegment[]).map(mapSegment), error: null };
 }
 
 export async function listTrucks(supabase: SupabaseClient) {
@@ -44,8 +84,11 @@ export type PlaceSegmentInput = {
 };
 
 // created_by must equal the caller (RLS insert policy checks created_by = auth.uid()).
-export async function placeSegment(supabase: SupabaseClient, input: PlaceSegmentInput) {
-  return supabase
+export async function placeSegment(
+  supabase: SupabaseClient,
+  input: PlaceSegmentInput,
+): Promise<{ data: OpsSegment | null; error: { message: string } | null }> {
+  const { data, error } = await supabase
     .from('ops_segments')
     .insert({
       work_order_id: input.workOrderId,
@@ -57,6 +100,8 @@ export async function placeSegment(supabase: SupabaseClient, input: PlaceSegment
     })
     .select(SEGMENT_SELECT)
     .single();
+
+  return { data: data ? mapSegment(data as unknown as RawSegment) : null, error };
 }
 
 export type MoveSegmentInput = {
@@ -67,11 +112,22 @@ export type MoveSegmentInput = {
 };
 
 // Patch a placement (drag to another truck/day, reorder). Only sent fields are written.
-export async function moveSegment(supabase: SupabaseClient, id: string, patch: MoveSegmentInput) {
+export async function moveSegment(
+  supabase: SupabaseClient,
+  id: string,
+  patch: MoveSegmentInput,
+): Promise<{ data: OpsSegment | null; error: { message: string } | null }> {
   const update: Record<string, unknown> = {};
   if (patch.truckId !== undefined) update.truck_id = patch.truckId;
   if (patch.startDay !== undefined) update.start_day = patch.startDay;
   if (patch.endDay !== undefined) update.end_day = patch.endDay;
   if (patch.sortIndex !== undefined) update.sort_index = patch.sortIndex;
-  return supabase.from('ops_segments').update(update).eq('id', id).select(SEGMENT_SELECT).single();
+
+  const { data, error } = await supabase.from('ops_segments').update(update).eq('id', id).select(SEGMENT_SELECT).single();
+  return { data: data ? mapSegment(data as unknown as RawSegment) : null, error };
+}
+
+// Unschedule a placement (e.g. dragged back to the backlog).
+export async function removeSegment(supabase: SupabaseClient, id: string) {
+  return supabase.from('ops_segments').delete().eq('id', id);
 }

--- a/lib/domains/planning/schedule.ts
+++ b/lib/domains/planning/schedule.ts
@@ -16,7 +16,7 @@ export function validateSegmentDates(startDay: string, endDay: string): 'invalid
 }
 
 const SEGMENT_SELECT =
-  'id, work_order_id, truck_id, start_day, end_day, sort_index, job_type, created_by, created_at, updated_at, ' +
+  'id, work_order_id, truck_id, start_day, end_day, sort_index, job_type, on_hold, created_by, created_at, updated_at, ' +
   'work_order:crm_work_orders(order_number, fortnox_order_number, project_name, client_name, status, customer_snapshot, work_address, line_items)';
 
 type RawSegment = {
@@ -27,6 +27,7 @@ type RawSegment = {
   end_day: string;
   sort_index: number;
   job_type: string | null;
+  on_hold: boolean;
   created_by: string | null;
   created_at: string;
   updated_at: string;
@@ -46,6 +47,7 @@ export function mapSegment(row: RawSegment): OpsSegment {
     end_day: row.end_day,
     sort_index: row.sort_index,
     job_type: row.job_type,
+    on_hold: row.on_hold ?? false,
     created_by: row.created_by,
     created_at: row.created_at,
     updated_at: row.updated_at,
@@ -135,9 +137,11 @@ export type MoveSegmentInput = {
   endDay?: string;
   sortIndex?: number;
   jobType?: string | null;
+  onHold?: boolean;
 };
 
-// Patch a placement (drag to another truck/day, reorder, set job type). Only sent fields written.
+// Patch a placement (drag to another truck/day, reorder, set job type, pause/resume). Only sent
+// fields are written.
 export async function moveSegment(
   supabase: SupabaseClient,
   id: string,
@@ -149,6 +153,7 @@ export async function moveSegment(
   if (patch.endDay !== undefined) update.end_day = patch.endDay;
   if (patch.sortIndex !== undefined) update.sort_index = patch.sortIndex;
   if (patch.jobType !== undefined) update.job_type = patch.jobType;
+  if (patch.onHold !== undefined) update.on_hold = patch.onHold;
 
   const { data, error } = await supabase.from('ops_segments').update(update).eq('id', id).select(SEGMENT_SELECT).single();
   return { data: data ? mapSegment(data as unknown as RawSegment) : null, error };

--- a/lib/domains/planning/truckCrew.ts
+++ b/lib/domains/planning/truckCrew.ts
@@ -96,7 +96,21 @@ export type CopyTruckCrewInput = {
   actorUserId: string;
 };
 
-// Copy a truck's crew from one week to another, skipping anyone already on the target week.
+// Pure: shift an ISO date by whole days (UTC, so date-only and DST-safe).
+export function shiftISO(iso: string, days: number): string {
+  const d = new Date(`${iso}T00:00:00Z`);
+  d.setUTCDate(d.getUTCDate() + days);
+  return d.toISOString().slice(0, 10);
+}
+
+// Whole-day delta between two ISO dates (target − source).
+function dayDelta(fromISO: string, toISO: string): number {
+  return Math.round((Date.parse(`${toISO}T00:00:00Z`) - Date.parse(`${fromISO}T00:00:00Z`)) / 86_400_000);
+}
+
+// Copy a truck's crew from one week to another, skipping anyone already on the target week. Each
+// member's own date range is preserved, shifted by the source→target delta, so a partial-week
+// assignment (e.g. Mon–Wed) stays partial after the copy instead of becoming a full week.
 export async function copyTruckCrewWeek(
   supabase: SupabaseClient,
   input: CopyTruckCrewInput,
@@ -106,13 +120,14 @@ export async function copyTruckCrewWeek(
   const toCopy = membersToCopy(source, target);
   if (toCopy.length === 0) return { data: { copied: 0 }, error: null };
 
+  const delta = dayDelta(input.sourceFrom, input.targetFrom);
   const { error } = await supabase.from('ops_truck_crew').insert(
     toCopy.map((m) => ({
       truck_id: input.truckId,
       member_id: m.member_id,
       member_name: m.member_name,
-      start_day: input.targetFrom,
-      end_day: input.targetTo,
+      start_day: shiftISO(m.start_day, delta),
+      end_day: shiftISO(m.end_day, delta),
       created_by: input.actorUserId,
     })),
   );

--- a/lib/domains/planning/truckCrew.ts
+++ b/lib/domains/planning/truckCrew.ts
@@ -1,0 +1,74 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+// Weekly truck crew (besättning per bil): who crews a truck over a date range. The board resolves
+// each truck's crew for the visible week from these rows. member_name is denormalised (profiles are
+// self-read-only) — same rationale as ops_segment_crew. Pure helpers here are unit-tested.
+
+export type TruckCrewMember = {
+  id: string;
+  truck_id: string;
+  member_id: string | null;
+  member_name: string;
+  start_day: string;
+  end_day: string;
+};
+
+// Pure: crew rows for a truck whose date range overlaps [from, to] (ISO dates sort lexically, so a
+// string compare is a correct overlap test).
+export function crewForTruckInRange(
+  rows: TruckCrewMember[],
+  truckId: string,
+  from: string,
+  to: string,
+): TruckCrewMember[] {
+  return rows.filter((r) => r.truck_id === truckId && r.start_day <= to && r.end_day >= from);
+}
+
+const TRUCK_CREW_SELECT = 'id, truck_id, member_id, member_name, start_day, end_day';
+
+// Crew rows overlapping [from, to]. RLS (planning.schedule.read) applies.
+export async function listTruckCrew(
+  supabase: SupabaseClient,
+  range: { from: string; to: string },
+): Promise<{ data: TruckCrewMember[]; error: { message: string } | null }> {
+  const { data, error } = await supabase
+    .from('ops_truck_crew')
+    .select(TRUCK_CREW_SELECT)
+    .lte('start_day', range.to)
+    .gte('end_day', range.from)
+    .order('member_name', { ascending: true });
+  return { data: (data ?? []) as TruckCrewMember[], error };
+}
+
+export type AssignTruckCrewInput = {
+  truckId: string;
+  memberId: string | null;
+  memberName: string;
+  startDay: string;
+  endDay: string;
+  actorUserId: string;
+};
+
+// created_by must equal the caller (RLS insert policy checks created_by = auth.uid()).
+export async function assignTruckCrew(
+  supabase: SupabaseClient,
+  input: AssignTruckCrewInput,
+): Promise<{ data: TruckCrewMember | null; error: { message: string } | null }> {
+  const { data, error } = await supabase
+    .from('ops_truck_crew')
+    .insert({
+      truck_id: input.truckId,
+      member_id: input.memberId,
+      member_name: input.memberName,
+      start_day: input.startDay,
+      end_day: input.endDay,
+      created_by: input.actorUserId,
+    })
+    .select(TRUCK_CREW_SELECT)
+    .single();
+  return { data: (data as TruckCrewMember) ?? null, error };
+}
+
+export async function unassignTruckCrew(supabase: SupabaseClient, id: string) {
+  return supabase.from('ops_truck_crew').delete().eq('id', id);
+}

--- a/lib/domains/planning/truckCrew.ts
+++ b/lib/domains/planning/truckCrew.ts
@@ -72,3 +72,49 @@ export async function assignTruckCrew(
 export async function unassignTruckCrew(supabase: SupabaseClient, id: string) {
   return supabase.from('ops_truck_crew').delete().eq('id', id);
 }
+
+// Pure: source crew members not already present in the target week (deduped by member_id). These
+// are the rows to copy when cloning a truck's crew to another week.
+export function membersToCopy(source: TruckCrewMember[], targetExisting: TruckCrewMember[]): TruckCrewMember[] {
+  const have = new Set(targetExisting.map((m) => m.member_id).filter((v): v is string => Boolean(v)));
+  const seen = new Set<string>();
+  const out: TruckCrewMember[] = [];
+  for (const m of source) {
+    if (!m.member_id || have.has(m.member_id) || seen.has(m.member_id)) continue;
+    seen.add(m.member_id);
+    out.push(m);
+  }
+  return out;
+}
+
+export type CopyTruckCrewInput = {
+  truckId: string;
+  sourceFrom: string;
+  sourceTo: string;
+  targetFrom: string;
+  targetTo: string;
+  actorUserId: string;
+};
+
+// Copy a truck's crew from one week to another, skipping anyone already on the target week.
+export async function copyTruckCrewWeek(
+  supabase: SupabaseClient,
+  input: CopyTruckCrewInput,
+): Promise<{ data: { copied: number } | null; error: { message: string } | null }> {
+  const source = (await listTruckCrew(supabase, { from: input.sourceFrom, to: input.sourceTo })).data.filter((m) => m.truck_id === input.truckId);
+  const target = (await listTruckCrew(supabase, { from: input.targetFrom, to: input.targetTo })).data.filter((m) => m.truck_id === input.truckId);
+  const toCopy = membersToCopy(source, target);
+  if (toCopy.length === 0) return { data: { copied: 0 }, error: null };
+
+  const { error } = await supabase.from('ops_truck_crew').insert(
+    toCopy.map((m) => ({
+      truck_id: input.truckId,
+      member_id: m.member_id,
+      member_name: m.member_name,
+      start_day: input.targetFrom,
+      end_day: input.targetTo,
+      created_by: input.actorUserId,
+    })),
+  );
+  return { data: error ? null : { copied: toCopy.length }, error };
+}

--- a/lib/domains/planning/trucks.ts
+++ b/lib/domains/planning/trucks.ts
@@ -1,0 +1,66 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { OpsTruck } from './types';
+
+// Truck (fleet) administration for the planning board. The board itself reads active trucks via the
+// segments route (listTrucks in schedule.ts); this module is the manage surface (list-all incl
+// inactive, create/update/delete), gated by planning.truck.manage. Pure validateTruck is unit-tested.
+
+const HEX_RE = /^#[0-9a-fA-F]{6}$/;
+
+// Pure validation for a truck. A name is required; a colour, when given, must be a 6-digit hex.
+export function validateTruck(name: string, color: string | null): 'name_required' | 'name_too_long' | 'bad_color' | null {
+  const n = name.trim();
+  if (!n) return 'name_required';
+  if (n.length > 60) return 'name_too_long';
+  if (color && !HEX_RE.test(color)) return 'bad_color';
+  return null;
+}
+
+// All trucks (including inactive) for the manage panel.
+export async function listAllTrucks(supabase: SupabaseClient) {
+  return supabase.from('ops_trucks').select('id, name, color, active').order('name', { ascending: true });
+}
+
+export async function createTruck(
+  supabase: SupabaseClient,
+  input: { name: string; color: string | null },
+): Promise<{ data: OpsTruck | null; error: { message: string } | null }> {
+  const { data, error } = await supabase
+    .from('ops_trucks')
+    .insert({ name: input.name.trim(), color: input.color })
+    .select('id, name, color, active')
+    .single();
+  return { data: (data as OpsTruck) ?? null, error };
+}
+
+export type UpdateTruckInput = {
+  name?: string;
+  color?: string | null;
+  active?: boolean;
+};
+
+export async function updateTruck(
+  supabase: SupabaseClient,
+  id: string,
+  patch: UpdateTruckInput,
+): Promise<{ data: OpsTruck | null; error: { message: string } | null }> {
+  const update: Record<string, unknown> = {};
+  if (patch.name !== undefined) update.name = patch.name.trim();
+  if (patch.color !== undefined) update.color = patch.color;
+  if (patch.active !== undefined) update.active = patch.active;
+
+  const { data, error } = await supabase
+    .from('ops_trucks')
+    .update(update)
+    .eq('id', id)
+    .select('id, name, color, active')
+    .single();
+  return { data: (data as OpsTruck) ?? null, error };
+}
+
+// Delete a truck. ops_segments.truck_id is ON DELETE RESTRICT, so a truck still referenced by a
+// placement can't be removed — the route turns that FK violation into a friendly "deactivate
+// instead" message.
+export async function deleteTruck(supabase: SupabaseClient, id: string) {
+  return supabase.from('ops_trucks').delete().eq('id', id);
+}

--- a/lib/domains/planning/trucks.ts
+++ b/lib/domains/planning/trucks.ts
@@ -18,7 +18,7 @@ export function validateTruck(name: string, color: string | null): 'name_require
 
 // All trucks (including inactive) for the manage panel.
 export async function listAllTrucks(supabase: SupabaseClient) {
-  return supabase.from('ops_trucks').select('id, name, color, active').order('name', { ascending: true });
+  return supabase.from('ops_trucks').select('id, name, color, active, depot_id').order('name', { ascending: true });
 }
 
 export async function createTruck(
@@ -28,7 +28,7 @@ export async function createTruck(
   const { data, error } = await supabase
     .from('ops_trucks')
     .insert({ name: input.name.trim(), color: input.color })
-    .select('id, name, color, active')
+    .select('id, name, color, active, depot_id')
     .single();
   return { data: (data as OpsTruck) ?? null, error };
 }
@@ -37,6 +37,7 @@ export type UpdateTruckInput = {
   name?: string;
   color?: string | null;
   active?: boolean;
+  depotId?: string | null;
 };
 
 export async function updateTruck(
@@ -48,12 +49,13 @@ export async function updateTruck(
   if (patch.name !== undefined) update.name = patch.name.trim();
   if (patch.color !== undefined) update.color = patch.color;
   if (patch.active !== undefined) update.active = patch.active;
+  if (patch.depotId !== undefined) update.depot_id = patch.depotId;
 
   const { data, error } = await supabase
     .from('ops_trucks')
     .update(update)
     .eq('id', id)
-    .select('id, name, color, active')
+    .select('id, name, color, active, depot_id')
     .single();
   return { data: (data as OpsTruck) ?? null, error };
 }

--- a/lib/domains/planning/types.ts
+++ b/lib/domains/planning/types.ts
@@ -1,20 +1,16 @@
-// Domain types for the new CRM-first planning (Wave 7). Pure, no React/Next — these mirror
-// the ops_* tables (supabase/sql/20260611_ops_planning_foundation.sql) and the backlog read
-// model built from crm_work_orders.
+import type { JobDisplay } from './display';
 
-// A CRM work order eligible to be scheduled, annotated for the planning backlog. The "what to
-// schedule" comes entirely from the CRM (customer, address, sacks, desired date) — no Blikk.
-export type SchedulableWorkOrder = {
+// Domain types for the new CRM-first planning (Wave 7). Pure, no React/Next — these mirror the
+// ops_* tables and the read models built from crm_work_orders. JobDisplay (display.ts) holds the
+// fields a job shows on a card (ref/customer/address/sacks/status/material), shared by the backlog
+// and the scheduled segments so a job looks identical wherever it appears.
+
+// A CRM work order eligible to be scheduled, annotated for the planning backlog.
+export type SchedulableWorkOrder = JobDisplay & {
   id: string;
-  order_number: string;
-  project_name: string;
-  client_name: string;
-  status: string;
   desired_installation_date: string | null;
-  address: string | null;
   contact_email: string | null;
   contact_phone: string | null;
-  total_sacks: number;
   // How many ops_segments already cover this order (0 = not yet placed on the calendar).
   segment_count: number;
 };
@@ -37,11 +33,6 @@ export type OpsSegment = {
   created_by: string | null;
   created_at: string;
   updated_at: string;
-  // Joined display fields from crm_work_orders (present on list/read responses).
-  work_order?: {
-    order_number: string;
-    project_name: string;
-    client_name: string;
-    status: string;
-  } | null;
+  // The job's card data (null only if the related work order is unreadable, which shouldn't happen).
+  job: JobDisplay | null;
 };

--- a/lib/domains/planning/types.ts
+++ b/lib/domains/planning/types.ts
@@ -1,0 +1,47 @@
+// Domain types for the new CRM-first planning (Wave 7). Pure, no React/Next — these mirror
+// the ops_* tables (supabase/sql/20260611_ops_planning_foundation.sql) and the backlog read
+// model built from crm_work_orders.
+
+// A CRM work order eligible to be scheduled, annotated for the planning backlog. The "what to
+// schedule" comes entirely from the CRM (customer, address, sacks, desired date) — no Blikk.
+export type SchedulableWorkOrder = {
+  id: string;
+  order_number: string;
+  project_name: string;
+  client_name: string;
+  status: string;
+  desired_installation_date: string | null;
+  address: string | null;
+  contact_email: string | null;
+  contact_phone: string | null;
+  total_sacks: number;
+  // How many ops_segments already cover this order (0 = not yet placed on the calendar).
+  segment_count: number;
+};
+
+export type OpsTruck = {
+  id: string;
+  name: string;
+  color: string | null;
+  active: boolean;
+};
+
+// One scheduled placement of a work order on a truck across a day-range.
+export type OpsSegment = {
+  id: string;
+  work_order_id: string;
+  truck_id: string;
+  start_day: string; // 'YYYY-MM-DD'
+  end_day: string; // 'YYYY-MM-DD'
+  sort_index: number;
+  created_by: string | null;
+  created_at: string;
+  updated_at: string;
+  // Joined display fields from crm_work_orders (present on list/read responses).
+  work_order?: {
+    order_number: string;
+    project_name: string;
+    client_name: string;
+    status: string;
+  } | null;
+};

--- a/lib/domains/planning/types.ts
+++ b/lib/domains/planning/types.ts
@@ -30,6 +30,9 @@ export type OpsSegment = {
   start_day: string; // 'YYYY-MM-DD'
   end_day: string; // 'YYYY-MM-DD'
   sort_index: number;
+  // Planner-set job type (Ekovilla/Vitull/Leverans/…) driving the card colour; null → fall back
+  // to the material inferred from the work order. See lib/domains/planning/jobTypes.ts.
+  job_type: string | null;
   created_by: string | null;
   created_at: string;
   updated_at: string;

--- a/lib/domains/planning/types.ts
+++ b/lib/domains/planning/types.ts
@@ -1,4 +1,5 @@
 import type { JobDisplay } from './display';
+import type { CrewMember } from './crew';
 
 // Domain types for the new CRM-first planning (Wave 7). Pure, no React/Next — these mirror the
 // ops_* tables and the read models built from crm_work_orders. JobDisplay (display.ts) holds the
@@ -40,4 +41,6 @@ export type OpsSegment = {
   job: JobDisplay | null;
   // Total sacks blown for this job across all its segments' reports (per-day sack reporting).
   sacks_reported: number;
+  // The crew (besättning) assigned to this specific placement; shown as initials on the card.
+  crew: CrewMember[];
 };

--- a/lib/domains/planning/types.ts
+++ b/lib/domains/planning/types.ts
@@ -35,4 +35,6 @@ export type OpsSegment = {
   updated_at: string;
   // The job's card data (null only if the related work order is unreadable, which shouldn't happen).
   job: JobDisplay | null;
+  // Total sacks blown for this job across all its segments' reports (per-day sack reporting).
+  sacks_reported: number;
 };

--- a/lib/domains/planning/types.ts
+++ b/lib/domains/planning/types.ts
@@ -13,6 +13,9 @@ export type SchedulableWorkOrder = JobDisplay & {
   desired_installation_date: string | null;
   contact_email: string | null;
   contact_phone: string | null;
+  // The work order's assignee (sales-responsible) user id; mapped to a name via the people list for
+  // the backlog sales filter. null when unassigned.
+  assigned_to: string | null;
   // How many ops_segments already cover this order (0 = not yet placed on the calendar).
   segment_count: number;
 };

--- a/lib/domains/planning/types.ts
+++ b/lib/domains/planning/types.ts
@@ -35,6 +35,9 @@ export type OpsSegment = {
   // Planner-set job type (Ekovilla/Vitull/Leverans/…) driving the card colour; null → fall back
   // to the material inferred from the work order. See lib/domains/planning/jobTypes.ts.
   job_type: string | null;
+  // Paused placement (customer postponed, material delayed, …): keeps its slot but is dimmed +
+  // badged "Pausad" so it isn't treated as active.
+  on_hold: boolean;
   created_by: string | null;
   created_at: string;
   updated_at: string;

--- a/lib/domains/planning/types.ts
+++ b/lib/domains/planning/types.ts
@@ -1,5 +1,6 @@
 import type { JobDisplay } from './display';
 import type { CrewMember } from './crew';
+import type { ConfirmationSummary } from './confirmations';
 
 // Domain types for the new CRM-first planning (Wave 7). Pure, no React/Next — these mirror the
 // ops_* tables and the read models built from crm_work_orders. JobDisplay (display.ts) holds the
@@ -43,4 +44,6 @@ export type OpsSegment = {
   sacks_reported: number;
   // The crew (besättning) assigned to this specific placement; shown as initials on the card.
   crew: CrewMember[];
+  // Whether the customer has been sent an order confirmation (per work order); drives the badge.
+  confirmation: ConfirmationSummary;
 };

--- a/lib/domains/planning/types.ts
+++ b/lib/domains/planning/types.ts
@@ -22,6 +22,15 @@ export type OpsTruck = {
   name: string;
   color: string | null;
   active: boolean;
+  // The depot this truck draws sacks from (null = unassigned). See lib/domains/planning/depots.ts.
+  depot_id: string | null;
+};
+
+export type OpsDepot = {
+  id: string;
+  name: string;
+  location: string | null;
+  active: boolean;
 };
 
 // One scheduled placement of a work order on a truck across a day-range.

--- a/supabase/sql/20260611_ops_planning_foundation.sql
+++ b/supabase/sql/20260611_ops_planning_foundation.sql
@@ -1,0 +1,104 @@
+-- Wave 7 — new CRM-first planning: scheduling foundation (slice 1 walking skeleton).
+--
+-- Fresh scheduling schema, fully independent of the old planning_* tables (which stay live on
+-- Blikk until cutover). Jobs scheduled here ARE CRM work orders: ops_segments.work_order_id →
+-- crm_work_orders.id. The "is it scheduled" state lives here, NEVER on the work order, so the
+-- CRM stays the source of the job and planning owns the schedule.
+--
+-- RLS + indexes from day one (deliberately designing away the old planning_truck_assignments
+-- RLS gap rather than inheriting it).
+--
+-- DEPLOY ORDER: run AFTER 20260611_planning_permissions.sql (RLS predicates call
+-- has_permission('planning.*')). Run in the Supabase SQL editor. Idempotent.
+
+-- ── ops_trucks ───────────────────────────────────────────────────────────────
+create table if not exists public.ops_trucks (
+  id         uuid primary key default gen_random_uuid(),
+  name       text not null,
+  color      text,
+  active     boolean not null default true,
+  created_at timestamptz not null default now()
+);
+
+alter table public.ops_trucks enable row level security;
+grant select, insert, update, delete on public.ops_trucks to authenticated;
+
+drop policy if exists ops_trucks_select on public.ops_trucks;
+create policy ops_trucks_select on public.ops_trucks
+  for select to authenticated
+  using (public.has_permission('planning.schedule.read'));
+
+drop policy if exists ops_trucks_insert on public.ops_trucks;
+create policy ops_trucks_insert on public.ops_trucks
+  for insert to authenticated
+  with check (public.has_permission('planning.truck.manage'));
+
+drop policy if exists ops_trucks_update on public.ops_trucks;
+create policy ops_trucks_update on public.ops_trucks
+  for update to authenticated
+  using (public.has_permission('planning.truck.manage'))
+  with check (public.has_permission('planning.truck.manage'));
+
+drop policy if exists ops_trucks_delete on public.ops_trucks;
+create policy ops_trucks_delete on public.ops_trucks
+  for delete to authenticated
+  using (public.has_permission('planning.truck.manage'));
+
+-- ── ops_segments ─────────────────────────────────────────────────────────────
+-- One scheduled placement of a CRM work order on a truck across a day-range. A work order can
+-- have several segments (multi-day / multi-truck) — coverage is computed from these rows.
+create table if not exists public.ops_segments (
+  id            uuid primary key default gen_random_uuid(),
+  work_order_id uuid not null references public.crm_work_orders(id) on delete cascade,
+  truck_id      uuid not null references public.ops_trucks(id) on delete restrict,
+  start_day     date not null,
+  end_day       date not null,
+  sort_index    integer not null default 0,
+  created_by    uuid references public.profiles(id) on delete set null,
+  created_at    timestamptz not null default now(),
+  updated_at    timestamptz not null default now(),
+  constraint ops_segments_day_range_check check (end_day >= start_day)
+);
+
+create index if not exists ops_segments_truck_range_idx on public.ops_segments (truck_id, start_day, end_day);
+create index if not exists ops_segments_work_order_idx  on public.ops_segments (work_order_id);
+
+alter table public.ops_segments enable row level security;
+grant select, insert, update, delete on public.ops_segments to authenticated;
+
+drop policy if exists ops_segments_select on public.ops_segments;
+create policy ops_segments_select on public.ops_segments
+  for select to authenticated
+  using (public.has_permission('planning.schedule.read'));
+
+drop policy if exists ops_segments_insert on public.ops_segments;
+create policy ops_segments_insert on public.ops_segments
+  for insert to authenticated
+  with check (created_by = auth.uid() and public.has_permission('planning.schedule.write'));
+
+drop policy if exists ops_segments_update on public.ops_segments;
+create policy ops_segments_update on public.ops_segments
+  for update to authenticated
+  using (public.has_permission('planning.schedule.write'))
+  with check (public.has_permission('planning.schedule.write'));
+
+drop policy if exists ops_segments_delete on public.ops_segments;
+create policy ops_segments_delete on public.ops_segments
+  for delete to authenticated
+  using (public.has_permission('planning.schedule.write'));
+
+create or replace function public.set_timestamp_ops_segments()
+returns trigger language plpgsql as $$
+begin new.updated_at = now(); return new; end;
+$$;
+
+drop trigger if exists set_timestamp_ops_segments on public.ops_segments;
+create trigger set_timestamp_ops_segments
+before update on public.ops_segments
+for each row execute procedure public.set_timestamp_ops_segments();
+
+-- ── seed a few trucks for the skeleton (only when the table is empty) ─────────
+insert into public.ops_trucks (name, color)
+select v.name, v.color
+from (values ('Bil 1', '#2563eb'), ('Bil 2', '#16a34a'), ('Bil 3', '#d97706')) as v(name, color)
+where not exists (select 1 from public.ops_trucks);

--- a/supabase/sql/20260611_ops_segment_reports.sql
+++ b/supabase/sql/20260611_ops_segment_reports.sql
@@ -1,0 +1,46 @@
+-- Wave 7 slice 3 — per-day sack reporting for the new planning.
+--
+-- Records how many sacks were blown for a scheduled segment on a given day. The job's "blown
+-- total" is the sum across its segments' reports; "kvar" = planned sacks (from the work order's
+-- line items) − blown. work_order_id is denormalised from the segment for cheap per-job sums.
+--
+-- DEPLOY ORDER: run AFTER 20260611_ops_planning_foundation.sql (and the permissions seed). RLS
+-- predicates reuse the planning.* keys. Run in the Supabase SQL editor. Idempotent.
+
+create table if not exists public.ops_segment_reports (
+  id            uuid primary key default gen_random_uuid(),
+  segment_id    uuid not null references public.ops_segments(id) on delete cascade,
+  work_order_id uuid not null references public.crm_work_orders(id) on delete cascade,
+  report_day    date not null,
+  sacks_blown   numeric(10, 2) not null check (sacks_blown >= 0),
+  note          text,
+  created_by    uuid references public.profiles(id) on delete set null,
+  created_at    timestamptz not null default now()
+);
+
+create index if not exists ops_segment_reports_segment_idx    on public.ops_segment_reports (segment_id);
+create index if not exists ops_segment_reports_work_order_idx on public.ops_segment_reports (work_order_id);
+
+alter table public.ops_segment_reports enable row level security;
+grant select, insert, update, delete on public.ops_segment_reports to authenticated;
+
+drop policy if exists ops_segment_reports_select on public.ops_segment_reports;
+create policy ops_segment_reports_select on public.ops_segment_reports
+  for select to authenticated
+  using (public.has_permission('planning.schedule.read'));
+
+drop policy if exists ops_segment_reports_insert on public.ops_segment_reports;
+create policy ops_segment_reports_insert on public.ops_segment_reports
+  for insert to authenticated
+  with check (created_by = auth.uid() and public.has_permission('planning.schedule.write'));
+
+drop policy if exists ops_segment_reports_update on public.ops_segment_reports;
+create policy ops_segment_reports_update on public.ops_segment_reports
+  for update to authenticated
+  using (public.has_permission('planning.schedule.write'))
+  with check (public.has_permission('planning.schedule.write'));
+
+drop policy if exists ops_segment_reports_delete on public.ops_segment_reports;
+create policy ops_segment_reports_delete on public.ops_segment_reports
+  for delete to authenticated
+  using (public.has_permission('planning.schedule.write'));

--- a/supabase/sql/20260611_ops_segments_job_type.sql
+++ b/supabase/sql/20260611_ops_segments_job_type.sql
@@ -1,0 +1,9 @@
+-- Wave 7 slice 4 — explicit job type per scheduled segment.
+--
+-- The planner tags a segment with a job type (Ekovilla / Vitull / Leverans / Utsugning /
+-- Snickerier / Övrigt) that drives the card colour. Free text (the app offers a fixed set);
+-- when unset the card falls back to the material inferred from the work order's line items.
+--
+-- Run AFTER 20260611_ops_planning_foundation.sql. Run in the Supabase SQL editor. Idempotent.
+
+alter table public.ops_segments add column if not exists job_type text;

--- a/supabase/sql/20260611_planning_permissions.sql
+++ b/supabase/sql/20260611_planning_permissions.sql
@@ -1,0 +1,31 @@
+-- Planning (Wave 7, CRM-first rebuild) permission keys — catalog + role seed.
+--
+-- Net-new keys for the NEW planning/scheduling surface (app/planering, ops_* tables). The
+-- old planning (app/plannering) never used the permission model; this is the first time
+-- planning joins RBAC. ADDITIVE and idempotent.
+--
+-- DEPLOY ORDER: run this BEFORE the app code that calls requirePermission('planning.*') and
+-- BEFORE 20260611_ops_planning_foundation.sql (whose RLS predicates call has_permission on
+-- these keys). getEffectivePermissions() fails closed, so keys must exist first.
+--
+-- Mirrors lib/auth/permissions.ts PERMISSION_KEYS (the count test guards parity).
+-- Run AFTER 20260608_permissions_model.sql. Run in the Supabase SQL editor.
+
+insert into public.permissions (key, description) values
+  ('planning.schedule.read',  'Planning: view the schedule/calendar'),
+  ('planning.schedule.write', 'Planning: place/move/remove scheduled jobs'),
+  ('planning.truck.manage',   'Planning: manage trucks'),
+  ('planning.depot.manage',   'Planning: manage depots and deliveries')
+on conflict (key) do nothing;
+
+-- Role seed (confirm exact roles as planning rolls out — adjustable later in the admin UI):
+--   admin   → full planning access
+--   sales   → view + schedule (place/move jobs)
+--   konsult → read-only schedule (consistent with their CRM read-only access)
+--   member  → none (installers reach their jobs via ownership/dashboard, a later slice)
+insert into public.role_permissions (role, permission_key) values
+  ('admin','planning.schedule.read'),   ('admin','planning.schedule.write'),
+  ('admin','planning.truck.manage'),    ('admin','planning.depot.manage'),
+  ('sales','planning.schedule.read'),   ('sales','planning.schedule.write'),
+  ('konsult','planning.schedule.read')
+on conflict do nothing;

--- a/supabase/sql/20260612_enable_realtime_ops_tables.sql
+++ b/supabase/sql/20260612_enable_realtime_ops_tables.sql
@@ -1,0 +1,36 @@
+-- Wave 7 — new CRM-first planning: enable Supabase Realtime on the ops_* tables.
+--
+-- ~10 people plan concurrently, so the board must reflect each other's placements/moves live to
+-- avoid double-bookings + missed updates. PlanningClient subscribes to postgres_changes on these
+-- tables and debounce-refetches the visible board when anyone changes them. RLS still applies, so
+-- a subscriber only receives changes to rows they could SELECT (planning.schedule.read).
+--
+-- DEPLOY ORDER: run AFTER the ops_* tables exist (20260611/20260612 migrations). Idempotent.
+
+do $$
+declare
+  t text;
+  tables text[] := array[
+    'ops_segments',
+    'ops_segment_crew',
+    'ops_truck_crew',
+    'ops_day_notes',
+    'ops_segment_reports',
+    'ops_work_order_confirmations',
+    'ops_trucks',
+    'ops_depots',
+    'ops_depot_deliveries',
+    'ops_job_types'
+  ];
+begin
+  foreach t in array tables loop
+    if not exists (
+      select 1 from pg_publication_tables
+      where pubname = 'supabase_realtime' and schemaname = 'public' and tablename = t
+    ) then
+      execute format('alter publication supabase_realtime add table %I.%I', 'public', t);
+    end if;
+    -- DELETE events need the old row to be carried so subscribers know what disappeared.
+    execute format('alter table %I.%I replica identity full', 'public', t);
+  end loop;
+end $$;

--- a/supabase/sql/20260612_ops_day_notes.sql
+++ b/supabase/sql/20260612_ops_day_notes.sql
@@ -1,0 +1,42 @@
+-- Wave 7 — new CRM-first planning: day notes (dagsanteckningar).
+--
+-- Free-text notes pinned to a calendar day on the board (e.g. "Anna ledig", "Bil 2 på service",
+-- "Helgjobb möjligt"). Global per day (not truck-scoped) — the planner reads them as a strip under
+-- each day column. Append-style: one row per note, add/remove individually.
+--
+-- DEPLOY ORDER: run AFTER 20260611_planning_permissions.sql (RLS predicates call
+-- has_permission('planning.*')). Run in the Supabase SQL editor. Idempotent.
+
+create table if not exists public.ops_day_notes (
+  id         uuid primary key default gen_random_uuid(),
+  note_day   date not null,
+  body       text not null,
+  created_by uuid references public.profiles(id) on delete set null,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists ops_day_notes_day_idx on public.ops_day_notes (note_day);
+
+alter table public.ops_day_notes enable row level security;
+grant select, insert, update, delete on public.ops_day_notes to authenticated;
+
+drop policy if exists ops_day_notes_select on public.ops_day_notes;
+create policy ops_day_notes_select on public.ops_day_notes
+  for select to authenticated
+  using (public.has_permission('planning.schedule.read'));
+
+drop policy if exists ops_day_notes_insert on public.ops_day_notes;
+create policy ops_day_notes_insert on public.ops_day_notes
+  for insert to authenticated
+  with check (created_by = auth.uid() and public.has_permission('planning.schedule.write'));
+
+drop policy if exists ops_day_notes_update on public.ops_day_notes;
+create policy ops_day_notes_update on public.ops_day_notes
+  for update to authenticated
+  using (public.has_permission('planning.schedule.write'))
+  with check (public.has_permission('planning.schedule.write'));
+
+drop policy if exists ops_day_notes_delete on public.ops_day_notes;
+create policy ops_day_notes_delete on public.ops_day_notes
+  for delete to authenticated
+  using (public.has_permission('planning.schedule.write'));

--- a/supabase/sql/20260612_ops_depot_deliveries.sql
+++ b/supabase/sql/20260612_ops_depot_deliveries.sql
@@ -1,0 +1,47 @@
+-- Wave 7 — new CRM-first planning: depot deliveries (leveranser), stock half (slice 12b).
+--
+-- Each row is a delivery of sacks of a given material into a depot (stock in). Per-material balance
+-- = sum(deliveries) − consumption, where consumption is derived from ops_segment_reports (a job's
+-- blown sacks → its segment's truck → that truck's depot, attributed to the work order's material).
+-- The material string is the canonical `short` from lib/domains/crm/materials.ts (EKOVILLA, …) so
+-- deliveries and consumption reconcile.
+--
+-- DEPLOY ORDER: run AFTER 20260612_ops_depots.sql (FK → ops_depots) and
+-- 20260611_planning_permissions.sql. Run in the Supabase SQL editor. Idempotent.
+
+create table if not exists public.ops_depot_deliveries (
+  id           uuid primary key default gen_random_uuid(),
+  depot_id     uuid not null references public.ops_depots(id) on delete cascade,
+  material     text not null,
+  sacks        integer not null check (sacks > 0),
+  delivered_on date not null,
+  note         text,
+  created_by   uuid references public.profiles(id) on delete set null,
+  created_at   timestamptz not null default now()
+);
+
+create index if not exists ops_depot_deliveries_depot_idx on public.ops_depot_deliveries (depot_id, material);
+
+alter table public.ops_depot_deliveries enable row level security;
+grant select, insert, update, delete on public.ops_depot_deliveries to authenticated;
+
+drop policy if exists ops_depot_deliveries_select on public.ops_depot_deliveries;
+create policy ops_depot_deliveries_select on public.ops_depot_deliveries
+  for select to authenticated
+  using (public.has_permission('planning.schedule.read'));
+
+drop policy if exists ops_depot_deliveries_insert on public.ops_depot_deliveries;
+create policy ops_depot_deliveries_insert on public.ops_depot_deliveries
+  for insert to authenticated
+  with check (created_by = auth.uid() and public.has_permission('planning.schedule.write'));
+
+drop policy if exists ops_depot_deliveries_update on public.ops_depot_deliveries;
+create policy ops_depot_deliveries_update on public.ops_depot_deliveries
+  for update to authenticated
+  using (public.has_permission('planning.schedule.write'))
+  with check (public.has_permission('planning.schedule.write'));
+
+drop policy if exists ops_depot_deliveries_delete on public.ops_depot_deliveries;
+create policy ops_depot_deliveries_delete on public.ops_depot_deliveries
+  for delete to authenticated
+  using (public.has_permission('planning.schedule.write'));

--- a/supabase/sql/20260612_ops_depots.sql
+++ b/supabase/sql/20260612_ops_depots.sql
@@ -1,0 +1,43 @@
+-- Wave 7 — new CRM-first planning: depots (depåer), foundation half (slice 12a).
+--
+-- A depot is a physical store of insulation sacks. Each truck belongs to a depot (ops_trucks.depot_id);
+-- deliveries (stock in) and per-material balances come in slice 12b. Reading depots is a board-level
+-- read (planning.schedule.read) so lanes/pickers can show them; managing them is planning.depot.manage.
+--
+-- DEPLOY ORDER: run AFTER 20260611_ops_planning_foundation.sql (ALTER ops_trucks) and
+-- 20260611_planning_permissions.sql. Run in the Supabase SQL editor. Idempotent.
+
+create table if not exists public.ops_depots (
+  id         uuid primary key default gen_random_uuid(),
+  name       text not null,
+  location   text,
+  active     boolean not null default true,
+  created_at timestamptz not null default now()
+);
+
+alter table public.ops_depots enable row level security;
+grant select, insert, update, delete on public.ops_depots to authenticated;
+
+drop policy if exists ops_depots_select on public.ops_depots;
+create policy ops_depots_select on public.ops_depots
+  for select to authenticated
+  using (public.has_permission('planning.schedule.read'));
+
+drop policy if exists ops_depots_insert on public.ops_depots;
+create policy ops_depots_insert on public.ops_depots
+  for insert to authenticated
+  with check (public.has_permission('planning.depot.manage'));
+
+drop policy if exists ops_depots_update on public.ops_depots;
+create policy ops_depots_update on public.ops_depots
+  for update to authenticated
+  using (public.has_permission('planning.depot.manage'))
+  with check (public.has_permission('planning.depot.manage'));
+
+drop policy if exists ops_depots_delete on public.ops_depots;
+create policy ops_depots_delete on public.ops_depots
+  for delete to authenticated
+  using (public.has_permission('planning.depot.manage'));
+
+-- Each truck belongs to a depot (nullable; nulls out if the depot is removed).
+alter table public.ops_trucks add column if not exists depot_id uuid references public.ops_depots(id) on delete set null;

--- a/supabase/sql/20260612_ops_job_types.sql
+++ b/supabase/sql/20260612_ops_job_types.sql
@@ -1,0 +1,53 @@
+-- Wave 7 — new CRM-first planning: editable job types (jobbtyper + färg).
+--
+-- Job types were a hardcoded set; this makes them admin-editable. ops_segments.job_type still stores
+-- the stable `key`; label + colour are resolved from here. Reading is board-level
+-- (planning.schedule.read, for the card chip + the picker); managing reuses planning.truck.manage
+-- (the planning-admin gate, admin-only). Seeded with the original six.
+--
+-- DEPLOY ORDER: run AFTER 20260611_planning_permissions.sql. Run in the Supabase SQL editor.
+-- Idempotent.
+
+create table if not exists public.ops_job_types (
+  id         uuid primary key default gen_random_uuid(),
+  key        text not null unique,
+  label      text not null,
+  color      text not null,
+  sort_index integer not null default 0,
+  active     boolean not null default true,
+  created_at timestamptz not null default now()
+);
+
+alter table public.ops_job_types enable row level security;
+grant select, insert, update, delete on public.ops_job_types to authenticated;
+
+drop policy if exists ops_job_types_select on public.ops_job_types;
+create policy ops_job_types_select on public.ops_job_types
+  for select to authenticated
+  using (public.has_permission('planning.schedule.read'));
+
+drop policy if exists ops_job_types_insert on public.ops_job_types;
+create policy ops_job_types_insert on public.ops_job_types
+  for insert to authenticated
+  with check (public.has_permission('planning.truck.manage'));
+
+drop policy if exists ops_job_types_update on public.ops_job_types;
+create policy ops_job_types_update on public.ops_job_types
+  for update to authenticated
+  using (public.has_permission('planning.truck.manage'))
+  with check (public.has_permission('planning.truck.manage'));
+
+drop policy if exists ops_job_types_delete on public.ops_job_types;
+create policy ops_job_types_delete on public.ops_job_types
+  for delete to authenticated
+  using (public.has_permission('planning.truck.manage'));
+
+-- Seed the original set (keys match the values already stored on ops_segments.job_type).
+insert into public.ops_job_types (key, label, color, sort_index) values
+  ('ekovilla',   'Ekovilla',   '#059669', 0),
+  ('vitull',     'Vitull',     '#0284c7', 1),
+  ('leverans',   'Leverans',   '#0d9488', 2),
+  ('utsugning',  'Utsugning',  '#d97706', 3),
+  ('snickerier', 'Snickerier', '#7c3aed', 4),
+  ('ovrigt',     'Övrigt',     '#64748b', 5)
+on conflict (key) do nothing;

--- a/supabase/sql/20260612_ops_segment_crew.sql
+++ b/supabase/sql/20260612_ops_segment_crew.sql
@@ -1,0 +1,49 @@
+-- Wave 7 — new CRM-first planning: per-segment crew (besättning/team).
+--
+-- Who is going out on a scheduled job. One row per crew member on an ops_segment. The member's
+-- name is DENORMALISED here (member_name) because profiles SELECT RLS is self-only — the planner
+-- cannot read other people's profile rows, so we snapshot the display name at assign time and never
+-- need to join profiles to render the board. member_id stays (nullable) for future "my jobs" /
+-- installer linking; on profile deletion it nulls out but the name survives.
+--
+-- DEPLOY ORDER: run AFTER 20260611_ops_planning_foundation.sql (FK → ops_segments) and
+-- 20260611_planning_permissions.sql (RLS predicates call has_permission('planning.*')).
+-- Run in the Supabase SQL editor. Idempotent.
+
+create table if not exists public.ops_segment_crew (
+  id          uuid primary key default gen_random_uuid(),
+  segment_id  uuid not null references public.ops_segments(id) on delete cascade,
+  member_id   uuid references public.profiles(id) on delete set null,
+  member_name text not null,
+  created_by  uuid references public.profiles(id) on delete set null,
+  created_at  timestamptz not null default now()
+);
+
+create index if not exists ops_segment_crew_segment_idx on public.ops_segment_crew (segment_id);
+-- A given person can't be added to the same segment twice (freetext-only rows are unconstrained).
+create unique index if not exists ops_segment_crew_member_uniq
+  on public.ops_segment_crew (segment_id, member_id) where member_id is not null;
+
+alter table public.ops_segment_crew enable row level security;
+grant select, insert, update, delete on public.ops_segment_crew to authenticated;
+
+drop policy if exists ops_segment_crew_select on public.ops_segment_crew;
+create policy ops_segment_crew_select on public.ops_segment_crew
+  for select to authenticated
+  using (public.has_permission('planning.schedule.read'));
+
+drop policy if exists ops_segment_crew_insert on public.ops_segment_crew;
+create policy ops_segment_crew_insert on public.ops_segment_crew
+  for insert to authenticated
+  with check (created_by = auth.uid() and public.has_permission('planning.schedule.write'));
+
+drop policy if exists ops_segment_crew_update on public.ops_segment_crew;
+create policy ops_segment_crew_update on public.ops_segment_crew
+  for update to authenticated
+  using (public.has_permission('planning.schedule.write'))
+  with check (public.has_permission('planning.schedule.write'));
+
+drop policy if exists ops_segment_crew_delete on public.ops_segment_crew;
+create policy ops_segment_crew_delete on public.ops_segment_crew
+  for delete to authenticated
+  using (public.has_permission('planning.schedule.write'));

--- a/supabase/sql/20260612_ops_segments_on_hold.sql
+++ b/supabase/sql/20260612_ops_segments_on_hold.sql
@@ -1,0 +1,11 @@
+-- Wave 7 — new CRM-first planning: paused jobs (pausade jobb / on-hold).
+--
+-- A scheduled placement can be put on hold (customer postponed, material delayed, …). The job keeps
+-- its slot on the board but is visually dimmed + badged "Pausad" so it isn't treated as active. This
+-- is just a flag on the placement; RLS is already enforced by the existing ops_segments policies
+-- (write = planning.schedule.write), so no new policy is needed.
+--
+-- DEPLOY ORDER: run AFTER 20260611_ops_planning_foundation.sql. Run in the Supabase SQL editor.
+-- Idempotent.
+
+alter table public.ops_segments add column if not exists on_hold boolean not null default false;

--- a/supabase/sql/20260612_ops_truck_crew.sql
+++ b/supabase/sql/20260612_ops_truck_crew.sql
@@ -1,0 +1,51 @@
+-- Wave 7 — new CRM-first planning: weekly truck crew (besättning per bil / rotation).
+--
+-- Who crews a truck over a date range (typically a week). The board shows each truck's crew for the
+-- visible week on its lane and lets the planner rotate it week to week. This is the truck's standing
+-- team; a specific job can still carry its own extra crew (ops_segment_crew, slice 5). Like that
+-- table, member_name is DENORMALISED because profiles SELECT RLS is self-only — the board renders
+-- without joining profiles. member_id stays (nullable) for future linking.
+--
+-- DEPLOY ORDER: run AFTER 20260611_ops_planning_foundation.sql (FK → ops_trucks) and
+-- 20260611_planning_permissions.sql. Run in the Supabase SQL editor. Idempotent.
+
+create table if not exists public.ops_truck_crew (
+  id          uuid primary key default gen_random_uuid(),
+  truck_id    uuid not null references public.ops_trucks(id) on delete cascade,
+  member_id   uuid references public.profiles(id) on delete set null,
+  member_name text not null,
+  start_day   date not null,
+  end_day     date not null,
+  created_by  uuid references public.profiles(id) on delete set null,
+  created_at  timestamptz not null default now(),
+  constraint ops_truck_crew_day_range_check check (end_day >= start_day)
+);
+
+create index if not exists ops_truck_crew_truck_range_idx on public.ops_truck_crew (truck_id, start_day, end_day);
+-- A person can't be added to the same truck twice for the same period start (weekly key).
+create unique index if not exists ops_truck_crew_member_uniq
+  on public.ops_truck_crew (truck_id, member_id, start_day) where member_id is not null;
+
+alter table public.ops_truck_crew enable row level security;
+grant select, insert, update, delete on public.ops_truck_crew to authenticated;
+
+drop policy if exists ops_truck_crew_select on public.ops_truck_crew;
+create policy ops_truck_crew_select on public.ops_truck_crew
+  for select to authenticated
+  using (public.has_permission('planning.schedule.read'));
+
+drop policy if exists ops_truck_crew_insert on public.ops_truck_crew;
+create policy ops_truck_crew_insert on public.ops_truck_crew
+  for insert to authenticated
+  with check (created_by = auth.uid() and public.has_permission('planning.schedule.write'));
+
+drop policy if exists ops_truck_crew_update on public.ops_truck_crew;
+create policy ops_truck_crew_update on public.ops_truck_crew
+  for update to authenticated
+  using (public.has_permission('planning.schedule.write'))
+  with check (public.has_permission('planning.schedule.write'));
+
+drop policy if exists ops_truck_crew_delete on public.ops_truck_crew;
+create policy ops_truck_crew_delete on public.ops_truck_crew
+  for delete to authenticated
+  using (public.has_permission('planning.schedule.write'));

--- a/supabase/sql/20260612_ops_work_order_confirmations.sql
+++ b/supabase/sql/20260612_ops_work_order_confirmations.sql
@@ -1,0 +1,56 @@
+-- Wave 7 — new CRM-first planning: order confirmations (orderbekräftelse) sent to the customer.
+--
+-- Append-only log of confirmations sent for a scheduled job: one row per channel per send. The
+-- recipient is resolved from the CRM customer (CRM-first) at send time and snapshotted here. The
+-- board reads a per-work-order summary (latest email + latest sms) keyed by work_order_id — the
+-- same aggregate-by-work-order pattern as ops_segment_reports — and shows a "bekräftad" badge on
+-- every one of the job's cards. segment_id records which placement triggered the send (nullable
+-- for durability if that placement is later removed).
+--
+-- provider_message_id/status capture Twilio's SID + initial status; wiring the delivery-status
+-- callback into this table is a later slice (the existing app/api/twilio/sms-status route still
+-- targets the old planning_project_meta).
+--
+-- DEPLOY ORDER: run AFTER 20260611_ops_planning_foundation.sql (FK → ops_segments / crm_work_orders)
+-- and 20260611_planning_permissions.sql. Run in the Supabase SQL editor. Idempotent.
+
+create table if not exists public.ops_work_order_confirmations (
+  id                  uuid primary key default gen_random_uuid(),
+  work_order_id       uuid not null references public.crm_work_orders(id) on delete cascade,
+  segment_id          uuid references public.ops_segments(id) on delete set null,
+  channel             text not null check (channel in ('email', 'sms')),
+  recipient           text not null,
+  start_day           date not null,
+  end_day             date not null,
+  provider_message_id text,
+  status              text,
+  created_by          uuid references public.profiles(id) on delete set null,
+  created_at          timestamptz not null default now()
+);
+
+create index if not exists ops_wo_confirmations_work_order_idx on public.ops_work_order_confirmations (work_order_id, created_at desc);
+create index if not exists ops_wo_confirmations_segment_idx    on public.ops_work_order_confirmations (segment_id);
+
+alter table public.ops_work_order_confirmations enable row level security;
+grant select, insert, update, delete on public.ops_work_order_confirmations to authenticated;
+
+drop policy if exists ops_wo_confirmations_select on public.ops_work_order_confirmations;
+create policy ops_wo_confirmations_select on public.ops_work_order_confirmations
+  for select to authenticated
+  using (public.has_permission('planning.schedule.read'));
+
+drop policy if exists ops_wo_confirmations_insert on public.ops_work_order_confirmations;
+create policy ops_wo_confirmations_insert on public.ops_work_order_confirmations
+  for insert to authenticated
+  with check (created_by = auth.uid() and public.has_permission('planning.schedule.write'));
+
+drop policy if exists ops_wo_confirmations_update on public.ops_work_order_confirmations;
+create policy ops_wo_confirmations_update on public.ops_work_order_confirmations
+  for update to authenticated
+  using (public.has_permission('planning.schedule.write'))
+  with check (public.has_permission('planning.schedule.write'));
+
+drop policy if exists ops_wo_confirmations_delete on public.ops_work_order_confirmations;
+create policy ops_wo_confirmations_delete on public.ops_work_order_confirmations
+  for delete to authenticated
+  using (public.has_permission('planning.schedule.write'));

--- a/tests/auth/permissions.test.ts
+++ b/tests/auth/permissions.test.ts
@@ -20,7 +20,7 @@ describe('PERMISSION_KEYS catalog', () => {
   // Mirrors the SQL `permissions` catalog in 20260608_permissions_model.sql. If you add a key
   // there, add it here too (and to the seed + parity assert) — this guards the count.
   it('has the expected count and no duplicates', () => {
-    expect(PERMISSION_KEYS.length).toBe(35);
+    expect(PERMISSION_KEYS.length).toBe(39);
     expect(new Set(PERMISSION_KEYS).size).toBe(PERMISSION_KEYS.length);
   });
 
@@ -40,6 +40,12 @@ describe('PERMISSION_KEYS catalog', () => {
 
   it('includes the Fortnox bookkeeping action keys', () => {
     for (const key of ['fortnox.offer.push', 'fortnox.workorder.push', 'fortnox.invoice.create', 'fortnox.customer.sync', 'fortnox.read'] as const) {
+      expect(PERMISSION_KEYS).toContain(key);
+    }
+  });
+
+  it('includes the planning scheduling keys (Wave 7)', () => {
+    for (const key of ['planning.schedule.read', 'planning.schedule.write', 'planning.truck.manage', 'planning.depot.manage'] as const) {
       expect(PERMISSION_KEYS).toContain(key);
     }
   });

--- a/tests/planning/backlog.test.ts
+++ b/tests/planning/backlog.test.ts
@@ -9,6 +9,7 @@ const baseRow = {
   client_name: 'Bygg AB',
   status: 'scheduled',
   desired_installation_date: '2026-06-20',
+  assigned_to: null as string | null,
   work_address: null as Record<string, unknown> | null,
   customer_snapshot: null as Record<string, unknown> | null,
   line_items: [] as unknown[],
@@ -71,7 +72,10 @@ describe('mapWorkOrderToBacklogItem', () => {
   });
 
   it('passes through identity, date, contact and the segment count', () => {
-    const item = mapWorkOrderToBacklogItem({ ...baseRow, customer_snapshot: { email: 'a@b.se', phone: '070-1234567' } }, 2);
+    const item = mapWorkOrderToBacklogItem(
+      { ...baseRow, assigned_to: 'user-9', customer_snapshot: { email: 'a@b.se', phone: '070-1234567' } },
+      2,
+    );
     expect(item).toMatchObject({
       id: baseRow.id,
       project_name: 'Vind Storgatan',
@@ -80,6 +84,7 @@ describe('mapWorkOrderToBacklogItem', () => {
       desired_installation_date: '2026-06-20',
       contact_email: 'a@b.se',
       contact_phone: '070-1234567',
+      assigned_to: 'user-9',
       segment_count: 2,
     });
   });

--- a/tests/planning/backlog.test.ts
+++ b/tests/planning/backlog.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { mapWorkOrderToBacklogItem, resolveBacklogAddress } from '@/lib/domains/planning/backlog';
+
+const baseRow = {
+  id: '00000000-0000-0000-0000-000000000001',
+  order_number: 'AO-1',
+  project_name: 'Vind Storgatan',
+  client_name: 'Bygg AB',
+  status: 'scheduled',
+  desired_installation_date: '2026-06-20',
+  work_address: null as Record<string, unknown> | null,
+  customer_snapshot: null as Record<string, unknown> | null,
+  line_items: [] as unknown[],
+};
+
+describe('resolveBacklogAddress', () => {
+  it('prefers the separate work address', () => {
+    expect(
+      resolveBacklogAddress(
+        { street_address: 'Jobbvägen 1', postal_code: '11122', city: 'Stockholm' },
+        { street_address: 'Kontoret 9', city: 'Göteborg' },
+      ),
+    ).toBe('Jobbvägen 1, 11122, Stockholm');
+  });
+
+  it('falls back to a delivery address on the snapshot', () => {
+    expect(
+      resolveBacklogAddress(null, {
+        delivery_address: 'Leveransgatan 2',
+        delivery_city: 'Malmö',
+        street_address: 'Kontoret 9',
+      }),
+    ).toBe('Leveransgatan 2, Malmö');
+  });
+
+  it('falls back to the customer card address', () => {
+    expect(
+      resolveBacklogAddress({}, { street_address: 'Kontoret 9', postal_code: '40010', city: 'Göteborg' }),
+    ).toBe('Kontoret 9, 40010, Göteborg');
+  });
+
+  it('returns null when there is no address', () => {
+    expect(resolveBacklogAddress(null, null)).toBeNull();
+  });
+});
+
+describe('mapWorkOrderToBacklogItem', () => {
+  it('computes total sacks from Ekovilla line items (m³ × density ÷ bag weight, rounded up)', () => {
+    const row = {
+      ...baseRow,
+      // 10 m² × 200 mm = 2 m³; 2 × 45 / 14 (Ekovilla bag weight) = 6.43 → 7 säck
+      line_items: [{ article_name: 'Ekovilla Cellulosa Lösull', m2: '10', thickness_mm: '200', density: '45', pricing_mode: 'm3' }],
+    };
+    expect(mapWorkOrderToBacklogItem(row, 0).total_sacks).toBe(7);
+  });
+
+  it('skips sacks when the material or density is missing', () => {
+    const row = {
+      ...baseRow,
+      line_items: [
+        { article_name: 'Okänt material', m2: '10', thickness_mm: '200', density: '45', pricing_mode: 'm3' },
+        { article_name: 'Ekovilla', m2: '10', thickness_mm: '200', pricing_mode: 'm3' }, // no density
+      ],
+    };
+    expect(mapWorkOrderToBacklogItem(row, 0).total_sacks).toBe(0);
+  });
+
+  it('passes through identity, date, contact and the segment count', () => {
+    const item = mapWorkOrderToBacklogItem({ ...baseRow, customer_snapshot: { email: 'a@b.se', phone: '070-1234567' } }, 2);
+    expect(item).toMatchObject({
+      id: baseRow.id,
+      order_number: 'AO-1',
+      project_name: 'Vind Storgatan',
+      client_name: 'Bygg AB',
+      desired_installation_date: '2026-06-20',
+      contact_email: 'a@b.se',
+      contact_phone: '070-1234567',
+      segment_count: 2,
+    });
+  });
+});

--- a/tests/planning/backlog.test.ts
+++ b/tests/planning/backlog.test.ts
@@ -4,6 +4,7 @@ import { mapWorkOrderToBacklogItem, resolveBacklogAddress } from '@/lib/domains/
 const baseRow = {
   id: '00000000-0000-0000-0000-000000000001',
   order_number: 'AO-1',
+  fortnox_order_number: null as string | null,
   project_name: 'Vind Storgatan',
   client_name: 'Bygg AB',
   status: 'scheduled',
@@ -51,27 +52,31 @@ describe('mapWorkOrderToBacklogItem', () => {
       // 10 m² × 200 mm = 2 m³; 2 × 45 / 14 (Ekovilla bag weight) = 6.43 → 7 säck
       line_items: [{ article_name: 'Ekovilla Cellulosa Lösull', m2: '10', thickness_mm: '200', density: '45', pricing_mode: 'm3' }],
     };
-    expect(mapWorkOrderToBacklogItem(row, 0).total_sacks).toBe(7);
+    const item = mapWorkOrderToBacklogItem(row, 0);
+    expect(item.total_sacks).toBe(7);
+    expect(item.material).toBe('Ekovilla');
   });
 
-  it('skips sacks when the material or density is missing', () => {
-    const row = {
-      ...baseRow,
-      line_items: [
-        { article_name: 'Okänt material', m2: '10', thickness_mm: '200', density: '45', pricing_mode: 'm3' },
-        { article_name: 'Ekovilla', m2: '10', thickness_mm: '200', pricing_mode: 'm3' }, // no density
-      ],
-    };
-    expect(mapWorkOrderToBacklogItem(row, 0).total_sacks).toBe(0);
+  it('leads with the internal order number when no Fortnox number yet', () => {
+    const item = mapWorkOrderToBacklogItem(baseRow, 0);
+    expect(item.ref).toBe('AO-1');
+    expect(item.is_fortnox_ref).toBe(false);
+    expect(item.material).toBeNull();
+  });
+
+  it('leads with the Fortnox order number once synced', () => {
+    const item = mapWorkOrderToBacklogItem({ ...baseRow, fortnox_order_number: '5418' }, 0);
+    expect(item.ref).toBe('#5418');
+    expect(item.is_fortnox_ref).toBe(true);
   });
 
   it('passes through identity, date, contact and the segment count', () => {
     const item = mapWorkOrderToBacklogItem({ ...baseRow, customer_snapshot: { email: 'a@b.se', phone: '070-1234567' } }, 2);
     expect(item).toMatchObject({
       id: baseRow.id,
-      order_number: 'AO-1',
       project_name: 'Vind Storgatan',
       client_name: 'Bygg AB',
+      status: 'scheduled',
       desired_installation_date: '2026-06-20',
       contact_email: 'a@b.se',
       contact_phone: '070-1234567',

--- a/tests/planning/confirmations.test.ts
+++ b/tests/planning/confirmations.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { summarizeConfirmations } from '@/lib/domains/planning/confirmations';
+import { summarizeConfirmations, describeSmsStatus } from '@/lib/domains/planning/confirmations';
 
 describe('summarizeConfirmations', () => {
   it('returns an empty map for no rows', () => {
@@ -9,7 +9,7 @@ describe('summarizeConfirmations', () => {
   it('keeps the latest email + latest sms per work order, regardless of input order', () => {
     const rows = [
       { work_order_id: 'wo1', channel: 'email', recipient: 'old@x.se', created_at: '2026-06-01T08:00:00Z' },
-      { work_order_id: 'wo1', channel: 'sms', recipient: '+46700000001', created_at: '2026-06-02T08:00:00Z' },
+      { work_order_id: 'wo1', channel: 'sms', recipient: '+46700000001', created_at: '2026-06-02T08:00:00Z', status: 'delivered' },
       { work_order_id: 'wo1', channel: 'email', recipient: 'new@x.se', created_at: '2026-06-03T08:00:00Z' },
     ];
     const summary = summarizeConfirmations(rows).get('wo1');
@@ -18,6 +18,7 @@ describe('summarizeConfirmations', () => {
       email_to: 'new@x.se',
       sms_sent_at: '2026-06-02T08:00:00Z',
       sms_to: '+46700000001',
+      sms_status: 'delivered',
     });
   });
 
@@ -31,5 +32,32 @@ describe('summarizeConfirmations', () => {
     expect(map.get('wo1')?.sms_sent_at).toBeNull();
     expect(map.get('wo2')?.sms_to).toBe('+46700000002');
     expect(map.get('wo2')?.email_sent_at).toBeNull();
+  });
+
+  it('captures the latest sms status (newest row wins)', () => {
+    const rows = [
+      { work_order_id: 'wo1', channel: 'sms', recipient: '+4670', created_at: '2026-06-01T08:00:00Z', status: 'queued' },
+      { work_order_id: 'wo1', channel: 'sms', recipient: '+4670', created_at: '2026-06-01T09:00:00Z', status: 'delivered' },
+    ];
+    expect(summarizeConfirmations(rows).get('wo1')?.sms_status).toBe('delivered');
+  });
+});
+
+describe('describeSmsStatus', () => {
+  it('returns null when there is no status', () => {
+    expect(describeSmsStatus(null)).toBeNull();
+    expect(describeSmsStatus(undefined)).toBeNull();
+    expect(describeSmsStatus('')).toBeNull();
+  });
+  it('marks delivered as ok', () => {
+    expect(describeSmsStatus('delivered')).toEqual({ label: 'Levererat', tone: 'ok' });
+  });
+  it('marks failed + undelivered as fail (case-insensitive)', () => {
+    expect(describeSmsStatus('failed')?.tone).toBe('fail');
+    expect(describeSmsStatus('UNDELIVERED')?.tone).toBe('fail');
+  });
+  it('treats in-flight statuses as pending', () => {
+    expect(describeSmsStatus('queued')?.tone).toBe('pending');
+    expect(describeSmsStatus('sent')?.tone).toBe('pending');
   });
 });

--- a/tests/planning/confirmations.test.ts
+++ b/tests/planning/confirmations.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { summarizeConfirmations } from '@/lib/domains/planning/confirmations';
+
+describe('summarizeConfirmations', () => {
+  it('returns an empty map for no rows', () => {
+    expect(summarizeConfirmations([]).size).toBe(0);
+  });
+
+  it('keeps the latest email + latest sms per work order, regardless of input order', () => {
+    const rows = [
+      { work_order_id: 'wo1', channel: 'email', recipient: 'old@x.se', created_at: '2026-06-01T08:00:00Z' },
+      { work_order_id: 'wo1', channel: 'sms', recipient: '+46700000001', created_at: '2026-06-02T08:00:00Z' },
+      { work_order_id: 'wo1', channel: 'email', recipient: 'new@x.se', created_at: '2026-06-03T08:00:00Z' },
+    ];
+    const summary = summarizeConfirmations(rows).get('wo1');
+    expect(summary).toEqual({
+      email_sent_at: '2026-06-03T08:00:00Z',
+      email_to: 'new@x.se',
+      sms_sent_at: '2026-06-02T08:00:00Z',
+      sms_to: '+46700000001',
+    });
+  });
+
+  it('summarises each work order independently', () => {
+    const rows = [
+      { work_order_id: 'wo1', channel: 'email', recipient: 'a@x.se', created_at: '2026-06-01T08:00:00Z' },
+      { work_order_id: 'wo2', channel: 'sms', recipient: '+46700000002', created_at: '2026-06-01T08:00:00Z' },
+    ];
+    const map = summarizeConfirmations(rows);
+    expect(map.get('wo1')?.email_to).toBe('a@x.se');
+    expect(map.get('wo1')?.sms_sent_at).toBeNull();
+    expect(map.get('wo2')?.sms_to).toBe('+46700000002');
+    expect(map.get('wo2')?.email_sent_at).toBeNull();
+  });
+});

--- a/tests/planning/crew.test.ts
+++ b/tests/planning/crew.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { crewInitials, crewColor, validateCrewAssignment } from '@/lib/domains/planning/crew';
+
+describe('crewInitials', () => {
+  it('takes the first + last name initials', () => {
+    expect(crewInitials('Anna Svensson')).toBe('AS');
+    expect(crewInitials('Erik Johan Berg')).toBe('EB');
+  });
+  it('uses the first two letters of a single name', () => {
+    expect(crewInitials('Kenta')).toBe('KE');
+  });
+  it('uppercases and trims surrounding whitespace', () => {
+    expect(crewInitials('  lars  ohlin ')).toBe('LO');
+  });
+  it('falls back to ? for an empty name', () => {
+    expect(crewInitials('')).toBe('?');
+    expect(crewInitials('   ')).toBe('?');
+  });
+});
+
+describe('crewColor', () => {
+  it('is deterministic for the same seed', () => {
+    expect(crewColor('abc')).toBe(crewColor('abc'));
+  });
+  it('always returns a hex from the palette', () => {
+    for (const seed of ['anna', 'erik', 'lars-123', '']) {
+      expect(crewColor(seed)).toMatch(/^#[0-9a-f]{6}$/);
+    }
+  });
+});
+
+describe('validateCrewAssignment', () => {
+  it('accepts a non-empty name', () => {
+    expect(validateCrewAssignment('Anna Svensson')).toBeNull();
+  });
+  it('rejects an empty/whitespace name', () => {
+    expect(validateCrewAssignment('')).toBe('invalid_name');
+    expect(validateCrewAssignment('   ')).toBe('invalid_name');
+  });
+});

--- a/tests/planning/dates.test.ts
+++ b/tests/planning/dates.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { addDaysISO, daysBetweenInclusive, isoWeek, buildWeekDays, buildMonthWeeks, parseISO } from '@/app/crm/planering/planningDates';
+
+describe('addDaysISO / daysBetweenInclusive', () => {
+  it('adds days across a month boundary', () => {
+    expect(addDaysISO('2026-06-30', 1)).toBe('2026-07-01');
+    expect(addDaysISO('2026-06-15', 6)).toBe('2026-06-21');
+  });
+  it('counts an inclusive span (same day = 1)', () => {
+    expect(daysBetweenInclusive('2026-06-15', '2026-06-15')).toBe(1);
+    expect(daysBetweenInclusive('2026-06-15', '2026-06-17')).toBe(3);
+  });
+});
+
+describe('isoWeek', () => {
+  it('numbers June 2026 weeks (Mon 15 Jun 2026 = ISO week 25)', () => {
+    expect(isoWeek(parseISO('2026-06-15'))).toBe(25);
+    expect(isoWeek(parseISO('2026-06-01'))).toBe(23);
+  });
+});
+
+describe('buildWeekDays', () => {
+  it('builds Mon..Sun from a Monday with weekend flags', () => {
+    const days = buildWeekDays(parseISO('2026-06-15'));
+    expect(days.map((d) => d.iso)).toEqual([
+      '2026-06-15', '2026-06-16', '2026-06-17', '2026-06-18', '2026-06-19', '2026-06-20', '2026-06-21',
+    ]);
+    expect(days[0].weekday).toBe('mån');
+    expect(days[5].isWeekend).toBe(true);
+    expect(days[6].isWeekend).toBe(true);
+    expect(days[0].isWeekend).toBe(false);
+  });
+});
+
+describe('buildMonthWeeks', () => {
+  it('covers June 2026 with Mon-start weeks and in/out-of-month flags', () => {
+    const weeks = buildMonthWeeks(parseISO('2026-06-17'));
+    // June 1 2026 is a Monday → first week starts on the 1st
+    expect(weeks[0].days[0].iso).toBe('2026-06-01');
+    expect(weeks[0].weekNo).toBe(23);
+    // last week must include June 30 and spill into July (out of month)
+    const last = weeks[weeks.length - 1];
+    const july1 = last.days.find((d) => d.iso === '2026-07-01');
+    expect(july1?.inMonth).toBe(false);
+    const jun30 = weeks.flatMap((w) => w.days).find((d) => d.iso === '2026-06-30');
+    expect(jun30?.inMonth).toBe(true);
+  });
+});

--- a/tests/planning/dayNotes.test.ts
+++ b/tests/planning/dayNotes.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { groupNotesByDay, validateNoteBody, type DayNote } from '@/lib/domains/planning/dayNotes';
+
+function note(id: string, note_day: string, body: string): DayNote {
+  return { id, note_day, body, created_by: null };
+}
+
+describe('validateNoteBody', () => {
+  it('accepts a non-empty body', () => {
+    expect(validateNoteBody('Anna ledig')).toBeNull();
+  });
+  it('rejects empty / whitespace', () => {
+    expect(validateNoteBody('')).toBe('empty');
+    expect(validateNoteBody('   ')).toBe('empty');
+  });
+  it('rejects an over-long body', () => {
+    expect(validateNoteBody('x'.repeat(501))).toBe('too_long');
+  });
+});
+
+describe('groupNotesByDay', () => {
+  it('returns an empty map for no notes', () => {
+    expect(groupNotesByDay([]).size).toBe(0);
+  });
+
+  it('groups notes by day, preserving input order within a day', () => {
+    const notes = [
+      note('1', '2026-06-15', 'Bil 2 på service'),
+      note('2', '2026-06-15', 'Anna ledig'),
+      note('3', '2026-06-16', 'Helgjobb möjligt'),
+    ];
+    const map = groupNotesByDay(notes);
+    expect(map.get('2026-06-15')?.map((n) => n.id)).toEqual(['1', '2']);
+    expect(map.get('2026-06-16')?.map((n) => n.id)).toEqual(['3']);
+    expect(map.get('2026-06-17')).toBeUndefined();
+  });
+});

--- a/tests/planning/depotStock.test.ts
+++ b/tests/planning/depotStock.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { computeDepotBalances, type StockRow } from '@/lib/domains/planning/depotStock';
+import { materialShortFromLineItems, MATERIAL_SHORTS } from '@/lib/domains/crm/materials';
+
+describe('computeDepotBalances', () => {
+  const depots = [
+    { id: 'd1', name: 'Huvudlager' },
+    { id: 'd2', name: 'Syd' },
+  ];
+
+  it('nets deliveries against consumption per depot + material', () => {
+    const delivered: StockRow[] = [
+      { depot_id: 'd1', material: 'EKOVILLA', sacks: 100 },
+      { depot_id: 'd1', material: 'EKOVILLA', sacks: 50 }, // two deliveries, same material
+      { depot_id: 'd1', material: 'PAROC', sacks: 40 },
+    ];
+    const consumed: StockRow[] = [{ depot_id: 'd1', material: 'EKOVILLA', sacks: 30 }];
+
+    const d1 = computeDepotBalances(depots, delivered, consumed).find((d) => d.depot_id === 'd1')!;
+    const eko = d1.rows.find((r) => r.material === 'EKOVILLA')!;
+    expect(eko).toEqual({ material: 'EKOVILLA', delivered: 150, consumed: 30, balance: 120 });
+    expect(d1.rows.find((r) => r.material === 'PAROC')!.balance).toBe(40);
+    expect(d1.total_balance).toBe(160);
+  });
+
+  it('shows a material that has only consumption (negative balance)', () => {
+    const d1 = computeDepotBalances(depots, [], [{ depot_id: 'd1', material: 'EKOVILLA', sacks: 25 }]).find((d) => d.depot_id === 'd1')!;
+    expect(d1.rows[0]).toEqual({ material: 'EKOVILLA', delivered: 0, consumed: 25, balance: -25 });
+  });
+
+  it('returns every depot, with empty rows when it has no movements', () => {
+    const result = computeDepotBalances(depots, [{ depot_id: 'd1', material: 'PAROC', sacks: 10 }], []);
+    expect(result.map((d) => d.depot_id)).toEqual(['d1', 'd2']);
+    expect(result.find((d) => d.depot_id === 'd2')!.rows).toEqual([]);
+    expect(result.find((d) => d.depot_id === 'd2')!.total_balance).toBe(0);
+  });
+});
+
+describe('materialShortFromLineItems', () => {
+  it('returns the short of the first recognised material', () => {
+    const short = materialShortFromLineItems([{ article_name: 'Ekovilla Cellulosa Lösull' }]);
+    expect(short).toBe('EKOVILLA');
+    expect(MATERIAL_SHORTS).toContain(short);
+  });
+  it('returns null when no material is recognised', () => {
+    expect(materialShortFromLineItems([{ article_name: 'Arbete' }])).toBeNull();
+    expect(materialShortFromLineItems(null)).toBeNull();
+  });
+});

--- a/tests/planning/depots.test.ts
+++ b/tests/planning/depots.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { validateDepot } from '@/lib/domains/planning/depots';
+
+describe('validateDepot', () => {
+  it('accepts a named depot', () => {
+    expect(validateDepot('Huvudlager')).toBeNull();
+  });
+  it('requires a name', () => {
+    expect(validateDepot('')).toBe('name_required');
+    expect(validateDepot('   ')).toBe('name_required');
+  });
+  it('rejects an over-long name', () => {
+    expect(validateDepot('x'.repeat(81))).toBe('name_too_long');
+  });
+});

--- a/tests/planning/display.test.ts
+++ b/tests/planning/display.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { workOrderRef, materialLabelFromLineItems, mapWorkOrderJob } from '@/lib/domains/planning/display';
+
+describe('workOrderRef', () => {
+  it('leads with the Fortnox number when present', () => {
+    expect(workOrderRef('5418', 'AO-20260611-A1B2')).toEqual({ ref: '#5418', isFortnox: true });
+  });
+  it('falls back to the internal order number when not synced', () => {
+    expect(workOrderRef(null, 'AO-20260611-A1B2')).toEqual({ ref: 'AO-20260611-A1B2', isFortnox: false });
+    expect(workOrderRef('  ', 'AO-1')).toEqual({ ref: 'AO-1', isFortnox: false });
+  });
+});
+
+describe('materialLabelFromLineItems', () => {
+  it('title-cases the recognised material brand', () => {
+    expect(materialLabelFromLineItems([{ article_name: 'EKOVILLA cellulosa lösull' }])).toBe('Ekovilla');
+  });
+  it('returns null when no known material is present', () => {
+    expect(materialLabelFromLineItems([{ article_name: 'Diverse' }])).toBeNull();
+    expect(materialLabelFromLineItems(null)).toBeNull();
+  });
+});
+
+describe('mapWorkOrderJob', () => {
+  it('produces the shared card fields', () => {
+    const job = mapWorkOrderJob({
+      order_number: 'AO-1',
+      fortnox_order_number: '5418',
+      project_name: 'Vind',
+      client_name: 'Bygg AB',
+      status: 'in_progress',
+      work_address: { street_address: 'Jobbvägen 1', city: 'Nacka' },
+      customer_snapshot: { street_address: 'Kontoret 9', city: 'Sthlm' },
+      line_items: [{ article_name: 'Ekovilla', m2: '10', thickness_mm: '200', density: '45', pricing_mode: 'm3' }],
+    });
+    expect(job).toMatchObject({
+      ref: '#5418',
+      is_fortnox_ref: true,
+      project_name: 'Vind',
+      client_name: 'Bygg AB',
+      status: 'in_progress',
+      address: 'Jobbvägen 1, Nacka',
+      total_sacks: 7,
+      material: 'Ekovilla',
+    });
+  });
+});

--- a/tests/planning/holidays.test.ts
+++ b/tests/planning/holidays.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { swedishHoliday } from '@/lib/domains/planning/holidays';
+
+describe('swedishHoliday', () => {
+  it('resolves fixed-date red days', () => {
+    expect(swedishHoliday('2026-01-01')).toBe('Nyårsdagen');
+    expect(swedishHoliday('2026-01-06')).toBe('Trettondedag jul');
+    expect(swedishHoliday('2026-05-01')).toBe('Första maj');
+    expect(swedishHoliday('2026-06-06')).toBe('Sveriges nationaldag');
+    expect(swedishHoliday('2026-12-25')).toBe('Juldagen');
+    expect(swedishHoliday('2026-12-26')).toBe('Annandag jul');
+  });
+
+  it('resolves Easter-derived holidays (Easter 2026 = 5 Apr)', () => {
+    expect(swedishHoliday('2026-04-03')).toBe('Långfredagen');
+    expect(swedishHoliday('2026-04-05')).toBe('Påskdagen');
+    expect(swedishHoliday('2026-04-06')).toBe('Annandag påsk');
+    expect(swedishHoliday('2026-05-14')).toBe('Kristi himmelsfärds dag');
+    expect(swedishHoliday('2026-05-24')).toBe('Pingstdagen');
+  });
+
+  it('resolves midsummer (Sat 20 Jun 2026) + its eve', () => {
+    expect(swedishHoliday('2026-06-20')).toBe('Midsommardagen');
+    expect(swedishHoliday('2026-06-19')).toBe('Midsommarafton');
+  });
+
+  it('returns null on an ordinary day', () => {
+    expect(swedishHoliday('2026-06-10')).toBeNull();
+    expect(swedishHoliday('2026-03-17')).toBeNull();
+  });
+
+  it('works across years (Easter 2025 = 20 Apr)', () => {
+    expect(swedishHoliday('2025-04-20')).toBe('Påskdagen');
+    expect(swedishHoliday('2025-04-18')).toBe('Långfredagen');
+  });
+});

--- a/tests/planning/jobTypes.test.ts
+++ b/tests/planning/jobTypes.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { resolveJobType, JOB_TYPES } from '@/lib/domains/planning/jobTypes';
+
+describe('resolveJobType', () => {
+  it('resolves a known key (case-insensitive) to label + colour', () => {
+    expect(resolveJobType('ekovilla')).toMatchObject({ key: 'ekovilla', label: 'Ekovilla' });
+    expect(resolveJobType('UTSUGNING')).toMatchObject({ key: 'utsugning', label: 'Utsugning' });
+  });
+  it('returns null for empty/nullish', () => {
+    expect(resolveJobType(null)).toBeNull();
+    expect(resolveJobType('  ')).toBeNull();
+  });
+  it('renders an unknown key in a neutral colour', () => {
+    const r = resolveJobType('special');
+    expect(r?.label).toBe('special');
+    expect(r?.color).toBe('#64748b');
+  });
+  it('has unique keys', () => {
+    expect(new Set(JOB_TYPES.map((t) => t.key)).size).toBe(JOB_TYPES.length);
+  });
+});

--- a/tests/planning/jobTypes.test.ts
+++ b/tests/planning/jobTypes.test.ts
@@ -1,21 +1,43 @@
 import { describe, it, expect } from 'vitest';
-import { resolveJobType, JOB_TYPES } from '@/lib/domains/planning/jobTypes';
+import { resolveJobTypeFrom, validateJobType, slugifyJobType, DEFAULT_JOB_TYPES } from '@/lib/domains/planning/jobTypes';
 
-describe('resolveJobType', () => {
+describe('resolveJobTypeFrom', () => {
   it('resolves a known key (case-insensitive) to label + colour', () => {
-    expect(resolveJobType('ekovilla')).toMatchObject({ key: 'ekovilla', label: 'Ekovilla' });
-    expect(resolveJobType('UTSUGNING')).toMatchObject({ key: 'utsugning', label: 'Utsugning' });
+    expect(resolveJobTypeFrom(DEFAULT_JOB_TYPES, 'ekovilla')).toMatchObject({ key: 'ekovilla', label: 'Ekovilla' });
+    expect(resolveJobTypeFrom(DEFAULT_JOB_TYPES, 'UTSUGNING')).toMatchObject({ key: 'utsugning', label: 'Utsugning' });
   });
   it('returns null for empty/nullish', () => {
-    expect(resolveJobType(null)).toBeNull();
-    expect(resolveJobType('  ')).toBeNull();
+    expect(resolveJobTypeFrom(DEFAULT_JOB_TYPES, null)).toBeNull();
+    expect(resolveJobTypeFrom(DEFAULT_JOB_TYPES, '  ')).toBeNull();
   });
-  it('renders an unknown key in a neutral colour', () => {
-    const r = resolveJobType('special');
+  it('renders an unknown key in a neutral colour, labelled by the raw key', () => {
+    const r = resolveJobTypeFrom(DEFAULT_JOB_TYPES, 'special');
     expect(r?.label).toBe('special');
     expect(r?.color).toBe('#64748b');
   });
-  it('has unique keys', () => {
-    expect(new Set(JOB_TYPES.map((t) => t.key)).size).toBe(JOB_TYPES.length);
+  it('default set has unique keys', () => {
+    expect(new Set(DEFAULT_JOB_TYPES.map((t) => t.key)).size).toBe(DEFAULT_JOB_TYPES.length);
+  });
+});
+
+describe('validateJobType', () => {
+  it('accepts a label + hex colour', () => {
+    expect(validateJobType('Specialjobb', '#112233')).toBeNull();
+  });
+  it('requires a label', () => {
+    expect(validateJobType('', '#112233')).toBe('label_required');
+  });
+  it('rejects a malformed colour', () => {
+    expect(validateJobType('X', 'blue')).toBe('bad_color');
+  });
+});
+
+describe('slugifyJobType', () => {
+  it('lowercases + transliterates Swedish + dashes spaces', () => {
+    expect(slugifyJobType('Övrigt jobb')).toBe('ovrigt-jobb');
+    expect(slugifyJobType('Vitull')).toBe('vitull');
+  });
+  it('falls back to "typ" when nothing usable remains', () => {
+    expect(slugifyJobType('!!!')).toBe('typ');
   });
 });

--- a/tests/planning/order.test.ts
+++ b/tests/planning/order.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { dayGroup, orderInfo, reorderWithinGroup } from '@/lib/domains/planning/order';
+
+type Seg = { id: string; truck_id: string; start_day: string; sort_index: number };
+const s = (id: string, truck_id: string, start_day: string, sort_index = 0): Seg => ({ id, truck_id, start_day, sort_index });
+
+describe('dayGroup', () => {
+  const segs = [
+    s('a', 't1', '2026-06-15', 1),
+    s('b', 't1', '2026-06-15', 0),
+    s('c', 't1', '2026-06-16', 0), // different day
+    s('d', 't2', '2026-06-15', 0), // different truck
+  ];
+  it('groups by truck + start day, ordered by sort_index then id', () => {
+    expect(dayGroup(segs, s('x', 't1', '2026-06-15')).map((g) => g.id)).toEqual(['b', 'a']);
+  });
+  it('excludes other trucks and days', () => {
+    expect(dayGroup(segs, s('x', 't2', '2026-06-15')).map((g) => g.id)).toEqual(['d']);
+  });
+});
+
+describe('orderInfo', () => {
+  const segs = [s('a', 't1', '2026-06-15', 0), s('b', 't1', '2026-06-15', 1)];
+  it('reports index + total within the group', () => {
+    expect(orderInfo(segs, segs[1])).toEqual({ index: 1, total: 2 });
+  });
+  it('total 1 for a lone job', () => {
+    expect(orderInfo([s('a', 't1', '2026-06-15', 0)], s('a', 't1', '2026-06-15', 0))).toEqual({ index: 0, total: 1 });
+  });
+});
+
+describe('reorderWithinGroup', () => {
+  it('moves a job up, renumbering so positions are distinct (handles all-zero seed)', () => {
+    const group = [s('a', 't1', 'd', 0), s('b', 't1', 'd', 0), s('c', 't1', 'd', 0)];
+    // move 'c' up → order becomes a, c, b → c gets index 1, b gets index 2 (a already 0, unchanged)
+    expect(reorderWithinGroup(group, 'c', 'up')).toEqual([
+      { id: 'c', sort_index: 1 },
+      { id: 'b', sort_index: 2 },
+    ]);
+  });
+  it('moves a job down', () => {
+    const group = [s('a', 't1', 'd', 0), s('b', 't1', 'd', 1)];
+    expect(reorderWithinGroup(group, 'a', 'down')).toEqual([
+      { id: 'b', sort_index: 0 },
+      { id: 'a', sort_index: 1 },
+    ]);
+  });
+  it('is a no-op at the edges', () => {
+    const group = [s('a', 't1', 'd', 0), s('b', 't1', 'd', 1)];
+    expect(reorderWithinGroup(group, 'a', 'up')).toEqual([]);
+    expect(reorderWithinGroup(group, 'b', 'down')).toEqual([]);
+  });
+});

--- a/tests/planning/reports.test.ts
+++ b/tests/planning/reports.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { validateReport, sacksRemaining } from '@/lib/domains/planning/reports';
+import { validateReport, sacksRemaining, sacksOverrun } from '@/lib/domains/planning/reports';
 
 describe('validateReport', () => {
   it('accepts a valid report', () => {
@@ -21,5 +21,15 @@ describe('sacksRemaining', () => {
   });
   it('floors at zero (never negative)', () => {
     expect(sacksRemaining(40, 55)).toBe(0);
+  });
+});
+
+describe('sacksOverrun', () => {
+  it('is zero while within plan', () => {
+    expect(sacksOverrun(130, 46)).toBe(0);
+    expect(sacksOverrun(40, 40)).toBe(0);
+  });
+  it('is blown minus planned once over plan', () => {
+    expect(sacksOverrun(40, 55)).toBe(15);
   });
 });

--- a/tests/planning/reports.test.ts
+++ b/tests/planning/reports.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { validateReport, sacksRemaining } from '@/lib/domains/planning/reports';
+
+describe('validateReport', () => {
+  it('accepts a valid report', () => {
+    expect(validateReport('2026-06-17', 12)).toBeNull();
+    expect(validateReport('2026-06-17', 0)).toBeNull();
+  });
+  it('rejects a bad date', () => {
+    expect(validateReport('2026/06/17', 12)).toBe('invalid_date');
+  });
+  it('rejects a negative or non-finite amount', () => {
+    expect(validateReport('2026-06-17', -1)).toBe('invalid_amount');
+    expect(validateReport('2026-06-17', Number.NaN)).toBe('invalid_amount');
+  });
+});
+
+describe('sacksRemaining', () => {
+  it('is planned minus blown', () => {
+    expect(sacksRemaining(130, 46)).toBe(84);
+  });
+  it('floors at zero (never negative)', () => {
+    expect(sacksRemaining(40, 55)).toBe(0);
+  });
+});

--- a/tests/planning/schedule.test.ts
+++ b/tests/planning/schedule.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { validateSegmentDates } from '@/lib/domains/planning/schedule';
+
+describe('validateSegmentDates', () => {
+  it('accepts a same-day or forward range', () => {
+    expect(validateSegmentDates('2026-06-20', '2026-06-20')).toBeNull();
+    expect(validateSegmentDates('2026-06-20', '2026-06-22')).toBeNull();
+  });
+
+  it('rejects a non-ISO date', () => {
+    expect(validateSegmentDates('2026/06/20', '2026-06-22')).toBe('invalid_date');
+    expect(validateSegmentDates('20-06-2026', '2026-06-22')).toBe('invalid_date');
+  });
+
+  it('rejects an end before the start', () => {
+    expect(validateSegmentDates('2026-06-22', '2026-06-20')).toBe('end_before_start');
+  });
+});

--- a/tests/planning/truckCrew.test.ts
+++ b/tests/planning/truckCrew.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { crewForTruckInRange, type TruckCrewMember } from '@/lib/domains/planning/truckCrew';
+
+function row(id: string, truck_id: string, start_day: string, end_day: string): TruckCrewMember {
+  return { id, truck_id, member_id: id, member_name: `M${id}`, start_day, end_day };
+}
+
+describe('crewForTruckInRange', () => {
+  const rows = [
+    row('a', 't1', '2026-06-15', '2026-06-21'), // covers the week
+    row('b', 't1', '2026-06-08', '2026-06-14'), // the week before
+    row('c', 't2', '2026-06-15', '2026-06-21'), // other truck
+    row('d', 't1', '2026-06-20', '2026-06-26'), // overlaps the tail of the week
+  ];
+
+  it('returns crew for the truck whose range overlaps the window', () => {
+    const ids = crewForTruckInRange(rows, 't1', '2026-06-15', '2026-06-21').map((r) => r.id);
+    expect(ids.sort()).toEqual(['a', 'd']);
+  });
+
+  it('excludes other trucks', () => {
+    expect(crewForTruckInRange(rows, 't2', '2026-06-15', '2026-06-21').map((r) => r.id)).toEqual(['c']);
+  });
+
+  it('excludes non-overlapping ranges', () => {
+    expect(crewForTruckInRange(rows, 't1', '2026-06-22', '2026-06-28').map((r) => r.id)).toEqual(['d']);
+  });
+
+  it('returns empty when nothing matches', () => {
+    expect(crewForTruckInRange(rows, 't9', '2026-06-15', '2026-06-21')).toEqual([]);
+  });
+});

--- a/tests/planning/truckCrew.test.ts
+++ b/tests/planning/truckCrew.test.ts
@@ -1,8 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { crewForTruckInRange, type TruckCrewMember } from '@/lib/domains/planning/truckCrew';
+import { crewForTruckInRange, membersToCopy, type TruckCrewMember } from '@/lib/domains/planning/truckCrew';
 
 function row(id: string, truck_id: string, start_day: string, end_day: string): TruckCrewMember {
   return { id, truck_id, member_id: id, member_name: `M${id}`, start_day, end_day };
+}
+
+function member(memberId: string | null): TruckCrewMember {
+  return { id: `row-${memberId}`, truck_id: 't1', member_id: memberId, member_name: `M${memberId}`, start_day: '2026-06-15', end_day: '2026-06-21' };
 }
 
 describe('crewForTruckInRange', () => {
@@ -28,5 +32,21 @@ describe('crewForTruckInRange', () => {
 
   it('returns empty when nothing matches', () => {
     expect(crewForTruckInRange(rows, 't9', '2026-06-15', '2026-06-21')).toEqual([]);
+  });
+});
+
+describe('membersToCopy', () => {
+  it('copies source members not already on the target week', () => {
+    const source = [member('a'), member('b'), member('c')];
+    const target = [member('b')];
+    expect(membersToCopy(source, target).map((m) => m.member_id)).toEqual(['a', 'c']);
+  });
+  it('dedupes the source and skips freetext (null member_id)', () => {
+    const source = [member('a'), member('a'), member(null)];
+    expect(membersToCopy(source, []).map((m) => m.member_id)).toEqual(['a']);
+  });
+  it('copies nothing when the target already has everyone', () => {
+    const source = [member('a'), member('b')];
+    expect(membersToCopy(source, [member('a'), member('b')])).toEqual([]);
   });
 });

--- a/tests/planning/truckCrew.test.ts
+++ b/tests/planning/truckCrew.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { crewForTruckInRange, membersToCopy, type TruckCrewMember } from '@/lib/domains/planning/truckCrew';
+import { crewForTruckInRange, membersToCopy, shiftISO, type TruckCrewMember } from '@/lib/domains/planning/truckCrew';
 
 function row(id: string, truck_id: string, start_day: string, end_day: string): TruckCrewMember {
   return { id, truck_id, member_id: id, member_name: `M${id}`, start_day, end_day };
@@ -48,5 +48,19 @@ describe('membersToCopy', () => {
   it('copies nothing when the target already has everyone', () => {
     const source = [member('a'), member('b')];
     expect(membersToCopy(source, [member('a'), member('b')])).toEqual([]);
+  });
+});
+
+describe('shiftISO', () => {
+  it('shifts a date forward by whole days', () => {
+    expect(shiftISO('2026-06-15', 7)).toBe('2026-06-22');
+  });
+  it('shifts across a month boundary', () => {
+    expect(shiftISO('2026-06-29', 7)).toBe('2026-07-06');
+  });
+  it('preserves a partial-week range offset (Mon–Wed stays 3 days after a +7 copy)', () => {
+    // Source Mon–Wed copied to next week must remain Mon–Wed, not become the full week.
+    expect(shiftISO('2026-06-15', 7)).toBe('2026-06-22'); // Mon → next Mon
+    expect(shiftISO('2026-06-17', 7)).toBe('2026-06-24'); // Wed → next Wed
   });
 });

--- a/tests/planning/trucks.test.ts
+++ b/tests/planning/trucks.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { validateTruck } from '@/lib/domains/planning/trucks';
+
+describe('validateTruck', () => {
+  it('accepts a named truck with a valid hex colour', () => {
+    expect(validateTruck('Bil 4', '#3f6f52')).toBeNull();
+  });
+  it('accepts a named truck with no colour', () => {
+    expect(validateTruck('Bil 4', null)).toBeNull();
+  });
+  it('requires a name', () => {
+    expect(validateTruck('', '#3f6f52')).toBe('name_required');
+    expect(validateTruck('   ', null)).toBe('name_required');
+  });
+  it('rejects an over-long name', () => {
+    expect(validateTruck('x'.repeat(61), null)).toBe('name_too_long');
+  });
+  it('rejects a malformed colour', () => {
+    expect(validateTruck('Bil 4', 'red')).toBe('bad_color');
+    expect(validateTruck('Bil 4', '#fff')).toBe('bad_color');
+  });
+});


### PR DESCRIPTION
feat(planning): Wave 7 — new CRM-first planning (ops_*), greenfield + ready for cutover

## Overview
A ground-up rebuild of the planning/scheduling board, built greenfield alongside the
old `app/plannering` (which stays live on Blikk until a deliberate cutover — untouched
here). Jobs scheduled here ARE CRM work orders: `ops_segments.work_order_id →
crm_work_orders.id`. The "is it scheduled" state lives in `ops_*`, never on the work
order, so the CRM stays the source of the job and planning owns the schedule.

- New route: `app/crm/planering` (under the CRM layout/auth)
- New domain: `lib/domains/planning/*` (pure, unit-tested)
- New API: `app/api/crm/planering/**` (Zod + requirePermission, mirrors app/api/crm)
- New tables: `ops_*` with RLS + indexes from day one
- New RBAC keys: `planning.schedule.read/write`, `planning.truck.manage`, `planning.depot.manage`

## What's included
- **Week + month boards** — drag/click to place, move, unschedule; multi-day segments;
  "Hela månaden" toggle (stack the month's weeks in week view); "Visa helg" toggle.
- **Job cards** — Fortnox order ref, customer, address (+ map link), job type/material,
  sack progress, confirmation badge, crew; shared `SegmentCardBody` across both views.
- **Per-segment kebab menu** — set work-order status, job type, length (multi-day),
  crew, pause/resume, send order confirmation; 3-column layout, viewport-aware.
- **Crew** — per-segment crew + per-week truck crew (+ copy to next week, preserving ranges).
- **Job types** — DB-backed + admin-editable (name/colour/active).
- **Depots** — depot management, truck→depot link, deliveries + per-material stock balances
  (consumption derives from installer sack-reporting once that flow lands).
- **Order confirmations** — SMS/email to the CRM customer (reuses existing transports) +
  Twilio delivery-status into the board badge.
- **Day notes**, **paused jobs**, **Swedish holidays**, **over-/under-run warnings**,
  **same-day job ordering** (sort_index ↑/↓), **sales filter**, drag-target highlight.
- **Realtime** — ~10 concurrent planners: subscribes to `ops_*` changes and
  debounce-refetches the board so placements/moves appear within ~1s (RLS still applies).
  Presence / edit-locking intentionally deferred.

## Quality
- Passed `/code-review` (correctness/security fixes applied), supabase-review (RLS healthy:
  RLS + WITH CHECK on every table, session client for user ops, service role only for the
  crew picker + Twilio webhook, no `using(true)`, no missing SELECT policies).
- Cleanup refactors: shared form tokens, `useEntityCrud` for manager modals, shared
  `SegmentCardBody`, scoped `.planning-board` border reset.
- type-check ✓ · build ✓ · 448 unit tests ✓

## Migrations — run in this order before/at merge (Supabase SQL editor; idempotent)
1. `20260611_planning_permissions.sql`            (keys first — RLS + fail-closed code)
2. `20260611_ops_planning_foundation.sql`
3. `20260611_ops_segment_reports.sql`
4. `20260611_ops_segments_job_type.sql`
5. `20260612_ops_segments_on_hold.sql`
6. `20260612_ops_depots.sql`
7. `20260612_ops_depot_deliveries.sql`
8. `20260612_ops_segment_crew.sql`
9. `20260612_ops_truck_crew.sql`
10. `20260612_ops_day_notes.sql`
11. `20260612_ops_job_types.sql`
12. `20260612_ops_work_order_confirmations.sql`
13. `20260612_enable_realtime_ops_tables.sql`     (last — all ops_* must exist)

Permissions must exist before the app runs (fail-closed). Realtime is silent until #13.

## Post-merge
- Smoke-test realtime with two sessions (place/move in one → other updates ~1s later).
- Old `app/plannering` is unchanged; cutover (repoint dashboard schedule, retire old
  tables/routes) is a later, deliberate step.

## Not in scope / deferred
- Realtime presence + "X is editing" indicators
- Depot consumption numbers (wait for installer sack-reporting flow; documented in code)
- Egenkontroll badge (data-source decision pending)
