### PR TITLE
fix(fortnox): härda kundimport mot rate-limit + identity-constraint-k…

### DIFF
--- a/app/api/fortnox/customers/verify-types/route.ts
+++ b/app/api/fortnox/customers/verify-types/route.ts
@@ -1,0 +1,18 @@
+import { requireCrmAdmin, ok, routeError } from '../../_shared';
+import { verifyCustomerTypesBatch } from '@/lib/domains/fortnox/customers';
+
+// Processes one throttled batch of heuristic-imported customers and confirms their
+// Type against Fortnox. Resumable – the client loops until remaining === 0.
+export const maxDuration = 60;
+
+export async function POST() {
+  try {
+    const admin = await requireCrmAdmin();
+    if (admin.response) return admin.response;
+
+    const result = await verifyCustomerTypesBatch();
+    return ok(result);
+  } catch (e: any) {
+    return routeError(500, 'fortnox_verify_types_failed', e?.message || 'Verifiering av kundtyper misslyckades');
+  }
+}

--- a/app/crm/installningar/FortnoxIntegrationBlock.tsx
+++ b/app/crm/installningar/FortnoxIntegrationBlock.tsx
@@ -22,6 +22,7 @@ export default function FortnoxIntegrationBlock({
   const [disconnecting, setDisconnecting] = useState(false);
   const [articleSync, setArticleSync] = useState<SyncResult>(defaultSync);
   const [customerSync, setCustomerSync] = useState<SyncResult>(defaultSync);
+  const [verifySync, setVerifySync] = useState<SyncResult>(defaultSync);
 
   async function handleDisconnect() {
     if (!confirm('Är du säker på att du vill koppla från Fortnox?')) return;
@@ -56,6 +57,44 @@ export default function FortnoxIntegrationBlock({
       }
     } catch {
       setter({ label: '', state: 'error', message: 'Nätverksfel' });
+    }
+  }
+
+  // Confirms heuristic-classified customer types against Fortnox. The endpoint
+  // processes one throttled batch per call and returns how many remain, so we
+  // loop until the queue is empty, accumulating progress as we go.
+  async function runVerifyTypes() {
+    setVerifySync({ label: '', state: 'loading', message: 'Startar verifiering...' });
+    let processed = 0;
+    let corrected = 0;
+    try {
+      for (let guard = 0; guard < 1000; guard++) {
+        const res = await fetch('/api/fortnox/customers/verify-types', { method: 'POST' });
+        const json = await res.json();
+        if (!res.ok || !json.ok) {
+          setVerifySync({ label: '', state: 'error', message: json.error || 'Okänt fel' });
+          return;
+        }
+        const d = json.data as { processed: number; corrected: number; remaining: number };
+        processed += d.processed;
+        corrected += d.corrected;
+        if (d.processed === 0 || d.remaining === 0) {
+          setVerifySync({
+            label: '',
+            state: 'success',
+            message: `Klart – ${processed} kunder verifierade, ${corrected} omklassade. ${d.remaining} kvar.`,
+          });
+          return;
+        }
+        setVerifySync({
+          label: '',
+          state: 'loading',
+          message: `${processed} verifierade, ${corrected} omklassade, ${d.remaining} kvar...`,
+        });
+      }
+      setVerifySync({ label: '', state: 'success', message: `Pausat efter ${processed} kunder – kör igen för resten.` });
+    } catch {
+      setVerifySync({ label: '', state: 'error', message: 'Nätverksfel' });
     }
   }
 
@@ -112,10 +151,19 @@ export default function FortnoxIntegrationBlock({
           {/* Customer sync */}
           <SyncRow
             label="Synka kunder från Fortnox"
-            description="Importerar Fortnox-kunder som Fortnox-kunder i CRM:et."
+            description="Importerar Fortnox-kunder som Fortnox-kunder i CRM:et. Kundtyp sätts preliminärt och bekräftas i steget nedan."
             state={customerSync.state}
             message={customerSync.message}
             onSync={() => runSync('/api/fortnox/customers/sync', setCustomerSync)}
+          />
+
+          {/* Customer type verification (confirms heuristic classification) */}
+          <SyncRow
+            label="Verifiera kundtyper"
+            description="Bekräftar företag/privat mot Fortnox för importerade kunder. Körs i bakgrunden, kan ta en stund vid många kunder."
+            state={verifySync.state}
+            message={verifySync.message}
+            onSync={runVerifyTypes}
           />
 
           <div className="mt-1 border-t border-slate-100 pt-3">

--- a/lib/domains/fortnox/client.ts
+++ b/lib/domains/fortnox/client.ts
@@ -63,6 +63,35 @@ function buildFortnoxError(status: number, method: string, path: string, text: s
   return new FortnoxApiError(status, `Fortnox ${method} ${path} misslyckades (${status}): ${text}`, code, message);
 }
 
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// Fortnox rate-limits the API (~4 req/s). On 429 it returns Retry-After. Retry
+// transparently with backoff so callers (sync passes, document pushes) ride out
+// a throttle instead of failing. Caps the wait so a request never hangs forever.
+const MAX_429_RETRIES = 5;
+const MAX_BACKOFF_MS = 8000;
+
+// Wraps fetch with transparent 429 handling. The body is drained between
+// attempts so the connection can be reused; the final Response is returned
+// untouched for the caller to read.
+async function fortnoxFetch(url: string, init: RequestInit): Promise<Response> {
+  for (let attempt = 0; ; attempt++) {
+    const res = await fetch(url, init);
+    if (res.status !== 429 || attempt >= MAX_429_RETRIES) return res;
+
+    const retryAfter = Number(res.headers.get('retry-after'));
+    const waitMs =
+      Number.isFinite(retryAfter) && retryAfter > 0
+        ? retryAfter * 1000
+        : Math.min(1000 * 2 ** attempt, MAX_BACKOFF_MS);
+    // Drain the throttle body so the socket frees up before we wait + retry.
+    await res.text().catch(() => {});
+    await sleep(waitMs);
+  }
+}
+
 // Known Fortnox error codes → plain-language Swedish a salesperson understands.
 // Add codes here as we hit them; unknown codes fall back to Fortnox's own message.
 const FRIENDLY_FORTNOX_MESSAGES: Record<number, string> = {
@@ -212,7 +241,7 @@ export async function fortnoxGet<T>(
     for (const [k, v] of Object.entries(params)) url.searchParams.set(k, v);
   }
 
-  const res = await fetch(url.toString(), {
+  const res = await fortnoxFetch(url.toString(), {
     // Never serve a cached response – Next.js App Router caches fetch() by
     // default, which would return stale Fortnox data after a write.
     cache: 'no-store',
@@ -239,7 +268,7 @@ export async function fortnoxGetBinary(
 ): Promise<{ bytes: Uint8Array; contentType: string }> {
   const token = await getValidAccessToken();
 
-  const res = await fetch(`${FORTNOX_API_BASE}${path}`, {
+  const res = await fortnoxFetch(`${FORTNOX_API_BASE}${path}`, {
     cache: 'no-store',
     headers: {
       Authorization: `Bearer ${token}`,
@@ -263,7 +292,7 @@ export async function fortnoxGetBinary(
 export async function fortnoxPut<T>(path: string, body?: unknown): Promise<T> {
   const token = await getValidAccessToken();
 
-  const res = await fetch(`${FORTNOX_API_BASE}${path}`, {
+  const res = await fortnoxFetch(`${FORTNOX_API_BASE}${path}`, {
     method: 'PUT',
     cache: 'no-store',
     headers: {
@@ -286,7 +315,7 @@ export async function fortnoxPut<T>(path: string, body?: unknown): Promise<T> {
 export async function fortnoxPost<T>(path: string, body: unknown): Promise<T> {
   const token = await getValidAccessToken();
 
-  const res = await fetch(`${FORTNOX_API_BASE}${path}`, {
+  const res = await fortnoxFetch(`${FORTNOX_API_BASE}${path}`, {
     method: 'POST',
     cache: 'no-store',
     headers: {
@@ -310,7 +339,7 @@ export async function fortnoxPost<T>(path: string, body: unknown): Promise<T> {
 export async function fortnoxDelete(path: string): Promise<void> {
   const token = await getValidAccessToken();
 
-  const res = await fetch(`${FORTNOX_API_BASE}${path}`, {
+  const res = await fortnoxFetch(`${FORTNOX_API_BASE}${path}`, {
     method: 'DELETE',
     cache: 'no-store',
     headers: {

--- a/lib/domains/fortnox/customers.ts
+++ b/lib/domains/fortnox/customers.ts
@@ -10,11 +10,41 @@ import type {
 type FortnoxCustomerDetailResponse = { Customer: FortnoxCustomer };
 
 const PAGE_SIZE = 500;
-const FETCH_CONCURRENCY = 10;
+// Concurrency for DB writes (no Fortnox calls happen in the bulk import path, so
+// this is only about not flooding Supabase with simultaneous statements).
+const DB_CONCURRENCY = 10;
+// Verification pass: small batch + spacing keeps the per-customer Fortnox GETs
+// well under the ~4 req/s rate limit. Resumable, so size is just per-request cost.
+const VERIFY_BATCH_SIZE = 50;
+const VERIFY_SPACING_MS = 300; // ~3 req/s
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// Heuristic company-vs-private from the list endpoint, which omits Type. A Swedish
+// organisationsnummer's 3rd digit is the "group" digit (2–9), while a personnummer's
+// 3rd digit is the tens-of-month, always 0 or 1 (months 01–12). Falls back to
+// VAT-number presence, then private (safe default). Known edge case: a sole trader
+// (enskild firma) uses the owner's personnummer as org.nr and is read as private
+// until the verification pass fetches Fortnox's authoritative Type.
+export function inferCustomerType(
+  orgNumber: string | null | undefined,
+  vatNumber: string | null | undefined,
+): 'business' | 'private' {
+  const digits = (orgNumber ?? '').replace(/\D/g, '');
+  // A 12-digit number is century-prefixed (YYYYMMDD… or 16-prefixed org.nr) – the
+  // last 10 carry the discriminating digit either way.
+  const normalized = digits.length === 12 ? digits.slice(2) : digits;
+  if (normalized.length >= 10) {
+    return Number(normalized[2]) >= 2 ? 'business' : 'private';
+  }
+  if (vatNumber && vatNumber.trim()) return 'business';
+  return 'private';
+}
 
 // Runs fn over items in serial batches of batchSize concurrent calls. Used for
-// both reads (per-customer GETs) and writes (per-customer UPDATEs) to stay within
-// Fortnox rate limits / avoid flooding the DB with concurrent statements.
+// per-customer DB UPDATEs to avoid flooding the DB with concurrent statements.
 async function runInBatches<T, R>(
   items: T[],
   batchSize: number,
@@ -54,21 +84,27 @@ export function buildFortnoxAddress(
   return { street: street ?? null, postal_code: postalCode ?? null, city: city ?? null };
 }
 
-function mapFortnoxCustomerToRow(c: FortnoxCustomer, now: string) {
-  // Type is only returned by the individual GET endpoint, not the list endpoint.
-  // Default to 'private' when missing – safer than guessing from OrganisationNumber
-  // since private persons can also have a personal number in that field.
-  const isCompany = c.Type === 'COMPANY';
-  const isPrivate = c.Type === 'PRIVATE';
-  if (!isCompany && !isPrivate) {
-    console.warn(`[Fortnox sync] Kund ${c.CustomerNumber} har oväntat Type-värde: "${c.Type}" → klassificeras som privat`);
-  }
+// Maps a Fortnox customer onto a crm_customers row. `resolvedType` is decided by
+// the caller (heuristic on import, Fortnox's authoritative Type on verification),
+// and `verified` records which of those it is. Guards the identity constraint: a
+// single-word/empty Fortnox Name must never produce an all-null-identity row.
+function mapFortnoxCustomerToRow(
+  c: FortnoxCustomer,
+  resolvedType: 'business' | 'private',
+  verified: boolean,
+  now: string,
+) {
+  const isCompany = resolvedType === 'business';
   const name = splitSwedishName(c.Name);
+  // Fortnox always has a Name, but stay defensive: fall back to a stable label so
+  // company_name / first_name can never both be null (constraint violation).
+  const fallbackName = (c.Name ?? '').trim() || `Fortnox-kund ${c.CustomerNumber}`;
   return {
-    customer_type: isCompany ? 'business' : 'private',
+    customer_type: resolvedType,
+    customer_type_verified: verified,
     customer_stage: 'fortnox_customer' as const,
-    company_name: isCompany ? (c.Name ?? null) : null,
-    first_name: isCompany ? null : name.first,
+    company_name: isCompany ? fallbackName : null,
+    first_name: isCompany ? null : (name.first ?? fallbackName),
     last_name: isCompany ? null : name.last,
     // OrganisationNumber holds a company's org.nr or a private person's personnummer.
     organization_number: isCompany ? (c.OrganisationNumber ?? null) : null,
@@ -94,8 +130,38 @@ function mapFortnoxCustomerToRow(c: FortnoxCustomer, now: string) {
   };
 }
 
+// Bulk-insert rows, falling back to row-by-row on failure so a single bad record
+// (e.g. an identity-constraint edge case) never aborts the whole page. Returns
+// how many rows actually landed.
+async function insertCustomersResilient(
+  supabase: ReturnType<typeof getSupabaseAdmin>,
+  rows: Record<string, unknown>[],
+): Promise<number> {
+  const { error } = await supabase.from('crm_customers').insert(rows);
+  if (!error) return rows.length;
+
+  console.warn(`[Fortnox sync] Bulk-insert misslyckades (${error.message}) → faller tillbaka på rad-för-rad`);
+  let inserted = 0;
+  for (const row of rows) {
+    const { error: rowErr } = await supabase.from('crm_customers').insert(row);
+    if (rowErr) {
+      console.warn(`[Fortnox sync] Hoppar över kund ${row.fortnox_customer_id} (${rowErr.message})`);
+    } else {
+      inserted++;
+    }
+  }
+  return inserted;
+}
+
 // Fetch all customers from Fortnox and upsert into crm_customers.
 // Matches on fortnox_customer_id (unique) to update existing rows.
+//
+// The list endpoint does NOT return Type, so company-vs-private is decided by
+// inferCustomerType() heuristic and the row is marked customer_type_verified=false.
+// We deliberately do NOT fetch each customer individually here – that fan-out
+// (one GET per customer) blew past Fortnox's rate limit on real-size registers
+// (thousands of customers → mass 429s → every row mis-classified as private).
+// verifyCustomerTypesBatch() confirms Type afterwards, throttled.
 export async function syncFortnoxCustomers(triggeredByUserId: string): Promise<CustomerSyncResult> {
   const supabase = getSupabaseAdmin();
   let page = 1;
@@ -116,57 +182,46 @@ export async function syncFortnoxCustomers(triggeredByUserId: string): Promise<C
     totalPages = response.MetaInformation?.['@TotalPages'] ?? 1;
 
     if (listCustomers.length > 0) {
-      // Fetch each customer individually – the list endpoint does not return Type.
-      // Batched at FETCH_CONCURRENCY to stay within Fortnox rate limits.
-      const customers = await runInBatches(
-        listCustomers,
-        FETCH_CONCURRENCY,
-        (c) =>
-          fortnoxGet<FortnoxCustomerDetailResponse>(`/customers/${c.CustomerNumber}`)
-            .then((r) => r.Customer)
-            .catch((err) => {
-              console.warn(`[Fortnox sync] Kunde inte hämta kund ${c.CustomerNumber} individuellt (${(err as Error)?.message ?? err}) → faller tillbaka på listdata, Type saknas`);
-              return c;
-            }),
-      );
-
-      // Check which fortnox_customer_ids already exist
-      const ids = customers.map((c) => c.CustomerNumber);
+      const ids = listCustomers.map((c) => c.CustomerNumber);
       const { data: existing } = await supabase
         .from('crm_customers')
-        .select('id, fortnox_customer_id')
+        .select('id, fortnox_customer_id, customer_type, customer_type_verified')
         .in('fortnox_customer_id', ids);
 
-      const existingIds = new Set((existing ?? []).map((r) => r.fortnox_customer_id));
+      const existingById = new Map((existing ?? []).map((r) => [r.fortnox_customer_id, r]));
 
-      const toCreate = customers.filter((c) => !existingIds.has(c.CustomerNumber));
-      const toUpdate = customers.filter((c) => existingIds.has(c.CustomerNumber));
+      const toCreate = listCustomers.filter((c) => !existingById.has(c.CustomerNumber));
+      const toUpdate = listCustomers.filter((c) => existingById.has(c.CustomerNumber));
 
-      // Create new rows (assign_to = null, created_by = null – no user owns Fortnox imports)
+      // Create new rows. Heuristic Type, unverified until the verification pass runs.
       if (toCreate.length > 0) {
         const rows = toCreate.map((c) => ({
-          ...mapFortnoxCustomerToRow(c, now),
+          ...mapFortnoxCustomerToRow(c, inferCustomerType(c.OrganisationNumber, c.VATNumber), false, now),
           assigned_to: triggeredByUserId,
           created_by: triggeredByUserId,
           created_at: now,
         }));
-
-        const { error } = await supabase.from('crm_customers').insert(rows);
-        if (error) throw new Error(`Kunde inte skapa Fortnox-kunder: ${error.message}`);
-        totalCreated += rows.length;
+        totalCreated += await insertCustomersResilient(supabase, rows);
       }
 
-      // Update existing rows with a real UPDATE per customer (matched on the
-      // unique fortnox_customer_id). An upsert would treat the row as a potential
-      // INSERT and fail the NOT NULL constraint on assigned_to/created_by, which
-      // mapFortnoxCustomerToRow intentionally omits to preserve ownership.
+      // Update existing rows. An upsert would clobber assigned_to/created_by
+      // ownership, so we UPDATE per customer (matched on unique fortnox_customer_id).
+      // A row already verified keeps its authoritative Type – we must not regress it
+      // back to a heuristic guess on a routine re-sync.
       if (toUpdate.length > 0) {
-        await runInBatches(toUpdate, FETCH_CONCURRENCY, async (c) => {
+        await runInBatches(toUpdate, DB_CONCURRENCY, async (c) => {
+          const prev = existingById.get(c.CustomerNumber)!;
+          const verified = prev.customer_type_verified === true;
+          const type: 'business' | 'private' = verified
+            ? (prev.customer_type === 'business' ? 'business' : 'private')
+            : inferCustomerType(c.OrganisationNumber, c.VATNumber);
           const { error } = await supabase
             .from('crm_customers')
-            .update(mapFortnoxCustomerToRow(c, now))
+            .update(mapFortnoxCustomerToRow(c, type, verified, now))
             .eq('fortnox_customer_id', c.CustomerNumber);
-          if (error) throw new Error(`Kunde inte uppdatera Fortnox-kund ${c.CustomerNumber}: ${error.message}`);
+          if (error) {
+            console.warn(`[Fortnox sync] Kunde inte uppdatera kund ${c.CustomerNumber} (${error.message})`);
+          }
           return null;
         });
         totalUpdated += toUpdate.length;
@@ -177,6 +232,64 @@ export async function syncFortnoxCustomers(triggeredByUserId: string): Promise<C
   } while (page <= totalPages);
 
   return { created: totalCreated, updated: totalUpdated, pages: totalPages };
+}
+
+export type VerifyTypesResult = {
+  processed: number;
+  corrected: number;
+  remaining: number;
+};
+
+// Confirm customer_type for rows imported via heuristic (customer_type_verified=false)
+// by fetching each customer's authoritative Type from Fortnox, throttled to stay
+// under the rate limit. Resumable: processes one batch per call and reports how
+// many still remain, so a UI/cron can loop until remaining === 0.
+export async function verifyCustomerTypesBatch(limit = VERIFY_BATCH_SIZE): Promise<VerifyTypesResult> {
+  const supabase = getSupabaseAdmin();
+  const now = new Date().toISOString();
+
+  const { data: pending, error } = await supabase
+    .from('crm_customers')
+    .select('id, fortnox_customer_id, customer_type')
+    .eq('customer_type_verified', false)
+    .not('fortnox_customer_id', 'is', null)
+    .order('fortnox_customer_id', { ascending: true })
+    .limit(limit);
+
+  if (error) throw new Error(`Kunde inte hämta overifierade kunder: ${error.message}`);
+
+  const rows = pending ?? [];
+  let corrected = 0;
+
+  for (const row of rows) {
+    try {
+      const detail = await fortnoxGet<FortnoxCustomerDetailResponse>(`/customers/${row.fortnox_customer_id}`);
+      const c = detail.Customer;
+      const realType: 'business' | 'private' = c.Type === 'COMPANY' ? 'business' : 'private';
+
+      const { error: updErr } = await supabase
+        .from('crm_customers')
+        .update(mapFortnoxCustomerToRow(c, realType, true, now))
+        .eq('id', row.id);
+
+      if (updErr) {
+        console.warn(`[Fortnox verify] Kunde inte uppdatera kund ${row.fortnox_customer_id} (${updErr.message})`);
+        continue;
+      }
+      if (realType !== row.customer_type) corrected++;
+    } catch (err) {
+      console.warn(`[Fortnox verify] Kunde inte hämta kund ${row.fortnox_customer_id} (${(err as Error)?.message ?? err})`);
+    }
+    await sleep(VERIFY_SPACING_MS);
+  }
+
+  const { count } = await supabase
+    .from('crm_customers')
+    .select('id', { count: 'exact', head: true })
+    .eq('customer_type_verified', false)
+    .not('fortnox_customer_id', 'is', null);
+
+  return { processed: rows.length, corrected, remaining: count ?? 0 };
 }
 
 // Search Fortnox customers live (for use in quote form, etc.)

--- a/supabase/sql/20260624_crm_customers_import_hardening.sql
+++ b/supabase/sql/20260624_crm_customers_import_hardening.sql
@@ -1,0 +1,30 @@
+-- Härdar Fortnox-kundimporten (2026-06-24).
+--
+-- 1. Relaxar identitets-constraintet. Fortnox har bara ETT Name-fält, så en
+--    importerad privatkund kan legitimt sakna efternamn (enordsnamn). Det gamla
+--    kravet "first_name OCH last_name" välte hela bulk-inserten på sådana rader.
+--    Det striktare för-+efternamn-kravet ligger kvar i app-lagret (Zod) för
+--    MANUELLT skapade privatkunder – DB-backstoppet behöver bara garantera att
+--    raden har någon identitet alls.
+--
+-- 2. Lägger till customer_type_verified. Importen klassar företag-vs-privat via
+--    en org.nr-heuristik (snabb, inga per-kund-anrop → ingen rate limit) och
+--    sätter false; ett throttlat bakgrundspass hämtar Fortnox auktoritativa Type
+--    och sätter true. Default true → befintliga + manuellt skapade kunder är
+--    redan "verifierade" och rörs inte.
+
+alter table public.crm_customers
+  drop constraint if exists crm_customers_identity_check;
+
+alter table public.crm_customers
+  add constraint crm_customers_identity_check check (
+    company_name is not null or first_name is not null or last_name is not null
+  );
+
+alter table public.crm_customers
+  add column if not exists customer_type_verified boolean not null default true;
+
+-- Index för att snabbt plocka overifierade kunder i verifieringspasset.
+create index if not exists crm_customers_type_unverified_idx
+  on public.crm_customers (fortnox_customer_id)
+  where customer_type_verified = false;

--- a/tests/fortnox/customers.test.ts
+++ b/tests/fortnox/customers.test.ts
@@ -4,6 +4,7 @@ import {
   fortnoxCustomerFieldsChanged,
   splitSwedishName,
   buildFortnoxAddress,
+  inferCustomerType,
   type FortnoxCustomerSource,
 } from '@/lib/domains/fortnox/customers';
 
@@ -189,5 +190,34 @@ describe('buildFortnoxAddress', () => {
     expect(buildFortnoxAddress(null, null, null)).toBeNull();
     expect(buildFortnoxAddress('', '', '')).toBeNull();
     expect(buildFortnoxAddress(undefined, undefined, undefined)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// inferCustomerType — heuristic company-vs-private used on import (the list
+// endpoint omits Type). Org.nr 3rd digit >= 2 → company; personnummer 3rd digit
+// (tens-of-month) is 0/1 → private.
+// ---------------------------------------------------------------------------
+
+describe('inferCustomerType', () => {
+  it('classifies a Swedish organisationsnummer as business (3rd digit >= 2)', () => {
+    expect(inferCustomerType('556677-8899', null)).toBe('business');
+    expect(inferCustomerType('5566778899', null)).toBe('business');
+    // 16-prefixed / 12-digit org.nr normalises to the last 10.
+    expect(inferCustomerType('165566778899', null)).toBe('business');
+  });
+
+  it('classifies a personnummer as private (month tens digit 0/1)', () => {
+    expect(inferCustomerType('900101-1234', null)).toBe('private'); // 3rd digit 0
+    expect(inferCustomerType('8512159876', null)).toBe('private');  // 3rd digit 1
+    // 12-digit (century-prefixed) personnummer.
+    expect(inferCustomerType('199001011234', null)).toBe('private');
+  });
+
+  it('falls back to VAT-number presence, then private, when no usable number', () => {
+    expect(inferCustomerType(null, 'SE556677889901')).toBe('business');
+    expect(inferCustomerType('', '   ')).toBe('private');
+    expect(inferCustomerType(null, null)).toBe('private');
+    expect(inferCustomerType('12345', null)).toBe('private'); // too short to discriminate
   });
 });


### PR DESCRIPTION
Första skarpa kundsynken (riktiga bolaget, tusentals kunder) kraschade på crm_customers_identity_check. Kedjan: per-kund GET /customers/{nr} (gjordes bara för fältet Type, som listendpointen inte returnerar) sprängde Fortnox ~4 req/s → mass-429 → fallback till listdata utan Type → alla kunder klassades privata → enordsnamn (företag) gav last_name + company_name null → constraintet bröts → hela bulk-inserten dog på en rad.

- Ta bort per-kund-fan-out ur syncFortnoxCustomers. Klassa företag/privat via inferCustomerType (org.nr-heuristik) + customer_type_verified=false.
- verifyCustomerTypesBatch() + POST /api/fortnox/customers/verify-types + UI-knapp "Verifiera kundtyper": throttlat, resumebart pass som hämtar Fortnox auktoritativa Type efteråt.
- 429-retry med backoff (Retry-After) i client.ts fortnoxFetch → skyddar alla Fortnox-anrop (offert/order/faktura med).
- Härda mappning (enordsnamn/tomt namn → aldrig allt-null-identitet) + insertCustomersResilient (rad-för-rad-fallback). Re-sync bevarar verifierad klassning.
- Migration 20260624: relaxa identity-constraint till minst ett av company_name/first_name/last_name + customer_type_verified-kolumn.

type-check + 475 tester + build gröna.