### PR TITLE
feat(crm): hämta tic.io-företagsdata på befintlig kund (för Fortnox-i…

### DIFF
--- a/app/api/crm/customers/[id]/enrich/route.ts
+++ b/app/api/crm/customers/[id]/enrich/route.ts
@@ -1,0 +1,89 @@
+import { cookies } from 'next/headers';
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
+import { getCrmCustomer, updateCrmCustomer, type UpdateCrmCustomerInput } from '@/lib/domains/crm/customers';
+import { getSupabaseAdmin } from '@/lib/supabase/server';
+import { getTicCompanyByOrgNumber } from '@/lib/domains/tic/companies';
+import { ticRouteErrorInfo } from '@/lib/domains/tic/client';
+import { ok, requireCrmWriter, routeError } from '../../_lib';
+
+type RouteContext = { params: { id: string } };
+
+const isEmptyStr = (v: unknown) => v == null || String(v).trim() === '';
+const addressEmpty = (a: { street: string | null; postal_code: string | null; city: string | null } | null | undefined) =>
+  !a || (isEmptyStr(a.street) && isEmptyStr(a.postal_code) && isEmptyStr(a.city));
+
+// Enrich an existing company customer with tic.io company data (bransch, bolagsform,
+// ekonomi/nyckeltal, risk, plus contact/address). Mirrors the create-form lookup: fills only
+// EMPTY fields so Fortnox-imported identity data is never clobbered. Writer-gated; saves via
+// the admin client so any CRM writer can enrich regardless of the row's assigned_to.
+export async function POST(_req: Request, context: RouteContext) {
+  try {
+    const crmUser = await requireCrmWriter();
+    if (crmUser.response) return crmUser.response;
+
+    const supabase = createRouteHandlerClient({ cookies });
+    const { data: existing, error } = await getCrmCustomer(supabase, context.params.id);
+    if (error || !existing) {
+      return routeError(404, 'crm_customer_not_found', error?.message || 'Kund hittades inte');
+    }
+    if (existing.customer_type !== 'business') {
+      return routeError(400, 'crm_customer_not_company', 'Företagsdata är endast tillgänglig för företagskunder.');
+    }
+    if (!existing.organization_number) {
+      return routeError(400, 'crm_customer_missing_org_number', 'Kunden saknar organisationsnummer – kan inte hämta företagsdata.');
+    }
+
+    let company;
+    try {
+      company = await getTicCompanyByOrgNumber(existing.organization_number);
+    } catch (ticErr) {
+      const info = ticRouteErrorInfo(ticErr);
+      return routeError(info.status, info.code, info.message);
+    }
+    if (!company) {
+      return routeError(404, 'tic_company_not_found', 'Företaget kunde inte hittas hos tic.io.');
+    }
+
+    // Fill-only-empty: build an update from fields tic has a value for AND the customer lacks.
+    const update: UpdateCrmCustomerInput = {};
+    if (isEmptyStr(existing.company_name) && company.company_name) update.company_name = company.company_name;
+    if (isEmptyStr(existing.email) && company.email) update.email = company.email;
+    if (isEmptyStr(existing.phone) && company.phone) update.phone = company.phone;
+    if (addressEmpty(existing.visit_address) && company.address) {
+      update.visit_address = {
+        street: company.address.street || null,
+        postal_code: company.address.postal_code || null,
+        city: company.address.city || null,
+      };
+    }
+    if (existing.annual_revenue == null && company.annual_revenue != null) update.annual_revenue = company.annual_revenue;
+    if (existing.number_of_employees == null && company.number_of_employees != null) update.number_of_employees = company.number_of_employees;
+    if (isEmptyStr(existing.legal_entity_type) && company.legal_entity_type) update.legal_entity_type = company.legal_entity_type;
+    if (isEmptyStr(existing.sni_code) && company.sni_code) update.sni_code = company.sni_code;
+    if (isEmptyStr(existing.sni_name) && company.sni_name) update.sni_name = company.sni_name;
+    if (existing.operating_profit == null && company.operating_profit != null) update.operating_profit = company.operating_profit;
+    if (existing.profit_after_financial_items == null && company.profit_after_financial_items != null) update.profit_after_financial_items = company.profit_after_financial_items;
+    if (existing.total_assets == null && company.total_assets != null) update.total_assets = company.total_assets;
+    if (existing.operating_margin == null && company.operating_margin != null) update.operating_margin = company.operating_margin;
+    if (existing.equity_ratio == null && company.equity_ratio != null) update.equity_ratio = company.equity_ratio;
+    if (existing.financial_year == null && company.financial_year != null) update.financial_year = company.financial_year;
+    if ((!existing.risk_indicators || existing.risk_indicators.length === 0) && company.risk_indicators && company.risk_indicators.length > 0) {
+      update.risk_indicators = company.risk_indicators;
+    }
+
+    const filled = Object.keys(update).length;
+    if (filled === 0) {
+      return ok({ item: existing, filled: 0 });
+    }
+
+    const admin = getSupabaseAdmin();
+    const { data: updated, error: saveError } = await updateCrmCustomer(admin, context.params.id, update);
+    if (saveError || !updated) {
+      return routeError(500, 'crm_customer_enrich_save_failed', saveError?.message || 'Kunde inte spara företagsdata.');
+    }
+
+    return ok({ item: updated, filled });
+  } catch (e: any) {
+    return routeError(500, 'crm_customer_enrich_unexpected', e?.message || 'Failed to enrich customer');
+  }
+}

--- a/app/crm/kunder/CustomerDetailClient.tsx
+++ b/app/crm/kunder/CustomerDetailClient.tsx
@@ -241,6 +241,7 @@ export default function CustomerDetailClient({ customerId, fortnoxConnected }: {
   const [editDraft, setEditDraft] = useState<EditDraft | null>(null);
   const [pushingFortnox, setPushingFortnox] = useState(false);
   const [fetchingCredit, setFetchingCredit] = useState(false);
+  const [enriching, setEnriching] = useState(false);
 
   const [contacts, setContacts] = useState<CustomerContact[]>([]);
   const [addingContact, setAddingContact] = useState(false);
@@ -433,6 +434,23 @@ export default function CustomerDetailClient({ customerId, fortnoxConnected }: {
     finally { setPushingFortnox(false); }
   }
 
+  // Enrich the customer's company data from tic.io (fills only empty fields). Mainly for
+  // Fortnox-imported customers that never went through the create-form lookup.
+  async function fetchCompanyData() {
+    if (!customer) return;
+    setEnriching(true);
+    try {
+      const res = await fetch(`/api/crm/customers/${customer.id}/enrich`, { method: 'POST' });
+      const json = await res.json().catch(() => ({}));
+      if (!res.ok || !json.ok) { toast.error(json?.error || 'Kunde inte hämta företagsdata'); return; }
+      const updated: Customer = json.data?.item;
+      if (updated) { setCustomer(updated); setContacts(updated.contacts || []); }
+      const filled = json.data?.filled ?? 0;
+      toast.success(filled > 0 ? `Företagsdata hämtad (${filled} fält ifyllda)` : 'Inga nya fält att fylla – datan är redan komplett');
+    } catch { toast.error('Fel vid hämtning av företagsdata'); }
+    finally { setEnriching(false); }
+  }
+
   // Manually pull a tic.io credit report and persist the snapshot (writer-gated server-side).
   async function fetchCreditReport() {
     if (!customer) return;
@@ -517,6 +535,14 @@ export default function CustomerDetailClient({ customerId, fortnoxConnected }: {
 
   const displayName = getDisplayName(customer);
   const isB2B = customer.customer_type === 'business';
+  const hasCompanyInfo = Boolean(
+    customer.legal_entity_type || customer.sni_code || customer.sni_name ||
+    customer.annual_revenue != null || customer.number_of_employees != null ||
+    customer.operating_profit != null || customer.profit_after_financial_items != null ||
+    customer.total_assets != null || customer.operating_margin != null ||
+    customer.equity_ratio != null || customer.financial_year != null ||
+    (customer.risk_indicators && customer.risk_indicators.length > 0)
+  );
 
   // ─── Sidebar (shared between read + edit views) ────────────────────────────
 
@@ -907,21 +933,32 @@ export default function CustomerDetailClient({ customerId, fortnoxConnected }: {
           ) : null}
 
           {/* Företagsinformation (företag, från tic.io-uppslaget) */}
-          {isB2B && (
-            customer.legal_entity_type || customer.sni_code || customer.sni_name ||
-            customer.annual_revenue != null || customer.number_of_employees != null ||
-            customer.operating_profit != null || customer.profit_after_financial_items != null ||
-            customer.total_assets != null || customer.operating_margin != null ||
-            customer.equity_ratio != null || customer.financial_year != null ||
-            (customer.risk_indicators && customer.risk_indicators.length > 0)
-          ) ? (
+          {isB2B ? (
             <Card>
-              <SectionTitle>
-                Företagsinformation
-                {customer.financial_year != null ? (
-                  <span className="ml-2 text-xs font-normal normal-case tracking-normal text-slate-400">räkenskapsår {customer.financial_year}</span>
-                ) : null}
-              </SectionTitle>
+              <div className="mb-4 flex items-center justify-between gap-3">
+                <SectionTitle>
+                  Företagsinformation
+                  {customer.financial_year != null ? (
+                    <span className="ml-2 text-xs font-normal normal-case tracking-normal text-slate-400">räkenskapsår {customer.financial_year}</span>
+                  ) : null}
+                </SectionTitle>
+                <button
+                  type="button"
+                  onClick={fetchCompanyData}
+                  disabled={enriching || !customer.organization_number}
+                  className={cn(crm.ghostButton, 'shrink-0 disabled:opacity-50')}
+                  title={!customer.organization_number ? 'Kräver organisationsnummer' : undefined}
+                >
+                  {enriching ? 'Hämtar…' : hasCompanyInfo ? 'Uppdatera' : 'Hämta företagsdata'}
+                </button>
+              </div>
+              {!hasCompanyInfo ? (
+                <p className="text-sm text-slate-500">
+                  {customer.organization_number
+                    ? 'Hämta bransch, bolagsform, ekonomi och risk från tic.io.'
+                    : 'Lägg till ett organisationsnummer för att kunna hämta företagsdata.'}
+                </p>
+              ) : (
               <div className="grid gap-5">
 
                 {/* Bransch & bolagsform */}
@@ -968,6 +1005,7 @@ export default function CustomerDetailClient({ customerId, fortnoxConnected }: {
                 ) : null}
 
               </div>
+              )}
             </Card>
           ) : null}
 

--- a/lib/domains/tic/companies.ts
+++ b/lib/domains/tic/companies.ts
@@ -18,3 +18,14 @@ export async function searchTicCompanies(q: string): Promise<TicLookupResult[]> 
     .filter((d): d is TicRawCompany => !!d)
     .map(mapTicCompany);
 }
+
+// Look up a single company by org.nr and return the mapped result (or null). Prefers an
+// exact registrationNumber match, falling back to the first hit. Used to enrich an existing
+// customer's company data on demand (e.g. Fortnox imports that never went through lookup).
+export async function getTicCompanyByOrgNumber(orgNumber: string): Promise<TicLookupResult | null> {
+  const normalized = orgNumber.replace(/\D/g, '');
+  if (!normalized) return null;
+  const results = await searchTicCompanies(normalized);
+  const exact = results.find((r) => (r.organization_number || '').replace(/\D/g, '') === normalized);
+  return exact ?? results[0] ?? null;
+}


### PR DESCRIPTION
…mporter)

Fortnox-importerade kunder gick aldrig genom skapa-formulärets tic-uppslag och saknar därför bransch/bolagsform/ekonomi/risk. Lägg till en "Hämta företagsdata"-knapp på kunddetaljen.

- Domän: getTicCompanyByOrgNumber(orgnr) i companies.ts (exakt org.nr-match).
- API: POST /api/crm/customers/[id]/enrich (requireCrmWriter) — slår upp via org.nr och fyller BARA tomma fält (speglar create-formulärets applyLookup, rör aldrig befintlig Fortnox-data). Sparar via admin-klient. Returnerar antal ifyllda fält.
- UI: Företagsinformation-kortet visas nu alltid för företagskunder, med knapp + empty-state; toast säger hur många fält som fylldes.