### PR TITLE
feat(crm): pre-launch hardening for kund/offert/arbetsorder

### DIFF
--- a/app/api/crm/quotes/_lib.ts
+++ b/app/api/crm/quotes/_lib.ts
@@ -47,6 +47,8 @@ const customerSnapshotSchema = z.object({
   delivery_postal_code: z.preprocess((value) => normalizeOptionalText(value), z.string().nullable()).optional().default(null),
   delivery_city: z.preprocess((value) => normalizeOptionalText(value), z.string().nullable()).optional().default(null),
   invoice_address: z.preprocess((value) => normalizeOptionalText(value), z.string().nullable()).optional().default(null),
+  // Point-in-time byggmoms flag (omvänd skattskyldighet). null = unknown (legacy rows).
+  reverse_vat: z.boolean().nullable().optional().default(null),
 });
 
 const pricingSummarySchema = z.object({

--- a/app/api/crm/work-orders/_lib.ts
+++ b/app/api/crm/work-orders/_lib.ts
@@ -50,11 +50,18 @@ export const createWorkOrderCommentSchema = z.object({
 export const listCrmWorkOrdersQuerySchema = z.object({
   q: z.string().trim().optional(),
   status: workOrderStatusSchema.optional(),
+  // Board composite filter (status group). Server-side so the paginated list is correct.
+  filter: z.enum(['all', 'draft', 'scheduled', 'active', 'completed', 'invoiced']).optional(),
+  // Assignee scope — comma-separated user ids ('mine' is resolved to the current user id on
+  // the client before sending). Empty/absent = everyone.
+  assignee: z.string().trim().optional(),
   work_order_id: z.string().uuid('Ogiltig arbetsorder').optional(),
   customer_id: z.string().uuid('Ogiltig kund').optional(),
   // Optional cap override (default 100). Board views that index every work order's
   // Fortnox number pass a higher value so the lookup map isn't truncated.
   limit: z.coerce.number().int().min(1).max(2000).optional(),
+  // Pagination offset for the "Visa fler" board.
+  offset: z.coerce.number().int().min(0).optional(),
 });
 
 export const updateCrmWorkOrderSchema = z.object({

--- a/app/api/crm/work-orders/route.ts
+++ b/app/api/crm/work-orders/route.ts
@@ -1,6 +1,6 @@
 import { cookies } from 'next/headers';
 import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
-import { listCrmWorkOrdersWithFilters, createStandaloneCrmWorkOrder } from '@/lib/domains/crm/work-orders';
+import { listCrmWorkOrdersWithFilters, getCrmWorkOrderFilterCounts, createStandaloneCrmWorkOrder, CRM_WORK_ORDERS_PAGE_SIZE } from '@/lib/domains/crm/work-orders';
 import { createStandaloneWorkOrderSchema, listCrmWorkOrdersQuerySchema, ok, requireCrmUser, requirePermission, routeError, validationError } from './_lib';
 
 export async function GET(req: Request) {
@@ -12,28 +12,51 @@ export async function GET(req: Request) {
     const parsedQuery = listCrmWorkOrdersQuerySchema.safeParse({
       q: url.searchParams.get('q') || undefined,
       status: url.searchParams.get('status') || undefined,
+      filter: url.searchParams.get('filter') || undefined,
+      assignee: url.searchParams.get('assignee') || undefined,
       work_order_id: url.searchParams.get('work_order_id') || undefined,
       customer_id: url.searchParams.get('customer_id') || undefined,
       limit: url.searchParams.get('limit') || undefined,
+      offset: url.searchParams.get('offset') || undefined,
     });
 
     if (!parsedQuery.success) return validationError(parsedQuery.error);
 
+    // Assignee scope: a comma-separated list of user ids (the client resolves 'mine' to the
+    // current user id before sending). Empty = everyone.
+    const assignedToIn = (parsedQuery.data.assignee || '')
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean);
+    const search = parsedQuery.data.q;
+    const filter = parsedQuery.data.filter;
+    const offset = parsedQuery.data.offset ?? 0;
+    const limit = parsedQuery.data.limit ?? CRM_WORK_ORDERS_PAGE_SIZE;
+
     const supabase = createRouteHandlerClient({ cookies });
     const query = await listCrmWorkOrdersWithFilters(supabase, {
-      search: parsedQuery.data.q,
+      search,
       status: parsedQuery.data.status,
+      filter,
+      assignedToIn,
       workOrderId: parsedQuery.data.work_order_id,
       customerId: parsedQuery.data.customer_id,
-      limit: parsedQuery.data.limit,
+      limit,
+      offset,
     });
-    const { data, error } = await query;
+    const { data, error, count } = await query;
 
     if (error) {
       return routeError(500, 'crm_work_orders_list_failed', error.message);
     }
 
-    return ok({ items: data || [] });
+    // Per-filter chip counts (scoped to the same search + assignee filter). Only the board
+    // requests them (counts=1, first page) — other consumers of this route (säljtavla, customer
+    // detail, overview) skip the extra count queries.
+    const wantCounts = url.searchParams.get('counts') === '1' && offset === 0;
+    const counts = wantCounts ? await getCrmWorkOrderFilterCounts(supabase, { search, assignedToIn }) : undefined;
+
+    return ok({ items: data || [], total: count ?? 0, offset, limit, counts });
   } catch (e: any) {
     return routeError(500, 'crm_work_orders_unexpected', e?.message || 'Failed to list work orders');
   }

--- a/app/crm/arbetsorder/WorkOrdersClient.tsx
+++ b/app/crm/arbetsorder/WorkOrdersClient.tsx
@@ -6,7 +6,7 @@ import Input from '../../../components/ui/Input';
 import { cn } from '@/lib/shared/cn';
 import { crm, syncStatusLabel, syncStatusClass, workOrderStatusLabel, workOrderStatusClass, workOrderStatusAccent } from '@/app/crm/lib/crmTokens';
 import { formatDate, formatCurrency, isWorkOrderOverdue, documentRef } from '@/app/crm/lib/format';
-import AssigneeFilter, { matchesAssignee, type AssigneeFilterValue, type AssigneeOption } from '@/app/crm/components/AssigneeFilter';
+import AssigneeFilter, { MINE, type AssigneeFilterValue, type AssigneeOption } from '@/app/crm/components/AssigneeFilter';
 import DocumentNumberBadge from '@/app/crm/components/DocumentNumberBadge';
 import CrmModal from '@/app/crm/components/CrmModal';
 import EntityCombobox, { type EntityResult } from '@/app/crm/components/EntityCombobox';
@@ -40,16 +40,10 @@ const FILTERS: Array<[WorkOrderFilter, string]> = [
   ['all', 'Alla'], ['draft', 'Ej planerade'], ['scheduled', 'Planerade'], ['active', 'Pågående'], ['completed', 'Fakturera'], ['invoiced', 'Avslutade'],
 ];
 
-function matchesFilter(item: WorkOrderItem, filter: WorkOrderFilter) {
-  if (filter === 'all') return true;
-  if (filter === 'draft') return item.status === 'draft';
-  if (filter === 'scheduled') return item.status === 'scheduled' || item.status === 'ready';
-  // 'Fakturera' covers orders still in the invoicing stage — completed AND mid-delfakturering,
-  // so a partially-invoiced order stays visible there until it's fully invoiced ('Avslutade').
-  if (filter === 'completed') return item.status === 'completed' || item.status === 'partially_invoiced';
-  if (filter === 'invoiced') return item.status === 'invoiced';
-  return item.status === 'in_progress';
-}
+// Status filtering and pagination are now server-side (see lib/domains/crm/work-orders.ts).
+// The board fetches one page per filter and accumulates via "Visa fler".
+const PAGE_SIZE = 100;
+const EMPTY_COUNTS: Record<WorkOrderFilter, number> = { all: 0, draft: 0, scheduled: 0, active: 0, completed: 0, invoiced: 0 };
 
 function initialsOf(name: string | null | undefined) {
   if (!name) return '–';
@@ -65,13 +59,52 @@ export default function WorkOrdersClient({ currentUserId }: { currentUserId: str
   const toast = useToast();
   const searchParams = useSearchParams();
   const [workOrders, setWorkOrders] = useState<WorkOrderItem[]>([]);
+  const [total, setTotal] = useState(0);
+  const [counts, setCounts] = useState<Record<WorkOrderFilter, number>>(EMPTY_COUNTS);
   const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [search, setSearch] = useState('');
   const [filter, setFilter] = useState<WorkOrderFilter>('all');
   const [filtersOpen, setFiltersOpen] = useState(false);
   const [assigneeFilter, setAssigneeFilter] = useState<AssigneeFilterValue>([]);
   const [assignees, setAssignees] = useState<AssigneeOption[]>([]);
+
+  // 'mine' → the current user id, resolved before the request so status/assignee filtering and
+  // counts are all computed server-side (the list can exceed the PostgREST row cap).
+  const assigneeParam = useMemo(
+    () => assigneeFilter.map((v) => (v === MINE ? (currentUserId ?? '') : v)).filter(Boolean).join(','),
+    [assigneeFilter, currentUserId],
+  );
+
+  function buildListQuery(nextOffset: number) {
+    const query = new URLSearchParams();
+    if (search.trim()) query.set('q', search.trim());
+    query.set('filter', filter);
+    if (assigneeParam) query.set('assignee', assigneeParam);
+    query.set('offset', String(nextOffset));
+    query.set('limit', String(PAGE_SIZE));
+    // Chip counts only need recomputing on a fresh first page, not on "Visa fler".
+    if (nextOffset === 0) query.set('counts', '1');
+    return query.toString();
+  }
+
+  async function loadMore() {
+    if (loadingMore || workOrders.length >= total) return;
+    setLoadingMore(true);
+    try {
+      const res = await fetch(`/api/crm/work-orders?${buildListQuery(workOrders.length)}`, { cache: 'no-store' });
+      const json = await res.json().catch(() => ({}));
+      if (!res.ok || !json.ok) { toast.error(json?.error || 'Kunde inte ladda fler arbetsorder.'); return; }
+      const items = Array.isArray(json?.data?.items) ? json.data.items : [];
+      setWorkOrders((prev) => [...prev, ...items]);
+      setTotal(json?.data?.total ?? total);
+    } catch {
+      toast.error('Kunde inte ladda fler arbetsorder.');
+    } finally {
+      setLoadingMore(false);
+    }
+  }
 
   // "Ny order" (standalone, no quote) — requires a linked customer.
   const [newOrderOpen, setNewOrderOpen] = useState(false);
@@ -142,36 +175,29 @@ export default function WorkOrdersClient({ currentUserId }: { currentUserId: str
     if (deepLinkId) router.replace(`/crm/arbetsorder/${deepLinkId}`);
   }, [deepLinkId, router]);
 
+  // Reset + first page whenever the search, status filter or assignee scope changes. The
+  // server filters and paginates; the chip counts come back on the first page (offset 0).
   useEffect(() => {
     let active = true;
     async function load() {
       setLoading(true); setError(null);
       try {
-        const query = new URLSearchParams();
-        if (search.trim()) query.set('q', search.trim());
-        const res = await fetch(`/api/crm/work-orders${query.size > 0 ? `?${query.toString()}` : ''}`, { cache: 'no-store' });
+        const res = await fetch(`/api/crm/work-orders?${buildListQuery(0)}`, { cache: 'no-store' });
         const json = await res.json().catch(() => ({}));
         if (!active) return;
-        if (!res.ok || !json.ok) { setError(json?.error || 'Kunde inte ladda arbetsorder.'); setWorkOrders([]); return; }
+        if (!res.ok || !json.ok) { setError(json?.error || 'Kunde inte ladda arbetsorder.'); setWorkOrders([]); setTotal(0); return; }
         setWorkOrders(Array.isArray(json?.data?.items) ? json.data.items : []);
-      } catch { if (active) { setError('Kunde inte ladda arbetsorder.'); setWorkOrders([]); } }
+        setTotal(json?.data?.total ?? 0);
+        if (json?.data?.counts) setCounts(json.data.counts);
+      } catch { if (active) { setError('Kunde inte ladda arbetsorder.'); setWorkOrders([]); setTotal(0); } }
       finally { if (active) setLoading(false); }
     }
     void load();
     return () => { active = false; };
-  }, [search]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [search, filter, assigneeParam]);
 
-  const filterCounts = useMemo(() => {
-    const counts = {} as Record<WorkOrderFilter, number>;
-    const scoped = workOrders.filter((item) => matchesAssignee(item.assigned_to, assigneeFilter, currentUserId));
-    for (const [value] of FILTERS) counts[value] = scoped.filter((item) => matchesFilter(item, value)).length;
-    return counts;
-  }, [workOrders, assigneeFilter, currentUserId]);
-
-  const visibleWorkOrders = useMemo(
-    () => workOrders.filter((item) => matchesFilter(item, filter) && matchesAssignee(item.assigned_to, assigneeFilter, currentUserId)),
-    [filter, workOrders, assigneeFilter, currentUserId],
-  );
+  const hasMore = workOrders.length < total;
 
   // Resolve the responsible user's name from the admin-sourced assignees list. The
   // work-order list is read with the session client, whose profiles RLS only returns the
@@ -257,7 +283,7 @@ export default function WorkOrdersClient({ currentUserId }: { currentUserId: str
                 )}
                 style={filter === value ? { backgroundColor: 'var(--crm-primary)', borderColor: 'var(--crm-primary)' } : undefined}
               >
-                {label} <span className={cn('ml-0.5', filter === value ? 'text-white/70' : 'text-slate-400')}>{filterCounts[value]}</span>
+                {label} <span className={cn('ml-0.5', filter === value ? 'text-white/70' : 'text-slate-400')}>{counts[value]}</span>
               </button>
             ))}
           </div>
@@ -266,15 +292,15 @@ export default function WorkOrdersClient({ currentUserId }: { currentUserId: str
 
         {/* List */}
         {loading ? <div className="py-4 text-sm text-slate-500">Laddar arbetsorder…</div> : null}
-          {!loading && visibleWorkOrders.length === 0 ? (
+          {!loading && workOrders.length === 0 ? (
             <div className="rounded-2xl border border-dashed border-[#cfdcc9] bg-[#f1f5ee] px-4 py-8 text-center text-sm text-slate-500">
               Inga arbetsorder matchar just nu.
             </div>
           ) : null}
 
-          {!loading && visibleWorkOrders.length > 0 ? (
+          {!loading && workOrders.length > 0 ? (
             <div className="grid gap-1">
-              {visibleWorkOrders.map((item) => {
+              {workOrders.map((item) => {
                 const overdue = isWorkOrderOverdue(item.desired_installation_date, item.status);
                 const sellerName = item.assigned_to
                   ? (assigneeNameById.get(item.assigned_to) || item.assignee?.full_name || 'Okänd')
@@ -352,6 +378,21 @@ export default function WorkOrdersClient({ currentUserId }: { currentUserId: str
                   </button>
                 );
               })}
+            </div>
+          ) : null}
+
+          {/* Visa fler — server-side pagination so the board never silently truncates */}
+          {!loading && hasMore ? (
+            <div className="flex flex-col items-center gap-1 pt-1">
+              <button
+                type="button"
+                onClick={() => void loadMore()}
+                disabled={loadingMore}
+                className="rounded-full border border-[#dce4d8] bg-white px-4 py-1.5 text-[13px] font-semibold text-slate-600 transition hover:border-[#c8d4c3] disabled:opacity-60"
+              >
+                {loadingMore ? 'Laddar…' : 'Visa fler'}
+              </button>
+              <span className="text-[11px] text-slate-400">Visar {workOrders.length} av {total}</span>
             </div>
           ) : null}
       </div>

--- a/app/crm/offerter/QuoteFormClient.tsx
+++ b/app/crm/offerter/QuoteFormClient.tsx
@@ -1232,7 +1232,12 @@ export default function QuoteFormClient({ quoteId }: { quoteId?: string }) {
           fortnox_customer_id: draft.customer_source.fortnox_customer_id || null,
           fortnox_customer_name: draft.customer_source.fortnox_customer_name || null,
         },
-        customer_snapshot: buildCustomerSnapshot(draft),
+        // Business quote at 0 % VAT = omvänd skattskyldighet (byggmoms) — the app's canonical
+        // signal (see quoteAmountDisplay). Captured point-in-time so the Fortnox push resolves
+        // the VAT regime even for snapshot-only quotes with no linked customer.
+        customer_snapshot: buildCustomerSnapshot(draft, {
+          reverseVat: draft.quote_type === 'business' && parseDecimal(draft.vat_percent) === 0,
+        }),
         pricing_summary: {
           subtotal: hasAnyLineItemInput ? totals.subtotal : amountNumber,
           vat: vatAmount,
@@ -1322,14 +1327,17 @@ export default function QuoteFormClient({ quoteId }: { quoteId?: string }) {
   const summarySubtotal = hasAnyLineItemInput ? totals.subtotal : (draft.amount ? parseDecimal(draft.amount) : null);
   const summaryVat = summarySubtotal == null ? null : (hasAnyLineItemInput ? totals.vat : summarySubtotal * (vatPct / 100));
   const summaryTotal = summarySubtotal == null ? null : (hasAnyLineItemInput ? totals.total : summarySubtotal + (summaryVat ?? 0));
-  // VAT display convention (agreed with finance): private leads with the price to pay
-  // INCL moms; business leads with the EX-moms figure, the moms shown in the breakdown.
-  const headlineLabel = isPrivateQuote
-    ? (totals.rotDeduction > 0 ? 'Att betala' : 'Total inkl. moms')
-    : 'Belopp ex moms';
-  const headlineAmount = isPrivateQuote
-    ? (totals.rotDeduction > 0 ? totals.toPay : summaryTotal)
-    : summarySubtotal;
+  // VAT display convention (agreed with finance): private leads with the price INCL moms;
+  // business leads with the EX-moms figure, the moms shown in the breakdown.
+  //
+  // The headline is ALWAYS the gross offer value — the figure Fortnox shows as the offer
+  // total and the value we book the quote at (pricing_summary.total). A ROT deduction is NOT
+  // subtracted from the headline: ROT is settled between the customer and Skatteverket, so the
+  // company's value is still the gross. The customer's net-after-ROT (`toPay`) is shown as a
+  // clearly-labelled secondary line, never as the headline, so the displayed price matches
+  // Fortnox.
+  const headlineLabel = isPrivateQuote ? 'Total inkl. moms' : 'Belopp ex moms';
+  const headlineAmount = isPrivateQuote ? summaryTotal : summarySubtotal;
 
   // Single source of truth for the visible sections (in order). Drives both the
   // section header numbers and the sidebar nav so they can never drift apart.
@@ -1592,7 +1600,7 @@ export default function QuoteFormClient({ quoteId }: { quoteId?: string }) {
                   {formatCurrency(headlineAmount ?? totals.total, 'SEK')}
                 </span>
                 {isPrivateQuote && totals.rotDeduction > 0 ? (
-                  <span className="text-[11px] text-slate-400">Total inkl. moms {formatCurrency(totals.total, 'SEK')}</span>
+                  <span className="text-[11px] text-slate-400">Kund betalar efter ROT {formatCurrency(totals.toPay, 'SEK')}</span>
                 ) : !isPrivateQuote ? (
                   <span className="text-[11px] text-slate-400">Inkl. moms {formatCurrency(totals.total, 'SEK')}</span>
                 ) : null}
@@ -1835,16 +1843,6 @@ export default function QuoteFormClient({ quoteId }: { quoteId?: string }) {
                       <span>Moms ({vatPct} %)</span>
                       <span className="tabular-nums">{formatCurrency(totals.vat, 'SEK')}</span>
                     </div>
-                    <div className="flex items-center justify-between border-t border-slate-200/70 pt-1.5 text-xs font-medium text-slate-600">
-                      <span>Total inkl. moms</span>
-                      <span className="tabular-nums">{formatCurrency(totals.total, 'SEK')}</span>
-                    </div>
-                    {totals.rotDeduction > 0 ? (
-                      <div className="flex items-center justify-between text-xs font-medium text-emerald-700">
-                        <span>Avgår ROT</span>
-                        <span className="tabular-nums">−{formatCurrency(totals.rotDeduction, 'SEK')}</span>
-                      </div>
-                    ) : null}
                     <div className="mt-1 flex items-end justify-between border-t border-slate-200/70 pt-2">
                       <span className="text-[10px] font-semibold uppercase tracking-[0.12em] text-slate-400">
                         {headlineLabel}
@@ -1853,6 +1851,18 @@ export default function QuoteFormClient({ quoteId }: { quoteId?: string }) {
                         {formatCurrency(headlineAmount ?? totals.total, 'SEK')}
                       </span>
                     </div>
+                    {totals.rotDeduction > 0 ? (
+                      <>
+                        <div className="flex items-center justify-between text-xs font-medium text-emerald-700">
+                          <span>Avgår ROT</span>
+                          <span className="tabular-nums">−{formatCurrency(totals.rotDeduction, 'SEK')}</span>
+                        </div>
+                        <div className="flex items-center justify-between text-xs text-slate-500">
+                          <span>Kund betalar efter ROT-avdrag</span>
+                          <span className="tabular-nums">{formatCurrency(totals.toPay, 'SEK')}</span>
+                        </div>
+                      </>
+                    ) : null}
                   </div>
                 ) : (
                   <>

--- a/app/crm/offerter/quoteSerializers.ts
+++ b/app/crm/offerter/quoteSerializers.ts
@@ -49,7 +49,7 @@ export function getEffectiveCustomerName(
 
 // Point-in-time snapshot of the customer details, stored on every quote regardless
 // of whether the customer is a saved record. Empty strings become null.
-export function buildCustomerSnapshot(d: QuoteCustomerFields) {
+export function buildCustomerSnapshot(d: QuoteCustomerFields, opts?: { reverseVat?: boolean | null }) {
   const effectiveCustomerName = getEffectiveCustomerName(d);
 
   // Work address: anchored on the STREET line — only stored when a street is entered AND
@@ -80,6 +80,12 @@ export function buildCustomerSnapshot(d: QuoteCustomerFields) {
     delivery_postal_code: hasWorkAddress ? d.delivery_postal_code || null : null,
     delivery_city: hasWorkAddress ? d.delivery_city || null : null,
     invoice_address: d.invoice_address || null,
+    // Point-in-time byggmoms (omvänd skattskyldighet). Stored on the snapshot so the Fortnox
+    // push (resolveReverseVat) can decide the 0 %-row VAT regime without depending on the live
+    // customer record — essential for snapshot-only quotes with no linked customer_id. `null`
+    // = unknown (legacy rows / callers that don't supply it) → resolver falls back to the
+    // customer. A boolean is authoritative.
+    reverse_vat: opts?.reverseVat ?? null,
   };
 }
 

--- a/lib/domains/crm/work-orders.ts
+++ b/lib/domains/crm/work-orders.ts
@@ -330,36 +330,89 @@ export async function createCrmWorkOrderFromQuote(supabase: SupabaseClient, quot
   };
 }
 
-export async function listCrmWorkOrdersWithFilters(
-  supabase: SupabaseClient,
-  options: { search?: string; status?: CrmWorkOrderStatus; workOrderId?: string; customerId?: string; limit?: number },
-) {
-  let query = supabase
-    .from('crm_work_orders')
-    .select(crmWorkOrderSelect)
-    .order('desired_installation_date', { ascending: true, nullsFirst: false })
-    .order('created_at', { ascending: false })
-    .limit(options.limit ?? 100);
+// Page size for the work-order board. The list is paginated server-side (range + exact
+// count) instead of an unbounded `.limit()`, so it can never silently truncate past the
+// PostgREST row cap once the company accumulates orders (see SUPABASE_CONVENTIONS.md).
+export const CRM_WORK_ORDERS_PAGE_SIZE = 100;
 
+// The board's composite status filters → the concrete statuses each one covers. Mirrors the
+// client's matchesFilter so server-side filtering and the chip labels agree. `all` = no status
+// filter (includes cancelled, exactly like the old client-side 'all'). Kept here so the list
+// query and the per-filter counts can never diverge.
+export type CrmWorkOrderBoardFilter = 'all' | 'draft' | 'scheduled' | 'active' | 'completed' | 'invoiced';
+export const CRM_WORK_ORDER_BOARD_FILTERS: CrmWorkOrderBoardFilter[] = ['all', 'draft', 'scheduled', 'active', 'completed', 'invoiced'];
+const BOARD_FILTER_STATUSES: Record<CrmWorkOrderBoardFilter, CrmWorkOrderStatus[] | null> = {
+  all: null,
+  draft: ['draft'],
+  scheduled: ['scheduled', 'ready'],
+  active: ['in_progress'],
+  // 'Fakturera' covers orders still in the invoicing stage — completed AND mid-delfakturering.
+  completed: ['completed', 'partially_invoiced'],
+  invoiced: ['invoiced'],
+};
+
+type WorkOrderListFilters = {
+  search?: string;
+  filter?: CrmWorkOrderBoardFilter;
+  status?: CrmWorkOrderStatus;
+  assignedToIn?: string[];
+  workOrderId?: string;
+  customerId?: string;
+};
+
+// Apply the shared WHERE clauses so the paginated list and the per-filter counts always use
+// the exact same predicates (search, status group, assignee, deep-link, customer scope).
+function applyWorkOrderListFilters<Q extends {
+  or: (f: string) => Q; eq: (c: string, v: string) => Q; in: (c: string, v: string[]) => Q;
+}>(query: Q, options: WorkOrderListFilters): Q {
   if (options.search) {
     query = query.or(
       `order_number.ilike.%${options.search}%,project_name.ilike.%${options.search}%,client_name.ilike.%${options.search}%,notes.ilike.%${options.search}%`,
     );
   }
-
-  if (options.status) {
-    query = query.eq('status', options.status);
-  }
-
-  if (options.workOrderId) {
-    query = query.eq('id', options.workOrderId);
-  }
-
-  if (options.customerId) {
-    query = query.eq('customer_id', options.customerId);
-  }
-
+  const statuses = options.filter ? BOARD_FILTER_STATUSES[options.filter] : null;
+  if (statuses) query = query.in('status', statuses);
+  if (options.status) query = query.eq('status', options.status);
+  if (options.assignedToIn && options.assignedToIn.length > 0) query = query.in('assigned_to', options.assignedToIn);
+  if (options.workOrderId) query = query.eq('id', options.workOrderId);
+  if (options.customerId) query = query.eq('customer_id', options.customerId);
   return query;
+}
+
+export async function listCrmWorkOrdersWithFilters(
+  supabase: SupabaseClient,
+  options: WorkOrderListFilters & { limit?: number; offset?: number },
+) {
+  const limit = options.limit ?? CRM_WORK_ORDERS_PAGE_SIZE;
+  const offset = options.offset ?? 0;
+  const query = supabase
+    .from('crm_work_orders')
+    .select(crmWorkOrderSelect, { count: 'exact' })
+    .order('desired_installation_date', { ascending: true, nullsFirst: false })
+    .order('created_at', { ascending: false })
+    .range(offset, offset + limit - 1);
+
+  return applyWorkOrderListFilters(query, options);
+}
+
+// Per-filter counts for the board chips. One head-count query per filter (count-only, no rows
+// transferred) so the chips stay accurate at any table size — same pattern as the customer
+// stage counts. The assignee/search scope is applied so the counts match the visible list.
+export async function getCrmWorkOrderFilterCounts(
+  supabase: SupabaseClient,
+  options: { search?: string; assignedToIn?: string[] },
+): Promise<Record<CrmWorkOrderBoardFilter, number>> {
+  const entries = await Promise.all(
+    CRM_WORK_ORDER_BOARD_FILTERS.map(async (filter) => {
+      const query = applyWorkOrderListFilters(
+        supabase.from('crm_work_orders').select('id', { count: 'exact', head: true }),
+        { search: options.search, filter, assignedToIn: options.assignedToIn },
+      );
+      const { count } = await query;
+      return [filter, count ?? 0] as const;
+    }),
+  );
+  return Object.fromEntries(entries) as Record<CrmWorkOrderBoardFilter, number>;
 }
 
 export async function updateCrmWorkOrder(supabase: SupabaseClient, id: string, input: Partial<WorkOrderUpdateInput>) {

--- a/supabase/sql/20260629_crm_customers_shared_register.sql
+++ b/supabase/sql/20260629_crm_customers_shared_register.sql
@@ -1,0 +1,90 @@
+-- Shared customer register. The CRM launches as a single shared book of customers for the
+-- whole sales team: every CRM reader must SEE every customer (not just the ones they are
+-- assigned to), and every CRM writer must be able to EDIT any customer (a customer record is
+-- shared master data — address/phone/org.nr — not an owned deal). This was a product decision
+-- at launch (the previous assigned_to-only model left reps unable to see each other's
+-- customers and konsult seeing none, and broke the offer form's customer picker).
+--
+-- This widens crm_customers (and the contacts that inherit its visibility) to the same
+-- has_permission(...) shape that crm_quotes / crm_work_orders already use. The assigned_to
+-- ownership branch is preserved on SELECT/UPDATE so it never NARROWS access. Writes are still
+-- gated by crm.customer.write, so konsult (read-only) stays read-only.
+--
+-- Behavior change vs 20260609_rls_permissions_crm_core.sql:
+--   crm_customers SELECT: assigned_to OR admin            → assigned_to OR crm.customer.read
+--   crm_customers UPDATE: assigned_to OR admin            → assigned_to OR crm.customer.write
+--   crm_customer_contacts (select/insert/update/delete): customer-owner OR admin
+--                                                         → customer-owner OR crm.customer.{read|write}
+
+-- ── crm_customers ──────────────────────────────────────────────────────────────
+drop policy if exists "crm_customers_select_visible" on public.crm_customers;
+create policy "crm_customers_select_visible"
+  on public.crm_customers
+  for select
+  using (
+    auth.uid() = assigned_to
+    or public.has_permission('crm.customer.read')
+  );
+
+drop policy if exists "crm_customers_update_assigned_or_admin" on public.crm_customers;
+create policy "crm_customers_update_assigned_or_admin"
+  on public.crm_customers
+  for update
+  using (
+    auth.uid() = assigned_to
+    or public.has_permission('crm.customer.write')
+  )
+  with check (
+    auth.uid() = assigned_to
+    or public.has_permission('crm.customer.write')
+  );
+
+-- ── crm_customer_contacts (inherit the customer's widened visibility) ────────────
+drop policy if exists "crm_customer_contacts_select_visible" on public.crm_customer_contacts;
+create policy "crm_customer_contacts_select_visible"
+  on public.crm_customer_contacts
+  for select
+  using (
+    exists (
+      select 1 from public.crm_customers c
+      where c.id = customer_id
+        and (c.assigned_to = auth.uid() or public.has_permission('crm.customer.read'))
+    )
+  );
+
+drop policy if exists "crm_customer_contacts_insert_sales_or_admin" on public.crm_customer_contacts;
+create policy "crm_customer_contacts_insert_sales_or_admin"
+  on public.crm_customer_contacts
+  for insert
+  to authenticated
+  with check (
+    exists (
+      select 1 from public.crm_customers c
+      where c.id = customer_id
+        and (c.assigned_to = auth.uid() or public.has_permission('crm.customer.write'))
+    )
+  );
+
+drop policy if exists "crm_customer_contacts_update_sales_or_admin" on public.crm_customer_contacts;
+create policy "crm_customer_contacts_update_sales_or_admin"
+  on public.crm_customer_contacts
+  for update
+  using (
+    exists (
+      select 1 from public.crm_customers c
+      where c.id = customer_id
+        and (c.assigned_to = auth.uid() or public.has_permission('crm.customer.write'))
+    )
+  );
+
+drop policy if exists "crm_customer_contacts_delete_sales_or_admin" on public.crm_customer_contacts;
+create policy "crm_customer_contacts_delete_sales_or_admin"
+  on public.crm_customer_contacts
+  for delete
+  using (
+    exists (
+      select 1 from public.crm_customers c
+      where c.id = customer_id
+        and (c.assigned_to = auth.uid() or public.has_permission('crm.customer.write'))
+    )
+  );

--- a/supabase/sql/20260629_crm_work_order_comments_update_grant.sql
+++ b/supabase/sql/20260629_crm_work_order_comments_update_grant.sql
@@ -1,0 +1,16 @@
+-- Fix: comment editing on work orders is dead in production.
+--
+-- 20260606_crm_work_order_edit_policies.sql added an UPDATE *policy*
+-- (crm_wo_comments_update_own) on public.crm_work_order_comments, but the table's original
+-- grant (20260530064347_crm_work_order_activity.sql) only granted select, insert, delete to
+-- `authenticated` — never UPDATE. A row-level policy does nothing without the table-level
+-- privilege: PostgreSQL denies the statement ("permission denied for table
+-- crm_work_order_comments") before RLS is ever evaluated. So every comment edit
+-- (updateCrmWorkOrderComment → PATCH /work-orders/[id]/comments/[commentId]) fails with a 500.
+--
+-- Grant the missing privilege. The existing crm_wo_comments_update_own policy already scopes
+-- UPDATE to the comment's author (created_by = auth.uid()), so this does not widen who can
+-- edit — it only makes the already-intended edit actually reachable. (Time entries were never
+-- affected: the activity migration granted update there.)
+
+grant update on table public.crm_work_order_comments to authenticated;

--- a/tests/offerter/quote-serializers.test.ts
+++ b/tests/offerter/quote-serializers.test.ts
@@ -131,9 +131,15 @@ describe('buildCustomerSnapshot', () => {
         'city', 'company_name', 'contact_name', 'customer_name', 'delivery_address',
         'delivery_city', 'delivery_postal_code',
         'email', 'invoice_address', 'organization_number', 'personal_number', 'phone',
-        'postal_code', 'street_address', 'visit_address',
+        'postal_code', 'reverse_vat', 'street_address', 'visit_address',
       ].sort(),
     );
+  });
+
+  it('reverse_vat: null när inget anges, speglar opts annars', () => {
+    expect(buildCustomerSnapshot(customer()).reverse_vat).toBeNull();
+    expect(buildCustomerSnapshot(customer(), { reverseVat: true }).reverse_vat).toBe(true);
+    expect(buildCustomerSnapshot(customer(), { reverseVat: false }).reverse_vat).toBe(false);
   });
 });
 


### PR DESCRIPTION
Pre-launch review fixes across the three core CRM domains.

- Shared customer register: widen crm_customers (+ contacts) RLS so every CRM reader sees the whole book and every writer can edit it (assigned_to-only left reps blind to each other's customers).
- Work-order comment editing: add the missing UPDATE grant on crm_work_order_comments (policy existed without table privilege → 500).
- Quote ROT headline now leads with the gross offer value (matches Fortnox and the booked value); customer's net-after-ROT shown as a secondary line.
- Persist reverse_vat into customer_snapshot so the byggmoms regime is point-in-time correct for snapshot-only quotes.
- Work-order board: server-side status filter + per-filter counts + "Visa fler" pagination, replacing the silent 100-row client-side cap.

type-check, 535 tests and build all green.