### PR TITLE
feat(crm): månadsbudget för topplistan + antal ordrar & ordervärde

### DIFF
--- a/app/api/crm/goals/_lib.ts
+++ b/app/api/crm/goals/_lib.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { getCurrentWeekStartDate } from '@/lib/domains/crm/goals';
+import { getCurrentMonthStartDate } from '@/lib/domains/crm/goals';
 export { ok, routeError, validationError, requireCrmUser, requireCrmWriter, requireCrmAdmin } from '../_shared';
 
 function normalizeOptionalText(value: unknown) {
@@ -12,17 +12,17 @@ const nonNegativeIntSchema = z.coerce.number().int().min(0, 'Värdet kan inte va
 const nonNegativeNumberSchema = z.coerce.number().min(0, 'Värdet kan inte vara negativt');
 
 export const listCrmGoalsQuerySchema = z.object({
-  period_type: z.enum(['week']).optional().default('week'),
+  period_type: z.enum(['week', 'month']).optional().default('month'),
   period_start: z.preprocess(
-    (value) => normalizeOptionalText(value) || getCurrentWeekStartDate(),
+    (value) => normalizeOptionalText(value) || getCurrentMonthStartDate(),
     z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Ogiltigt perioddatum'),
   ),
 });
 
 export const upsertCrmGoalsSchema = z.object({
-  period_type: z.enum(['week']).optional().default('week'),
+  period_type: z.enum(['week', 'month']).optional().default('month'),
   period_start: z.preprocess(
-    (value) => normalizeOptionalText(value) || getCurrentWeekStartDate(),
+    (value) => normalizeOptionalText(value) || getCurrentMonthStartDate(),
     z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Ogiltigt perioddatum'),
   ),
   goals: z.array(z.object({
@@ -30,6 +30,8 @@ export const upsertCrmGoalsSchema = z.object({
     calls_target: nonNegativeIntSchema,
     quotes_target: nonNegativeIntSchema,
     quote_value_target: nonNegativeNumberSchema,
+    order_count_target: nonNegativeIntSchema,
+    order_value_target: nonNegativeNumberSchema,
   })).min(1, 'Minst ett mål krävs').max(50, 'För många mål i samma uppdatering'),
 });
 

--- a/app/crm/components/CrmOverview.tsx
+++ b/app/crm/components/CrmOverview.tsx
@@ -8,6 +8,7 @@ import type { UserRole } from '@/lib/roles';
 import { getVisibleCrmNavItems } from '../_lib/nav';
 import { cn } from '@/lib/shared/cn';
 import { crm } from '@/app/crm/lib/crmTokens';
+import { weeklyFromMonthly } from '@/lib/domains/crm/goals';
 
 type ProspectItem = {
   id: string;
@@ -88,6 +89,7 @@ type WorkOrderItem = {
   status: string;
   assigned_to: string;
   created_at: string;
+  fortnox_invoiced_at: string | null;
 };
 
 type LoadState = {
@@ -108,11 +110,13 @@ type GoalUser = {
 type GoalItem = {
   id: string;
   user_id: string;
-  period_type: 'week';
+  period_type: 'week' | 'month';
   period_start: string;
   calls_target: number;
   quotes_target: number;
   quote_value_target: number | string;
+  order_count_target: number;
+  order_value_target: number | string;
   user: GoalUser | GoalUser[] | null;
 };
 
@@ -176,7 +180,8 @@ function getGoalUser(value: GoalItem['user']) {
 }
 
 function hasActiveGoalTarget(goal: GoalItem) {
-  return goal.calls_target > 0 || goal.quotes_target > 0 || Number(goal.quote_value_target) > 0;
+  return goal.calls_target > 0 || goal.quotes_target > 0 || Number(goal.quote_value_target) > 0
+    || goal.order_count_target > 0 || Number(goal.order_value_target) > 0;
 }
 
 function isPipelineProspect(prospect: ProspectItem) {
@@ -219,6 +224,28 @@ function isWithinLastDays(value: string, days: number) {
   if (Number.isNaN(date.getTime())) return false;
   const from = addDays(startOfToday(), -days);
   return date >= from;
+}
+
+// Current ISO week range [Monday 00:00, next Monday 00:00) in local time. The leaderboard
+// scopes its actuals to this so weekly targets compare against the current week's activity.
+function currentWeekRange() {
+  const start = startOfToday();
+  const mondayOffset = (start.getDay() + 6) % 7;
+  start.setDate(start.getDate() - mondayOffset);
+  return { start, end: addDays(start, 7) };
+}
+
+// Parse a call_at/created_at timestamp OR a quote_date (date-only) consistently in local time.
+function parseActivityDate(value: string | null | undefined): Date | null {
+  if (!value) return null;
+  const iso = value.length === 10 ? `${value}T12:00:00` : value;
+  const date = new Date(iso);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function isWithin(value: string | null | undefined, range: { start: Date; end: Date }) {
+  const date = parseActivityDate(value);
+  return date != null && date >= range.start && date < range.end;
 }
 
 function isOverdue(task: TaskItem) {
@@ -286,7 +313,7 @@ export default function CrmOverview({ role }: { role: UserRole | null }) {
           fetch('/api/crm/calls', { cache: 'no-store' }),
           fetch('/api/crm/tasks', { cache: 'no-store' }),
           fetch('/api/crm/quotes', { cache: 'no-store' }),
-          fetch('/api/crm/goals?period_type=week', { cache: 'no-store' }),
+          fetch('/api/crm/goals?period_type=month', { cache: 'no-store' }),
           fetch('/api/crm/work-orders', { cache: 'no-store' }),
         ]);
 
@@ -353,9 +380,10 @@ export default function CrmOverview({ role }: { role: UserRole | null }) {
     const quotedProspects = state.prospects.filter((prospect) => prospect.status === 'quoted');
     const qualifiedProspects = state.prospects.filter((prospect) => prospect.status === 'qualified' || prospect.status === 'quoted');
     const wonProspects = state.prospects.filter((prospect) => prospect.status === 'won');
-    const callsTarget = state.goals.reduce((total, goal) => total + goal.calls_target, 0);
-    const quotesTarget = state.goals.reduce((total, goal) => total + goal.quotes_target, 0);
-    const quoteValueTarget = state.goals.reduce((total, goal) => total + Number(goal.quote_value_target || 0), 0);
+    // Monthly budgets → weekly targets (÷4) so the team summary compares against ~one week.
+    const callsTarget = Math.round(weeklyFromMonthly(state.goals.reduce((total, goal) => total + goal.calls_target, 0)));
+    const quotesTarget = Math.round(weeklyFromMonthly(state.goals.reduce((total, goal) => total + goal.quotes_target, 0)));
+    const quoteValueTarget = weeklyFromMonthly(state.goals.reduce((total, goal) => total + Number(goal.quote_value_target || 0), 0));
 
     return {
       prospectsTotal: state.prospects.length,
@@ -387,32 +415,41 @@ export default function CrmOverview({ role }: { role: UserRole | null }) {
   const nextTasks = useMemo(() => [...state.tasks].filter((task) => task.status === 'open').sort(sortTasks).slice(0, 3), [state.tasks]);
   const nextActions = buildOverviewActions({ overdueTasks: summary.overdueTasks, followUpCalls: summary.followUpCalls, newProspects: summary.newProspects, standaloneCalls: summary.standaloneCalls, quoteFollowUps: summary.quoteFollowUps });
   const teamLeaderboard = useMemo(() => {
+    // Goals are MONTHLY budgets; the leaderboard shows the weekly target (budget ÷ 4) against
+    // THIS WEEK's actuals — so every actual is scoped to the current ISO week.
+    const week = currentWeekRange();
     const callsByUser = new Map<string, number>();
     const quotesByUser = new Map<string, number>();
     const quoteValueByUser = new Map<string, number>();
+    const orderCountByUser = new Map<string, number>();
     const orderValueByUser = new Map<string, number>();
     const invoicedValueByUser = new Map<string, number>();
+    const add = (map: Map<string, number>, key: string, value: number) => map.set(key, (map.get(key) || 0) + value);
+    const numeric = (value: number | string) => {
+      const n = typeof value === 'number' ? value : Number(String(value));
+      return Number.isFinite(n) ? n : 0;
+    };
 
     for (const call of state.calls) {
-      callsByUser.set(call.user_id, (callsByUser.get(call.user_id) || 0) + 1);
+      if (isWithin(call.call_at, week)) add(callsByUser, call.user_id, 1);
     }
 
     for (const quote of state.quotes) {
-      quotesByUser.set(quote.assigned_to, (quotesByUser.get(quote.assigned_to) || 0) + 1);
-      const numericAmount = typeof quote.amount === 'number' ? quote.amount : Number(String(quote.amount));
-      quoteValueByUser.set(
-        quote.assigned_to,
-        (quoteValueByUser.get(quote.assigned_to) || 0) + (Number.isFinite(numericAmount) ? numericAmount : 0),
-      );
+      if (!isWithin(quote.quote_date, week)) continue;
+      add(quotesByUser, quote.assigned_to, 1);
+      add(quoteValueByUser, quote.assigned_to, numeric(quote.amount));
     }
 
     for (const workOrder of state.workOrders) {
-      const numericAmount = typeof workOrder.amount === 'number' ? workOrder.amount : Number(String(workOrder.amount));
-      const amount = Number.isFinite(numericAmount) ? numericAmount : 0;
-      orderValueByUser.set(workOrder.assigned_to, (orderValueByUser.get(workOrder.assigned_to) || 0) + amount);
-      // "Fakturerat" = order reached the terminal invoiced state (see work-order status flow).
-      if (workOrder.status === 'invoiced') {
-        invoicedValueByUser.set(workOrder.assigned_to, (invoicedValueByUser.get(workOrder.assigned_to) || 0) + amount);
+      const amount = numeric(workOrder.amount);
+      // Order count + value: orders created this week.
+      if (isWithin(workOrder.created_at, week)) {
+        add(orderCountByUser, workOrder.assigned_to, 1);
+        add(orderValueByUser, workOrder.assigned_to, amount);
+      }
+      // "Fakturerat": value of orders invoiced this week (by the Fortnox invoice date).
+      if (workOrder.status === 'invoiced' && isWithin(workOrder.fortnox_invoiced_at, week)) {
+        add(invoicedValueByUser, workOrder.assigned_to, amount);
       }
     }
 
@@ -420,15 +457,26 @@ export default function CrmOverview({ role }: { role: UserRole | null }) {
       .filter(hasActiveGoalTarget)
       .map((goal) => {
         const user = getGoalUser(goal.user);
+        // Weekly targets derived from the monthly budget (÷4). Count targets are rounded for
+        // a clean "x / y" display; value targets stay exact (formatted as currency).
+        const callsTarget = Math.round(weeklyFromMonthly(goal.calls_target));
+        const quotesTarget = Math.round(weeklyFromMonthly(goal.quotes_target));
+        const quoteValueTarget = weeklyFromMonthly(goal.quote_value_target);
+        const orderCountTarget = Math.round(weeklyFromMonthly(goal.order_count_target));
+        const orderValueTarget = weeklyFromMonthly(goal.order_value_target);
+
         const callsDone = callsByUser.get(goal.user_id) || 0;
         const quotesDone = quotesByUser.get(goal.user_id) || 0;
         const quoteValueDone = quoteValueByUser.get(goal.user_id) || 0;
+        const orderCountDone = orderCountByUser.get(goal.user_id) || 0;
         const orderValueDone = orderValueByUser.get(goal.user_id) || 0;
         const invoicedValueDone = invoicedValueByUser.get(goal.user_id) || 0;
         const progressValues = [
-          goal.calls_target > 0 ? callsDone / goal.calls_target : null,
-          goal.quotes_target > 0 ? quotesDone / goal.quotes_target : null,
-          Number(goal.quote_value_target) > 0 ? quoteValueDone / Number(goal.quote_value_target) : null,
+          callsTarget > 0 ? callsDone / callsTarget : null,
+          quotesTarget > 0 ? quotesDone / quotesTarget : null,
+          quoteValueTarget > 0 ? quoteValueDone / quoteValueTarget : null,
+          orderCountTarget > 0 ? orderCountDone / orderCountTarget : null,
+          orderValueTarget > 0 ? orderValueDone / orderValueTarget : null,
         ].filter((value): value is number => value != null);
         const progressScore = progressValues.length > 0
           ? progressValues.reduce((total, value) => total + value, 0) / progressValues.length
@@ -440,12 +488,15 @@ export default function CrmOverview({ role }: { role: UserRole | null }) {
           userName: user?.full_name || 'Okänd användare',
           role: user?.role || 'sales',
           callsDone,
-          callsTarget: goal.calls_target,
+          callsTarget,
           quotesDone,
-          quotesTarget: goal.quotes_target,
+          quotesTarget,
           quoteValueDone,
-          quoteValueTarget: Number(goal.quote_value_target) || 0,
+          quoteValueTarget,
+          orderCountDone,
+          orderCountTarget,
           orderValueDone,
+          orderValueTarget,
           invoicedValueDone,
           progressScore,
         };
@@ -751,7 +802,10 @@ function LeaderboardPanel({
     quotesTarget: number;
     quoteValueDone: number;
     quoteValueTarget: number;
+    orderCountDone: number;
+    orderCountTarget: number;
     orderValueDone: number;
+    orderValueTarget: number;
     invoicedValueDone: number;
     progressScore: number;
   }>;
@@ -788,7 +842,8 @@ function LeaderboardPanel({
                 <TeamProgressRow label="Samtal" value={entry.callsDone} target={entry.callsTarget} tone="sky" />
                 <TeamProgressRow label="Offerter" value={entry.quotesDone} target={entry.quotesTarget} tone="emerald" />
                 <TeamProgressRow label="Offertvärde" value={entry.quoteValueDone} target={entry.quoteValueTarget} tone="teal" currency />
-                <TeamProgressRow label="Ordervärde" value={entry.orderValueDone} tone="amber" currency />
+                <TeamProgressRow label="Antal ordrar" value={entry.orderCountDone} target={entry.orderCountTarget} tone="amber" />
+                <TeamProgressRow label="Ordervärde" value={entry.orderValueDone} target={entry.orderValueTarget} tone="amber" currency />
                 <TeamProgressRow label="Fakturerat ordervärde" value={entry.invoicedValueDone} tone="violet" currency />
               </div>
             </div>

--- a/app/crm/installningar/CrmGoalsPanel.tsx
+++ b/app/crm/installningar/CrmGoalsPanel.tsx
@@ -4,6 +4,7 @@ import { useMemo, useState } from 'react';
 import Input from '../../../components/ui/Input';
 import SectionCard from '../../../components/ui/SectionCard';
 import { useToast } from '@/lib/Toast';
+import { GOAL_WEEKS_PER_MONTH, weeklyFromMonthly } from '@/lib/domains/crm/goals';
 
 type TeamMember = {
   id: string;
@@ -16,12 +17,20 @@ type GoalItem = {
   calls_target: number;
   quotes_target: number;
   quote_value_target: number | string;
+  order_count_target: number;
+  order_value_target: number | string;
 };
 
 type GoalDraft = {
   calls_target: string;
   quotes_target: string;
   quote_value_target: string;
+  order_count_target: string;
+  order_value_target: string;
+};
+
+const EMPTY_DRAFT: GoalDraft = {
+  calls_target: '', quotes_target: '', quote_value_target: '', order_count_target: '', order_value_target: '',
 };
 
 function formatGoalInputValue(value: number | string | null | undefined) {
@@ -30,14 +39,22 @@ function formatGoalInputValue(value: number | string | null | undefined) {
   return String(value);
 }
 
+// Month label, e.g. "juni 2026".
 function formatPeriodLabel(periodStart: string) {
   const start = new Date(`${periodStart}T12:00:00`);
   if (Number.isNaN(start.getTime())) return periodStart;
-  const end = new Date(start);
-  end.setDate(end.getDate() + 6);
+  return new Intl.DateTimeFormat('sv-SE', { month: 'long', year: 'numeric' }).format(start);
+}
 
-  const formatter = new Intl.DateTimeFormat('sv-SE', { day: 'numeric', month: 'short' });
-  return `${formatter.format(start)} - ${formatter.format(end)}`;
+// Weekly equivalent shown under each field so the admin sees what the leaderboard will display.
+function WeeklyHint({ value, currency = false }: { value: string; currency?: boolean }) {
+  const monthly = Number(value || 0);
+  if (!Number.isFinite(monthly) || monthly <= 0) return null;
+  const weekly = weeklyFromMonthly(monthly);
+  const text = currency
+    ? new Intl.NumberFormat('sv-SE', { maximumFractionDigits: 0 }).format(Math.round(weekly))
+    : (Math.round(weekly * 10) / 10).toString();
+  return <span className="text-[11px] text-slate-400">≈ {text}/vecka</span>;
 }
 
 export default function CrmGoalsPanel({
@@ -62,6 +79,8 @@ export default function CrmGoalsPanel({
           calls_target: formatGoalInputValue(goal?.calls_target),
           quotes_target: formatGoalInputValue(goal?.quotes_target),
           quote_value_target: formatGoalInputValue(goal?.quote_value_target),
+          order_count_target: formatGoalInputValue(goal?.order_count_target),
+          order_value_target: formatGoalInputValue(goal?.order_value_target),
         }];
       }),
     );
@@ -70,7 +89,10 @@ export default function CrmGoalsPanel({
   const configuredCount = useMemo(
     () => team.filter((member) => {
       const draft = drafts[member.id];
-      return draft && (Number(draft.calls_target) > 0 || Number(draft.quotes_target) > 0 || Number(draft.quote_value_target) > 0);
+      return draft && (
+        Number(draft.calls_target) > 0 || Number(draft.quotes_target) > 0 || Number(draft.quote_value_target) > 0 ||
+        Number(draft.order_count_target) > 0 || Number(draft.order_value_target) > 0
+      );
     }).length,
     [drafts, team],
   );
@@ -80,28 +102,22 @@ export default function CrmGoalsPanel({
     return {
       calls: accumulator.calls + Number(draft?.calls_target || 0),
       quotes: accumulator.quotes + Number(draft?.quotes_target || 0),
-      value: accumulator.value + Number(draft?.quote_value_target || 0),
+      orders: accumulator.orders + Number(draft?.order_count_target || 0),
+      orderValue: accumulator.orderValue + Number(draft?.order_value_target || 0),
     };
-  }, {
-    calls: 0,
-    quotes: 0,
-    value: 0,
-  }), [drafts, team]);
+  }, { calls: 0, quotes: 0, orders: 0, orderValue: 0 }), [drafts, team]);
 
   const summaryItems = [
     { label: 'Säljare med mål', value: `${configuredCount} av ${team.length}` },
-    { label: 'Samtal totalt', value: String(totals.calls) },
-    { label: 'Offerter totalt', value: String(totals.quotes) },
-    { label: 'Offertvärde totalt', value: new Intl.NumberFormat('sv-SE').format(totals.value) },
+    { label: 'Samtal/mån totalt', value: String(totals.calls) },
+    { label: 'Ordrar/mån totalt', value: String(totals.orders) },
+    { label: 'Ordervärde/mån totalt', value: new Intl.NumberFormat('sv-SE').format(totals.orderValue) },
   ];
 
   function setDraftValue(userId: string, field: keyof GoalDraft, value: string) {
     setDrafts((current) => ({
       ...current,
-      [userId]: {
-        ...(current[userId] || { calls_target: '', quotes_target: '', quote_value_target: '' }),
-        [field]: value,
-      },
+      [userId]: { ...(current[userId] || EMPTY_DRAFT), [field]: value },
     }));
   }
 
@@ -115,13 +131,15 @@ export default function CrmGoalsPanel({
         calls_target: Number(drafts[member.id]?.calls_target || 0),
         quotes_target: Number(drafts[member.id]?.quotes_target || 0),
         quote_value_target: Number(drafts[member.id]?.quote_value_target || 0),
+        order_count_target: Number(drafts[member.id]?.order_count_target || 0),
+        order_value_target: Number(drafts[member.id]?.order_value_target || 0),
       }));
 
       const res = await fetch('/api/crm/goals', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          period_type: 'week',
+          period_type: 'month',
           period_start: periodStart,
           goals,
         }),
@@ -129,13 +147,13 @@ export default function CrmGoalsPanel({
 
       const json = await res.json().catch(() => ({}));
       if (!res.ok || !json.ok) {
-        setError(json?.error || 'Kunde inte spara målen.');
+        setError(json?.error || 'Kunde inte spara budgeten.');
         return;
       }
 
-      toast.success('Veckomålen sparades.');
+      toast.success('Månadsbudgeten sparades.');
     } catch {
-      setError('Kunde inte spara målen.');
+      setError('Kunde inte spara budgeten.');
     } finally {
       setSaving(false);
     }
@@ -145,21 +163,21 @@ export default function CrmGoalsPanel({
     <SectionCard className="grid gap-3 border-emerald-200/65 bg-[linear-gradient(180deg,rgba(250,253,250,0.98),rgba(244,249,245,0.98))] p-4 shadow-[0_18px_38px_rgba(15,23,42,0.06)] md:p-5">
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div className="grid gap-1">
-          <strong className="text-base font-bold text-slate-950">Veckomål per säljare</strong>
-          <p className="m-0 text-sm leading-6 text-slate-600">Sätt mål för samtal, offerter och offertvärde för veckan. Översikten kan sedan jämföra aktiviteten mot dessa nivåer.</p>
+          <strong className="text-base font-bold text-slate-950">Månadsbudget per säljare</strong>
+          <p className="m-0 text-sm leading-6 text-slate-600">Sätt budget per månad för samtal, offerter, offertvärde, antal ordrar och ordervärde. Topplistan visar veckomål (budget ÷ {GOAL_WEEKS_PER_MONTH}).</p>
         </div>
         <div className="flex flex-wrap items-center gap-2 sm:justify-end">
           <div className="rounded-[22px] border border-slate-200 bg-white/90 px-4 py-3 text-right shadow-[0_10px_20px_rgba(15,23,42,0.04)]">
-            <div className="text-[11px] font-semibold uppercase tracking-[0.14em] text-slate-400">Aktiv vecka</div>
-            <strong className="block text-sm text-slate-900">{formatPeriodLabel(periodStart)}</strong>
-            <div className="mt-1 text-xs text-slate-500">{configuredCount} av {team.length} med mål</div>
+            <div className="text-[11px] font-semibold uppercase tracking-[0.14em] text-slate-400">Aktiv månad</div>
+            <strong className="block text-sm capitalize text-slate-900">{formatPeriodLabel(periodStart)}</strong>
+            <div className="mt-1 text-xs text-slate-500">{configuredCount} av {team.length} med budget</div>
           </div>
           <button
             type="button"
             onClick={() => setIsExpanded((current) => !current)}
             className="inline-flex min-h-11 items-center justify-center rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-slate-300 hover:bg-slate-50"
           >
-            {isExpanded ? 'Dölj veckomål' : 'Visa veckomål'}
+            {isExpanded ? 'Dölj budget' : 'Visa budget'}
           </button>
         </div>
       </div>
@@ -177,46 +195,47 @@ export default function CrmGoalsPanel({
 
       {isExpanded ? (
         <>
-          <div className="grid gap-3 xl:grid-cols-2 2xl:grid-cols-3">
-            {team.map((member) => (
-              <div key={member.id} className="grid gap-3 rounded-[22px] border border-slate-200 bg-[linear-gradient(180deg,#ffffff_0%,#f8fafc_100%)] px-4 py-4 shadow-[0_12px_24px_rgba(15,23,42,0.05)]">
-                <div className="flex flex-wrap items-center justify-between gap-2">
-                  <strong className="text-sm font-semibold text-slate-950">{member.full_name || 'Namn saknas'}</strong>
-                  <span className="rounded-full border border-slate-200 bg-white px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.08em] text-slate-600">
-                    {member.role === 'admin' ? 'Admin' : 'Sälj'}
-                  </span>
+          <div className="grid gap-3 xl:grid-cols-2">
+            {team.map((member) => {
+              const draft = drafts[member.id] || EMPTY_DRAFT;
+              return (
+                <div key={member.id} className="grid gap-3 rounded-[22px] border border-slate-200 bg-[linear-gradient(180deg,#ffffff_0%,#f8fafc_100%)] px-4 py-4 shadow-[0_12px_24px_rgba(15,23,42,0.05)]">
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <strong className="text-sm font-semibold text-slate-950">{member.full_name || 'Namn saknas'}</strong>
+                    <span className="rounded-full border border-slate-200 bg-white px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.08em] text-slate-600">
+                      {member.role === 'admin' ? 'Admin' : 'Sälj'}
+                    </span>
+                  </div>
+                  <div className="grid gap-3 sm:grid-cols-3">
+                    <label className="grid gap-1 text-xs font-medium text-slate-500">
+                      <span>Mål samtal</span>
+                      <Input value={draft.calls_target} onChange={(e) => setDraftValue(member.id, 'calls_target', e.target.value)} inputMode="numeric" placeholder="0" />
+                      <WeeklyHint value={draft.calls_target} />
+                    </label>
+                    <label className="grid gap-1 text-xs font-medium text-slate-500">
+                      <span>Mål offerter</span>
+                      <Input value={draft.quotes_target} onChange={(e) => setDraftValue(member.id, 'quotes_target', e.target.value)} inputMode="numeric" placeholder="0" />
+                      <WeeklyHint value={draft.quotes_target} />
+                    </label>
+                    <label className="grid gap-1 text-xs font-medium text-slate-500">
+                      <span>Offertvärde (SEK)</span>
+                      <Input value={draft.quote_value_target} onChange={(e) => setDraftValue(member.id, 'quote_value_target', e.target.value)} inputMode="decimal" placeholder="0" />
+                      <WeeklyHint value={draft.quote_value_target} currency />
+                    </label>
+                    <label className="grid gap-1 text-xs font-medium text-slate-500">
+                      <span>Mål antal ordrar</span>
+                      <Input value={draft.order_count_target} onChange={(e) => setDraftValue(member.id, 'order_count_target', e.target.value)} inputMode="numeric" placeholder="0" />
+                      <WeeklyHint value={draft.order_count_target} />
+                    </label>
+                    <label className="grid gap-1 text-xs font-medium text-slate-500">
+                      <span>Ordervärde (SEK)</span>
+                      <Input value={draft.order_value_target} onChange={(e) => setDraftValue(member.id, 'order_value_target', e.target.value)} inputMode="decimal" placeholder="0" />
+                      <WeeklyHint value={draft.order_value_target} currency />
+                    </label>
+                  </div>
                 </div>
-                <div className="grid gap-3 sm:grid-cols-3">
-                  <label className="grid gap-1 text-xs font-medium text-slate-500">
-                    <span>Mål samtal</span>
-                    <Input
-                      value={drafts[member.id]?.calls_target || ''}
-                      onChange={(event) => setDraftValue(member.id, 'calls_target', event.target.value)}
-                      inputMode="numeric"
-                      placeholder="0"
-                    />
-                  </label>
-                  <label className="grid gap-1 text-xs font-medium text-slate-500">
-                    <span>Mål offerter</span>
-                    <Input
-                      value={drafts[member.id]?.quotes_target || ''}
-                      onChange={(event) => setDraftValue(member.id, 'quotes_target', event.target.value)}
-                      inputMode="numeric"
-                      placeholder="0"
-                    />
-                  </label>
-                  <label className="grid gap-1 text-xs font-medium text-slate-500">
-                    <span>Offertvärde (SEK)</span>
-                    <Input
-                      value={drafts[member.id]?.quote_value_target || ''}
-                      onChange={(event) => setDraftValue(member.id, 'quote_value_target', event.target.value)}
-                      inputMode="decimal"
-                      placeholder="0"
-                    />
-                  </label>
-                </div>
-              </div>
-            ))}
+              );
+            })}
           </div>
 
           <div className="flex justify-end">
@@ -226,13 +245,13 @@ export default function CrmGoalsPanel({
               disabled={saving}
               className="inline-flex min-h-11 items-center justify-center rounded-full border border-slate-900 bg-slate-900 px-4 py-2 text-sm font-semibold text-white transition hover:bg-slate-950 disabled:cursor-not-allowed disabled:opacity-60"
             >
-              {saving ? 'Sparar…' : 'Spara veckomål'}
+              {saving ? 'Sparar…' : 'Spara månadsbudget'}
             </button>
           </div>
         </>
       ) : (
         <div className="rounded-[22px] border border-dashed border-slate-300 bg-white/70 px-4 py-5 text-sm text-slate-600">
-          Veckomålen är hopfällda för att hålla adminsidan kompakt. Öppna panelen när du vill justera mål per säljare.
+          Budgeten är hopfälld för att hålla adminsidan kompakt. Öppna panelen när du vill justera månadsbudget per säljare.
         </div>
       )}
     </SectionCard>

--- a/app/crm/installningar/CrmSettingsView.tsx
+++ b/app/crm/installningar/CrmSettingsView.tsx
@@ -30,6 +30,8 @@ type GoalItem = {
   calls_target: number;
   quotes_target: number;
   quote_value_target: number | string;
+  order_count_target: number;
+  order_value_target: number | string;
 };
 
 const roleClass: Record<CrmTeamMember['role'], string> = {

--- a/app/crm/installningar/page.tsx
+++ b/app/crm/installningar/page.tsx
@@ -1,6 +1,6 @@
 import { redirect } from 'next/navigation';
 import { getUserProfile } from '@/lib/getUserProfile';
-import { getCurrentWeekStartDate, mapCrmGoalRows, type CrmGoalRow } from '@/lib/domains/crm/goals';
+import { getCurrentMonthStartDate, mapCrmGoalRows, type CrmGoalRow } from '@/lib/domains/crm/goals';
 import { getSupabaseAdmin } from '@/lib/supabase/server';
 import { getFortnoxConnectionStatus } from '@/lib/domains/fortnox/auth';
 import CrmSettingsView from './CrmSettingsView';
@@ -12,7 +12,7 @@ export default async function CrmSettingsPage() {
   if (profile?.role !== 'admin') redirect('/crm');
 
   const supabase = getSupabaseAdmin();
-  const currentWeekStart = getCurrentWeekStartDate();
+  const currentMonthStart = getCurrentMonthStartDate();
 
   const [teamRes, goalsRes, unassignedProspectsRes, openTasksRes, quoteFollowUpsRes, fortnoxStatus] = await Promise.all([
     supabase
@@ -21,9 +21,9 @@ export default async function CrmSettingsPage() {
       .in('role', ['sales', 'admin', 'konsult']),
     supabase
       .from('crm_goals')
-      .select('id, user_id, period_type, period_start, calls_target, quotes_target, quote_value_target, created_by, updated_by, created_at, updated_at, user:profiles!crm_goals_user_id_fkey(id, full_name, role)')
-      .eq('period_type', 'week')
-      .eq('period_start', currentWeekStart),
+      .select('id, user_id, period_type, period_start, calls_target, quotes_target, quote_value_target, order_count_target, order_value_target, created_by, updated_by, created_at, updated_at, user:profiles!crm_goals_user_id_fkey(id, full_name, role)')
+      .eq('period_type', 'month')
+      .eq('period_start', currentMonthStart),
     supabase
       .from('crm_customers')
       .select('id', { count: 'exact', head: true })
@@ -121,7 +121,7 @@ export default async function CrmSettingsPage() {
       team={crmTeam}
       goalTeam={goalTeam}
       goals={currentGoals}
-      goalPeriodStart={currentWeekStart}
+      goalPeriodStart={currentMonthStart}
       stats={stats}
       integrations={integrations}
       fortnoxStatus={fortnoxStatus}

--- a/lib/domains/crm/goals.ts
+++ b/lib/domains/crm/goals.ts
@@ -1,7 +1,12 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
 
+// Budgets are set monthly; the leaderboard derives the weekly target as budget ÷ this.
+export const GOAL_WEEKS_PER_MONTH = 4;
+
+export type CrmGoalPeriodType = 'week' | 'month';
+
 export const crmGoalSelect =
-  'id, user_id, period_type, period_start, calls_target, quotes_target, quote_value_target, created_by, updated_by, created_at, updated_at, user:profiles!crm_goals_user_id_fkey(id, full_name, role)';
+  'id, user_id, period_type, period_start, calls_target, quotes_target, quote_value_target, order_count_target, order_value_target, created_by, updated_by, created_at, updated_at, user:profiles!crm_goals_user_id_fkey(id, full_name, role)';
 
 type GoalUserRow = {
   id: string;
@@ -12,11 +17,13 @@ type GoalUserRow = {
 export type CrmGoalRow = {
   id: string;
   user_id: string;
-  period_type: 'week';
+  period_type: CrmGoalPeriodType;
   period_start: string;
   calls_target: number;
   quotes_target: number;
   quote_value_target: number | string;
+  order_count_target: number;
+  order_value_target: number | string;
   created_by: string;
   updated_by: string;
   created_at: string;
@@ -29,17 +36,19 @@ export type CrmGoal = Omit<CrmGoalRow, 'user'> & {
 };
 
 type ListCrmGoalsArgs = {
-  periodType: 'week';
+  periodType: CrmGoalPeriodType;
   periodStart: string;
 };
 
 type UpsertCrmGoalInput = {
   user_id: string;
-  period_type: 'week';
+  period_type: CrmGoalPeriodType;
   period_start: string;
   calls_target: number;
   quotes_target: number;
   quote_value_target: number;
+  order_count_target: number;
+  order_value_target: number;
   created_by: string;
   updated_by: string;
 };
@@ -73,6 +82,18 @@ export function getCurrentWeekStartDate() {
   const mondayOffset = (start.getDay() + 6) % 7;
   start.setDate(start.getDate() - mondayOffset);
   return formatLocalDateOnly(start);
+}
+
+// First day of the current month (YYYY-MM-01) — the key for a monthly budget.
+export function getCurrentMonthStartDate() {
+  const now = new Date();
+  return formatLocalDateOnly(new Date(now.getFullYear(), now.getMonth(), 1));
+}
+
+// Derive the displayed weekly target from a monthly budget (budget ÷ 4, fixed).
+export function weeklyFromMonthly(monthly: number | string): number {
+  const numeric = typeof monthly === 'number' ? monthly : Number(String(monthly));
+  return Number.isFinite(numeric) ? numeric / GOAL_WEEKS_PER_MONTH : 0;
 }
 
 export function formatGoalCurrency(value: number | string) {

--- a/supabase/sql/20260626_crm_goals_monthly_orders.sql
+++ b/supabase/sql/20260626_crm_goals_monthly_orders.sql
@@ -1,0 +1,15 @@
+-- Goals become MONTHLY budgets (set once per month) while the leaderboard derives the
+-- weekly target as budget ÷ 4. Also adds order-count and order-value budget metrics.
+-- Additive + non-destructive: existing weekly rows stay valid; the app now reads/writes
+-- period_type = 'month' (period_start = first of month).
+
+-- Allow 'month' alongside the existing 'week'.
+ALTER TABLE public.crm_goals
+  DROP CONSTRAINT IF EXISTS crm_goals_period_type_check;
+ALTER TABLE public.crm_goals
+  ADD CONSTRAINT crm_goals_period_type_check CHECK (period_type IN ('week', 'month'));
+
+-- New budget metrics: antal ordrar + ordervärde.
+ALTER TABLE public.crm_goals
+  ADD COLUMN IF NOT EXISTS order_count_target integer NOT NULL DEFAULT 0 CHECK (order_count_target >= 0),
+  ADD COLUMN IF NOT EXISTS order_value_target numeric(12,2) NOT NULL DEFAULT 0 CHECK (order_value_target >= 0);

--- a/tests/crm/goals.test.ts
+++ b/tests/crm/goals.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { weeklyFromMonthly, GOAL_WEEKS_PER_MONTH, formatLocalDateOnly } from '@/lib/domains/crm/goals';
+
+describe('weeklyFromMonthly', () => {
+  it('divides a monthly budget by the fixed weeks-per-month (4)', () => {
+    expect(GOAL_WEEKS_PER_MONTH).toBe(4);
+    expect(weeklyFromMonthly(40)).toBe(10);
+    expect(weeklyFromMonthly(100000)).toBe(25000);
+  });
+
+  it('accepts numeric strings (Supabase numeric columns)', () => {
+    expect(weeklyFromMonthly('200')).toBe(50);
+  });
+
+  it('returns 0 for empty/invalid input', () => {
+    expect(weeklyFromMonthly(0)).toBe(0);
+    expect(weeklyFromMonthly('')).toBe(0);
+    expect(weeklyFromMonthly('abc')).toBe(0);
+  });
+
+  it('keeps fractional results (rounding is a display concern)', () => {
+    expect(weeklyFromMonthly(50)).toBe(12.5);
+  });
+});
+
+describe('formatLocalDateOnly', () => {
+  it('formats a date as YYYY-MM-DD in local time', () => {
+    expect(formatLocalDateOnly(new Date(2026, 5, 1))).toBe('2026-06-01'); // month is 0-indexed → June
+    expect(formatLocalDateOnly(new Date(2026, 11, 9))).toBe('2026-12-09');
+  });
+});


### PR DESCRIPTION
Mål sätts nu som MÅNADSBUDGET en gång per säljare; topplistan visar veckomål = budget ÷ 4 mot innevarande veckas utfall.

- DB: 20260626_crm_goals_monthly_orders.sql — period_type tillåter 'month', nya kolumner order_count_target + order_value_target.
- Domän (goals.ts): period_type 'week'|'month', getCurrentMonthStartDate, weeklyFromMonthly (÷4, GOAL_WEEKS_PER_MONTH), nya fält i select/typer.
- API/schema: goals accepterar 'month' (default) + de två nya målfälten.
- Admin (CrmGoalsPanel): "Månadsbudget per säljare", månadsetikett, två nya fält (antal ordrar, ordervärde) + "≈ /vecka"-hint per fält.
- Topplista (CrmOverview): hämtar månadsmål, scope:ar utfallet till innevarande vecka (samtal=call_at, offerter=quote_date, ordrar=created_at, fakturerat=fortnox_invoiced_at), härleder veckomål ÷4, ny rad "Antal ordrar"
  + mål på "Ordervärde". Team-summeringen blev också veckobaserad.
- Tester: weeklyFromMonthly + formatLocalDateOnly.
