### PR TITLE
Planering: optimistiska uppdateringar, Insikter-vy, lager-täckning + UX-polish

### DIFF
--- a/app/api/crm/planering/insights/route.ts
+++ b/app/api/crm/planering/insights/route.ts
@@ -1,0 +1,25 @@
+import { cookies } from 'next/headers';
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
+import { getPlanningInsights } from '@/lib/domains/planning/insights';
+import { ok, routeError, requirePermission } from '../_lib';
+
+// Forward-looking planning insights (scheduled revenue/sacks per week, per truck, per material +
+// unplanned backlog value). Read-only aggregation over the next `weeks` weeks (default 8).
+export async function GET(req: Request) {
+  try {
+    const gate = await requirePermission('planning.schedule.read');
+    if (gate.response) return gate.response;
+
+    const weeksParam = Number(new URL(req.url).searchParams.get('weeks'));
+    const weeks = Number.isFinite(weeksParam) && weeksParam >= 1 && weeksParam <= 26 ? Math.floor(weeksParam) : 8;
+    const fromISO = new Date().toISOString().slice(0, 10);
+
+    const supabase = createRouteHandlerClient({ cookies });
+    const { data, error } = await getPlanningInsights(supabase, { fromISO, weeks });
+    if (error) return routeError(500, 'planning_insights_failed', error.message);
+
+    return ok(data);
+  } catch (e: any) {
+    return routeError(500, 'planning_insights_unexpected', e?.message || 'Failed to load insights');
+  }
+}

--- a/app/crm/planering/Backlog.tsx
+++ b/app/crm/planering/Backlog.tsx
@@ -76,12 +76,12 @@ export default function Backlog({
                   >
                     <span className={cn('absolute bottom-2.5 left-0 top-2.5 w-[3px] rounded-full', statusMeta(item.status).rail)} />
                     <div className="flex items-baseline justify-between gap-2">
-                      <span className="text-[13px] font-bold text-slate-900">{item.project_name}</span>
+                      <span className="text-[11px] font-bold text-slate-900">{item.project_name}</span>
                       <JobRef job={item} />
                     </div>
-                    <div className="mt-0.5 text-[11px] text-slate-500">{item.client_name}</div>
+                    <div className="mt-0.5 text-[10px] text-slate-500">{item.client_name}</div>
                     {item.address && (
-                      <div className="flex items-center gap-1 text-[11px] text-slate-400">
+                      <div className="flex items-center gap-1 text-[9.5px] text-slate-400">
                         <span className="truncate">{item.address}</span>
                         <MapLink address={item.address} />
                       </div>

--- a/app/crm/planering/ConfirmModal.tsx
+++ b/app/crm/planering/ConfirmModal.tsx
@@ -136,22 +136,32 @@ export default function ConfirmModal({
       }
     >
       <form id={FORM_ID} onSubmit={handleSubmit} className="grid gap-4">
-        <p className="rounded-lg border border-[#e0e8dc] bg-[#f3f6f1] px-3 py-2 text-[11.5px] text-slate-500">
-          Mottagaren hämtas från kundkortet i CRM. Kontrollera och justera vid behov innan du skickar.
-        </p>
+        {loading ? (
+          <p className="flex items-center gap-2 rounded-lg border border-[#e0e8dc] bg-[#f3f6f1] px-3 py-2 text-[11.5px] text-slate-500">
+            <svg className="h-3.5 w-3.5 animate-spin text-slate-400" viewBox="0 0 24 24" fill="none">
+              <circle cx="12" cy="12" r="9" stroke="currentColor" strokeWidth="3" className="opacity-25" />
+              <path d="M21 12a9 9 0 0 0-9-9" stroke="currentColor" strokeWidth="3" strokeLinecap="round" />
+            </svg>
+            Hämtar kontaktuppgifter från kundkortet…
+          </p>
+        ) : (
+          <p className="rounded-lg border border-[#e0e8dc] bg-[#f3f6f1] px-3 py-2 text-[11.5px] text-slate-500">
+            Mottagaren hämtas från kundkortet i CRM. Kontrollera och justera vid behov innan du skickar.
+          </p>
+        )}
 
         {/* Email */}
         <div className="grid gap-1.5">
           <label className="flex items-center gap-2 text-[13px] font-semibold text-slate-700">
-            <input type="checkbox" checked={sendEmail} onChange={(e) => setSendEmail(e.target.checked)} className="h-4 w-4 accent-emerald-600" />
+            <input type="checkbox" checked={sendEmail} onChange={(e) => setSendEmail(e.target.checked)} disabled={loading} className="h-4 w-4 accent-emerald-600" />
             Skicka mejl
           </label>
           <input
             type="email"
             value={email}
             onChange={(e) => setEmail(e.target.value)}
-            disabled={!sendEmail}
-            placeholder="kund@exempel.se"
+            disabled={!sendEmail || loading}
+            placeholder={loading ? 'Hämtar…' : 'kund@exempel.se'}
             className={FIELD}
           />
         </div>
@@ -159,15 +169,15 @@ export default function ConfirmModal({
         {/* SMS */}
         <div className="grid gap-1.5">
           <label className="flex items-center gap-2 text-[13px] font-semibold text-slate-700">
-            <input type="checkbox" checked={sendSms} onChange={(e) => setSendSms(e.target.checked)} className="h-4 w-4 accent-emerald-600" />
+            <input type="checkbox" checked={sendSms} onChange={(e) => setSendSms(e.target.checked)} disabled={loading} className="h-4 w-4 accent-emerald-600" />
             Skicka SMS
           </label>
           <input
             type="tel"
             value={phone}
             onChange={(e) => setPhone(e.target.value)}
-            disabled={!sendSms}
-            placeholder="+46 70 123 45 67"
+            disabled={!sendSms || loading}
+            placeholder={loading ? 'Hämtar…' : '+46 70 123 45 67'}
             className={FIELD}
           />
         </div>

--- a/app/crm/planering/InsightsView.tsx
+++ b/app/crm/planering/InsightsView.tsx
@@ -1,0 +1,135 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { ResponsiveContainer, ComposedChart, BarChart, Bar, Line, XAxis, YAxis, CartesianGrid, Tooltip, Cell } from 'recharts';
+import { crm } from '@/app/crm/lib/crmTokens';
+import { formatCurrency } from '@/app/crm/lib/format';
+import type { PlanningInsights } from '@/lib/domains/planning/insights';
+
+const REVENUE = '#1a3f26';
+const SACKS = '#0284c7';
+const TRUCK_PALETTE = ['#2563eb', '#16a34a', '#d97706', '#7c3aed', '#0d9488', '#a05c6b', '#5a7d9a', '#8a7a4e'];
+const compact = new Intl.NumberFormat('sv-SE', { notation: 'compact', maximumFractionDigits: 1 });
+const kr = (v: number) => formatCurrency(v, 'SEK');
+
+function Kpi({ label, value, sub }: { label: string; value: string; sub?: string }) {
+  return (
+    <div className="rounded-2xl border border-[#e0e8dc] bg-white p-4">
+      <div className="text-[10.5px] font-bold uppercase tracking-wide text-slate-400">{label}</div>
+      <div className="mt-1 text-[20px] font-extrabold tracking-tight tabular-nums text-[#142c1b]">{value}</div>
+      {sub && <div className="mt-0.5 text-[11.5px] text-slate-500">{sub}</div>}
+    </div>
+  );
+}
+
+function ChartCard({ title, hint, children }: { title: string; hint?: string; children: React.ReactNode }) {
+  return (
+    <div className="rounded-2xl border border-[#e0e8dc] bg-white p-4">
+      <h3 className="text-[13.5px] font-extrabold text-[#142c1b]">{title}</h3>
+      {hint && <p className="mb-2 mt-0.5 text-[11.5px] text-slate-500">{hint}</p>}
+      <div className="mt-2 h-[240px]">{children}</div>
+    </div>
+  );
+}
+
+export default function InsightsView({ weeks = 8 }: { weeks?: number }) {
+  const [data, setData] = useState<PlanningInsights | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    setLoading(true);
+    fetch(`/api/crm/planering/insights?weeks=${weeks}`, { cache: 'no-store' })
+      .then((r) => r.json())
+      .then((j) => {
+        if (!active) return;
+        if (!j.ok) throw new Error(j.error || 'Kunde inte ladda insikterna');
+        setData(j.data as PlanningInsights);
+      })
+      .catch((e) => active && setError(e?.message || 'Kunde inte ladda insikterna'))
+      .finally(() => active && setLoading(false));
+    return () => {
+      active = false;
+    };
+  }, [weeks]);
+
+  if (loading) return <div className="grid place-items-center py-20 text-[13px] text-slate-400">Laddar insikter…</div>;
+  if (error) return <div className="rounded-xl border border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-700">{error}</div>;
+  if (!data) return null;
+
+  const totalRevenue = data.weeks.reduce((s, w) => s + w.revenue, 0);
+  const totalSacks = data.weeks.reduce((s, w) => s + w.sacks, 0);
+  const axisTick = { fontSize: 11, fill: '#64748b' } as const;
+
+  return (
+    <div className="grid gap-4">
+      {/* KPIs */}
+      <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+        <Kpi label={`Schemalagt · ${weeks} v`} value={kr(totalRevenue)} sub="omsättning ex moms" />
+        <Kpi label={`Säckar · ${weeks} v`} value={`${totalSacks}`} sub="planerat att blåsa" />
+        <Kpi label="Oplanerat värde" value={kr(data.backlog.revenue)} sub={`${data.backlog.sacks} säck väntar`} />
+        <Kpi label="Oplanerade jobb" value={`${data.backlog.count}`} sub="väntar på planering" />
+      </div>
+
+      {/* Revenue + sacks per week */}
+      <ChartCard title="Omsättning & säckar per vecka" hint={`Schemalagt arbete kommande ${weeks} veckor (omsättning = staplar, säckar = linje).`}>
+        <ResponsiveContainer width="100%" height="100%">
+          <ComposedChart data={data.weeks} margin={{ top: 8, right: 8, left: 4, bottom: 0 }}>
+            <CartesianGrid strokeDasharray="3 3" stroke="#eef3eb" vertical={false} />
+            <XAxis dataKey="label" tick={axisTick} />
+            <YAxis yAxisId="rev" tickFormatter={(v) => compact.format(Number(v))} tick={axisTick} width={44} />
+            <YAxis yAxisId="sacks" orientation="right" tick={axisTick} width={32} />
+            <Tooltip
+              formatter={(value, name) => (name === 'Säckar' ? [`${value} säck`, name] : [kr(Number(value)), name])}
+              labelStyle={{ color: '#0f172a', fontWeight: 700 }}
+              contentStyle={{ borderRadius: 12, border: '1px solid #e0e8dc', fontSize: 12 }}
+            />
+            <Bar yAxisId="rev" dataKey="revenue" name="Omsättning" fill={REVENUE} radius={[4, 4, 0, 0]} maxBarSize={38} />
+            <Line yAxisId="sacks" type="monotone" dataKey="sacks" name="Säckar" stroke={SACKS} strokeWidth={2} dot={{ r: 3 }} />
+          </ComposedChart>
+        </ResponsiveContainer>
+      </ChartCard>
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        {/* Per truck */}
+        <ChartCard title="Omsättning per bil" hint="Belastning per lastbil i perioden.">
+          {data.byTruck.length === 0 ? (
+            <div className="grid h-full place-items-center text-[12px] text-slate-400">Inget schemalagt än.</div>
+          ) : (
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart layout="vertical" data={data.byTruck} margin={{ top: 4, right: 12, left: 4, bottom: 0 }}>
+                <CartesianGrid strokeDasharray="3 3" stroke="#eef3eb" horizontal={false} />
+                <XAxis type="number" tickFormatter={(v) => compact.format(Number(v))} tick={axisTick} />
+                <YAxis type="category" dataKey="truck_name" tick={axisTick} width={70} />
+                <Tooltip formatter={(value) => [kr(Number(value)), 'Omsättning']} contentStyle={{ borderRadius: 12, border: '1px solid #e0e8dc', fontSize: 12 }} />
+                <Bar dataKey="revenue" radius={[0, 4, 4, 0]} maxBarSize={26}>
+                  {data.byTruck.map((t, i) => (
+                    <Cell key={t.truck_id} fill={TRUCK_PALETTE[i % TRUCK_PALETTE.length]} />
+                  ))}
+                </Bar>
+              </BarChart>
+            </ResponsiveContainer>
+          )}
+        </ChartCard>
+
+        {/* Per material */}
+        <ChartCard title="Säckbehov per material" hint="Underlag för depåpåfyllning.">
+          {data.byMaterial.length === 0 ? (
+            <div className="grid h-full place-items-center text-[12px] text-slate-400">Inget schemalagt än.</div>
+          ) : (
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart data={data.byMaterial} margin={{ top: 8, right: 8, left: 4, bottom: 0 }}>
+                <CartesianGrid strokeDasharray="3 3" stroke="#eef3eb" vertical={false} />
+                <XAxis dataKey="material" tick={axisTick} />
+                <YAxis tick={axisTick} width={36} />
+                <Tooltip formatter={(value) => [`${value} säck`, 'Behov']} contentStyle={{ borderRadius: 12, border: '1px solid #e0e8dc', fontSize: 12 }} />
+                <Bar dataKey="sacks" fill={SACKS} radius={[4, 4, 0, 0]} maxBarSize={48} />
+              </BarChart>
+            </ResponsiveContainer>
+          )}
+        </ChartCard>
+      </div>
+    </div>
+  );
+}

--- a/app/crm/planering/MonthGrid.tsx
+++ b/app/crm/planering/MonthGrid.tsx
@@ -145,7 +145,8 @@ export default function MonthGrid({
                         key={seg.id}
                         draggable={canWrite}
                         onDragStart={(ev) => onSegDragStart(ev, seg)}
-                        onClick={(ev) => {
+                        onClick={(ev) => ev.stopPropagation()}
+                        onDoubleClick={(ev) => {
                           ev.stopPropagation();
                           onSegClick(seg);
                         }}

--- a/app/crm/planering/MonthGrid.tsx
+++ b/app/crm/planering/MonthGrid.tsx
@@ -152,7 +152,8 @@ export default function MonthGrid({
                         }}
                         style={{ backgroundColor: `${tc}1f`, borderColor: `${tc}66` }}
                         className={cn(
-                          'relative overflow-hidden rounded-lg border border-solid p-2 pl-2.5 shadow-[0_1px_2px_rgba(20,44,27,0.06)] transition hover:shadow-[0_3px_10px_rgba(20,44,27,0.12)]',
+                          'group relative overflow-hidden rounded-lg border border-solid p-2 pl-2.5 shadow-[0_1px_2px_rgba(20,44,27,0.06)] transition hover:shadow-[0_3px_10px_rgba(20,44,27,0.12)]',
+                          seg.job && 'hover:ring-2 hover:ring-emerald-400/40',
                           canWrite ? 'cursor-grab active:cursor-grabbing' : 'cursor-pointer',
                           seg.on_hold && 'opacity-60 ring-1 ring-amber-200',
                         )}

--- a/app/crm/planering/PlanningAdminModal.tsx
+++ b/app/crm/planering/PlanningAdminModal.tsx
@@ -654,12 +654,15 @@ function StockPanel({ canWrite }: { canWrite: boolean }) {
           <div className={PANEL}>
             <h3 className="mb-3 text-[13.5px] font-extrabold text-[#142c1b]">Saldo per depå</h3>
             <div className="grid gap-2.5">
-              {depots.map((d) => (
+              {depots.map((d) => {
+                const shortfall = d.rows.reduce((s, r) => s + r.shortfall, 0);
+                return (
                 <div key={d.depot_id} className="rounded-xl border border-[#e0e8dc] bg-[#f9fbf7] p-3">
                   <div className="mb-1.5 flex items-baseline justify-between gap-2">
-                    <span className="flex items-center gap-2">
+                    <span className="flex flex-wrap items-center gap-2">
                       <span className="text-[13px] font-bold text-slate-800">{d.depot_name}</span>
-                      {d.rows.some((r) => r.balance < 0) && <span className="rounded-full border border-rose-200 bg-rose-50 px-2 py-px text-[9px] font-bold text-rose-700">Underskott</span>}
+                      {shortfall > 0 && <span className="rounded-full border border-rose-200 bg-rose-50 px-2 py-px text-[9px] font-bold text-rose-700">Lager räcker inte · −{shortfall}</span>}
+                      {shortfall === 0 && d.rows.some((r) => r.balance < 0) && <span className="rounded-full border border-amber-200 bg-amber-50 px-2 py-px text-[9px] font-bold text-amber-700">Underskott</span>}
                     </span>
                     <span className={cn('shrink-0 text-[12px] font-bold tabular-nums', balanceClass(d.total_balance))}>{d.total_balance} säck</span>
                   </div>
@@ -667,7 +670,7 @@ function StockPanel({ canWrite }: { canWrite: boolean }) {
                     <p className="text-[11px] text-slate-400">Inga rörelser än.</p>
                   ) : (
                     <table className="w-full text-[11.5px]">
-                      <thead><tr className="text-left text-[10px] uppercase tracking-wide text-slate-400"><th className="font-semibold">Material</th><th className="text-right font-semibold">Levererat</th><th className="text-right font-semibold">Förbrukat</th><th className="text-right font-semibold">Saldo</th></tr></thead>
+                      <thead><tr className="text-left text-[10px] uppercase tracking-wide text-slate-400"><th className="font-semibold">Material</th><th className="text-right font-semibold">Levererat</th><th className="text-right font-semibold">Förbrukat</th><th className="text-right font-semibold">Saldo</th><th className="text-right font-semibold">Planerat</th><th className="text-right font-semibold">Räcker?</th></tr></thead>
                       <tbody>
                         {d.rows.map((r) => (
                           <tr key={r.material} className="border-t border-[#eef3eb]">
@@ -675,14 +678,19 @@ function StockPanel({ canWrite }: { canWrite: boolean }) {
                             <td className="py-1 text-right tabular-nums text-slate-500">{r.delivered}</td>
                             <td className="py-1 text-right tabular-nums text-slate-500">{r.consumed}</td>
                             <td className={cn('py-1 text-right font-bold tabular-nums', balanceClass(r.balance))}>{r.balance}</td>
+                            <td className="py-1 text-right tabular-nums text-slate-500">{r.planned}</td>
+                            <td className="py-1 text-right font-bold tabular-nums">
+                              {r.shortfall > 0 ? <span className="text-rose-600">−{r.shortfall}</span> : <span className="text-emerald-600">✓</span>}
+                            </td>
                           </tr>
                         ))}
                       </tbody>
                     </table>
                   )}
                 </div>
-              ))}
-              <p className="text-[10.5px] text-slate-400">Förbrukning fylls i automatiskt när installatörernas säckrapportering är på plats.</p>
+                );
+              })}
+              <p className="text-[10.5px] text-slate-400">Planerat = säckar bokade på öppna jobb från depån. "Räcker?" visar om lagret täcker det planerade. Förbrukning fylls i automatiskt när installatörernas säckrapportering är på plats.</p>
             </div>
           </div>
         )}

--- a/app/crm/planering/PlanningClient.tsx
+++ b/app/crm/planering/PlanningClient.tsx
@@ -25,8 +25,9 @@ import ConfirmModal from './ConfirmModal';
 import PlanningAdminModal from './PlanningAdminModal';
 import ActivityLogModal from './ActivityLogModal';
 import PlaceholderModal, { type PlaceholderInput } from './PlaceholderModal';
+import InsightsView from './InsightsView';
 
-type View = 'week' | 'month';
+type View = 'week' | 'month' | 'insights';
 type DragData =
   | { kind: 'backlog'; id: string }
   | { kind: 'segment'; id: string; start: string; end: string; truckId: string };
@@ -714,7 +715,7 @@ export default function PlanningClient({
         </div>
 
         <div className="inline-flex rounded-xl border border-[#e0e8dc] bg-white p-0.5">
-          {(['week', 'month'] as View[]).map((v) => (
+          {(['week', 'month', 'insights'] as View[]).map((v) => (
             <button
               key={v}
               onClick={() => setView(v)}
@@ -724,7 +725,7 @@ export default function PlanningClient({
               )}
               style={view === v ? { backgroundColor: 'var(--crm-primary)' } : undefined}
             >
-              {v === 'week' ? 'Vecka' : 'Månad'}
+              {({ week: 'Vecka', month: 'Månad', insights: 'Insikter' } as const)[v]}
             </button>
           ))}
         </div>
@@ -871,6 +872,10 @@ export default function PlanningClient({
         </div>
       )}
 
+      {view === 'insights' ? (
+        <InsightsView weeks={8} />
+      ) : (
+      <>
       <div className="grid items-start gap-4 lg:grid-cols-[320px_minmax(0,1fr)]">
         <Backlog
           items={visibleBacklog}
@@ -979,6 +984,8 @@ export default function PlanningClient({
         <span className="inline-flex items-center gap-1.5"><span className="h-2 w-2 rounded-full bg-violet-400" />Pågående</span>
         <span className="inline-flex items-center gap-1.5"><span className="h-2 w-2 rounded-full bg-emerald-500" />Fakturera</span>
       </div>
+      </>
+      )}
     </div>
 
       {/* Modals/overlays live OUTSIDE .planning-density so their `fixed` positioning isn't thrown

--- a/app/crm/planering/PlanningClient.tsx
+++ b/app/crm/planering/PlanningClient.tsx
@@ -61,6 +61,7 @@ export default function PlanningClient({
   const [defaultCrew, setDefaultCrew] = useState<DefaultCrewMember[]>([]);
   const [depotStock, setDepotStock] = useState<DepotBalance[]>([]);
   const [loadingBacklog, setLoadingBacklog] = useState(true);
+  const [boardLoaded, setBoardLoaded] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const [selectedId, setSelectedId] = useState<string | null>(null);
@@ -125,6 +126,7 @@ export default function PlanningClient({
     if (!j.ok) throw new Error(j.error || 'Kunde inte hämta schemat');
     setSegments(j.data.segments as OpsSegment[]);
     setTrucks(j.data.trucks as OpsTruck[]);
+    setBoardLoaded(true);
   }, []);
 
   const loadDayNotes = useCallback(async (from: string, to: string) => {
@@ -292,7 +294,14 @@ export default function PlanningClient({
       const j = await r.json();
       if (!j.ok) return toast.error(j.error || 'Kunde inte placera ordern');
       toast.success('Order placerad');
-      await refresh();
+      // Append the created segment locally instead of refetching the whole board; bump the source
+      // job's backlog count so its badge stays in sync.
+      if (j.data?.item) {
+        setSegments((prev) => [...prev, j.data.item as OpsSegment]);
+        setBacklog((prev) => prev.map((b) => (b.id === workOrderId ? { ...b, segment_count: b.segment_count + 1 } : b)));
+      } else {
+        refresh();
+      }
     },
     [refresh, toast],
   );
@@ -331,11 +340,16 @@ export default function PlanningClient({
 
   const unschedule = useCallback(
     async (id: string) => {
+      // Optimistic: drop the card at once; re-sync from the server only if the delete fails.
+      setSegments((prev) => prev.filter((s) => s.id !== id));
       const r = await fetch(`${API}/segments/${id}`, { method: 'DELETE' });
       const j = await r.json();
-      if (!j.ok) return toast.error(j.error || 'Kunde inte avplanera');
+      if (!j.ok) {
+        toast.error(j.error || 'Kunde inte avplanera');
+        refresh();
+        return;
+      }
       toast.success('Jobbet avplanerat');
-      await refresh();
     },
     [refresh, toast],
   );
@@ -875,7 +889,20 @@ export default function PlanningClient({
           dropActive={backlogDropActive}
         />
 
-        {view === 'week' ? (
+        {!boardLoaded ? (
+          // Skeleton while the schedule first loads — avoids flashing "Inga bilar upplagda än".
+          <div className={cn(crm.card, 'p-3')}>
+            <div className="grid gap-2.5">
+              {Array.from({ length: 4 }).map((_, i) => (
+                <div key={i} className="flex items-center gap-3">
+                  <div className="h-3 w-16 shrink-0 animate-pulse rounded bg-[#e8efe5]" />
+                  <div className="h-14 flex-1 animate-pulse rounded-xl bg-[#eef3eb]" />
+                </div>
+              ))}
+            </div>
+            <div className="mt-2.5 text-center text-[11px] text-slate-400">Laddar schema…</div>
+          </div>
+        ) : view === 'week' ? (
           <div className="grid gap-4">
             {weekMondays.map((m, i) => {
               const wd = weekDaysList[i];

--- a/app/crm/planering/PlanningClient.tsx
+++ b/app/crm/planering/PlanningClient.tsx
@@ -287,14 +287,32 @@ export default function PlanningClient({
 
   const move = useCallback(
     async (id: string, patch: { truck_id?: string; start_day?: string; end_day?: string; job_type?: string | null; on_hold?: boolean }) => {
+      // Optimistic: reflect the change locally at once so the card doesn't snap back to its old value
+      // while the PATCH is in flight (and a full refetch lands). Re-sync from the server only on error.
+      setSegments((cur) =>
+        cur.map((s) =>
+          s.id === id
+            ? {
+                ...s,
+                ...(patch.truck_id !== undefined ? { truck_id: patch.truck_id } : {}),
+                ...(patch.start_day !== undefined ? { start_day: patch.start_day } : {}),
+                ...(patch.end_day !== undefined ? { end_day: patch.end_day } : {}),
+                ...(patch.job_type !== undefined ? { job_type: patch.job_type } : {}),
+                ...(patch.on_hold !== undefined ? { on_hold: patch.on_hold } : {}),
+              }
+            : s,
+        ),
+      );
       const r = await fetch(`${API}/segments/${id}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(patch),
       });
       const j = await r.json();
-      if (!j.ok) return toast.error(j.error || 'Kunde inte flytta jobbet');
-      await refresh();
+      if (!j.ok) {
+        toast.error(j.error || 'Kunde inte flytta jobbet');
+        refresh();
+      }
     },
     [refresh, toast],
   );
@@ -634,6 +652,9 @@ export default function PlanningClient({
     async (seg: OpsSegment, direction: 'up' | 'down') => {
       const changes = reorderWithinGroup(dayGroup(segments, seg), seg.id, direction);
       if (!changes.length) return;
+      // Optimistic: apply the new sort_index locally before the PATCHes land.
+      const order = new Map(changes.map((c) => [c.id, c.sort_index]));
+      setSegments((cur) => cur.map((s) => (order.has(s.id) ? { ...s, sort_index: order.get(s.id) as number } : s)));
       const results = await Promise.all(
         changes.map((ch) =>
           fetch(`${API}/segments/${ch.id}`, {
@@ -643,8 +664,10 @@ export default function PlanningClient({
           }).then((r) => r.json()),
         ),
       );
-      if (results.some((j) => !j.ok)) toast.error('Kunde inte ändra ordningen');
-      await refresh();
+      if (results.some((j) => !j.ok)) {
+        toast.error('Kunde inte ändra ordningen');
+        refresh();
+      }
     },
     [segments, refresh, toast],
   );

--- a/app/crm/planering/PlanningClient.tsx
+++ b/app/crm/planering/PlanningClient.tsx
@@ -11,6 +11,7 @@ import type { AssignablePerson, CrewMember } from '@/lib/domains/planning/crew';
 import type { DayNote } from '@/lib/domains/planning/dayNotes';
 import type { TruckCrewMember } from '@/lib/domains/planning/truckCrew';
 import type { DefaultCrewMember } from '@/lib/domains/planning/defaultCrew';
+import type { DepotBalance } from '@/lib/domains/planning/depotStock';
 import { DEFAULT_JOB_TYPES, type JobType, type JobTypeRow } from '@/lib/domains/planning/jobTypes';
 import {
   addDays, addDaysISO, buildMonthWeeks, buildWeekDays, daysBetweenInclusive, fmtISO, isoWeek, startOfWeek, swedishMonthYear,
@@ -58,6 +59,7 @@ export default function PlanningClient({
   const [dayNotes, setDayNotes] = useState<DayNote[]>([]);
   const [truckCrew, setTruckCrew] = useState<TruckCrewMember[]>([]);
   const [defaultCrew, setDefaultCrew] = useState<DefaultCrewMember[]>([]);
+  const [depotStock, setDepotStock] = useState<DepotBalance[]>([]);
   const [loadingBacklog, setLoadingBacklog] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -147,6 +149,14 @@ export default function PlanningClient({
     if (j.ok) setDefaultCrew(j.data.crew as DefaultCrewMember[]);
   }, []);
 
+  // Depot stock + planned demand — range-independent (all open booked jobs vs current stock). Drives
+  // the "lager räcker inte"-banner so planners catch a shortfall before over-committing.
+  const loadDepotStock = useCallback(async () => {
+    const r = await fetch(`${API}/depot-stock`, { cache: 'no-store' });
+    const j = await r.json();
+    if (j.ok) setDepotStock(j.data.depots as DepotBalance[]);
+  }, []);
+
   useEffect(() => {
     setLoadingBacklog(true);
     loadBacklog()
@@ -214,7 +224,8 @@ export default function PlanningClient({
     loadDayNotes(range.from, range.to).catch(() => {});
     loadTruckCrew(range.from, range.to).catch(() => {});
     loadDefaultCrew().catch(() => {});
-  }, [range.from, range.to, loadSegments, loadDayNotes, loadTruckCrew, loadDefaultCrew]);
+    loadDepotStock().catch(() => {});
+  }, [range.from, range.to, loadSegments, loadDayNotes, loadTruckCrew, loadDefaultCrew, loadDepotStock]);
 
   // ── Realtime: ~10 planners work this board at once, so reflect each other's changes live to
   // avoid double-bookings + missed updates. Subscribe once to ops_* changes and debounce-refetch
@@ -227,6 +238,7 @@ export default function PlanningClient({
     loadDayNotes(range.from, range.to).catch(() => {});
     loadTruckCrew(range.from, range.to).catch(() => {});
     loadDefaultCrew().catch(() => {});
+    loadDepotStock().catch(() => {});
     loadBacklog().catch(() => {});
     loadJobTypes().catch(() => {});
   };
@@ -816,6 +828,28 @@ export default function PlanningClient({
       </div>
 
       {error && <div className="mb-3 rounded-xl border border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-700">{error}</div>}
+
+      {/* Depot stock shortfall — the booked work needs more sacks than the depot has in stock. */}
+      {depotStock.some((d) => d.rows.some((r) => r.shortfall > 0)) && (
+        <div className="mb-3 rounded-xl border border-rose-200 bg-rose-50 px-3 py-2 text-[12px] text-rose-700">
+          <div className="flex items-center gap-1.5 font-bold">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round"><path d="M10.3 3.9 1.8 18a2 2 0 0 0 1.7 3h17a2 2 0 0 0 1.7-3L13.7 3.9a2 2 0 0 0-3.4 0Z" /><path d="M12 9v4M12 17h.01" /></svg>
+            Lagret räcker inte för det som är bokat
+          </div>
+          <ul className="mt-1 grid gap-0.5 pl-0.5">
+            {depotStock.flatMap((d) =>
+              d.rows
+                .filter((r) => r.shortfall > 0)
+                .map((r) => (
+                  <li key={`${d.depot_id}-${r.material}`} className="tabular-nums">
+                    <strong>{d.depot_name}</strong> · {r.material}: planerat {r.planned}, lager {r.balance} <strong>(−{r.shortfall} säck)</strong>
+                  </li>
+                )),
+            )}
+          </ul>
+          <div className="mt-1 text-[11px] text-rose-500">Registrera en påfyllning under Administrera → Lager.</div>
+        </div>
+      )}
 
       {selected && (
         <div className="mb-3 rounded-xl border border-emerald-200 bg-emerald-50 px-3 py-2 text-[12px] text-emerald-800">

--- a/app/crm/planering/WeekBoard.tsx
+++ b/app/crm/planering/WeekBoard.tsx
@@ -41,6 +41,8 @@ type WeekBoardProps = {
   onRestoreWeek: (truckId: string, startDay: string, endDay: string) => void;
 };
 
+const krFmt = new Intl.NumberFormat('sv-SE', { maximumFractionDigits: 0 });
+
 // A read-only avatar row marking the leader with a star — used for the inherited default team.
 function DefaultCrewAvatars({ team }: { team: DefaultCrewMember[] }) {
   if (team.length === 0) return null;
@@ -185,6 +187,17 @@ export default function WeekBoard({
             const overridden = laneWeekly.length > 0;
             const defaultTeam = defaultCrew.filter((m) => m.truck_id === truck.id);
             const laneColor = truck.color || '#94a3b8';
+            // Weekly per-truck totals from the jobs on it, deduped by work order (a multi-segment job
+            // counts once): planned sacks to blow + revenue (omsättning, ex moms).
+            const seenWO = new Set<string>();
+            let plannedSacks = 0;
+            let revenue = 0;
+            for (const s of laneSegs) {
+              if (!s.job || !s.work_order_id || seenWO.has(s.work_order_id)) continue;
+              seenWO.add(s.work_order_id);
+              plannedSacks += s.job.total_sacks;
+              revenue += s.job.revenue;
+            }
             return (
               <div
                 key={truck.id}
@@ -196,6 +209,13 @@ export default function WeekBoard({
                     <span className="h-2.5 w-2.5 shrink-0 rounded-full ring-2 ring-black/[0.03]" style={{ backgroundColor: truck.color || '#94a3b8' }} />
                     <span className="truncate text-[12.5px] font-bold text-slate-700">{truck.name}</span>
                   </div>
+                  {seenWO.size > 0 && (
+                    <div className="flex flex-wrap items-center gap-x-1.5 pl-[18px] text-[9px] leading-tight text-slate-400" title="Planerat den här veckan: säckar att blåsa · omsättning (ex moms)">
+                      <span className="tabular-nums"><span className="font-bold text-slate-500">{plannedSacks}</span> säck</span>
+                      <span className="text-slate-300">·</span>
+                      <span className="tabular-nums"><span className="font-bold text-slate-500">{krFmt.format(revenue)}</span> kr</span>
+                    </div>
+                  )}
                   <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1 pl-[18px]">
                     {overridden ? (
                       // This week deviates from the default — edit it directly.

--- a/app/crm/planering/WeekBoard.tsx
+++ b/app/crm/planering/WeekBoard.tsx
@@ -45,12 +45,12 @@ type WeekBoardProps = {
 function DefaultCrewAvatars({ team }: { team: DefaultCrewMember[] }) {
   if (team.length === 0) return null;
   return (
-    <div className="flex items-center -space-x-1.5">
+    <div className="flex items-center space-x-0.5">
       {team.map((m) => (
         <span key={m.id} className="relative inline-grid h-5 w-5 place-items-center rounded-full text-[7px] font-bold text-white ring-1 ring-white" style={{ backgroundColor: crewColor(m.member_id ?? m.member_name) }} title={`${m.member_name}${m.role === 'leader' ? ' (teamledare)' : ''}`}>
           {crewInitials(m.member_name)}
           {m.role === 'leader' && (
-            <svg className="absolute -right-1 -top-1 text-amber-500" width="8" height="8" viewBox="0 0 24 24" fill="currentColor" stroke="white" strokeWidth="1.5"><path d="M12 2l3 7h7l-5.5 4.5L18 21l-6-4-6 4 1.5-7.5L2 9h7z" /></svg>
+            <svg className="absolute right-5 -top-1 text-amber-500" width="12" height="12" viewBox="0 0 24 24" fill="currentColor" stroke="white" strokeWidth="1.5"><path d="M12 2l3 7h7l-5.5 4.5L18 21l-6-4-6 4 1.5-7.5L2 9h7z" /></svg>
           )}
         </span>
       ))}

--- a/app/crm/planering/WeekBoard.tsx
+++ b/app/crm/planering/WeekBoard.tsx
@@ -81,6 +81,21 @@ export default function WeekBoard({
   const dayCols = `repeat(${n}, minmax(0,1fr))`;
   const notesByDay = groupNotesByDay(dayNotes);
 
+  // Whole-week total across all trucks (deduped by work order, same basis as the per-lane totals).
+  const weekTotals = (() => {
+    const seen = new Set<string>();
+    let sacks = 0;
+    let revenue = 0;
+    for (const s of segments) {
+      if (s.end_day < weekStart || s.start_day > weekEnd) continue;
+      if (!s.job || !s.work_order_id || seen.has(s.work_order_id)) continue;
+      seen.add(s.work_order_id);
+      sacks += s.job.total_sacks;
+      revenue += s.job.revenue;
+    }
+    return { sacks, revenue, jobs: seen.size };
+  })();
+
   // First/last visible-day column a segment occupies (null when it falls entirely on hidden days).
   const segColumns = (seg: OpsSegment): { s: number; e: number } | null => {
     let s = -1;
@@ -142,7 +157,16 @@ export default function WeekBoard({
       <div style={{ minWidth: 112 + n * 132 }}>
         {/* Day header */}
         <div className="mb-1.5 grid" style={{ gridTemplateColumns: laneCols }}>
-          <div />
+          {/* Whole-week total for all trucks (top-left corner, above the notes row). */}
+          <div className="flex flex-col justify-center pl-1 pr-2">
+            {weekTotals.jobs > 0 && (
+              <>
+                <span className="text-[8.5px] font-bold uppercase tracking-wide text-slate-300">Veckan totalt</span>
+                <span className="text-[10px] leading-tight tabular-nums text-slate-500"><span className="font-bold text-slate-700">{weekTotals.sacks}</span> säck</span>
+                <span className="text-[10px] leading-tight tabular-nums text-slate-500"><span className="font-bold text-slate-700">{krFmt.format(weekTotals.revenue)}</span> kr</span>
+              </>
+            )}
+          </div>
           {days.map((wd) => {
             const isToday = wd.iso === todayISO;
             const hol = swedishHoliday(wd.iso);

--- a/app/crm/planering/WeekBoard.tsx
+++ b/app/crm/planering/WeekBoard.tsx
@@ -373,7 +373,8 @@ export default function WeekBoard({
                           key={seg.id}
                           draggable={canWrite}
                           onDragStart={(ev) => onSegDragStart(ev, seg)}
-                          onClick={(ev) => {
+                          onClick={(ev) => ev.stopPropagation()}
+                          onDoubleClick={(ev) => {
                             ev.stopPropagation();
                             if (suppressClickRef.current) return;
                             onSegClick(seg);

--- a/app/crm/planering/WeekBoard.tsx
+++ b/app/crm/planering/WeekBoard.tsx
@@ -105,15 +105,19 @@ export default function WeekBoard({
   }, []);
 
   // Pointer-drag a card's right edge to change how many days it spans (live preview via `resize`).
+  // The target day is read with elementFromPoint against a per-day overlay (rendered while resizing),
+  // not pointer-x ÷ rect math — the latter breaks under CSS `zoom` because WebKit's
+  // getBoundingClientRect ignores zoom while MouseEvent.clientX is visual, so the last day became
+  // unreachable. elementFromPoint uses the browser's own visual hit-testing, correct at any zoom.
   const startResize = (e: React.MouseEvent, seg: OpsSegment) => {
     e.stopPropagation();
     e.preventDefault();
-    const dayArea = (e.currentTarget as HTMLElement).closest('[data-dayarea]') as HTMLElement | null;
-    if (!dayArea) return;
-    const rect = dayArea.getBoundingClientRect();
     resizeEndRef.current = seg.end_day;
+    setResize({ segId: seg.id, endIso: seg.end_day }); // show the day overlay from the first move
     const onMove = (me: MouseEvent) => {
-      const idx = Math.max(0, Math.min(n - 1, Math.floor(((me.clientX - rect.left) / rect.width) * n)));
+      const cell = (document.elementFromPoint(me.clientX, me.clientY) as HTMLElement | null)?.closest('[data-dayidx]') as HTMLElement | null;
+      if (!cell) return;
+      const idx = Math.max(0, Math.min(n - 1, Number(cell.dataset.dayidx)));
       const endIso = days[idx].iso < seg.start_day ? seg.start_day : days[idx].iso;
       resizeEndRef.current = endIso;
       setResize({ segId: seg.id, endIso });
@@ -357,6 +361,16 @@ export default function WeekBoard({
                       );
                     })}
                   </div>
+
+                  {/* Day-index hit overlay — only while resizing a card in this lane. Sits above the
+                      cards so elementFromPoint reliably reports the day under the pointer (zoom-safe). */}
+                  {resize && laneSegs.some((s) => s.id === resize.segId) && (
+                    <div className="absolute inset-0 z-40 grid" style={{ gridTemplateColumns: dayCols }}>
+                      {days.map((wd, di) => (
+                        <div key={wd.iso} data-dayidx={di} />
+                      ))}
+                    </div>
+                  )}
                 </div>
               </div>
             );

--- a/app/crm/planering/WeekBoard.tsx
+++ b/app/crm/planering/WeekBoard.tsx
@@ -383,7 +383,8 @@ export default function WeekBoard({
                           // by truck at a glance everywhere — consistent across week + month.
                           style={{ gridColumn: `${col.s + 1} / ${endIdx + 2}`, backgroundColor: `${laneColor}1f`, borderColor: `${laneColor}66` }}
                           className={cn(
-                            'relative overflow-hidden rounded-xl border border-solid p-2.5 pl-3.5 shadow-[0_1px_2px_rgba(20,44,27,0.06)] transition hover:shadow-[0_3px_10px_rgba(20,44,27,0.12)]',
+                            'group relative overflow-hidden rounded-xl border border-solid p-2.5 pl-3.5 shadow-[0_1px_2px_rgba(20,44,27,0.06)] transition hover:shadow-[0_3px_10px_rgba(20,44,27,0.12)]',
+                            seg.job && 'hover:ring-2 hover:ring-emerald-400/40',
                             canWrite ? 'cursor-grab active:cursor-grabbing' : 'cursor-pointer',
                             seg.on_hold && 'opacity-60 ring-1 ring-amber-200',
                           )}

--- a/app/crm/planering/WeekBoard.tsx
+++ b/app/crm/planering/WeekBoard.tsx
@@ -184,6 +184,7 @@ export default function WeekBoard({
             const laneWeekly = crewForTruckInRange(truckCrew, truck.id, weekStart, weekEnd);
             const overridden = laneWeekly.length > 0;
             const defaultTeam = defaultCrew.filter((m) => m.truck_id === truck.id);
+            const laneColor = truck.color || '#94a3b8';
             return (
               <div
                 key={truck.id}
@@ -332,9 +333,11 @@ export default function WeekBoard({
                             if (suppressClickRef.current) return;
                             onSegClick(seg);
                           }}
-                          style={{ gridColumn: `${col.s + 1} / ${endIdx + 2}` }}
+                          // Tint the card by its truck's colour (same as the month view) so jobs read
+                          // by truck at a glance everywhere — consistent across week + month.
+                          style={{ gridColumn: `${col.s + 1} / ${endIdx + 2}`, backgroundColor: `${laneColor}1f`, borderColor: `${laneColor}66` }}
                           className={cn(
-                            'relative overflow-hidden rounded-xl border border-[#e0e8dc] bg-white p-2.5 pl-3.5 shadow-[0_1px_2px_rgba(20,44,27,0.06)] transition hover:shadow-[0_3px_10px_rgba(20,44,27,0.12)]',
+                            'relative overflow-hidden rounded-xl border border-solid p-2.5 pl-3.5 shadow-[0_1px_2px_rgba(20,44,27,0.06)] transition hover:shadow-[0_3px_10px_rgba(20,44,27,0.12)]',
                             canWrite ? 'cursor-grab active:cursor-grabbing' : 'cursor-pointer',
                             seg.on_hold && 'opacity-60 ring-1 ring-amber-200',
                           )}

--- a/app/crm/planering/WeekBoard.tsx
+++ b/app/crm/planering/WeekBoard.tsx
@@ -209,13 +209,6 @@ export default function WeekBoard({
                     <span className="h-2.5 w-2.5 shrink-0 rounded-full ring-2 ring-black/[0.03]" style={{ backgroundColor: truck.color || '#94a3b8' }} />
                     <span className="truncate text-[12.5px] font-bold text-slate-700">{truck.name}</span>
                   </div>
-                  {seenWO.size > 0 && (
-                    <div className="flex flex-wrap items-center gap-x-1.5 pl-[18px] text-[9px] leading-tight text-slate-400" title="Planerat den här veckan: säckar att blåsa · omsättning (ex moms)">
-                      <span className="tabular-nums"><span className="font-bold text-slate-500">{plannedSacks}</span> säck</span>
-                      <span className="text-slate-300">·</span>
-                      <span className="tabular-nums"><span className="font-bold text-slate-500">{krFmt.format(revenue)}</span> kr</span>
-                    </div>
-                  )}
                   <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1 pl-[18px]">
                     {overridden ? (
                       // This week deviates from the default — edit it directly.
@@ -282,6 +275,14 @@ export default function WeekBoard({
                       ) : null
                     )}
                   </div>
+
+                  {/* Weekly per-truck totals (planned sacks to blow · revenue ex moms). */}
+                  {seenWO.size > 0 && (
+                    <div className="mt-0.5 grid gap-0.5 pl-[18px] text-[9px] leading-tight text-slate-400" title="Planerat den här veckan">
+                      <span className="tabular-nums"><span className="font-bold text-slate-500">{plannedSacks}</span> säck planerat</span>
+                      <span className="tabular-nums"><span className="font-bold text-slate-500">{krFmt.format(revenue)}</span> kr omsättning</span>
+                    </div>
+                  )}
                 </div>
 
                 {/* Day-area: one drop zone; the target day is derived from the pointer x. */}

--- a/app/crm/planering/jobCard.tsx
+++ b/app/crm/planering/jobCard.tsx
@@ -755,6 +755,13 @@ export function SegmentCardBody({
               <CrewAvatars crew={seg.crew} />
             </div>
           </div>
+          {/* Hover hint — the card opens its work order on double-click. */}
+          <span className="pointer-events-none absolute inset-x-0 bottom-0 z-10 flex justify-center pb-1 opacity-0 transition-opacity duration-150 group-hover:opacity-100">
+            <span className="inline-flex items-center gap-1 whitespace-nowrap rounded-full border border-emerald-300 bg-white/95 px-2 py-0.5 text-[8.5px] font-bold text-emerald-700 shadow-sm">
+              <svg width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.6" strokeLinecap="round" strokeLinejoin="round"><path d="M7 17 17 7M8 7h9v9" /></svg>
+              Dubbelklicka för att öppna
+            </span>
+          </span>
         </>
       ) : seg.placeholder_title ? (
         <>

--- a/app/crm/planering/jobCard.tsx
+++ b/app/crm/planering/jobCard.tsx
@@ -333,7 +333,7 @@ export function JobRef({ job, className }: { job: Pick<JobDisplay, 'ref' | 'is_f
   return (
     <span
       className={cn(
-        'whitespace-nowrap text-[12px] font-extrabold tabular-nums tracking-tight',
+        'whitespace-nowrap text-[11px] font-extrabold tabular-nums tracking-tight',
         job.is_fortnox_ref ? 'text-[#1f4a2e]' : 'font-bold text-slate-400',
         className,
       )}
@@ -752,19 +752,19 @@ export function SegmentCardBody({
               </span>
             )}
           </div>
-          <div className="mt-1.5 truncate text-[13px] font-bold leading-tight text-slate-900">{job.project_name}</div>
-          <div className="truncate text-[11px] text-slate-500">{job.client_name}</div>
+          <div className="mt-1 truncate text-[11.5px] font-bold leading-tight text-slate-900">{job.project_name}</div>
+          <div className="truncate text-[10px] text-slate-500">{job.client_name}</div>
           {job.address && (
-            <div className="mt-0.5 flex items-center gap-1 text-[10.5px] text-slate-400">
+            <div className="mt-0.5 flex items-center gap-1 text-[9.5px] text-slate-400">
               <span className="truncate">{job.address}</span>
               <MapLink address={job.address} />
             </div>
           )}
-          <div className="mt-2 flex flex-wrap items-center gap-1.5">
+          <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
             {seg.on_hold && <HoldBadge />}
             <JobTypeOrMaterial jobType={resolveJobTypeFrom(jobTypes, seg.job_type)} material={job.material} />
           </div>
-          <div className="mt-2 flex flex-wrap items-center gap-2">
+          <div className="mt-1.5 flex flex-wrap items-center gap-2">
             <SackProgress planned={job.total_sacks} reported={seg.sacks_reported} />
             <ConfirmationBadge confirmation={seg.confirmation} />
             <CreatorBadge name={seg.created_by_name} />
@@ -794,8 +794,8 @@ export function SegmentCardBody({
               </button>
             )}
           </div>
-          <div className="mt-1.5 truncate text-[13px] font-bold leading-tight text-slate-800">{seg.placeholder_title}</div>
-          {seg.placeholder_customer && <div className="truncate text-[11px] text-slate-500">{seg.placeholder_customer}</div>}
+          <div className="mt-1 truncate text-[11.5px] font-bold leading-tight text-slate-800">{seg.placeholder_title}</div>
+          {seg.placeholder_customer && <div className="truncate text-[10px] text-slate-500">{seg.placeholder_customer}</div>}
           <div className="mt-2 flex flex-wrap items-center gap-2">
             <JobTypeOrMaterial jobType={resolveJobTypeFrom(jobTypes, seg.job_type)} material={null} />
             <div className="ml-auto flex items-center gap-1">

--- a/app/crm/planering/jobCard.tsx
+++ b/app/crm/planering/jobCard.tsx
@@ -473,10 +473,7 @@ export function SegmentMenu({
                         <button
                           key={st}
                           type="button"
-                          onClick={() => {
-                            onSetStatus(st);
-                            setOpen(false);
-                          }}
+                          onClick={() => onSetStatus(st)}
                           className={cn(
                             'flex w-full items-center gap-2 rounded-lg border px-2 py-1 text-left text-[11px] font-semibold transition',
                             active ? m.pill : 'border-transparent text-slate-600 hover:bg-slate-50',
@@ -500,10 +497,7 @@ export function SegmentMenu({
                         <button
                           key={t.key}
                           type="button"
-                          onClick={() => {
-                            onSetJobType(active ? null : t.key);
-                            setOpen(false);
-                          }}
+                          onClick={() => onSetJobType(active ? null : t.key)}
                           className={cn(
                             'flex w-full items-center gap-2 rounded-lg border px-2 py-1 text-left text-[11px] font-semibold transition',
                             active ? 'border-emerald-200 bg-emerald-50 text-emerald-700' : 'border-transparent text-slate-600 hover:bg-slate-50',
@@ -526,10 +520,7 @@ export function SegmentMenu({
                         <button
                           type="button"
                           disabled={order.index === 0}
-                          onClick={() => {
-                            order.onMove('up');
-                            setOpen(false);
-                          }}
+                          onClick={() => order.onMove('up')}
                           title="Tidigare"
                           className="inline-flex h-7 w-7 items-center justify-center rounded-md bg-slate-50 p-0 text-slate-600 transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-40"
                         >
@@ -539,10 +530,7 @@ export function SegmentMenu({
                         <button
                           type="button"
                           disabled={order.index === order.total - 1}
-                          onClick={() => {
-                            order.onMove('down');
-                            setOpen(false);
-                          }}
+                          onClick={() => order.onMove('down')}
                           title="Senare"
                           className="inline-flex h-7 w-7 items-center justify-center rounded-md bg-slate-50 p-0 text-slate-600 transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-40"
                         >
@@ -559,10 +547,7 @@ export function SegmentMenu({
                       <button
                         key={d}
                         type="button"
-                        onClick={() => {
-                          onSetLength(d);
-                          setOpen(false);
-                        }}
+                        onClick={() => onSetLength(d)}
                         className={cn(
                           'h-7 flex-1 rounded-md p-0 text-[11px] font-bold tabular-nums transition',
                           d === lengthDays ? 'bg-emerald-600 text-white shadow-sm' : 'bg-slate-50 text-slate-600 hover:bg-slate-100',
@@ -619,10 +604,7 @@ export function SegmentMenu({
               <div className="mt-3 grid grid-cols-2 gap-2 border-t border-[#eef3eb] pt-3">
                 <button
                   type="button"
-                  onClick={() => {
-                    onToggleHold();
-                    setOpen(false);
-                  }}
+                  onClick={() => onToggleHold()}
                   className={cn(
                     'flex items-center justify-center gap-1.5 rounded-lg border px-2 py-1.5 text-[11px] font-semibold transition',
                     onHold ? 'border-amber-200 bg-amber-50 text-amber-700 hover:bg-amber-100' : 'border-[#e0e8dc] bg-white text-slate-600 hover:bg-slate-50',

--- a/app/crm/planering/jobCard.tsx
+++ b/app/crm/planering/jobCard.tsx
@@ -333,7 +333,7 @@ export function JobRef({ job, className }: { job: Pick<JobDisplay, 'ref' | 'is_f
   return (
     <span
       className={cn(
-        'whitespace-nowrap text-[11px] font-extrabold tabular-nums tracking-tight',
+        'whitespace-nowrap text-[10px] font-extrabold tabular-nums tracking-tight',
         job.is_fortnox_ref ? 'text-[#1f4a2e]' : 'font-bold text-slate-400',
         className,
       )}
@@ -752,10 +752,10 @@ export function SegmentCardBody({
               </span>
             )}
           </div>
-          <div className="mt-1 truncate text-[11.5px] font-bold leading-tight text-slate-900">{job.project_name}</div>
-          <div className="truncate text-[10px] text-slate-500">{job.client_name}</div>
+          <div className="mt-1 truncate text-[10.5px] font-bold leading-tight text-slate-900">{job.project_name}</div>
+          <div className="truncate text-[9.5px] text-slate-500">{job.client_name}</div>
           {job.address && (
-            <div className="mt-0.5 flex items-center gap-1 text-[9.5px] text-slate-400">
+            <div className="mt-0.5 flex items-center gap-1 text-[9px] text-slate-400">
               <span className="truncate">{job.address}</span>
               <MapLink address={job.address} />
             </div>
@@ -794,8 +794,8 @@ export function SegmentCardBody({
               </button>
             )}
           </div>
-          <div className="mt-1 truncate text-[11.5px] font-bold leading-tight text-slate-800">{seg.placeholder_title}</div>
-          {seg.placeholder_customer && <div className="truncate text-[10px] text-slate-500">{seg.placeholder_customer}</div>}
+          <div className="mt-1 truncate text-[10.5px] font-bold leading-tight text-slate-800">{seg.placeholder_title}</div>
+          {seg.placeholder_customer && <div className="truncate text-[9.5px] text-slate-500">{seg.placeholder_customer}</div>}
           <div className="mt-2 flex flex-wrap items-center gap-2">
             <JobTypeOrMaterial jobType={resolveJobTypeFrom(jobTypes, seg.job_type)} material={null} />
             <div className="ml-auto flex items-center gap-1">

--- a/app/globals.css
+++ b/app/globals.css
@@ -3,18 +3,19 @@
 @tailwind utilities;
 
 /* Tailwind preflight is disabled project-wide (see tailwind.config.js → corePlugins.preflight:false),
-   so there is no global `border-width: 0` reset. Any element with a border *style* (e.g. the
-   `border-solid` utility) but no explicit width on a given side falls back to the CSS-initial
-   `medium` (~3px) border on that side — phantom borders that eat layout space. The planning boards
-   (week + month) use `border-solid` for their grid lines, so restore the reset *scoped to those
-   boards only* (in @layer base so real width utilities like `border-l`/`border-b` still win).
-   The proper app-wide fix (re-enable preflight / a global reset) is deferred: it would make
-   currently-hidden Tailwind div-borders appear across the not-yet-rebuilt non-CRM surfaces. */
+   so there is no global `border-width: 0 / border-style: solid` reset. A plain `border` utility on a
+   <div>/<span> then draws NOTHING (style defaults to none), and a `border-solid` without a width util
+   gets a phantom `medium` (~3px) border. Restore Tailwind's own preflight border reset scoped to the
+   whole planning surface (in @layer base so real width utilities like `border`/`border-l` still win),
+   so every bordered element — cards, grid lines, badges, the backlog — draws a clean hairline with no
+   phantom borders. The app-wide fix is deferred (would surface hidden borders on not-yet-rebuilt
+   non-CRM surfaces), hence the scope to .planning-density. */
 @layer base {
-  .planning-board *,
-  .planning-board *::before,
-  .planning-board *::after {
+  .planning-density *,
+  .planning-density *::before,
+  .planning-density *::after {
     border-width: 0;
+    border-style: solid;
   }
 
   /* The custom planning overlays (admin, activity log, placeholder) use plain `border` utilities on

--- a/app/globals.css
+++ b/app/globals.css
@@ -33,7 +33,7 @@
    to a denser default (≈ two Safari zoom-out notches). `zoom` re-rasterises like browser zoom, so
    text stays crisp and layout/scroll stay correct (unlike transform:scale). Tune via the variable. */
 .planning-density {
-  --planning-zoom: 0.80;
+  --planning-zoom: 1;
   zoom: var(--planning-zoom);
 }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -33,7 +33,7 @@
    to a denser default (≈ two Safari zoom-out notches). `zoom` re-rasterises like browser zoom, so
    text stays crisp and layout/scroll stay correct (unlike transform:scale). Tune via the variable. */
 .planning-density {
-  --planning-zoom: 0.70;
+  --planning-zoom: 0.80;
   zoom: var(--planning-zoom);
 }
 

--- a/app/plannering/page.tsx
+++ b/app/plannering/page.tsx
@@ -16,8 +16,6 @@ import CalendarDayList from './components/CalendarDayList';
 import { listDayNotes, type DayNote } from '@/lib/dayNotes';
 import nextDynamic from 'next/dynamic';
 const AdminJobTypes = nextDynamic(() => import('../admin/jobtypes/AdminJobTypes'), { ssr: false });
-// NOTE: The file header was previously corrupted by an accidental paste of JSX outside any component.
-// Restoring intended interface/type declarations here.
 
 interface Project {
   id: string;

--- a/lib/domains/planning/confirmationsSend.ts
+++ b/lib/domains/planning/confirmationsSend.ts
@@ -1,6 +1,7 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { sendEmail } from '@/lib/email';
 import { sendSms } from '@/lib/sms';
+import { toSwedishE164 } from '@/lib/phone';
 import { buildPlanningNotificationEmail } from '@/lib/planningNotificationEmail';
 import { buildPlanningNotificationSms } from '@/lib/planningNotificationSms';
 import type { ConfirmationChannel } from './confirmations';
@@ -158,7 +159,12 @@ export async function sendOrderConfirmation(
   }
 
   if (input.sendSms && input.recipientPhone) {
-    try {
+    // Twilio needs E.164 (+46…); normalise the Swedish number the planner typed so a plain
+    // "0701234567" / "070-123 45 67" isn't rejected as invalid.
+    const to = toSwedishE164(input.recipientPhone);
+    if (!to) {
+      result.sms.error = 'Ogiltigt telefonnummer';
+    } else try {
       const body = buildPlanningNotificationSms({
         projectName: ctx.project_name,
         orderNumber,
@@ -168,14 +174,14 @@ export async function sendOrderConfirmation(
         truck: ctx.truck_name,
         salesResponsible: input.actorName,
       });
-      const res = await sendSms({ to: input.recipientPhone, body });
+      const res = await sendSms({ to, body });
       result.sms.sent = true;
       result.sms.status = res.status;
       const rec = await recordConfirmation(supabase, {
         workOrderId: ctx.work_order_id,
         segmentId: input.segmentId,
         channel: 'sms',
-        recipient: input.recipientPhone,
+        recipient: to,
         startDay: ctx.start_day,
         endDay: ctx.end_day,
         providerMessageId: res.sid,

--- a/lib/domains/planning/depotStock.ts
+++ b/lib/domains/planning/depotStock.ts
@@ -1,5 +1,6 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
-import { materialShortFromLineItems } from '@/lib/domains/crm/materials';
+import { materialShortFromLineItems, totalSacks } from '@/lib/domains/crm/materials';
+import { SCHEDULABLE_WORK_ORDER_STATUSES } from './backlog';
 
 // Depot stock (slice 12b): per-material balance per depot = sum(deliveries) − consumption, where
 // consumption is derived from ops_segment_reports (a job's blown sacks → its segment's truck → that
@@ -13,6 +14,10 @@ export type DepotMaterialBalance = {
   delivered: number;
   consumed: number;
   balance: number;
+  // Planned sacks still booked to be blown (open scheduled jobs drawing from this depot+material).
+  planned: number;
+  // How many sacks the booked work needs beyond what's in stock (planned − balance, floored at 0).
+  shortfall: number;
 };
 
 export type DepotBalance = {
@@ -29,9 +34,10 @@ export function computeDepotBalances(
   depots: { id: string; name: string }[],
   delivered: StockRow[],
   consumed: StockRow[],
+  planned: StockRow[] = [],
 ): DepotBalance[] {
-  // depot_id -> material -> { delivered, consumed }
-  const acc = new Map<string, Map<string, { delivered: number; consumed: number }>>();
+  // depot_id -> material -> { delivered, consumed, planned }
+  const acc = new Map<string, Map<string, { delivered: number; consumed: number; planned: number }>>();
   const ensure = (depotId: string, material: string) => {
     let byMat = acc.get(depotId);
     if (!byMat) {
@@ -40,24 +46,30 @@ export function computeDepotBalances(
     }
     let cell = byMat.get(material);
     if (!cell) {
-      cell = { delivered: 0, consumed: 0 };
+      cell = { delivered: 0, consumed: 0, planned: 0 };
       byMat.set(material, cell);
     }
     return cell;
   };
   for (const r of delivered) ensure(r.depot_id, r.material).delivered += r.sacks;
   for (const r of consumed) ensure(r.depot_id, r.material).consumed += r.sacks;
+  for (const r of planned) ensure(r.depot_id, r.material).planned += r.sacks;
 
   return depots.map((d) => {
     const byMat = acc.get(d.id);
     const rows: DepotMaterialBalance[] = byMat
       ? [...byMat.entries()]
-          .map(([material, cell]) => ({
-            material,
-            delivered: cell.delivered,
-            consumed: cell.consumed,
-            balance: cell.delivered - cell.consumed,
-          }))
+          .map(([material, cell]) => {
+            const balance = cell.delivered - cell.consumed;
+            return {
+              material,
+              delivered: cell.delivered,
+              consumed: cell.consumed,
+              balance,
+              planned: cell.planned,
+              shortfall: Math.max(0, cell.planned - balance),
+            };
+          })
           .sort((a, b) => a.material.localeCompare(b.material, 'sv'))
       : [];
     return {
@@ -110,14 +122,47 @@ async function deriveConsumptionRows(supabase: SupabaseClient): Promise<StockRow
   return rows;
 }
 
-// Per-depot, per-material balances for the stock view. RLS (planning.schedule.read) applies.
+// Planned demand rows: for each OPEN scheduled job (work order still draft/scheduled/in_progress),
+// the sacks it's booked to blow → its segment's truck → that truck's depot, attributed to the work
+// order's material. Deduped by work order so a multi-segment job counts once. This is what the booked
+// schedule needs from the depot, regardless of the visible week. (While installer reporting is
+// dormant, consumed≈0, so balance is the physical stock and planned is the full booked demand —
+// refine to "remaining" once reports land.)
+async function derivePlannedDemandRows(supabase: SupabaseClient): Promise<StockRow[]> {
+  const { data: trucks } = await supabase.from('ops_trucks').select('id, depot_id');
+  const truckDepot = new Map((trucks ?? []).map((t: any) => [t.id as string, (t.depot_id as string | null) ?? null]));
+
+  const { data: segs } = await supabase
+    .from('ops_segments')
+    .select('work_order_id, truck_id, work_order:crm_work_orders(status, line_items)');
+
+  const open = new Set(SCHEDULABLE_WORK_ORDER_STATUSES as unknown as string[]);
+  const seen = new Set<string>();
+  const rows: StockRow[] = [];
+  for (const s of (segs ?? []) as Array<Record<string, any>>) {
+    const wo = Array.isArray(s.work_order) ? s.work_order[0] : s.work_order;
+    if (!wo || !open.has(wo.status) || !s.work_order_id || seen.has(s.work_order_id)) continue;
+    seen.add(s.work_order_id);
+    const depotId = truckDepot.get(s.truck_id);
+    const material = materialShortFromLineItems(wo.line_items);
+    const sacks = totalSacks(wo.line_items);
+    if (depotId && material && sacks > 0) rows.push({ depot_id: depotId, material, sacks });
+  }
+  return rows;
+}
+
+// Per-depot, per-material balances + planned demand for the stock view. RLS (planning.schedule.read).
 export async function getDepotStock(supabase: SupabaseClient): Promise<{ data: DepotBalance[]; error: { message: string } | null }> {
   const { data: depots, error } = await supabase.from('ops_depots').select('id, name').order('name', { ascending: true });
   if (error) return { data: [], error };
 
-  const [delivered, consumed] = await Promise.all([listDeliveryRows(supabase), deriveConsumptionRows(supabase)]);
+  const [delivered, consumed, planned] = await Promise.all([
+    listDeliveryRows(supabase),
+    deriveConsumptionRows(supabase),
+    derivePlannedDemandRows(supabase),
+  ]);
   return {
-    data: computeDepotBalances((depots ?? []) as { id: string; name: string }[], delivered, consumed),
+    data: computeDepotBalances((depots ?? []) as { id: string; name: string }[], delivered, consumed, planned),
     error: null,
   };
 }

--- a/lib/domains/planning/display.ts
+++ b/lib/domains/planning/display.ts
@@ -1,4 +1,12 @@
 import { inferMaterialFromArticle, totalSacks } from '@/lib/domains/crm/materials';
+import { lineItemRowTotal, type PricingLineItem } from '@/lib/domains/crm/pricing';
+
+// A work order's revenue (omsättning) = sum of its line-item row totals, ex VAT — the same row math
+// the quote/order/Fortnox use, so the figure can't drift.
+function lineItemsRevenue(items: unknown[] | null | undefined): number {
+  if (!Array.isArray(items)) return 0;
+  return items.reduce<number>((sum, it) => sum + lineItemRowTotal(it as PricingLineItem), 0);
+}
 
 // Shared, pure display mapping for a CRM work order shown in the planning board — used by both
 // the backlog read model and the scheduled-segment read model so a job looks identical wherever
@@ -27,6 +35,8 @@ export type JobDisplay = {
   address: string | null;
   total_sacks: number;
   material: string | null;
+  // Order value ex VAT (omsättning), summed from the line items.
+  revenue: number;
 };
 
 function str(value: unknown): string {
@@ -84,5 +94,6 @@ export function mapWorkOrderJob(row: WorkOrderJobRow): JobDisplay {
     address: resolveJobAddress(row.work_address, row.customer_snapshot),
     total_sacks: totalSacks((row.line_items ?? []) as never),
     material: materialLabelFromLineItems(row.line_items),
+    revenue: lineItemsRevenue(row.line_items),
   };
 }

--- a/lib/domains/planning/insights.ts
+++ b/lib/domains/planning/insights.ts
@@ -1,0 +1,150 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { mapWorkOrderJob, type WorkOrderJobRow } from './display';
+import { SCHEDULABLE_WORK_ORDER_STATUSES } from './backlog';
+
+// Forward-looking planning insights: scheduled revenue + sacks per week, per truck, per material,
+// and the value of work still waiting to be planned (unplanned backlog). Pure aggregation here is
+// unit-tested; the DB read is a thin RLS-scoped query. All figures are deduped by work order so a
+// multi-segment job counts once (attributed to its earliest scheduled week + that segment's truck).
+
+export type WeekPoint = { weekStart: string; label: string; revenue: number; sacks: number };
+export type TruckPoint = { truck_id: string; truck_name: string; revenue: number; sacks: number };
+export type MaterialPoint = { material: string; sacks: number };
+export type PlanningInsights = {
+  weeks: WeekPoint[];
+  byTruck: TruckPoint[];
+  byMaterial: MaterialPoint[];
+  backlog: { revenue: number; sacks: number; count: number };
+};
+
+const OPEN = new Set(SCHEDULABLE_WORK_ORDER_STATUSES as unknown as string[]);
+
+// Pure: Monday (UTC, date-only/DST-safe) of the week containing an ISO date.
+export function mondayOf(iso: string): string {
+  const d = new Date(`${iso}T00:00:00Z`);
+  d.setUTCDate(d.getUTCDate() - ((d.getUTCDay() + 6) % 7));
+  return d.toISOString().slice(0, 10);
+}
+
+function addDaysISO(iso: string, days: number): string {
+  const d = new Date(`${iso}T00:00:00Z`);
+  d.setUTCDate(d.getUTCDate() + days);
+  return d.toISOString().slice(0, 10);
+}
+
+// Pure: ISO week number for an ISO date (for the chart label "v.NN").
+export function isoWeek(iso: string): number {
+  const d = new Date(`${iso}T00:00:00Z`);
+  d.setUTCDate(d.getUTCDate() - ((d.getUTCDay() + 6) % 7) + 3); // Thursday of this week
+  const firstThu = new Date(Date.UTC(d.getUTCFullYear(), 0, 4));
+  firstThu.setUTCDate(firstThu.getUTCDate() - ((firstThu.getUTCDay() + 6) % 7) + 3);
+  return 1 + Math.round((d.getTime() - firstThu.getTime()) / (7 * 86_400_000));
+}
+
+export type InsightJob = {
+  weekStart: string;
+  truck_id: string;
+  truck_name: string;
+  revenue: number;
+  sacks: number;
+  material: string | null;
+};
+
+// Pure: bucket unique scheduled jobs into weekly / per-truck / per-material aggregates. weekStarts
+// fixes the week axis (so empty weeks still render); jobs outside it are ignored for the week series
+// but still count for truck/material totals.
+export function aggregateInsights(weekStarts: string[], jobs: InsightJob[]): Omit<PlanningInsights, 'backlog'> {
+  const weekMap = new Map<string, WeekPoint>(weekStarts.map((w) => [w, { weekStart: w, label: `v.${isoWeek(w)}`, revenue: 0, sacks: 0 }]));
+  const truckMap = new Map<string, TruckPoint>();
+  const matMap = new Map<string, number>();
+  for (const j of jobs) {
+    const wk = weekMap.get(j.weekStart);
+    if (wk) {
+      wk.revenue += j.revenue;
+      wk.sacks += j.sacks;
+    }
+    let t = truckMap.get(j.truck_id);
+    if (!t) {
+      t = { truck_id: j.truck_id, truck_name: j.truck_name, revenue: 0, sacks: 0 };
+      truckMap.set(j.truck_id, t);
+    }
+    t.revenue += j.revenue;
+    t.sacks += j.sacks;
+    if (j.material) matMap.set(j.material, (matMap.get(j.material) ?? 0) + j.sacks);
+  }
+  return {
+    weeks: weekStarts.map((w) => weekMap.get(w) as WeekPoint),
+    byTruck: [...truckMap.values()].sort((a, b) => b.revenue - a.revenue),
+    byMaterial: [...matMap.entries()].map(([material, sacks]) => ({ material, sacks })).sort((a, b) => b.sacks - a.sacks),
+  };
+}
+
+const JOB_FIELDS =
+  'order_number, fortnox_order_number, project_name, client_name, status, customer_snapshot, work_address, line_items';
+
+// Value (revenue + sacks) of schedulable work orders that have NO segments yet — the work still
+// waiting to be planned.
+async function computeBacklogValue(supabase: SupabaseClient): Promise<{ revenue: number; sacks: number; count: number }> {
+  const { data: orders } = await supabase
+    .from('crm_work_orders')
+    .select(`id, ${JOB_FIELDS}`)
+    .in('status', SCHEDULABLE_WORK_ORDER_STATUSES as unknown as string[]);
+  const rows = (orders ?? []) as Array<WorkOrderJobRow & { id: string }>;
+  if (rows.length === 0) return { revenue: 0, sacks: 0, count: 0 };
+
+  const { data: segs } = await supabase.from('ops_segments').select('work_order_id').in('work_order_id', rows.map((r) => r.id));
+  const scheduled = new Set((segs ?? []).map((s: any) => s.work_order_id as string));
+
+  let revenue = 0;
+  let sacks = 0;
+  let count = 0;
+  for (const o of rows) {
+    if (scheduled.has(o.id)) continue;
+    const job = mapWorkOrderJob(o);
+    revenue += job.revenue;
+    sacks += job.total_sacks;
+    count++;
+  }
+  return { revenue, sacks, count };
+}
+
+// Forward window of `weeks` starting from the Monday of `fromISO`. RLS (planning.schedule.read).
+export async function getPlanningInsights(
+  supabase: SupabaseClient,
+  opts: { fromISO: string; weeks: number },
+): Promise<{ data: PlanningInsights; error: { message: string } | null }> {
+  const from = mondayOf(opts.fromISO);
+  const weekStarts = Array.from({ length: opts.weeks }, (_, i) => addDaysISO(from, i * 7));
+  const to = addDaysISO(from, opts.weeks * 7 - 1);
+
+  const { data: segs, error } = await supabase
+    .from('ops_segments')
+    .select(`work_order_id, start_day, truck_id, truck:ops_trucks(name), work_order:crm_work_orders(${JOB_FIELDS})`)
+    .lte('start_day', to)
+    .gte('end_day', from)
+    .order('start_day', { ascending: true });
+
+  const empty: PlanningInsights = { weeks: [], byTruck: [], byMaterial: [], backlog: { revenue: 0, sacks: 0, count: 0 } };
+  if (error) return { data: empty, error };
+
+  const seen = new Set<string>();
+  const jobs: InsightJob[] = [];
+  for (const s of (segs ?? []) as Array<Record<string, any>>) {
+    const wo = Array.isArray(s.work_order) ? s.work_order[0] : s.work_order;
+    if (!wo || !OPEN.has(wo.status) || !s.work_order_id || seen.has(s.work_order_id)) continue;
+    seen.add(s.work_order_id);
+    const job = mapWorkOrderJob(wo as WorkOrderJobRow);
+    const truck = Array.isArray(s.truck) ? s.truck[0] : s.truck;
+    jobs.push({
+      weekStart: mondayOf(s.start_day),
+      truck_id: s.truck_id,
+      truck_name: truck?.name ?? '—',
+      revenue: job.revenue,
+      sacks: job.total_sacks,
+      material: job.material,
+    });
+  }
+
+  const backlog = await computeBacklogValue(supabase);
+  return { data: { ...aggregateInsights(weekStarts, jobs), backlog }, error: null };
+}

--- a/lib/phone.ts
+++ b/lib/phone.ts
@@ -1,0 +1,18 @@
+// Normalise a Swedish phone number to E.164 (+46…) for Twilio, which rejects national formats like
+// "0701234567" or "070-123 45 67". Returns null when the input can't be made into a plausible E.164
+// number. Swedish-first (this is a Swedish business); an already-international "+…" number is kept.
+export function toSwedishE164(raw: string | null | undefined): string | null {
+  if (!raw) return null;
+  const cleaned = raw.replace(/[\s\-().]/g, '').trim();
+  if (!cleaned) return null;
+
+  let s: string;
+  if (cleaned.startsWith('+')) s = cleaned; // already international
+  else if (cleaned.startsWith('00')) s = `+${cleaned.slice(2)}`; // 00-prefixed international
+  else if (cleaned.startsWith('0')) s = `+46${cleaned.slice(1)}`; // national: 0701… → +46701…
+  else if (cleaned.startsWith('46')) s = `+${cleaned}`; // 46701… → +46701…
+  else if (/^\d+$/.test(cleaned)) s = `+46${cleaned}`; // bare national digits, missing the leading 0
+  else return null;
+
+  return /^\+\d{8,15}$/.test(s) ? s : null;
+}

--- a/tests/lib/phone.test.ts
+++ b/tests/lib/phone.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { toSwedishE164 } from '@/lib/phone';
+
+describe('toSwedishE164', () => {
+  it('converts national 0-prefixed Swedish numbers', () => {
+    expect(toSwedishE164('0701234567')).toBe('+46701234567');
+    expect(toSwedishE164('070-123 45 67')).toBe('+46701234567');
+    expect(toSwedishE164('08-123 456')).toBe('+468123456');
+    expect(toSwedishE164('(070) 123 45 67')).toBe('+46701234567');
+  });
+
+  it('keeps already-international numbers', () => {
+    expect(toSwedishE164('+46701234567')).toBe('+46701234567');
+    expect(toSwedishE164('+46 70 123 45 67')).toBe('+46701234567');
+    expect(toSwedishE164('0046701234567')).toBe('+46701234567');
+    expect(toSwedishE164('46701234567')).toBe('+46701234567');
+  });
+
+  it('handles bare national digits missing the leading 0', () => {
+    expect(toSwedishE164('701234567')).toBe('+46701234567');
+  });
+
+  it('rejects empty / nonsense', () => {
+    expect(toSwedishE164(null)).toBeNull();
+    expect(toSwedishE164('')).toBeNull();
+    expect(toSwedishE164('   ')).toBeNull();
+    expect(toSwedishE164('abc')).toBeNull();
+    expect(toSwedishE164('+')).toBeNull();
+    expect(toSwedishE164('123')).toBeNull(); // too short for E.164
+  });
+});

--- a/tests/planning/depotStock.test.ts
+++ b/tests/planning/depotStock.test.ts
@@ -18,14 +18,27 @@ describe('computeDepotBalances', () => {
 
     const d1 = computeDepotBalances(depots, delivered, consumed).find((d) => d.depot_id === 'd1')!;
     const eko = d1.rows.find((r) => r.material === 'EKOVILLA')!;
-    expect(eko).toEqual({ material: 'EKOVILLA', delivered: 150, consumed: 30, balance: 120 });
+    expect(eko).toEqual({ material: 'EKOVILLA', delivered: 150, consumed: 30, balance: 120, planned: 0, shortfall: 0 });
     expect(d1.rows.find((r) => r.material === 'PAROC')!.balance).toBe(40);
     expect(d1.total_balance).toBe(160);
   });
 
   it('shows a material that has only consumption (negative balance)', () => {
     const d1 = computeDepotBalances(depots, [], [{ depot_id: 'd1', material: 'EKOVILLA', sacks: 25 }]).find((d) => d.depot_id === 'd1')!;
-    expect(d1.rows[0]).toEqual({ material: 'EKOVILLA', delivered: 0, consumed: 25, balance: -25 });
+    expect(d1.rows[0]).toEqual({ material: 'EKOVILLA', delivered: 0, consumed: 25, balance: -25, planned: 0, shortfall: 25 });
+  });
+
+  it('flags a shortfall when planned demand exceeds the balance', () => {
+    const delivered: StockRow[] = [{ depot_id: 'd1', material: 'EKOVILLA', sacks: 150 }];
+    const planned: StockRow[] = [{ depot_id: 'd1', material: 'EKOVILLA', sacks: 250 }];
+    const eko = computeDepotBalances(depots, delivered, [], planned).find((d) => d.depot_id === 'd1')!.rows[0];
+    expect(eko).toMatchObject({ material: 'EKOVILLA', balance: 150, planned: 250, shortfall: 100 });
+  });
+
+  it('no shortfall when the balance covers the planned demand', () => {
+    const delivered: StockRow[] = [{ depot_id: 'd1', material: 'EKOVILLA', sacks: 300 }];
+    const planned: StockRow[] = [{ depot_id: 'd1', material: 'EKOVILLA', sacks: 250 }];
+    expect(computeDepotBalances(depots, delivered, [], planned)[0].rows[0].shortfall).toBe(0);
   });
 
   it('returns every depot, with empty rows when it has no movements', () => {

--- a/tests/planning/insights.test.ts
+++ b/tests/planning/insights.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { mondayOf, isoWeek, aggregateInsights, type InsightJob } from '@/lib/domains/planning/insights';
+
+describe('mondayOf', () => {
+  it('returns the Monday of the week', () => {
+    expect(mondayOf('2026-06-17')).toBe('2026-06-15'); // Wed → Mon
+    expect(mondayOf('2026-06-15')).toBe('2026-06-15'); // Mon → itself
+    expect(mondayOf('2026-06-21')).toBe('2026-06-15'); // Sun → Mon
+  });
+});
+
+describe('isoWeek', () => {
+  it('matches the ISO week number', () => {
+    expect(isoWeek('2026-06-15')).toBe(25);
+    expect(isoWeek('2026-01-01')).toBe(1);
+  });
+});
+
+describe('aggregateInsights', () => {
+  const weekStarts = ['2026-06-15', '2026-06-22'];
+  const jobs: InsightJob[] = [
+    { weekStart: '2026-06-15', truck_id: 't1', truck_name: 'Bil 1', revenue: 1000, sacks: 40, material: 'Ekovilla' },
+    { weekStart: '2026-06-15', truck_id: 't2', truck_name: 'Bil 2', revenue: 500, sacks: 20, material: 'Vitull' },
+    { weekStart: '2026-06-22', truck_id: 't1', truck_name: 'Bil 1', revenue: 800, sacks: 30, material: 'Ekovilla' },
+  ];
+
+  it('sums revenue + sacks per week (empty weeks stay at zero)', () => {
+    const { weeks } = aggregateInsights(['2026-06-15', '2026-06-22', '2026-06-29'], jobs);
+    expect(weeks.map((w) => [w.label, w.revenue, w.sacks])).toEqual([
+      ['v.25', 1500, 60],
+      ['v.26', 800, 30],
+      ['v.27', 0, 0],
+    ]);
+  });
+
+  it('sums per truck, sorted by revenue desc', () => {
+    const { byTruck } = aggregateInsights(weekStarts, jobs);
+    expect(byTruck.map((t) => [t.truck_name, t.revenue, t.sacks])).toEqual([
+      ['Bil 1', 1800, 70],
+      ['Bil 2', 500, 20],
+    ]);
+  });
+
+  it('sums sacks per material, sorted desc, ignoring null material', () => {
+    const withNull = [...jobs, { weekStart: '2026-06-15', truck_id: 't3', truck_name: 'Bil 3', revenue: 100, sacks: 5, material: null }];
+    const { byMaterial } = aggregateInsights(weekStarts, withNull);
+    expect(byMaterial).toEqual([
+      { material: 'Ekovilla', sacks: 70 },
+      { material: 'Vitull', sacks: 20 },
+    ]);
+  });
+});


### PR DESCRIPTION
18 commits ovanpå main (PR #28). Allt grönt: type-check · build · 472 tester.

- Optimistiska board-uppdateringar (move/reorder/place/unschedule) — ingen flicker
- Resize når sista dagen under zoom (elementFromPoint)
- Svenskt telefonnr → E.164 + loading-state i bekräftelse-modalen
- Bil-färgade kort (vecka+månad), tätare typografi, säck/omsättning per bil + vecka
- Synliga borders (preflight-reset breddad)
- Lager-täcknings-varning (planerat vs depålager)
- Optimistisk place/unschedule + laddnings-skelett
- 'Insikter'-vy (recharts): omsättning/säckar per vecka, per bil, per material, oplanerat backlog-värde
- Kebab-meny stannar öppen vid in-meny-val; arbetsorder öppnas på dubbelklick
- Hover-ram + 'dubbelklicka för att öppna'-badge

Tip: 1948e87 (senaste). Ren fast-forward av main, inga konflikter.