### PR TITLE
feat(planning): backlog filter (oplanerade/planerade/alla) + placemen…

### DIFF
--- a/app/crm/planering/Backlog.tsx
+++ b/app/crm/planering/Backlog.tsx
@@ -5,17 +5,28 @@ import type { SchedulableWorkOrder } from '@/lib/domains/planning/types';
 import { statusMeta, SackBadge, JobRef, MapLink } from './jobCard';
 import { formatDate } from '@/app/crm/lib/format';
 
+type BacklogFilter = 'unplanned' | 'planned' | 'all';
+
 type BacklogProps = {
   items: SchedulableWorkOrder[];
   loading: boolean;
   canWrite: boolean;
   selectedId: string | null;
+  filter: BacklogFilter;
+  onFilterChange: (f: BacklogFilter) => void;
+  counts: { unplanned: number; planned: number; all: number };
   onSelect: (id: string) => void;
   onDragStartItem: (e: React.DragEvent, item: SchedulableWorkOrder) => void;
   onDropUnschedule: (e: React.DragEvent) => void;
   onDragOver: (e: React.DragEvent) => void;
   dropActive: boolean;
 };
+
+const FILTER_TABS: ReadonlyArray<readonly [BacklogFilter, string]> = [
+  ['unplanned', 'Oplanerade'],
+  ['planned', 'Planerade'],
+  ['all', 'Alla'],
+];
 
 function shortDate(value: string | null): string | null {
   if (!value) return null;
@@ -24,8 +35,16 @@ function shortDate(value: string | null): string | null {
 }
 
 export default function Backlog({
-  items, loading, canWrite, selectedId, onSelect, onDragStartItem, onDropUnschedule, onDragOver, dropActive,
+  items, loading, canWrite, selectedId, filter, onFilterChange, counts, onSelect, onDragStartItem, onDropUnschedule, onDragOver, dropActive,
 }: BacklogProps) {
+  const emptyText =
+    filter === 'planned'
+      ? 'Inga inplanerade jobb än.'
+      : filter === 'unplanned'
+        ? counts.planned > 0
+          ? 'Alla jobb är inplanerade. 🎉'
+          : 'Inga arbetsordrar att planera. Skapa en order i CRM:et så dyker den upp här.'
+        : 'Inga arbetsordrar att planera. Skapa en order i CRM:et så dyker den upp här.';
   return (
     <section
       className={cn(
@@ -43,13 +62,29 @@ export default function Backlog({
         <span className="text-[11px] tabular-nums text-slate-400">{items.length} st</span>
       </div>
 
+      {/* Filter — defaults to "Oplanerade" so scheduled jobs don't clutter the backlog. */}
+      <div className="flex gap-1 px-3.5 pb-2.5">
+        {FILTER_TABS.map(([key, label]) => (
+          <button
+            key={key}
+            type="button"
+            onClick={() => onFilterChange(key)}
+            className={cn(
+              'inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[10.5px] font-bold transition',
+              filter === key ? 'border-[#1a3f26] bg-[#1a3f26] text-white' : 'border-[#e0e8dc] bg-white text-slate-500 hover:border-[#c8d4c3]',
+            )}
+          >
+            {label}
+            <span className={cn('tabular-nums', filter === key ? 'text-white/70' : 'text-slate-400')}>{counts[key]}</span>
+          </button>
+        ))}
+      </div>
+
       <div className="min-h-0 flex-1 overflow-y-auto px-2.5 pb-3">
         {loading ? (
           <p className="py-6 text-center text-sm text-slate-400">Laddar…</p>
         ) : items.length === 0 ? (
-          <p className="px-2 py-6 text-center text-sm text-slate-400">
-            Inga arbetsordrar att planera. Skapa en order i CRM:et så dyker den upp här.
-          </p>
+          <p className="px-2 py-6 text-center text-sm text-slate-400">{emptyText}</p>
         ) : (
           <div className="grid gap-2">
             {items.map((item) => {
@@ -88,6 +123,11 @@ export default function Backlog({
                     )}
                     <div className="mt-2 flex flex-wrap items-center gap-1.5">
                       <SackBadge sacks={item.total_sacks} />
+                      {item.segment_count > 0 && (
+                        <span className="whitespace-nowrap rounded-full border border-violet-200 bg-violet-50 px-2 py-px text-[10px] font-bold text-violet-700">
+                          {item.segment_count} placering{item.segment_count > 1 ? 'ar' : ''}
+                        </span>
+                      )}
                       {item.desired_installation_date && (
                         <span className="whitespace-nowrap rounded-full border border-sky-200 bg-sky-50 px-2 py-px text-[10px] font-bold text-sky-700">
                           Önskat {shortDate(item.desired_installation_date)}

--- a/app/crm/planering/PlanningClient.tsx
+++ b/app/crm/planering/PlanningClient.tsx
@@ -68,6 +68,7 @@ export default function PlanningClient({
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [search, setSearch] = useState('');
   const [salesFilter, setSalesFilter] = useState<string | null>(null);
+  const [backlogFilter, setBacklogFilter] = useState<'unplanned' | 'planned' | 'all'>('unplanned');
   const [hiddenTrucks, setHiddenTrucks] = useState<Set<string>>(new Set());
   const [backlogDropActive, setBacklogDropActive] = useState(false);
   const [truckPicker, setTruckPicker] = useState<{ dayISO: string; workOrderId: string } | null>(null);
@@ -341,8 +342,11 @@ export default function PlanningClient({
 
   const unschedule = useCallback(
     async (id: string) => {
-      // Optimistic: drop the card at once; re-sync from the server only if the delete fails.
+      // Optimistic: drop the card at once + decrement the job's backlog placement count (so it hops
+      // back to "Oplanerade" when its last placement is removed); re-sync only if the delete fails.
+      const woId = segments.find((s) => s.id === id)?.work_order_id ?? null;
       setSegments((prev) => prev.filter((s) => s.id !== id));
+      if (woId) setBacklog((prev) => prev.map((b) => (b.id === woId ? { ...b, segment_count: Math.max(0, b.segment_count - 1) } : b)));
       const r = await fetch(`${API}/segments/${id}`, { method: 'DELETE' });
       const j = await r.json();
       if (!j.ok) {
@@ -352,7 +356,7 @@ export default function PlanningClient({
       }
       toast.success('Jobbet avplanerat');
     },
-    [refresh, toast],
+    [segments, refresh, toast],
   );
 
   // Crew is per-segment, so add/remove patch the one segment's crew locally (snappy) rather than
@@ -647,9 +651,22 @@ export default function PlanningClient({
       .sort((a, b) => a.name.localeCompare(b.name, 'sv'));
   }, [backlog, peopleById]);
 
-  const visibleBacklog = useMemo(
+  // Search + sales-filtered set, then split by whether the job is already placed (segment_count): the
+  // backlog defaults to showing only unplanned jobs so it doesn't fill up with scheduled work.
+  const backlogBase = useMemo(
     () => backlog.filter((b) => matchJob(b) && (!salesFilter || b.assigned_to === salesFilter)),
     [backlog, matchJob, salesFilter],
+  );
+  const backlogCounts = useMemo(() => {
+    const planned = backlogBase.reduce((n, b) => n + (b.segment_count > 0 ? 1 : 0), 0);
+    return { planned, unplanned: backlogBase.length - planned, all: backlogBase.length };
+  }, [backlogBase]);
+  const visibleBacklog = useMemo(
+    () =>
+      backlogFilter === 'all'
+        ? backlogBase
+        : backlogBase.filter((b) => (backlogFilter === 'planned' ? b.segment_count > 0 : b.segment_count === 0)),
+    [backlogBase, backlogFilter],
   );
   const visibleSegments = useMemo(
     () => segments.filter((s) => !hiddenTrucks.has(s.truck_id) && (s.job ? matchJob(s.job) : true)),
@@ -882,6 +899,9 @@ export default function PlanningClient({
           loading={loadingBacklog}
           canWrite={canWrite}
           selectedId={selectedId}
+          filter={backlogFilter}
+          onFilterChange={setBacklogFilter}
+          counts={backlogCounts}
           onSelect={onSelect}
           onDragStartItem={onBacklogDragStart}
           onDropUnschedule={onBacklogDrop}


### PR DESCRIPTION
The backlog kept showing jobs even after they were scheduled, cluttering it. Add filter chips at the top — Oplanerade / Planerade / Alla with live counts — defaulting to Oplanerade so the list is "what still needs planning". Each card shows a "N placering(ar)" badge once the job has been placed (helps spot a half-placed multi-day job that still needs more days). Unschedule now decrements the placement count so a job hops back to Oplanerade when its last placement is removed (optimistic place already bumps it).