### PR TITLE
Feature/crm prelaunch polish

### DIFF
--- a/app/api/crm/_shared.ts
+++ b/app/api/crm/_shared.ts
@@ -44,6 +44,14 @@ export function invalidUuidParam(id: string | undefined) {
   return id && UUID_RE.test(id) ? null : routeError(400, 'invalid_id', 'Ogiltigt id.');
 }
 
+// PostgREST returns PGRST116 from `.single()` when a statement matched no rows. For a mutation
+// that means the row is either missing OR hidden from this user by RLS — e.g. a non-owner
+// updating a row whose UPDATE policy is owner/admin while its SELECT policy is open to all CRM
+// readers. Callers use this to answer 403/404 deliberately instead of leaking a raw 500.
+export function isNoRowsError(error: { code?: string } | null | undefined): boolean {
+  return error?.code === 'PGRST116';
+}
+
 // Keep only the fields the client actually sent. Zod schemas inject defaults for absent
 // fields; persisting those on a partial PATCH would overwrite untouched columns with
 // empties. The schema still validates the full (defaulted) object — we just write the

--- a/app/api/crm/customers/[id]/contacts/[contactId]/route.ts
+++ b/app/api/crm/customers/[id]/contacts/[contactId]/route.ts
@@ -1,7 +1,7 @@
 import { cookies } from 'next/headers';
 import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
 import { deleteCrmCustomerContact, updateCrmCustomerContact } from '@/lib/domains/crm/customers';
-import { ok, requirePermission, routeError, updateCrmCustomerContactSchema, validationError } from '../../../_lib';
+import { invalidUuidParam, ok, requirePermission, routeError, updateCrmCustomerContactSchema, validationError } from '../../../_lib';
 
 type RouteContext = { params: { id: string; contactId: string } };
 
@@ -9,6 +9,9 @@ export async function PATCH(req: Request, context: RouteContext) {
   try {
     const crmUser = await requirePermission('crm.customer.write');
     if (crmUser.response || !crmUser.currentUser) return crmUser.response;
+
+    const badId = invalidUuidParam(context.params.id) || invalidUuidParam(context.params.contactId);
+    if (badId) return badId;
 
     const parsedBody = updateCrmCustomerContactSchema.safeParse(await req.json().catch(() => null));
     if (!parsedBody.success) return validationError(parsedBody.error);
@@ -30,6 +33,9 @@ export async function DELETE(_req: Request, context: RouteContext) {
   try {
     const crmUser = await requirePermission('crm.customer.write');
     if (crmUser.response || !crmUser.currentUser) return crmUser.response;
+
+    const badId = invalidUuidParam(context.params.id) || invalidUuidParam(context.params.contactId);
+    if (badId) return badId;
 
     const supabase = createRouteHandlerClient({ cookies });
     const { error } = await deleteCrmCustomerContact(supabase, context.params.contactId);

--- a/app/api/crm/customers/[id]/contacts/route.ts
+++ b/app/api/crm/customers/[id]/contacts/route.ts
@@ -1,7 +1,7 @@
 import { cookies } from 'next/headers';
 import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
 import { createCrmCustomerContact } from '@/lib/domains/crm/customers';
-import { createCrmCustomerContactSchema, ok, requirePermission, routeError, validationError } from '../../_lib';
+import { createCrmCustomerContactSchema, invalidUuidParam, ok, requirePermission, routeError, validationError } from '../../_lib';
 
 type RouteContext = { params: { id: string } };
 
@@ -9,6 +9,9 @@ export async function POST(req: Request, context: RouteContext) {
   try {
     const crmUser = await requirePermission('crm.customer.write');
     if (crmUser.response || !crmUser.currentUser) return crmUser.response;
+
+    const badId = invalidUuidParam(context.params.id);
+    if (badId) return badId;
 
     const parsedBody = createCrmCustomerContactSchema.safeParse(await req.json().catch(() => null));
     if (!parsedBody.success) return validationError(parsedBody.error);

--- a/app/api/crm/customers/[id]/credit/route.ts
+++ b/app/api/crm/customers/[id]/credit/route.ts
@@ -4,7 +4,7 @@ import { getCrmCustomer, saveCrmCustomerCreditReport } from '@/lib/domains/crm/c
 import { getSupabaseAdmin } from '@/lib/supabase/server';
 import { fetchTicCreditReport, TicCompanyNotFoundError } from '@/lib/domains/tic/credit';
 import { ticRouteErrorInfo } from '@/lib/domains/tic/client';
-import { ok, requireCrmWriter, routeError } from '../../_lib';
+import { invalidUuidParam, ok, requireCrmWriter, routeError } from '../../_lib';
 
 type RouteContext = { params: { id: string } };
 
@@ -15,6 +15,9 @@ export async function POST(_req: Request, context: RouteContext) {
   try {
     const crmUser = await requireCrmWriter();
     if (crmUser.response) return crmUser.response;
+
+    const badId = invalidUuidParam(context.params.id);
+    if (badId) return badId;
 
     const supabase = createRouteHandlerClient({ cookies });
     const { data: existing, error } = await getCrmCustomer(supabase, context.params.id);

--- a/app/api/crm/customers/[id]/enrich/route.ts
+++ b/app/api/crm/customers/[id]/enrich/route.ts
@@ -4,7 +4,7 @@ import { getCrmCustomer, updateCrmCustomer, type UpdateCrmCustomerInput } from '
 import { getSupabaseAdmin } from '@/lib/supabase/server';
 import { getTicCompanyByOrgNumber } from '@/lib/domains/tic/companies';
 import { ticRouteErrorInfo } from '@/lib/domains/tic/client';
-import { ok, requireCrmWriter, routeError } from '../../_lib';
+import { invalidUuidParam, ok, requireCrmWriter, routeError } from '../../_lib';
 
 type RouteContext = { params: { id: string } };
 
@@ -20,6 +20,9 @@ export async function POST(_req: Request, context: RouteContext) {
   try {
     const crmUser = await requireCrmWriter();
     if (crmUser.response) return crmUser.response;
+
+    const badId = invalidUuidParam(context.params.id);
+    if (badId) return badId;
 
     const supabase = createRouteHandlerClient({ cookies });
     const { data: existing, error } = await getCrmCustomer(supabase, context.params.id);

--- a/app/api/crm/customers/[id]/fortnox/route.ts
+++ b/app/api/crm/customers/[id]/fortnox/route.ts
@@ -2,7 +2,7 @@ import { cookies } from 'next/headers';
 import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
 import { getCrmCustomer } from '@/lib/domains/crm/customers';
 import { createFortnoxCustomer, updateFortnoxCustomer } from '@/lib/domains/fortnox/customers';
-import { ok, requirePermission, routeError } from '../../_lib';
+import { invalidUuidParam, ok, requirePermission, routeError } from '../../_lib';
 
 type RouteContext = { params: { id: string } };
 
@@ -12,6 +12,9 @@ export async function POST(_req: Request, context: RouteContext) {
   try {
     const crmUser = await requirePermission('fortnox.customer.sync');
     if (crmUser.response) return crmUser.response;
+
+    const badId = invalidUuidParam(context.params.id);
+    if (badId) return badId;
 
     const supabase = createRouteHandlerClient({ cookies });
     const { data: existing, error } = await getCrmCustomer(supabase, context.params.id);

--- a/app/api/crm/customers/[id]/route.ts
+++ b/app/api/crm/customers/[id]/route.ts
@@ -2,7 +2,7 @@ import { cookies } from 'next/headers';
 import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
 import { getCrmCustomer, updateCrmCustomer } from '@/lib/domains/crm/customers';
 import { updateFortnoxCustomer, fortnoxCustomerFieldsChanged } from '@/lib/domains/fortnox/customers';
-import { ok, requireCrmUser, requirePermission, routeError, updateCrmCustomerSchema, validationError } from '../_lib';
+import { invalidUuidParam, ok, requireCrmUser, requirePermission, routeError, updateCrmCustomerSchema, validationError } from '../_lib';
 
 type RouteContext = { params: { id: string } };
 
@@ -10,6 +10,9 @@ export async function GET(_req: Request, context: RouteContext) {
   try {
     const crmUser = await requireCrmUser();
     if (crmUser.response) return crmUser.response;
+
+    const badId = invalidUuidParam(context.params.id);
+    if (badId) return badId;
 
     const supabase = createRouteHandlerClient({ cookies });
     const { data, error } = await getCrmCustomer(supabase, context.params.id);
@@ -28,6 +31,9 @@ export async function PATCH(req: Request, context: RouteContext) {
   try {
     const crmUser = await requirePermission('crm.customer.write');
     if (crmUser.response || !crmUser.currentUser) return crmUser.response;
+
+    const badId = invalidUuidParam(context.params.id);
+    if (badId) return badId;
 
     const parsedBody = updateCrmCustomerSchema.safeParse(await req.json().catch(() => null));
     if (!parsedBody.success) return validationError(parsedBody.error);

--- a/app/api/crm/customers/[id]/route.ts
+++ b/app/api/crm/customers/[id]/route.ts
@@ -49,6 +49,23 @@ export async function PATCH(req: Request, context: RouteContext) {
     // created for the customer. This PATCH is also the path the "Ny order" / quote→order flows
     // use to save the personnummer the seller supplies at that point.
 
+    // Guard: don't let a Fortnox-synced customer's identity number be EMPTIED — clearing the
+    // personnummer (private) or org.nr (business) would push an empty OrganisationNumber to
+    // Fortnox and break invoicing/ROT. Keyed off the MERGED type so a real business→private
+    // switch (which swaps which number applies) is still allowed; only clearing the number
+    // that stays relevant is blocked.
+    if (before?.fortnox_customer_id) {
+      const effectiveType = parsedBody.data.customer_type ?? before.customer_type;
+      const clearsPersonal = effectiveType === 'private'
+        && 'personal_number' in parsedBody.data && !parsedBody.data.personal_number && !!before.personal_number;
+      const clearsOrg = effectiveType === 'business'
+        && 'organization_number' in parsedBody.data && !parsedBody.data.organization_number && !!before.organization_number;
+      if (clearsPersonal || clearsOrg) {
+        return routeError(409, 'crm_customer_identity_locked',
+          'Personnummer/org.nr kan inte tömmas på en kund som är synkad med Fortnox.');
+      }
+    }
+
     const { data, error } = await updateCrmCustomer(supabase, context.params.id, parsedBody.data);
 
     if (error) {

--- a/app/api/crm/customers/[id]/route.ts
+++ b/app/api/crm/customers/[id]/route.ts
@@ -44,16 +44,10 @@ export async function PATCH(req: Request, context: RouteContext) {
     // actually changed (avoids pushing to Fortnox on notes/status/owner-only edits).
     const { data: before } = await getCrmCustomer(supabase, context.params.id);
 
-    // Personnummer is mandatory for private customers (Fortnox uses it as
-    // OrganisationNumber for ROT). Guard the MERGED state so a PATCH can neither clear
-    // it nor flip a customer to private without one – the create schema enforces this
-    // on insert; this closes the same invariant on update.
-    const effectiveType = parsedBody.data.customer_type ?? before?.customer_type;
-    const effectivePersonalNumber =
-      'personal_number' in parsedBody.data ? parsedBody.data.personal_number : before?.personal_number;
-    if (effectiveType === 'private' && !effectivePersonalNumber) {
-      return routeError(400, 'crm_customer_personal_number_required', 'Personnummer krävs för privatkund');
-    }
+    // NOTE: a private customer may lack personal_number (sales sometimes get it only once the
+    // job is booked). It is no longer required here — it is enforced when a work order is
+    // created for the customer. This PATCH is also the path the "Ny order" / quote→order flows
+    // use to save the personnummer the seller supplies at that point.
 
     const { data, error } = await updateCrmCustomer(supabase, context.params.id, parsedBody.data);
 

--- a/app/api/crm/customers/_lib.ts
+++ b/app/api/crm/customers/_lib.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-export { ok, routeError, validationError, requireCrmUser, requireCrmWriter, requirePermission } from '../_shared';
+export { ok, routeError, validationError, invalidUuidParam, requireCrmUser, requireCrmWriter, requirePermission } from '../_shared';
 
 // Zod's built-in .email() rejects Unicode domain names (e.g. byggmästaren.se).
 // This helper validates the structural shape of an email while accepting IDN domains.

--- a/app/api/crm/customers/_lib.ts
+++ b/app/api/crm/customers/_lib.ts
@@ -111,13 +111,12 @@ export const createCrmCustomerSchema = z
     (d) =>
       d.customer_type === 'business' ? !!d.company_name : !!(d.first_name && d.last_name),
     { message: 'Företagsnamn krävs för företagskund, för- och efternamn krävs för privatkund' }
-  )
-  // Personal number is required for private customers – it is the OrganisationNumber
-  // Fortnox uses to compute ROT deductions, so a private customer must never lack it.
-  .refine(
-    (d) => d.customer_type !== 'private' || !!d.personal_number,
-    { message: 'Personnummer krävs för privatkund', path: ['personal_number'] }
   );
+  // NOTE: personal_number is intentionally NOT required for a private customer at create.
+  // Sales sometimes only get it once the job is booked, so a private customer can be created
+  // without it; it is instead enforced when a WORK ORDER is created for the customer (Fortnox
+  // needs it as OrganisationNumber for invoicing/ROT) — see createStandaloneCrmWorkOrder /
+  // createCrmWorkOrderFromQuote in lib/domains/crm/work-orders.ts.
 
 export const updateCrmCustomerSchema = z
   .object({

--- a/app/api/crm/quotes/[id]/route.ts
+++ b/app/api/crm/quotes/[id]/route.ts
@@ -4,6 +4,7 @@ import { getCrmQuote, markCrmQuoteWon, updateCrmQuote, type UpdateCrmQuoteInput 
 import { pushQuoteToFortnox } from '@/lib/domains/fortnox/offers';
 import { FortnoxNotConnectedError, friendlyFortnoxMessage } from '@/lib/domains/fortnox/client';
 import {
+  isNoRowsError,
   ok,
   pickProvidedQuoteFields,
   requireCrmUser,
@@ -18,6 +19,18 @@ type RouteContext = {
     id: string;
   };
 };
+
+// A quote UPDATE that matched 0 rows: distinguish "not your quote" (visible via the open
+// SELECT policy → 403) from "gone" (404), so the caller gets a clear message not a raw 500.
+async function quoteForbiddenOrMissing(
+  supabase: Parameters<typeof getCrmQuote>[0],
+  id: string,
+) {
+  const { data: existing } = await getCrmQuote(supabase, id);
+  return existing
+    ? routeError(403, 'crm_quote_forbidden', 'Du kan bara redigera offerter du är ansvarig för.')
+    : routeError(404, 'crm_quote_not_found', 'Offerten hittades inte.');
+}
 
 export async function GET(_req: Request, context: RouteContext) {
   try {
@@ -63,11 +76,19 @@ export async function PATCH(req: Request, context: RouteContext) {
         crmUser.currentUser.id,
         updateInput
       );
-      if (result.error) return routeError(500, result.error.code, result.error.message);
+      if (result.error) {
+        if (isNoRowsError(result.error)) return quoteForbiddenOrMissing(supabase, context.params.id);
+        return routeError(500, result.error.code, result.error.message);
+      }
       data = result.data;
     } else {
       const result = await updateCrmQuote(supabase, context.params.id, updateInput);
-      if (result.error) return routeError(500, 'crm_quote_update_failed', result.error.message);
+      if (result.error) {
+        // 0 rows = the quote is missing OR the caller isn't its assigned owner (UPDATE RLS is
+        // owner/admin, SELECT is open to all CRM readers) — answer 403/404, not a raw 500.
+        if (isNoRowsError(result.error)) return quoteForbiddenOrMissing(supabase, context.params.id);
+        return routeError(500, 'crm_quote_update_failed', result.error.message);
+      }
       data = result.data;
     }
 

--- a/app/api/crm/quotes/[id]/work-order/route.ts
+++ b/app/api/crm/quotes/[id]/work-order/route.ts
@@ -24,7 +24,13 @@ export async function POST(_req: Request, context: RouteContext) {
         return routeError(404, 'crm_quote_not_found', result.error?.message || 'Offerten hittades inte');
       }
 
-      if (result.reason === 'quote_not_won' || result.reason === 'already_created' || result.reason === 'missing_personal_number') {
+      // Emit the same code the standalone route uses so the client's personnummer prompt
+      // (which keys off crm_work_order_missing_personal_number) fires on both order paths.
+      if (result.reason === 'missing_personal_number') {
+        return routeError(409, 'crm_work_order_missing_personal_number', result.error?.message || 'Personnummer krävs för privatkund innan order kan skapas');
+      }
+
+      if (result.reason === 'quote_not_won' || result.reason === 'already_created') {
         return routeError(409, result.reason, result.error?.message || 'Arbetsorder kunde inte skapas');
       }
 

--- a/app/api/crm/quotes/[id]/work-order/route.ts
+++ b/app/api/crm/quotes/[id]/work-order/route.ts
@@ -24,7 +24,7 @@ export async function POST(_req: Request, context: RouteContext) {
         return routeError(404, 'crm_quote_not_found', result.error?.message || 'Offerten hittades inte');
       }
 
-      if (result.reason === 'quote_not_won' || result.reason === 'already_created') {
+      if (result.reason === 'quote_not_won' || result.reason === 'already_created' || result.reason === 'missing_personal_number') {
         return routeError(409, result.reason, result.error?.message || 'Arbetsorder kunde inte skapas');
       }
 

--- a/app/api/crm/quotes/_lib.ts
+++ b/app/api/crm/quotes/_lib.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { ROT_HOUSE_WORK_TYPES } from '@/lib/domains/fortnox/types';
-export { ok, routeError, validationError, requireCrmUser, requireCrmWriter, requirePermission } from '../_shared';
+export { ok, routeError, validationError, invalidUuidParam, isNoRowsError, requireCrmUser, requireCrmWriter, requirePermission } from '../_shared';
 
 function normalizeOptionalText(value: unknown) {
   if (value == null) return null;

--- a/app/api/crm/quotes/_lib.ts
+++ b/app/api/crm/quotes/_lib.ts
@@ -47,6 +47,10 @@ const customerSnapshotSchema = z.object({
   delivery_postal_code: z.preprocess((value) => normalizeOptionalText(value), z.string().nullable()).optional().default(null),
   delivery_city: z.preprocess((value) => normalizeOptionalText(value), z.string().nullable()).optional().default(null),
   invoice_address: z.preprocess((value) => normalizeOptionalText(value), z.string().nullable()).optional().default(null),
+  // Separate on-site contact (slutkund) outside the customer card. null unless entered.
+  end_contact_name: z.preprocess((value) => normalizeOptionalText(value), z.string().nullable()).optional().default(null),
+  end_contact_phone: z.preprocess((value) => normalizeOptionalText(value), z.string().nullable()).optional().default(null),
+  end_contact_email: z.preprocess((value) => normalizeOptionalText(value), z.string().nullable()).optional().default(null),
   // Point-in-time byggmoms flag (omvänd skattskyldighet). null = unknown (legacy rows).
   reverse_vat: z.boolean().nullable().optional().default(null),
 });

--- a/app/api/crm/quotes/_lib.ts
+++ b/app/api/crm/quotes/_lib.ts
@@ -141,11 +141,14 @@ export const createCrmQuoteSchema = z.object({
     });
   }
 
-  if (value.quote_type === 'private' && !value.customer_snapshot.personal_number) {
+  // Personnummer is required on the quote only when ROT is used (ROT can't be computed without
+  // it); otherwise it's optional here and enforced when the work order is created. Matches the
+  // client validation and the relaxed customer-create rule.
+  if (value.quote_type === 'private' && value.rot_details.enabled && !value.customer_snapshot.personal_number) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
       path: ['customer_snapshot', 'personal_number'],
-      message: 'Personnummer krävs för privatkund',
+      message: 'Personnummer krävs för ROT',
     });
   }
 

--- a/app/api/crm/quotes/route.ts
+++ b/app/api/crm/quotes/route.ts
@@ -1,8 +1,8 @@
 import { cookies } from 'next/headers';
 import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
-import { createCrmQuote, listCrmQuotesWithFilters } from '@/lib/domains/crm/quotes';
+import { createCrmQuote, getCrmQuote, listCrmQuotesWithFilters } from '@/lib/domains/crm/quotes';
 import { pushQuoteToFortnox } from '@/lib/domains/fortnox/offers';
-import { FortnoxNotConnectedError } from '@/lib/domains/fortnox/client';
+import { FortnoxNotConnectedError, friendlyFortnoxMessage } from '@/lib/domains/fortnox/client';
 import {
   createCrmQuoteSchema,
   listCrmQuotesQuerySchema,
@@ -71,18 +71,26 @@ export async function POST(req: Request) {
       return routeError(500, 'crm_quote_create_failed', error.message);
     }
 
-    // Auto-push to Fortnox. Non-fatal: quote creation succeeds regardless.
+    // Auto-push to Fortnox. Non-fatal: quote creation always succeeds. A push failure (other
+    // than "not connected") is surfaced as fortnox_error so the seller sees the offer didn't
+    // reach Fortnox — mirroring the PATCH auto-sync — instead of it failing silently.
+    let fortnoxError: string | null = null;
+    let responseItem = data;
     if (data) {
       try {
         await pushQuoteToFortnox(data.id);
+        // Re-read so the response carries the fresh fortnox_offer_number / sync status.
+        const refreshed = await getCrmQuote(supabase, data.id);
+        if (refreshed.data) responseItem = refreshed.data;
       } catch (e) {
         if (!(e instanceof FortnoxNotConnectedError)) {
           console.error('[fortnox] Auto-push offert misslyckades:', (e as any)?.message);
+          fortnoxError = friendlyFortnoxMessage(e);
         }
       }
     }
 
-    return ok({ item: data }, 201);
+    return ok({ item: responseItem, fortnox_error: fortnoxError }, 201);
   } catch (e: any) {
     return routeError(500, 'crm_quote_unexpected', e?.message || 'Failed to create quote');
   }

--- a/app/api/crm/work-orders/[id]/route.ts
+++ b/app/api/crm/work-orders/[id]/route.ts
@@ -1,7 +1,11 @@
 import { cookies } from 'next/headers';
 import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
 import { getCrmWorkOrder, updateCrmWorkOrder, listWorkOrderInvoiceRounds } from '@/lib/domains/crm/work-orders';
-import { ok, pickProvidedFields, requireCrmUser, requirePermission, requireSignedInUser, routeError, updateCrmWorkOrderSchema, validationError } from '../_lib';
+import { isNoRowsError, ok, pickProvidedFields, requireCrmUser, requirePermission, requireSignedInUser, routeError, updateCrmWorkOrderSchema, validationError } from '../_lib';
+
+// Fakturastatus is system-managed (set by the invoice/delfakturering flow), never chosen
+// by hand — so a crafted PATCH can't fake a billed order or regress one back to a manual state.
+const SYSTEM_MANAGED_WO_STATUSES: string[] = ['invoiced', 'partially_invoiced'];
 
 type RouteContext = {
   params: {
@@ -44,9 +48,33 @@ export async function PATCH(req: Request, context: RouteContext) {
     // Persist only fields the client actually sent, so a partial PATCH (e.g. a status-only
     // change) doesn't wipe untouched columns (internal_handoff, work_address) with defaults.
     const updateInput = pickProvidedFields(parsedBody.data, rawBody);
+
+    // System-managed status guard (only when a status change is actually requested):
+    if (updateInput.status) {
+      // …can't be SET manually…
+      if (SYSTEM_MANAGED_WO_STATUSES.includes(updateInput.status)) {
+        return routeError(409, 'crm_work_order_status_system_managed',
+          'Fakturastatus sätts automatiskt vid fakturering och kan inte väljas manuellt.');
+      }
+      // …and a billed order can't be regressed to a manual status either.
+      const { data: current } = await getCrmWorkOrder(supabase, context.params.id);
+      if (current && SYSTEM_MANAGED_WO_STATUSES.includes(current.status)) {
+        return routeError(409, 'crm_work_order_locked',
+          'Ordern är fakturerad och statusen kan inte ändras manuellt.');
+      }
+    }
+
     const { data, error } = await updateCrmWorkOrder(supabase, context.params.id, updateInput);
 
     if (error) {
+      // 0 rows = the order is missing OR the caller isn't its assigned owner (UPDATE RLS is
+      // owner/admin, SELECT is open to all CRM readers) — answer 403/404 rather than a raw 500.
+      if (isNoRowsError(error)) {
+        const { data: existing } = await getCrmWorkOrder(supabase, context.params.id);
+        return existing
+          ? routeError(403, 'crm_work_order_forbidden', 'Du kan bara redigera arbetsorder du är ansvarig för.')
+          : routeError(404, 'crm_work_order_not_found', 'Arbetsorder hittades inte.');
+      }
       return routeError(500, 'crm_work_order_update_failed', error.message);
     }
 

--- a/app/api/crm/work-orders/[id]/route.ts
+++ b/app/api/crm/work-orders/[id]/route.ts
@@ -49,11 +49,17 @@ export async function PATCH(req: Request, context: RouteContext) {
     // change) doesn't wipe untouched columns (internal_handoff, work_address) with defaults.
     const updateInput = pickProvidedFields(parsedBody.data, rawBody);
 
+    // Load the current row once — both the contact-snapshot merge and the status guard need it.
+    type WoCurrent = { status?: string | null; customer_snapshot?: Record<string, unknown> | null };
+    let current: WoCurrent | null = null;
+    if (updateInput.contact || updateInput.status) {
+      current = (await getCrmWorkOrder(supabase, context.params.id)).data as WoCurrent | null;
+    }
+
     // Contact override: merge into the (jsonb) customer_snapshot with a read-merge-write so the
     // other snapshot fields (personnummer, addresses, reverse_vat, end-contact) are preserved.
     // Lets a seller fix the responsible contact if it changed after the offer.
     if (updateInput.contact) {
-      const { data: current } = await getCrmWorkOrder(supabase, context.params.id);
       const snapshot = (current?.customer_snapshot ?? {}) as Record<string, unknown>;
       (updateInput as Record<string, unknown>).customer_snapshot = {
         ...snapshot,
@@ -64,16 +70,17 @@ export async function PATCH(req: Request, context: RouteContext) {
       delete (updateInput as { contact?: unknown }).contact;
     }
 
-    // System-managed status guard (only when a status change is actually requested):
-    if (updateInput.status) {
-      // …can't be SET manually…
+    // System-managed status guard — only a real TRANSITION is blocked. The client always sends
+    // the current status alongside a contact/address/notes edit; re-sending it is a no-op, so
+    // those edits still work on a billed order (they'd otherwise be wrongly rejected).
+    if (updateInput.status && updateInput.status !== current?.status) {
+      // Fakturastatus is set by the invoicing flow, never chosen manually…
       if (SYSTEM_MANAGED_WO_STATUSES.includes(updateInput.status)) {
         return routeError(409, 'crm_work_order_status_system_managed',
           'Fakturastatus sätts automatiskt vid fakturering och kan inte väljas manuellt.');
       }
       // …and a billed order can't be regressed to a manual status either.
-      const { data: current } = await getCrmWorkOrder(supabase, context.params.id);
-      if (current && SYSTEM_MANAGED_WO_STATUSES.includes(current.status)) {
+      if (current?.status && SYSTEM_MANAGED_WO_STATUSES.includes(current.status)) {
         return routeError(409, 'crm_work_order_locked',
           'Ordern är fakturerad och statusen kan inte ändras manuellt.');
       }

--- a/app/api/crm/work-orders/[id]/route.ts
+++ b/app/api/crm/work-orders/[id]/route.ts
@@ -49,6 +49,21 @@ export async function PATCH(req: Request, context: RouteContext) {
     // change) doesn't wipe untouched columns (internal_handoff, work_address) with defaults.
     const updateInput = pickProvidedFields(parsedBody.data, rawBody);
 
+    // Contact override: merge into the (jsonb) customer_snapshot with a read-merge-write so the
+    // other snapshot fields (personnummer, addresses, reverse_vat, end-contact) are preserved.
+    // Lets a seller fix the responsible contact if it changed after the offer.
+    if (updateInput.contact) {
+      const { data: current } = await getCrmWorkOrder(supabase, context.params.id);
+      const snapshot = (current?.customer_snapshot ?? {}) as Record<string, unknown>;
+      (updateInput as Record<string, unknown>).customer_snapshot = {
+        ...snapshot,
+        contact_name: updateInput.contact.contact_name ?? null,
+        email: updateInput.contact.email ?? null,
+        phone: updateInput.contact.phone ?? null,
+      };
+      delete (updateInput as { contact?: unknown }).contact;
+    }
+
     // System-managed status guard (only when a status change is actually requested):
     if (updateInput.status) {
       // …can't be SET manually…

--- a/app/api/crm/work-orders/_lib.ts
+++ b/app/api/crm/work-orders/_lib.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { quoteLineItemSchema } from '../quotes/_lib';
-export { ok, routeError, validationError, invalidUuidParam, requireCrmUser, requireCrmWriter, requirePermission, requireSignedInUser, pickProvidedFields } from '../_shared';
+export { ok, routeError, validationError, invalidUuidParam, isNoRowsError, requireCrmUser, requireCrmWriter, requirePermission, requireSignedInUser, pickProvidedFields } from '../_shared';
 
 // Reuses the quote line-item schema so work order article edits validate identically.
 export const updateWorkOrderLineItemsSchema = z.object({

--- a/app/api/crm/work-orders/_lib.ts
+++ b/app/api/crm/work-orders/_lib.ts
@@ -81,5 +81,12 @@ export const updateCrmWorkOrderSchema = z.object({
     delivery_address: z.preprocess((value) => normalizeOptionalText(value), z.string().nullable()).optional().default(null),
     invoice_address: z.preprocess((value) => normalizeOptionalText(value), z.string().nullable()).optional().default(null),
   }).optional().default({}),
+  // Responsible contact override — merged into customer_snapshot by the route so a contact that
+  // changed between offer→order flows to the installer view and the Fortnox YourReference.
+  contact: z.object({
+    contact_name: z.preprocess((value) => normalizeOptionalText(value), z.string().nullable()).optional().default(null),
+    email: z.preprocess((value) => normalizeOptionalText(value), z.string().nullable()).optional().default(null),
+    phone: z.preprocess((value) => normalizeOptionalText(value), z.string().nullable()).optional().default(null),
+  }).optional(),
 });
 

--- a/app/api/crm/work-orders/route.ts
+++ b/app/api/crm/work-orders/route.ts
@@ -80,7 +80,9 @@ export async function POST(req: Request) {
     });
 
     if (result.error) {
-      const status = result.reason === 'customer_not_found' ? 404 : 500;
+      const status = result.reason === 'customer_not_found'
+        ? 404
+        : result.reason === 'missing_personal_number' ? 409 : 500;
       return routeError(status, `crm_work_order_${result.reason}`, result.error.message || 'Kunde inte skapa order');
     }
 

--- a/app/crm/arbetsorder/WorkOrderDetailClient.tsx
+++ b/app/crm/arbetsorder/WorkOrderDetailClient.tsx
@@ -9,6 +9,7 @@ import { useToast } from '@/lib/Toast';
 import { cn } from '@/lib/shared/cn';
 import { crm, syncStatusLabel, syncStatusClass, workOrderStatusLabel, workOrderStatusClass, WORK_ORDER_STATUS_FLOW, WORK_ORDER_STATUS_OPTIONS } from '@/app/crm/lib/crmTokens';
 import { PhoneLink, EmailLink, AddressLink } from '@/app/crm/components/ContactLinks';
+import AddressAutocompleteInput from '@/app/crm/components/AddressAutocompleteInput';
 import { lineItemQuantity } from '@/lib/domains/crm/lineItems';
 import { lineItemEffectiveUnitPrice } from '@/lib/domains/crm/pricing';
 import { inferMaterialFromArticle, sacksFor } from '@/lib/domains/crm/materials';
@@ -100,8 +101,9 @@ type WorkOrderDraft = {
   street_address: string;
   postal_code: string;
   city: string;
-  delivery_address: string;
-  invoice_address: string;
+  contact_name: string;
+  contact_phone: string;
+  contact_email: string;
   work_scope: string;
   handoff_notes: string;
   notes: string;
@@ -189,6 +191,20 @@ export default function WorkOrderDetailClient({ workOrderId, fortnoxConnected, c
   const [assignees, setAssignees] = useState<AssignableUser[]>([]);
   const customerInfo = useCustomerContact(workOrderId);
 
+  // The linked customer's contacts, for the "change responsible contact" picker (in case the
+  // contact changed between offer→order). Empty for standalone orders with no linked customer.
+  const [customerContacts, setCustomerContacts] = useState<Array<{ id: string; name: string; role: string | null; phone: string | null; email: string | null; is_primary: boolean }>>([]);
+  useEffect(() => {
+    const cid = workOrder?.customer_id;
+    if (!cid) { setCustomerContacts([]); return; }
+    let active = true;
+    fetch(`/api/crm/customers/${cid}`, { cache: 'no-store' })
+      .then((r) => r.json().catch(() => ({})))
+      .then((json) => { if (active) setCustomerContacts(json?.ok && Array.isArray(json.data?.item?.contacts) ? json.data.item.contacts : []); })
+      .catch(() => { if (active) setCustomerContacts([]); });
+    return () => { active = false; };
+  }, [workOrder?.customer_id]);
+
   // Resolve the responsible user's name from the admin-sourced assignees list — the
   // joined `assignee` profile is null for colleagues' orders (session-client profiles RLS
   // only returns the current user's own profile). Same fix as the work-order list.
@@ -245,8 +261,9 @@ export default function WorkOrderDetailClient({ workOrderId, fortnoxConnected, c
       street_address: item.work_address?.street_address || '',
       postal_code: item.work_address?.postal_code || '',
       city: item.work_address?.city || '',
-      delivery_address: item.work_address?.delivery_address || '',
-      invoice_address: item.work_address?.invoice_address || '',
+      contact_name: item.customer_snapshot?.contact_name || '',
+      contact_phone: item.customer_snapshot?.phone || '',
+      contact_email: item.customer_snapshot?.email || '',
       work_scope: item.internal_handoff?.work_scope || '',
       handoff_notes: item.internal_handoff?.handoff_notes || '',
       notes: item.notes || '',
@@ -291,12 +308,19 @@ export default function WorkOrderDetailClient({ workOrderId, fortnoxConnected, c
             work_scope: draft.work_scope,
             handoff_notes: draft.handoff_notes,
           },
+          // Only the work address (where the job is performed) is edited here. Billing/other
+          // addresses live on the customer card, not on the order.
           work_address: {
             street_address: draft.street_address,
             postal_code: draft.postal_code,
             city: draft.city,
-            delivery_address: draft.delivery_address,
-            invoice_address: draft.invoice_address,
+          },
+          // Responsible contact (merged into the snapshot server-side) — lets us fix it if it
+          // changed between offer→order.
+          contact: {
+            contact_name: draft.contact_name,
+            phone: draft.contact_phone,
+            email: draft.contact_email,
           },
         }),
       });
@@ -441,10 +465,12 @@ export default function WorkOrderDetailClient({ workOrderId, fortnoxConnected, c
 
   const overdue = isWorkOrderOverdue(workOrder.desired_installation_date, workOrder.status);
   const snapshot = workOrder.customer_snapshot || {};
-  // Prefer the live customer record; fall back to the quote snapshot.
-  const customerPhone: string | null = customerInfo?.phone ?? (snapshot.phone || null);
-  const customerEmail: string | null = customerInfo?.email ?? (snapshot.email || null);
-  const customerContact: string | null = customerInfo?.contactName ?? (snapshot.contact_name || null);
+  // The order's own responsible contact (snapshot) is the source of truth here — it's what the
+  // picker below edits, so an edit reflects immediately. Fall back to the resolved customer
+  // contact for older orders that never captured one.
+  const customerPhone: string | null = (snapshot.phone || null) ?? customerInfo?.phone ?? null;
+  const customerEmail: string | null = (snapshot.email || null) ?? customerInfo?.email ?? null;
+  const customerContact: string | null = (snapshot.contact_name || null) ?? customerInfo?.contactName ?? null;
   const workAddressText = joinAddress([workOrder.work_address?.street_address, workOrder.work_address?.postal_code, workOrder.work_address?.city]);
   const rot = workOrder.rot_details || {};
   // Reverse charge (omvänd skattskyldighet / byggmoms): a business order whose VAT is 0. Detected
@@ -610,7 +636,17 @@ export default function WorkOrderDetailClient({ workOrderId, fortnoxConnected, c
                 <>
                   <label className="grid gap-1 text-sm text-slate-600">
                     <span className={crm.sectionTitle}>Gatuadress</span>
-                    <Input value={draft.street_address} onChange={(e) => setField('street_address', e.target.value)} placeholder="Gatuadress" />
+                    <AddressAutocompleteInput
+                      value={draft.street_address}
+                      onChange={(street) => setField('street_address', street)}
+                      onSelect={(s) => setDraft((d) => (d ? {
+                        ...d,
+                        street_address: s.street || d.street_address,
+                        postal_code: s.postal_code || d.postal_code,
+                        city: s.city || d.city,
+                      } : d))}
+                      placeholder="Sök adress, t.ex. Industrivägen 4 Södertälje"
+                    />
                   </label>
                   <div className="grid gap-4 sm:grid-cols-2">
                     <label className="grid gap-1 text-sm text-slate-600">
@@ -622,20 +658,11 @@ export default function WorkOrderDetailClient({ workOrderId, fortnoxConnected, c
                       <Input value={draft.city} onChange={(e) => setField('city', e.target.value)} placeholder="Ort" />
                     </label>
                   </div>
-                  <label className="grid gap-1 text-sm text-slate-600">
-                    <span className={crm.sectionTitle}>Leveransadress</span>
-                    <Input value={draft.delivery_address} onChange={(e) => setField('delivery_address', e.target.value)} placeholder="Leveransadress" />
-                  </label>
-                  <label className="grid gap-1 text-sm text-slate-600">
-                    <span className={crm.sectionTitle}>Fakturaadress</span>
-                    <Input value={draft.invoice_address} onChange={(e) => setField('invoice_address', e.target.value)} placeholder="Fakturaadress" />
-                  </label>
+                  <p className="text-[11px] leading-snug text-slate-400">Adressen där arbetet utförs. Faktura- och övriga adresser ligger på kundkortet.</p>
                 </>
               ) : (
                 <div className="grid gap-3">
                   {readField('Gatuadress', joinAddress([workOrder.work_address?.street_address, joinAddress([workOrder.work_address?.postal_code, workOrder.work_address?.city])]))}
-                  {readField('Leveransadress', workOrder.work_address?.delivery_address)}
-                  {readField('Fakturaadress', workOrder.work_address?.invoice_address)}
                 </div>
               )}
             </Card>
@@ -677,7 +704,39 @@ export default function WorkOrderDetailClient({ workOrderId, fortnoxConnected, c
           <div className="grid gap-5 lg:content-start">
 
             {/* Customer contact */}
-            {(customerPhone || customerEmail || customerContact) ? (
+            {editingOverview ? (
+              <Card className="grid gap-3">
+                <p className={crm.sectionTitle}>Kundkontakt</p>
+                {/* Pick a different contact if the responsible person changed offer→order. */}
+                {customerContacts.length > 0 ? (
+                  <Select
+                    aria-label="Välj kontaktperson"
+                    value={customerContacts.find((c) => c.name === draft.contact_name)?.id ?? ''}
+                    onChange={(e) => {
+                      const c = customerContacts.find((x) => x.id === e.target.value);
+                      if (c) setDraft((d) => (d ? { ...d, contact_name: c.name, contact_phone: c.phone || '', contact_email: c.email || '' } : d));
+                    }}
+                  >
+                    <option value="">Skriv manuellt…</option>
+                    {customerContacts.map((c) => (
+                      <option key={c.id} value={c.id}>{c.name}{c.role ? ` (${c.role})` : ''}{c.is_primary ? ' – primär' : ''}</option>
+                    ))}
+                  </Select>
+                ) : null}
+                <label className="grid gap-1 text-sm text-slate-600">
+                  <span className={crm.sectionTitle}>Namn</span>
+                  <Input value={draft.contact_name} onChange={(e) => setField('contact_name', e.target.value)} placeholder="Kontaktperson" />
+                </label>
+                <label className="grid gap-1 text-sm text-slate-600">
+                  <span className={crm.sectionTitle}>Telefon</span>
+                  <Input value={draft.contact_phone} onChange={(e) => setField('contact_phone', e.target.value)} placeholder="070-123 45 67" inputMode="tel" />
+                </label>
+                <label className="grid gap-1 text-sm text-slate-600">
+                  <span className={crm.sectionTitle}>E-post</span>
+                  <Input value={draft.contact_email} onChange={(e) => setField('contact_email', e.target.value)} placeholder="namn@exempel.se" type="email" />
+                </label>
+              </Card>
+            ) : (customerPhone || customerEmail || customerContact) ? (
               <Card className="grid gap-3">
                 <p className={crm.sectionTitle}>Kundkontakt</p>
                 <p className="text-sm font-semibold text-slate-900">{customerContact || workOrder.client_name}</p>

--- a/app/crm/arbetsorder/WorkOrderDetailClient.tsx
+++ b/app/crm/arbetsorder/WorkOrderDetailClient.tsx
@@ -520,7 +520,12 @@ export default function WorkOrderDetailClient({ workOrderId, fortnoxConnected, c
               <span>·</span>
               <span>{workOrder.quote_type === 'private' ? 'Privatkund' : 'Företag'}</span>
               {workOrder.customer_id ? (
-                <a href={`/crm/kunder/${workOrder.customer_id}`} className="font-medium text-emerald-700 transition hover:text-emerald-800 hover:underline">Öppna kundkort →</a>
+                <a
+                  href={`/crm/kunder/${workOrder.customer_id}?returnTo=${encodeURIComponent(`/crm/arbetsorder/${workOrder.id}`)}`}
+                  className="font-medium text-emerald-700 transition hover:text-emerald-800 hover:underline"
+                >
+                  Öppna kundkort →
+                </a>
               ) : null}
             </div>
           </div>

--- a/app/crm/arbetsorder/WorkOrdersClient.tsx
+++ b/app/crm/arbetsorder/WorkOrdersClient.tsx
@@ -10,6 +10,7 @@ import AssigneeFilter, { MINE, type AssigneeFilterValue, type AssigneeOption } f
 import DocumentNumberBadge from '@/app/crm/components/DocumentNumberBadge';
 import CrmModal from '@/app/crm/components/CrmModal';
 import EntityCombobox, { type EntityResult } from '@/app/crm/components/EntityCombobox';
+import { formatSwedishIdNumber } from '@/app/crm/kunder/customerNumbers';
 import { useToast } from '@/lib/Toast';
 
 type WorkOrderStatus = 'draft' | 'scheduled' | 'ready' | 'in_progress' | 'completed' | 'partially_invoiced' | 'invoiced' | 'cancelled';
@@ -482,7 +483,7 @@ export default function WorkOrdersClient({ currentUserId }: { currentUserId: str
                 <p className={cn('mb-1.5', crm.sectionTitle)}>Personnummer (privatkund)</p>
                 <Input
                   value={newOrderPersonalNumber}
-                  onChange={(e) => setNewOrderPersonalNumber(e.target.value)}
+                  onChange={(e) => setNewOrderPersonalNumber(formatSwedishIdNumber(e.target.value))}
                   placeholder="ÅÅMMDD-XXXX"
                   autoFocus
                 />

--- a/app/crm/arbetsorder/WorkOrdersClient.tsx
+++ b/app/crm/arbetsorder/WorkOrdersClient.tsx
@@ -113,6 +113,11 @@ export default function WorkOrdersClient({ currentUserId }: { currentUserId: str
   const [newOrderName, setNewOrderName] = useState('');
   const [newOrderDate, setNewOrderDate] = useState('');
   const [creatingOrder, setCreatingOrder] = useState(false);
+  // A private customer may lack a personnummer (optional at create); Fortnox needs it to invoice
+  // the order. The server rejects with 409 missing_personal_number — we then reveal a field and
+  // save it on the customer before retrying.
+  const [needsPersonalNumber, setNeedsPersonalNumber] = useState(false);
+  const [newOrderPersonalNumber, setNewOrderPersonalNumber] = useState('');
 
   async function searchCustomers(query: string): Promise<EntityResult[]> {
     const res = await fetch(`/api/crm/customers/search?q=${encodeURIComponent(query)}`, { cache: 'no-store' });
@@ -131,13 +136,27 @@ export default function WorkOrdersClient({ currentUserId }: { currentUserId: str
     setNewOrderCustomerLabel('');
     setNewOrderName('');
     setNewOrderDate('');
+    setNeedsPersonalNumber(false);
+    setNewOrderPersonalNumber('');
   }
 
   async function createOrder() {
     if (!newOrderCustomerId) { toast.error('Välj en kund'); return; }
     if (!newOrderName.trim()) { toast.error('Ange ett ordernamn'); return; }
+    if (needsPersonalNumber && !newOrderPersonalNumber.trim()) { toast.error('Fyll i personnummer för privatkunden'); return; }
     setCreatingOrder(true);
     try {
+      // If a prior attempt flagged a missing personnummer, save it on the customer first so the
+      // order (and its Fortnox push) has it.
+      if (needsPersonalNumber && newOrderPersonalNumber.trim()) {
+        const patch = await fetch(`/api/crm/customers/${newOrderCustomerId}`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ personal_number: newOrderPersonalNumber.trim() }),
+        });
+        const pj = await patch.json().catch(() => ({}));
+        if (!patch.ok || !pj.ok) { toast.error(pj?.error || 'Kunde inte spara personnummer'); return; }
+      }
       const res = await fetch('/api/crm/work-orders', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -148,7 +167,15 @@ export default function WorkOrdersClient({ currentUserId }: { currentUserId: str
         }),
       });
       const json = await res.json().catch(() => ({}));
-      if (!res.ok || !json.ok) { toast.error(json?.error || 'Kunde inte skapa order'); return; }
+      if (!res.ok || !json.ok) {
+        if (json?.errorDetails?.code === 'crm_work_order_missing_personal_number') {
+          setNeedsPersonalNumber(true);
+          toast.error('Privatkunden saknar personnummer – fyll i det för att skapa ordern.');
+          return;
+        }
+        toast.error(json?.error || 'Kunde inte skapa order');
+        return;
+      }
       const item = json?.data?.item as { id?: string; order_number?: string } | undefined;
       toast.success(item?.order_number ? `Order skapad: ${item.order_number}` : 'Order skapad');
       resetNewOrder();
@@ -450,6 +477,20 @@ export default function WorkOrdersClient({ currentUserId }: { currentUserId: str
               <p className={cn('mb-1.5', crm.sectionTitle)}>Önskat installationsdatum (valfritt)</p>
               <Input value={newOrderDate} onChange={(e) => setNewOrderDate(e.target.value)} type="date" lang="sv-SE" />
             </div>
+            {needsPersonalNumber ? (
+              <div className="rounded-xl border border-amber-200 bg-amber-50 p-3">
+                <p className={cn('mb-1.5', crm.sectionTitle)}>Personnummer (privatkund)</p>
+                <Input
+                  value={newOrderPersonalNumber}
+                  onChange={(e) => setNewOrderPersonalNumber(e.target.value)}
+                  placeholder="ÅÅMMDD-XXXX"
+                  autoFocus
+                />
+                <p className="mt-1.5 text-[11px] leading-snug text-amber-700">
+                  Privatkunden saknar personnummer. Fortnox behöver det för att fakturera ordern – det sparas på kundkortet.
+                </p>
+              </div>
+            ) : null}
           </div>
         </CrmModal>
       ) : null}

--- a/app/crm/kunder/CustomerDetailClient.tsx
+++ b/app/crm/kunder/CustomerDetailClient.tsx
@@ -222,14 +222,18 @@ function AddressEditColumn({
 export default function CustomerDetailClient({ customerId, fortnoxConnected }: { customerId: string; fortnoxConnected: boolean }) {
   const router = useRouter();
   const searchParams = useSearchParams();
-  // When opened from the offer form, go back there (and re-select this customer so
-  // edited details flow into the quote). Otherwise back to the customer register.
+  // When opened from the offer or a work order, go back there. Only same-origin CRM paths are
+  // accepted (no open-redirect). The offer also re-selects this customer via created_customer_id
+  // so edited details flow into the quote; a work order just returns to where we were.
   const returnTo = (() => {
     const rt = searchParams.get('returnTo');
-    return rt && rt.startsWith('/crm/offerter/') ? rt : null;
+    return rt && (rt.startsWith('/crm/offerter/') || rt.startsWith('/crm/arbetsorder/')) ? rt : null;
   })();
-  const backTo = returnTo ? `${returnTo}?created_customer_id=${customerId}` : '/crm/kunder';
-  const backLabel = returnTo ? 'Tillbaka till offert' : 'Kundregister';
+  const isOfferReturn = returnTo?.startsWith('/crm/offerter/') ?? false;
+  const backTo = returnTo
+    ? (isOfferReturn ? `${returnTo}?created_customer_id=${customerId}` : returnTo)
+    : '/crm/kunder';
+  const backLabel = returnTo ? (isOfferReturn ? 'Tillbaka till offert' : 'Tillbaka till order') : 'Kundregister';
   const toast = useToast();
 
   const [customer, setCustomer] = useState<Customer | null>(null);

--- a/app/crm/kunder/CustomerDetailClient.tsx
+++ b/app/crm/kunder/CustomerDetailClient.tsx
@@ -230,8 +230,9 @@ export default function CustomerDetailClient({ customerId, fortnoxConnected }: {
     return rt && (rt.startsWith('/crm/offerter/') || rt.startsWith('/crm/arbetsorder/')) ? rt : null;
   })();
   const isOfferReturn = returnTo?.startsWith('/crm/offerter/') ?? false;
+  const sep = returnTo?.includes('?') ? '&' : '?';
   const backTo = returnTo
-    ? (isOfferReturn ? `${returnTo}?created_customer_id=${customerId}` : returnTo)
+    ? (isOfferReturn ? `${returnTo}${sep}created_customer_id=${customerId}` : returnTo)
     : '/crm/kunder';
   const backLabel = returnTo ? (isOfferReturn ? 'Tillbaka till offert' : 'Tillbaka till order') : 'Kundregister';
   const toast = useToast();

--- a/app/crm/kunder/CustomerFormClient.tsx
+++ b/app/crm/kunder/CustomerFormClient.tsx
@@ -325,7 +325,8 @@ export default function CustomerFormClient({ fortnoxConnected }: Props) {
     const isB2B = draft.customer_type === 'business';
     if (isB2B && !draft.company_name.trim()) { toast.error('Företagsnamn krävs'); return; }
     if (!isB2B && (!draft.first_name.trim() || !draft.last_name.trim())) { toast.error('För- och efternamn krävs'); return; }
-    if (!isB2B && !draft.personal_number.trim()) { toast.error('Personnummer krävs för privatkund'); return; }
+    // Personnummer is optional at create — sales sometimes only get it once the job is booked.
+    // It is required later, when a work order is created for the customer.
 
     // When "same as visit address" is on, the invoice address + email follow the visit
     // address / contact email rather than the (locked, possibly stale) invoice fields.
@@ -533,8 +534,9 @@ export default function CustomerFormClient({ fortnoxConnected }: Props) {
                       </div>
                     </div>
                     <div>
-                      <FieldLabel>Personnummer *</FieldLabel>
+                      <FieldLabel>Personnummer</FieldLabel>
                       <Input value={draft.personal_number} onChange={(e) => set('personal_number', formatSwedishIdNumber(e.target.value))} placeholder="ÅÅMMDD-XXXX" />
+                      <p className="mt-1 text-[11px] leading-snug text-slate-400">Kan fyllas i senare, men krävs innan en order kan skapas för kunden.</p>
                     </div>
                   </>
                 )}

--- a/app/crm/offerter/QuoteFormClient.tsx
+++ b/app/crm/offerter/QuoteFormClient.tsx
@@ -1600,6 +1600,27 @@ export default function QuoteFormClient({ quoteId }: { quoteId?: string }) {
               <Input value={draft.project_name} onChange={(e) => setDraft((d) => ({ ...d, project_name: e.target.value }))} placeholder="Ex. Takisolering villa Norrköping" />
             </Field>
             <Field fieldId="field-contact-name" label="Er referens (kontaktperson) *" className="md:col-span-2" error={fieldErrors.contact_name}>
+              {/* Contact picker — for a customer with several contacts, choose which one is
+                  responsible for this offer/order. Fills name/phone/email from the chosen
+                  contact; the free-text field below still allows a manual override. */}
+              {selectedCustomer && selectedCustomer.contacts.length > 0 ? (
+                <Select
+                  className="mb-2"
+                  aria-label="Välj kontaktperson"
+                  value={selectedCustomer.contacts.find((c) => c.name === draft.contact_name)?.id ?? ''}
+                  onChange={(e) => {
+                    const c = selectedCustomer.contacts.find((x) => x.id === e.target.value);
+                    if (c) setDraft((d) => ({ ...d, contact_name: c.name, phone: c.phone || '', email: c.email || '' }));
+                  }}
+                >
+                  <option value="">Skriv manuellt…</option>
+                  {selectedCustomer.contacts.map((c) => (
+                    <option key={c.id} value={c.id}>
+                      {c.name}{c.role ? ` (${c.role})` : ''}{c.is_primary ? ' – primär' : ''}
+                    </option>
+                  ))}
+                </Select>
+              ) : null}
               <Input
                 value={draft.contact_name}
                 onChange={(e) => setDraft((d) => ({ ...d, contact_name: e.target.value }))}

--- a/app/crm/offerter/QuoteFormClient.tsx
+++ b/app/crm/offerter/QuoteFormClient.tsx
@@ -88,6 +88,9 @@ type QuoteItem = {
     delivery_postal_code?: string | null;
     delivery_city?: string | null;
     invoice_address?: string | null;
+    end_contact_name?: string | null;
+    end_contact_phone?: string | null;
+    end_contact_email?: string | null;
   } | null;
   pricing_summary: { subtotal?: number; vat?: number; total?: number } | null;
   line_items: QuoteLineItem[] | null;
@@ -145,6 +148,10 @@ type QuoteDraft = {
   delivery_postal_code: string;
   delivery_city: string;
   invoice_address: string;
+  // Separate on-site contact (slutkund) outside the customer card — see buildCustomerSnapshot.
+  end_contact_name: string;
+  end_contact_phone: string;
+  end_contact_email: string;
   items: QuoteLineItem[];
   project_name: string;
   description: string;
@@ -351,6 +358,9 @@ const initialDraft: QuoteDraft = {
   delivery_postal_code: '',
   delivery_city: '',
   invoice_address: '',
+  end_contact_name: '',
+  end_contact_phone: '',
+  end_contact_email: '',
   items: [createEmptyLineItem()],
   project_name: '',
   description: '',
@@ -838,6 +848,8 @@ export default function QuoteFormClient({ quoteId }: { quoteId?: string }) {
   // be filled. A deliberate toggle (vs silent prefill) so a wrong company address can't
   // slip through unnoticed.
   const [customWorkAddress, setCustomWorkAddress] = useState(false);
+  // Separate on-site contact (slutkund) outside the customer card, mirrors the work-address toggle.
+  const [customEndContact, setCustomEndContact] = useState(false);
   const restoredRef = useRef(false);
 
   const presetProspectId = searchParams.get('prospect_id') || '';
@@ -949,6 +961,9 @@ export default function QuoteFormClient({ quoteId }: { quoteId?: string }) {
           delivery_postal_code: item.customer_snapshot?.delivery_postal_code || '',
           delivery_city: item.customer_snapshot?.delivery_city || '',
           invoice_address: item.customer_snapshot?.invoice_address || '',
+          end_contact_name: item.customer_snapshot?.end_contact_name || '',
+          end_contact_phone: item.customer_snapshot?.end_contact_phone || '',
+          end_contact_email: item.customer_snapshot?.end_contact_email || '',
           items: item.line_items?.length
             ? item.line_items.map((line) => ({ ...line, line_note: line.line_note || '', is_rot_work: line.is_rot_work ?? false, house_work_type: line.house_work_type || 'CONSTRUCTION', density: line.density || '' }))
             : [createEmptyLineItem()],
@@ -972,6 +987,9 @@ export default function QuoteFormClient({ quoteId }: { quoteId?: string }) {
           create_follow_up_task: false,
         });
         setCustomWorkAddress(Boolean(item.customer_snapshot?.delivery_address));
+        setCustomEndContact(Boolean(
+          item.customer_snapshot?.end_contact_name || item.customer_snapshot?.end_contact_phone || item.customer_snapshot?.end_contact_email,
+        ));
 
         // Show the linked customer in the picker so editing doesn't look like no
         // customer is selected. Fetch the live row (silently ignored if it 404s).
@@ -1040,6 +1058,9 @@ export default function QuoteFormClient({ quoteId }: { quoteId?: string }) {
           if (fresh) {
             setDraft(envelope.draft);
             setCustomWorkAddress(Boolean(envelope.draft?.delivery_address));
+            setCustomEndContact(Boolean(
+              envelope.draft?.end_contact_name || envelope.draft?.end_contact_phone || envelope.draft?.end_contact_email,
+            ));
           }
         }
       } catch { /* ignore malformed draft */ }
@@ -1499,6 +1520,62 @@ export default function QuoteFormClient({ quoteId }: { quoteId?: string }) {
                   </div>
                   <p className="text-[11px] leading-snug text-slate-400">
                     Blir arbetsorderns adress och Fortnox leveransadress. Kundadressen ligger kvar som fakturaadress.
+                  </p>
+                </div>
+              ) : null}
+            </div>
+
+            {/* Separat kontaktperson på arbetsplatsen (slutkund) — t.ex. en byggare beställer
+                jobbet men arbetet utförs åt en annan person som inte ligger på kundkortet.
+                Speglar arbetsadress-toggeln. Ordergivaren stannar som "Er referens". */}
+            <div className="grid gap-3">
+              <label className="flex cursor-pointer select-none items-center justify-between gap-3 rounded-xl border border-slate-200 bg-slate-50/60 px-3.5 py-2.5">
+                <span className="grid min-w-0 gap-0.5">
+                  <span className="text-sm font-medium text-slate-700">Annan kontaktperson på arbetsplatsen</span>
+                  <span className="text-[11px] text-slate-400">Slutkund utanför kundkortet (jobbet utförs åt någon annan än ordergivaren)</span>
+                </span>
+                <input
+                  type="checkbox"
+                  checked={customEndContact}
+                  onChange={(e) => {
+                    const on = e.target.checked;
+                    setCustomEndContact(on);
+                    if (!on) setDraft((d) => ({ ...d, end_contact_name: '', end_contact_phone: '', end_contact_email: '' }));
+                  }}
+                  className="h-4 w-4 shrink-0 rounded border-slate-300 accent-emerald-600"
+                />
+              </label>
+
+              {customEndContact ? (
+                <div className="grid gap-3 rounded-xl border border-[#e0e8dc] bg-white/60 p-3">
+                  <p className={crm.sectionTitle}>Kontaktperson på arbetsplatsen</p>
+                  <Field label="Namn">
+                    <Input
+                      value={draft.end_contact_name}
+                      onChange={(e) => setDraft((d) => ({ ...d, end_contact_name: e.target.value }))}
+                      placeholder="T.ex. fastighetsägaren"
+                    />
+                  </Field>
+                  <div className="grid grid-cols-2 gap-3">
+                    <Field label="Telefon">
+                      <Input
+                        value={draft.end_contact_phone}
+                        onChange={(e) => setDraft((d) => ({ ...d, end_contact_phone: e.target.value }))}
+                        placeholder="070-123 45 67"
+                        inputMode="tel"
+                      />
+                    </Field>
+                    <Field label="E-post">
+                      <Input
+                        value={draft.end_contact_email}
+                        onChange={(e) => setDraft((d) => ({ ...d, end_contact_email: e.target.value }))}
+                        placeholder="namn@exempel.se"
+                        type="email"
+                      />
+                    </Field>
+                  </div>
+                  <p className="text-[11px] leading-snug text-slate-400">
+                    Visas för installatören på arbetsordern och som notering på Fortnox-dokumenten. Ordergivaren står kvar som Er referens.
                   </p>
                 </div>
               ) : null}

--- a/app/crm/offerter/QuoteFormClient.tsx
+++ b/app/crm/offerter/QuoteFormClient.tsx
@@ -10,6 +10,7 @@ import { parseDecimal } from '@/lib/shared/number';
 import { lineItemQuantity } from '@/lib/domains/crm/lineItems';
 import { crm } from '@/app/crm/lib/crmTokens';
 import AddressAutocompleteInput from '@/app/crm/components/AddressAutocompleteInput';
+import CrmModal from '@/app/crm/components/CrmModal';
 import {
   getEffectiveCustomerName,
   buildCustomerSnapshot,
@@ -316,7 +317,9 @@ function getValidationIssues(draft: QuoteDraft, effectiveRows: EffectiveRow[]) {
   if (!draft.prospect_id && !draft.customer_id && !effectiveCustomerName) issues.push('Kund måste anges');
   if (draft.customer_source.kind === 'prospect' && !draft.prospect_id) issues.push('Prospektkälla kräver valt prospekt');
   if (draft.customer_source.kind === 'fortnox' && !draft.customer_source.fortnox_customer_name.trim()) issues.push('Fortnox-kund behöver kundreferens');
-  if (draft.quote_type === 'private' && !draft.personal_number.trim()) issues.push('Personnummer krävs');
+  // Personnummer is only required on the quote when ROT is used (ROT can't be computed without
+  // it). Otherwise it's optional here and enforced when the work order is created.
+  if (draft.quote_type === 'private' && draft.rot_enabled && !draft.personal_number.trim()) issues.push('Personnummer krävs för ROT');
   if (draft.quote_type === 'business' && !draft.company_name.trim() && !draft.customer_name.trim()) issues.push('Företagsnamn krävs');
   // Er referens (kontaktperson) is required: it becomes YourReference on the Fortnox
   // offer and carries through offer → order → invoice. Enforced here so no quote leaves
@@ -840,6 +843,10 @@ export default function QuoteFormClient({ quoteId }: { quoteId?: string }) {
   const [submitting, setSubmitting] = useState(false);
   const [submitAttempted, setSubmitAttempted] = useState(false);
   const [creatingWorkOrder, setCreatingWorkOrder] = useState(false);
+  // Private customer without personnummer (optional at create) → the work-order route rejects
+  // with 409; we prompt for it, save it on the customer, then retry the conversion.
+  const [pnPromptOpen, setPnPromptOpen] = useState(false);
+  const [pnValue, setPnValue] = useState('');
   const [draft, setDraft] = useState<QuoteDraft>(initialDraft);
   const [loadedQuote, setLoadedQuote] = useState<QuoteItem | null>(null);
   const [selectedCustomer, setSelectedCustomer] = useState<CrmCustomerLite | null>(null);
@@ -1165,8 +1172,8 @@ export default function QuoteFormClient({ quoteId }: { quoteId?: string }) {
     if (draft.quote_type === 'business' && !draft.company_name.trim() && !draft.customer_name.trim()) {
       errs.company_name = 'Företagsnamn krävs';
     }
-    if (draft.quote_type === 'private' && !draft.personal_number.trim()) {
-      errs.personal_number = 'Personnummer krävs';
+    if (draft.quote_type === 'private' && draft.rot_enabled && !draft.personal_number.trim()) {
+      errs.personal_number = 'Personnummer krävs för ROT';
     }
     if (!draft.contact_name.trim()) errs.contact_name = 'Er referens krävs';
     if (!draft.amount.trim() && !hasAnyRows) errs.amount = 'Ange belopp eller lägg till rader';
@@ -1180,7 +1187,7 @@ export default function QuoteFormClient({ quoteId }: { quoteId?: string }) {
   const issueFieldIds: Record<string, string> = {
     'Kund måste anges': 'section-kund',
     'Företagsnamn krävs': 'section-kund',
-    'Personnummer krävs': 'section-kund',
+    'Personnummer krävs för ROT': 'section-kund',
     'Er referens krävs': 'field-contact-name',
     'Offertnamn saknas': 'field-project-name',
     'Ange belopp eller lägg till rader': 'field-amount',
@@ -1318,11 +1325,45 @@ export default function QuoteFormClient({ quoteId }: { quoteId?: string }) {
     try {
       const res = await fetch(`/api/crm/quotes/${quoteId}/work-order`, { method: 'POST', headers: { 'Content-Type': 'application/json' } });
       const json = await res.json().catch(() => ({}));
-      if (!res.ok || !json.ok) { toast.error(json?.error || 'Kunde inte skapa arbetsorder'); return; }
+      if (!res.ok || !json.ok) {
+        if (json?.errorDetails?.code === 'crm_work_order_missing_personal_number') {
+          if (!loadedQuote.customer_id) {
+            toast.error('Privatkunden saknar personnummer. Lägg till det på kundkortet först.');
+            return;
+          }
+          setPnValue(draft.personal_number || '');
+          setPnPromptOpen(true);
+          return;
+        }
+        toast.error(json?.error || 'Kunde inte skapa arbetsorder');
+        return;
+      }
       const workOrder = json?.data?.workOrder as { id?: string; order_number?: string } | undefined;
       toast.success(workOrder?.order_number ? `Arbetsorder skapad: ${workOrder.order_number}` : 'Arbetsorder skapad');
       if (workOrder?.id) router.push(`/crm/arbetsorder?work_order_id=${workOrder.id}`);
     } catch { toast.error('Kunde inte skapa arbetsorder'); } finally { setCreatingWorkOrder(false); }
+  }
+
+  // Save the personnummer on the linked customer, then retry the quote→order conversion.
+  async function savePersonalNumberAndCreateOrder() {
+    if (!loadedQuote?.customer_id) return;
+    if (!pnValue.trim()) { toast.error('Fyll i personnummer'); return; }
+    setCreatingWorkOrder(true);
+    try {
+      const patch = await fetch(`/api/crm/customers/${loadedQuote.customer_id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ personal_number: pnValue.trim() }),
+      });
+      const pj = await patch.json().catch(() => ({}));
+      if (!patch.ok || !pj.ok) { toast.error(pj?.error || 'Kunde inte spara personnummer'); return; }
+      setDraft((d) => ({ ...d, personal_number: pnValue.trim() }));
+      setPnPromptOpen(false);
+    } finally {
+      setCreatingWorkOrder(false);
+    }
+    // Retry the conversion now that the customer has a personnummer.
+    await createWorkOrderFromQuote();
   }
 
   if (loading) {
@@ -2096,6 +2137,45 @@ export default function QuoteFormClient({ quoteId }: { quoteId?: string }) {
           {submitting ? 'Sparar…' : isEditing ? 'Spara' : 'Skapa'}
         </button>
       </div>
+
+      {/* Personnummer-prompt vid order från privatkund utan personnr */}
+      {pnPromptOpen ? (
+        <CrmModal
+          onClose={() => setPnPromptOpen(false)}
+          ariaLabel="Personnummer krävs"
+          maxWidth="sm:max-w-[460px]"
+          header={
+            <>
+              <h2 className="text-lg font-bold text-slate-900">Personnummer krävs</h2>
+              <p className="m-0 mt-0.5 text-sm text-slate-500">Fortnox behöver privatkundens personnummer för att fakturera ordern. Det sparas på kundkortet.</p>
+            </>
+          }
+          footer={
+            <>
+              <button
+                type="button"
+                onClick={() => setPnPromptOpen(false)}
+                className="flex-1 rounded-xl border border-slate-200 bg-white py-2.5 text-sm font-semibold text-slate-600 transition hover:border-slate-300 sm:flex-none sm:px-5"
+              >
+                Avbryt
+              </button>
+              <button
+                type="button"
+                onClick={() => void savePersonalNumberAndCreateOrder()}
+                disabled={creatingWorkOrder || !pnValue.trim()}
+                className="flex-1 rounded-xl py-2.5 text-sm font-semibold text-white shadow-sm transition hover:brightness-95 disabled:cursor-not-allowed disabled:opacity-60 sm:ml-auto sm:flex-none sm:px-5"
+                style={{ backgroundColor: 'var(--crm-primary)' }}
+              >
+                {creatingWorkOrder ? 'Sparar…' : 'Spara och skapa order'}
+              </button>
+            </>
+          }
+        >
+          <Field label="Personnummer">
+            <Input value={pnValue} onChange={(e) => setPnValue(e.target.value)} placeholder="ÅÅMMDD-XXXX" autoFocus />
+          </Field>
+        </CrmModal>
+      ) : null}
     </div>
   );
 }

--- a/app/crm/offerter/QuoteFormClient.tsx
+++ b/app/crm/offerter/QuoteFormClient.tsx
@@ -11,6 +11,9 @@ import { lineItemQuantity } from '@/lib/domains/crm/lineItems';
 import { crm } from '@/app/crm/lib/crmTokens';
 import AddressAutocompleteInput from '@/app/crm/components/AddressAutocompleteInput';
 import CrmModal from '@/app/crm/components/CrmModal';
+import { DndContext, closestCenter, PointerSensor, TouchSensor, useSensor, useSensors, type DragEndEvent } from '@dnd-kit/core';
+import { SortableContext, verticalListSortingStrategy, arrayMove, useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
 import {
   getEffectiveCustomerName,
   buildCustomerSnapshot,
@@ -698,6 +701,34 @@ function SectionHeader({
 
 // ─── LineItemRow (one product/price row) ──────────────────────────────────────
 
+// Sortable wrapper for a line item (drag-and-drop reordering). Owns the sortable node ref +
+// transform; hands a drag-handle button (wired to the sensor listeners) to LineItemRow so the
+// row only reorders when the grip is dragged, not when a field is touched.
+function SortableLineItem({ id, children }: { id: string; children: (dragHandle: React.ReactNode) => React.ReactNode }) {
+  const { attributes, listeners, setNodeRef, setActivatorNodeRef, transform, transition, isDragging } = useSortable({ id });
+  const handle = (
+    <button
+      type="button"
+      ref={setActivatorNodeRef}
+      {...attributes}
+      {...listeners}
+      aria-label="Dra för att ändra ordning"
+      className="shrink-0 cursor-grab touch-none rounded-md p-1 text-slate-300 transition-colors hover:text-slate-500 active:cursor-grabbing"
+    >
+      <svg width="12" height="12" viewBox="0 0 12 12" fill="currentColor" aria-hidden>
+        <circle cx="3.5" cy="2.5" r="1" /><circle cx="8.5" cy="2.5" r="1" />
+        <circle cx="3.5" cy="6" r="1" /><circle cx="8.5" cy="6" r="1" />
+        <circle cx="3.5" cy="9.5" r="1" /><circle cx="8.5" cy="9.5" r="1" />
+      </svg>
+    </button>
+  );
+  return (
+    <div ref={setNodeRef} style={{ transform: CSS.Transform.toString(transform), transition, opacity: isDragging ? 0.6 : 1, zIndex: isDragging ? 20 : undefined }} className="relative">
+      {children(handle)}
+    </div>
+  );
+}
+
 function LineItemRow({
   row,
   index,
@@ -707,6 +738,7 @@ function LineItemRow({
   onSelectArticle,
   onClearArticle,
   onRemove,
+  dragHandle,
 }: {
   row: QuoteLineItem;
   index: number;
@@ -716,6 +748,7 @@ function LineItemRow({
   onSelectArticle: (article: ArticleLite) => void;
   onClearArticle: () => void;
   onRemove: () => void;
+  dragHandle?: React.ReactNode;
 }) {
   const isM3 = (row.pricing_mode ?? 'm3') === 'm3';
   // Collapsed by default once the row has an article; new/empty rows open for editing.
@@ -725,6 +758,7 @@ function LineItemRow({
   if (!expanded) {
     return (
       <div className="flex items-center gap-2 rounded-xl border border-slate-100 px-3.5 py-2.5 transition-colors hover:border-slate-200">
+        {dragHandle}
         <button type="button" onClick={() => setExpanded(true)} className="flex min-w-0 flex-1 items-center gap-3 text-left">
           <span className="shrink-0 text-xs font-semibold tabular-nums text-slate-300">{index + 1}</span>
           <span className="min-w-0 flex-1 truncate text-sm font-medium text-slate-800">
@@ -758,7 +792,7 @@ function LineItemRow({
   return (
     <div className="grid gap-3 rounded-xl border border-slate-200 bg-slate-50/40 p-4">
       <div className="flex items-center justify-between gap-3">
-        <span className="text-xs font-semibold text-slate-400">Rad {index + 1}</span>
+        <span className="flex items-center gap-2 text-xs font-semibold text-slate-400">{dragHandle}Rad {index + 1}</span>
         <div className="flex items-center gap-3">
           <button type="button" onClick={() => setExpanded(false)} className="text-xs font-medium text-slate-500 transition-colors hover:text-slate-800">
             Fäll ihop ▴
@@ -857,6 +891,23 @@ export default function QuoteFormClient({ quoteId }: { quoteId?: string }) {
   const [customWorkAddress, setCustomWorkAddress] = useState(false);
   // Separate on-site contact (slutkund) outside the customer card, mirrors the work-address toggle.
   const [customEndContact, setCustomEndContact] = useState(false);
+
+  // Drag-and-drop reordering of the article rows. Pointer for mouse (small distance so a click
+  // still selects), Touch with a short press-delay so scrolling the form on mobile isn't hijacked.
+  const itemSensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
+    useSensor(TouchSensor, { activationConstraint: { delay: 160, tolerance: 8 } }),
+  );
+  function handleItemsDragEnd(event: DragEndEvent) {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+    setDraft((d) => {
+      const oldIndex = d.items.findIndex((i) => i.id === active.id);
+      const newIndex = d.items.findIndex((i) => i.id === over.id);
+      if (oldIndex < 0 || newIndex < 0) return d;
+      return { ...d, items: arrayMove(d.items, oldIndex, newIndex) };
+    });
+  }
   const restoredRef = useRef(false);
 
   const presetProspectId = searchParams.get('prospect_id') || '';
@@ -1751,12 +1802,16 @@ export default function QuoteFormClient({ quoteId }: { quoteId?: string }) {
             </p>
           )}
 
+          <DndContext sensors={itemSensors} collisionDetection={closestCenter} onDragEnd={handleItemsDragEnd}>
+          <SortableContext items={draft.items.map((i) => i.id)} strategy={verticalListSortingStrategy}>
           <div className="grid gap-2">
             {draft.items.map((row, index) => (
+              <SortableLineItem key={row.id} id={row.id}>
+                {(dragHandle) => (
               <LineItemRow
-                key={row.id}
                 row={row}
                 index={index}
+                dragHandle={dragHandle}
                 metrics={effectiveRows.find((r) => r.id === row.id)}
                 rotEnabled={draft.rot_enabled}
                 onChange={(patch) => setDraft((d) => ({ ...d, items: d.items.map((item) => item.id === row.id ? { ...item, ...patch } : item) }))}
@@ -1790,8 +1845,12 @@ export default function QuoteFormClient({ quoteId }: { quoteId?: string }) {
                 }))}
                 onRemove={() => setDraft((d) => ({ ...d, items: d.items.length > 1 ? d.items.filter((item) => item.id !== row.id) : [createEmptyLineItem()] }))}
               />
+                )}
+              </SortableLineItem>
             ))}
           </div>
+          </SortableContext>
+          </DndContext>
 
           <button
             type="button"

--- a/app/crm/offerter/QuoteFormClient.tsx
+++ b/app/crm/offerter/QuoteFormClient.tsx
@@ -11,6 +11,7 @@ import { lineItemQuantity } from '@/lib/domains/crm/lineItems';
 import { crm } from '@/app/crm/lib/crmTokens';
 import AddressAutocompleteInput from '@/app/crm/components/AddressAutocompleteInput';
 import CrmModal from '@/app/crm/components/CrmModal';
+import { formatSwedishIdNumber } from '@/app/crm/kunder/customerNumbers';
 import { DndContext, closestCenter, PointerSensor, TouchSensor, useSensor, useSensors, type DragEndEvent } from '@dnd-kit/core';
 import { SortableContext, verticalListSortingStrategy, arrayMove, useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
@@ -2231,7 +2232,7 @@ export default function QuoteFormClient({ quoteId }: { quoteId?: string }) {
           }
         >
           <Field label="Personnummer">
-            <Input value={pnValue} onChange={(e) => setPnValue(e.target.value)} placeholder="ÅÅMMDD-XXXX" autoFocus />
+            <Input value={pnValue} onChange={(e) => setPnValue(formatSwedishIdNumber(e.target.value))} placeholder="ÅÅMMDD-XXXX" autoFocus />
           </Field>
         </CrmModal>
       ) : null}

--- a/app/crm/offerter/quoteSerializers.ts
+++ b/app/crm/offerter/quoteSerializers.ts
@@ -28,6 +28,12 @@ export type QuoteCustomerFields = {
   delivery_postal_code: string;
   delivery_city: string;
   invoice_address: string;
+  // Separate on-site contact (slutkund) OUTSIDE the customer card: e.g. a builder orders the
+  // job but the work is done for a different end customer. Independent of "Er referens"
+  // (contact_name), which stays the order-giver. Stored only when explicitly entered.
+  end_contact_name: string;
+  end_contact_phone: string;
+  end_contact_email: string;
 };
 
 // Two address strings are "the same place" if their trimmed, case-folded forms match.
@@ -64,6 +70,11 @@ export function buildCustomerSnapshot(d: QuoteCustomerFields, opts?: { reverseVa
     sameAddressPart(d.delivery_city, d.city);
   const hasWorkAddress = !workMatchesCustomer && Boolean(d.delivery_address.trim());
 
+  // Separate on-site contact: stored only when at least a name/phone/email was entered.
+  const hasEndContact = Boolean(
+    d.end_contact_name?.trim() || d.end_contact_phone?.trim() || d.end_contact_email?.trim(),
+  );
+
   return {
     customer_name: d.quote_type === 'private' ? d.customer_name || null : effectiveCustomerName || null,
     company_name: d.quote_type === 'business' ? d.company_name || null : null,
@@ -80,6 +91,10 @@ export function buildCustomerSnapshot(d: QuoteCustomerFields, opts?: { reverseVa
     delivery_postal_code: hasWorkAddress ? d.delivery_postal_code || null : null,
     delivery_city: hasWorkAddress ? d.delivery_city || null : null,
     invoice_address: d.invoice_address || null,
+    // Separate on-site contact (slutkund) — null unless explicitly entered.
+    end_contact_name: hasEndContact ? d.end_contact_name || null : null,
+    end_contact_phone: hasEndContact ? d.end_contact_phone || null : null,
+    end_contact_email: hasEndContact ? d.end_contact_email || null : null,
     // Point-in-time byggmoms (omvänd skattskyldighet). Stored on the snapshot so the Fortnox
     // push (resolveReverseVat) can decide the 0 %-row VAT regime without depending on the live
     // customer record — essential for snapshot-only quotes with no linked customer_id. `null`

--- a/lib/domains/crm/quotes.ts
+++ b/lib/domains/crm/quotes.ts
@@ -224,7 +224,9 @@ export async function markCrmQuoteWon(
   // Already won, or no prospect to convert — just update
   if (current.status === 'won' || !current.prospect_id) {
     const { data, error } = await updateCrmQuote(supabase, quoteId, updateInput);
-    if (error) return { data: null, error: { code: 'crm_quote_update_failed', message: error.message } };
+    // Preserve PGRST116 (0 rows) so the route can answer 403/404 for a non-owner instead of a
+    // raw 500 (RLS scopes the UPDATE to the owner while SELECT is open) — mirrors the plain path.
+    if (error) return { data: null, error: { code: error.code === 'PGRST116' ? 'PGRST116' : 'crm_quote_update_failed', message: error.message } };
     return { data, error: null };
   }
 

--- a/lib/domains/crm/work-orders.ts
+++ b/lib/domains/crm/work-orders.ts
@@ -440,8 +440,26 @@ export async function listWorkOrderInvoiceRounds(supabase: SupabaseClient, workO
 // Returns { data: null } when the work order has no linked customer.
 export async function getWorkOrderCustomerContact(supabase: SupabaseClient, workOrderId: string) {
   const { data: wo, error: woError } = await supabase
-    .from('crm_work_orders').select('customer_id').eq('id', workOrderId).maybeSingle();
+    .from('crm_work_orders').select('customer_id, customer_snapshot').eq('id', workOrderId).maybeSingle();
   if (woError) return { data: null, error: woError };
+
+  // A separate on-site contact (slutkund, captured outside the customer card) is who the
+  // installer should reach at the job site — prefer it over the customer-card contact. Works
+  // even for a standalone order with no linked customer.
+  const snap = (wo?.customer_snapshot ?? null) as
+    { end_contact_name?: string | null; end_contact_phone?: string | null; end_contact_email?: string | null } | null;
+  if (snap && (snap.end_contact_name?.trim() || snap.end_contact_phone?.trim() || snap.end_contact_email?.trim())) {
+    return {
+      data: {
+        contactName: snap.end_contact_name || null,
+        phone: snap.end_contact_phone || null,
+        email: snap.end_contact_email || null,
+        isOnSiteContact: true,
+      },
+      error: null,
+    };
+  }
+
   if (!wo?.customer_id) return { data: null, error: null };
 
   const { data: c, error } = await supabase
@@ -459,6 +477,7 @@ export async function getWorkOrderCustomerContact(supabase: SupabaseClient, work
       contactName: primary?.name || null,
       phone: (c as any).phone || (c as any).mobile || primary?.phone || null,
       email: (c as any).email || primary?.email || null,
+      isOnSiteContact: false,
     },
     error: null,
   };

--- a/lib/domains/crm/work-orders.ts
+++ b/lib/domains/crm/work-orders.ts
@@ -146,6 +146,13 @@ export async function createStandaloneCrmWorkOrder(supabase: SupabaseClient, inp
   if (custErr) return { data: null, error: custErr, reason: 'customer_fetch_failed' as const };
   if (!customer) return { data: null, error: { message: 'Kunden hittades inte' }, reason: 'customer_not_found' as const };
 
+  // Fortnox needs a private customer's personnummer (its OrganisationNumber) to invoice the
+  // order. It is optional at customer-create, so enforce it here: the caller collects it and
+  // saves it on the customer card before the order is created.
+  if (customer.customer_type === 'private' && !customer.personal_number) {
+    return { data: null, error: { message: 'Personnummer krävs för privatkund innan order kan skapas' }, reason: 'missing_personal_number' as const };
+  }
+
   const isBusiness = customer.customer_type === 'business';
   const clientName = isBusiness
     ? (customer.company_name || 'Okänd kund')
@@ -261,6 +268,24 @@ export async function createCrmWorkOrderFromQuote(supabase: SupabaseClient, quot
     return { data: null, error: { message: 'Arbetsorder finns redan för offerten' }, reason: 'already_created' as const };
   }
 
+  // Fortnox needs a private customer's personnummer to invoice the order. The quote snapshot may
+  // predate it (the quote was saved before the number was known), so fall back to the customer's
+  // current value and bake it into the order snapshot. If neither has it, block — the caller
+  // collects it and saves it on the customer before retrying.
+  let orderSnapshot = (quote.customer_snapshot || {}) as Record<string, unknown>;
+  if (quote.quote_type === 'private' && !orderSnapshot.personal_number) {
+    let personalNumber: string | null = null;
+    if (quote.customer_id) {
+      const { data: cust } = await supabase
+        .from('crm_customers').select('personal_number').eq('id', quote.customer_id).maybeSingle();
+      personalNumber = (cust as { personal_number?: string | null } | null)?.personal_number ?? null;
+    }
+    if (!personalNumber) {
+      return { data: null, error: { message: 'Personnummer krävs för privatkund innan order kan skapas' }, reason: 'missing_personal_number' as const };
+    }
+    orderSnapshot = { ...orderSnapshot, personal_number: personalNumber };
+  }
+
   const orderNumber = buildWorkOrderNumber(quote.id);
 
   const createResult = await supabase
@@ -273,7 +298,7 @@ export async function createCrmWorkOrderFromQuote(supabase: SupabaseClient, quot
       project_name: quote.project_name,
       client_name: getClientName(quote),
       quote_type: quote.quote_type,
-      customer_snapshot: quote.customer_snapshot || {},
+      customer_snapshot: orderSnapshot,
       work_address: getWorkAddress(quote),
       pricing_summary: quote.pricing_summary || {},
       line_items: quote.line_items || [],

--- a/lib/domains/fortnox/helpers.ts
+++ b/lib/domains/fortnox/helpers.ts
@@ -73,6 +73,20 @@ export async function resolveReverseVat(
   return (data as { reverse_vat?: boolean | null } | null)?.reverse_vat === true;
 }
 
+// Builds the Fortnox Remarks line for a separate on-site contact (slutkund) captured on the
+// quote/order outside the customer card. Returns null when no on-site contact was entered, so
+// the caller can conditionally include it. Kept document-level (Remarks) rather than a line-item
+// row — it's not a priced row and reads better as a note.
+export function buildEndContactNote(
+  snapshot: { end_contact_name?: string | null; end_contact_phone?: string | null; end_contact_email?: string | null } | null | undefined,
+): string | null {
+  const name = snapshot?.end_contact_name?.trim();
+  const phone = snapshot?.end_contact_phone?.trim();
+  const email = snapshot?.end_contact_email?.trim();
+  const parts = [name, phone, email].filter(Boolean);
+  return parts.length ? `Kontaktperson på arbetsplatsen: ${parts.join(', ')}` : null;
+}
+
 // Looks up the assigned user's full name for use as OurReference in Fortnox documents.
 export async function resolveOurReference(
   userId: string | null,

--- a/lib/domains/fortnox/offers.ts
+++ b/lib/domains/fortnox/offers.ts
@@ -84,6 +84,12 @@ type FortnoxOfferRow = {
   HouseWorkType?: string;
 };
 
+// A text-only Fortnox row: carries a Description and no amounts, so Fortnox renders it as a
+// comment line under the article (used for measurements and the per-row free text / Radtext).
+export function offerTextRow(description: string): FortnoxOfferRow {
+  return { Description: description };
+}
+
 // Free-text description of a line item's measurements (m² + thickness), shown as its
 // own row on the Fortnox offer. Returns null when the item has no measurements.
 function buildMeasurementText(item: QuoteLineItem): string | null {
@@ -138,13 +144,17 @@ export function buildOfferRows(
       row.HouseWorkType = item.house_work_type || DEFAULT_ROT_HOUSE_WORK_TYPE;
     }
 
-    // Measurements (m² + thickness) get their own text row so they appear on the
-    // offer PDF below the article. Text rows carry only a Description (no amounts).
+    // Measurements (m² + thickness) and the per-row free text (Radtext) each get their own
+    // text row so they appear on the offer PDF below the article. Text rows carry only a
+    // Description (no amounts). Radtext is only added as a separate row when an article name
+    // is present — otherwise it is already the row Description (the fallback above), so a
+    // separate row would duplicate it.
+    const extraRows: FortnoxOfferRow[] = [];
     const measurement = buildMeasurementText(item);
-    if (measurement) {
-      return [row, { Description: measurement } as FortnoxOfferRow];
-    }
-    return [row];
+    if (measurement) extraRows.push(offerTextRow(measurement));
+    const lineNote = item.line_note?.trim();
+    if (lineNote && item.article_name?.trim()) extraRows.push(offerTextRow(lineNote));
+    return [row, ...extraRows];
   });
 }
 

--- a/lib/domains/fortnox/offers.ts
+++ b/lib/domains/fortnox/offers.ts
@@ -154,17 +154,18 @@ export function buildOfferRows(
       row.HouseWorkType = item.house_work_type || DEFAULT_ROT_HOUSE_WORK_TYPE;
     }
 
-    // Measurements (m² + thickness) and the per-row free text (Radtext) each get their own
-    // text row so they appear on the offer PDF below the article. Text rows carry only a
-    // Description (no amounts). Radtext is only added as a separate row when an article name
-    // is present — otherwise it is already the row Description (the fallback above), so a
-    // separate row would duplicate it.
-    const extraRows: FortnoxOfferRow[] = [];
+    // Measurement (m² + thickness) and the per-row free text (Radtext) go into a SINGLE text row
+    // under the article — NOT two separate rows. Fortnox treats the first text row after an
+    // article as that article's comment, but a SECOND consecutive text row as a new (priced)
+    // product row (it stamped the Radtext as a bogus priced m³ row). One text row (like a lone
+    // measurement, which works) keeps them as plain description lines. Radtext is only included
+    // when an article name is present — otherwise it is already the row Description (above).
     const measurement = buildMeasurementText(item);
-    if (measurement) extraRows.push(offerTextRow(measurement));
     const lineNote = item.line_note?.trim();
-    if (lineNote && item.article_name?.trim()) extraRows.push(offerTextRow(lineNote));
-    return [row, ...extraRows];
+    const detail = [measurement, lineNote && item.article_name?.trim() ? lineNote : null]
+      .filter(Boolean)
+      .join('\n');
+    return detail ? [row, offerTextRow(detail)] : [row];
   });
 }
 

--- a/lib/domains/fortnox/offers.ts
+++ b/lib/domains/fortnox/offers.ts
@@ -2,7 +2,7 @@ import { getSupabaseAdmin } from '@/lib/supabase/server';
 import { parseDecimal } from '@/lib/shared/number';
 import { lineItemQuantity } from '@/lib/domains/crm/lineItems';
 import { fortnoxPost, fortnoxPut, fortnoxGet, fortnoxGetBinary, FortnoxApiError, FortnoxNotConnectedError, FortnoxPushInProgressError } from './client';
-import { claimFortnoxPush, resolveOurReference, resolveReverseVat } from './helpers';
+import { buildEndContactNote, claimFortnoxPush, resolveOurReference, resolveReverseVat } from './helpers';
 import { buildFortnoxCustomerPayload, createFortnoxCustomer, splitSwedishName, buildFortnoxAddress, type FortnoxCustomerSource } from './customers';
 import { DEFAULT_ROT_HOUSE_WORK_TYPE } from './types';
 
@@ -52,6 +52,9 @@ type QuoteRow = {
     postal_code?: string | null;
     city?: string | null;
     reverse_vat?: boolean | null;
+    end_contact_name?: string | null;
+    end_contact_phone?: string | null;
+    end_contact_email?: string | null;
   } | null;
   assigned_to: string | null;
   rot_details: {
@@ -406,7 +409,7 @@ export async function pushQuoteToFortnox(quoteId: string): Promise<PushOfferResu
     const brfOrgNumber = rotEnabled && quote.rot_details?.brf_org_number
       ? `BRF org.nr: ${quote.rot_details.brf_org_number}`
       : null;
-    const remarks = [quote.description, propertyDesignation, brfOrgNumber].filter(Boolean).join('\n') || undefined;
+    const remarks = [quote.description, propertyDesignation, brfOrgNumber, buildEndContactNote(snapshot)].filter(Boolean).join('\n') || undefined;
 
     const offerBody = {
       Offer: {

--- a/lib/domains/fortnox/offers.ts
+++ b/lib/domains/fortnox/offers.ts
@@ -142,9 +142,16 @@ export function buildOfferRows(
       row.Discount = discount;
       row.DiscountType = 'PERCENT';
     }
+    // Send HouseWork explicitly on EVERY row — including `false`. Some Fortnox articles (e.g.
+    // etableringskostnad) are configured as husarbete/ROT articles at the article level; if we
+    // OMIT HouseWork, Fortnox inherits that default and stamps the row as husarbete (OTHERCOSTS),
+    // which a non-ROT document (TaxReductionType 'none') rejects with error 2004021. Explicit
+    // `false` overrides the article default so a non-ROT offer always syncs.
     if (rotEnabled && item.is_rot_work) {
       row.HouseWork = true;
       row.HouseWorkType = item.house_work_type || DEFAULT_ROT_HOUSE_WORK_TYPE;
+    } else {
+      row.HouseWork = false;
     }
 
     // Measurements (m² + thickness) and the per-row free text (Radtext) each get their own

--- a/lib/domains/fortnox/offers.ts
+++ b/lib/domains/fortnox/offers.ts
@@ -235,7 +235,28 @@ async function createCustomerInFortnox(quote: QuoteRow): Promise<string> {
 
   const supabase = getSupabaseAdmin();
 
-  // assigned_to/created_by are NOT NULL – use the quote's assigned user.
+  // Link the Fortnox customer number onto the quote FIRST — before the (optional) crm_customers
+  // row + contact inserts below. resolveFortnoxCustomerNumber keys off customer_source, so
+  // recording it immediately means a failure in any later step can't orphan the freshly-created
+  // Fortnox customer and duplicate it on the next push. If even this minimal write fails we throw,
+  // because a retry genuinely would create a second Fortnox customer.
+  const { error: linkError } = await supabase
+    .from('crm_quotes')
+    .update({
+      customer_source: {
+        kind: 'fortnox',
+        sync_intent: 'linked',
+        fortnox_customer_id: customerNumber,
+        fortnox_customer_name: name,
+      },
+    })
+    .eq('id', quote.id);
+  if (linkError) {
+    throw new Error(`[Fortnox] Kunde inte länka customer_source på offert ${quote.id}: ${linkError.message}`);
+  }
+
+  // assigned_to/created_by are NOT NULL – use the quote's assigned user. Without it we can't
+  // create the local mirror row, but the quote is already linked above so returning here is safe.
   if (!quote.assigned_to) {
     console.warn(`[Fortnox] Kan inte skapa crm_customers-rad för offert ${quote.id}: assigned_to saknas`);
     return customerNumber;
@@ -286,26 +307,18 @@ async function createCustomerInFortnox(quote: QuoteRow): Promise<string> {
         is_primary: true,
       });
     }
-  }
 
-  // Always link customer_source on the quote regardless of whether the DB insert succeeded.
-  // This ensures resolveFortnoxCustomerNumber finds the Fortnox number on the next push
-  // and skips createCustomerInFortnox – preventing duplicate Fortnox customers on retry.
-  const { error: quoteUpdateError } = await supabase
-    .from('crm_quotes')
-    .update({
-      ...(newCustomer?.id ? { customer_id: newCustomer.id } : {}),
-      customer_source: {
-        kind: 'fortnox',
-        sync_intent: 'linked',
-        fortnox_customer_id: customerNumber,
-        fortnox_customer_name: name,
-      },
-    })
-    .eq('id', quote.id);
-
-  if (quoteUpdateError) {
-    throw new Error(`[Fortnox] Kunde inte länka customer_source på offert ${quote.id}: ${quoteUpdateError.message}`);
+    // Enrich the quote with the local customer_id now that the mirror row exists. Best-effort:
+    // the anti-duplicate link (customer_source) is already persisted above, so a failure here
+    // only means the quote isn't joined to the local customer row — never a duplicate Fortnox
+    // customer.
+    const { error: customerIdError } = await supabase
+      .from('crm_quotes')
+      .update({ customer_id: newCustomer.id })
+      .eq('id', quote.id);
+    if (customerIdError) {
+      console.error(`[Fortnox] Kunde inte länka customer_id på offert ${quote.id}:`, customerIdError.message);
+    }
   }
 
   return customerNumber;

--- a/lib/domains/fortnox/offers.ts
+++ b/lib/domains/fortnox/offers.ts
@@ -142,16 +142,16 @@ export function buildOfferRows(
       row.Discount = discount;
       row.DiscountType = 'PERCENT';
     }
-    // Send HouseWork explicitly on EVERY row — including `false`. Some Fortnox articles (e.g.
-    // etableringskostnad) are configured as husarbete/ROT articles at the article level; if we
-    // OMIT HouseWork, Fortnox inherits that default and stamps the row as husarbete (OTHERCOSTS),
-    // which a non-ROT document (TaxReductionType 'none') rejects with error 2004021. Explicit
-    // `false` overrides the article default so a non-ROT offer always syncs.
+    // Mark a row as husarbete ONLY on a ROT document. Do NOT send `HouseWork: false` on non-ROT
+    // rows: Fortnox then stamps the row with an empty husarbete type ('EMPTYHOUSEWORK') and a
+    // non-ROT document (TaxReductionType 'none') rejects ANY husarbete type — even the empty one
+    // (error 2004021). Omitting it is the behaviour that syncs cleanly.
+    // NOTE: if an article is configured as a husarbete article in Fortnox, Fortnox inherits that
+    // on the row regardless — the only fix for that is to turn husarbete OFF on the article in
+    // Fortnox; it can't be overridden from the row here.
     if (rotEnabled && item.is_rot_work) {
       row.HouseWork = true;
       row.HouseWorkType = item.house_work_type || DEFAULT_ROT_HOUSE_WORK_TYPE;
-    } else {
-      row.HouseWork = false;
     }
 
     // Measurements (m² + thickness) and the per-row free text (Radtext) each get their own

--- a/lib/domains/fortnox/orders.ts
+++ b/lib/domains/fortnox/orders.ts
@@ -104,7 +104,12 @@ export function buildOrderRows(lineItems: WorkOrderRow['line_items'], vatPercent
       // DiscountType:'PERCENT' is required — Fortnox defaults to AMOUNT (kronor), which would
       // book discount_percent as a kronor discount and diverge from the CRM total.
       ...(discount > 0 ? { Discount: discount, DiscountType: 'PERCENT' as const } : {}),
-      ...(rotEnabled && item.is_rot_work ? { HouseWork: true, HouseWorkType: item.house_work_type || DEFAULT_ROT_HOUSE_WORK_TYPE } : {}),
+      // Explicit HouseWork on every row (incl. false) overrides an article-level husarbete
+      // default in Fortnox — otherwise a non-ROT order rejects an inherited OTHERCOSTS row
+      // (error 2004021). See offers.ts for the full rationale.
+      ...(rotEnabled && item.is_rot_work
+        ? { HouseWork: true, HouseWorkType: item.house_work_type || DEFAULT_ROT_HOUSE_WORK_TYPE }
+        : { HouseWork: false }),
     };
     // The per-row free text (Radtext) gets its own text row — only when an article name is
     // present, since otherwise it is already the row Description (the fallback above).

--- a/lib/domains/fortnox/orders.ts
+++ b/lib/domains/fortnox/orders.ts
@@ -2,7 +2,7 @@ import { getSupabaseAdmin } from '@/lib/supabase/server';
 import { parseDecimal } from '@/lib/shared/number';
 import { lineItemQuantity } from '@/lib/domains/crm/lineItems';
 import { fortnoxGet, fortnoxGetBinary, fortnoxPost, fortnoxPut, FortnoxApiError, FortnoxNotConnectedError, FortnoxPushInProgressError } from './client';
-import { claimFortnoxPush, resolveOurReference, resolveReverseVat } from './helpers';
+import { buildEndContactNote, claimFortnoxPush, resolveOurReference, resolveReverseVat } from './helpers';
 import { DEFAULT_ROT_HOUSE_WORK_TYPE } from './types';
 
 type WorkOrderRow = {
@@ -18,6 +18,9 @@ type WorkOrderRow = {
     postal_code?: string | null;
     city?: string | null;
     reverse_vat?: boolean | null;
+    end_contact_name?: string | null;
+    end_contact_phone?: string | null;
+    end_contact_email?: string | null;
   } | null;
   project_name: string;
   client_name: string | null;
@@ -195,6 +198,9 @@ export async function pushWorkOrderToFortnox(workOrderId: string): Promise<PushO
         postal_code?: string | null;
         city?: string | null;
         reverse_vat?: boolean | null;
+        end_contact_name?: string | null;
+        end_contact_phone?: string | null;
+        end_contact_email?: string | null;
       } | null;
       rot_details: { enabled?: boolean | null } | null;
     };
@@ -280,6 +286,7 @@ export async function pushWorkOrderToFortnox(workOrderId: string): Promise<PushO
           // the customer card drives the VAT regime, and rows carry the matching VAT (0 % for
           // reverse charge, see buildOrderRows) so header and rows never diverge.
           ...(rotEnabled ? { TaxReductionType: 'rot' } : {}),
+          ...(buildEndContactNote(snapshot) ? { Remarks: buildEndContactNote(snapshot) } : {}),
           ...(deliveryAddress
             ? {
                 DeliveryAddress1: deliveryAddress,

--- a/lib/domains/fortnox/orders.ts
+++ b/lib/domains/fortnox/orders.ts
@@ -50,12 +50,34 @@ export type CreateInvoiceResult = {
   fortnox_invoice_number: string;
 };
 
+type FortnoxOrderRow = {
+  ArticleNumber?: string;
+  Description: string;
+  OrderedQuantity?: number;
+  DeliveredQuantity?: number;
+  Price?: number;
+  VAT?: number;
+  Unit?: string;
+  Discount?: number;
+  DiscountType?: 'PERCENT' | 'AMOUNT';
+  HouseWork?: boolean;
+  HouseWorkType?: string;
+};
+
+// A text-only order row: Description with no article/quantities, so Fortnox renders it as a
+// comment line under the article (carries the per-row free text / Radtext).
+// NOTE: if a Fortnox test company rejects a text-only /orders row, the fallback is to append
+// the Radtext to the article row's Description instead — the offer side is unaffected.
+function orderTextRow(description: string): FortnoxOrderRow {
+  return { Description: description };
+}
+
 // Exported for tests. NOTE: Fortnox order rows use `OrderedQuantity` (offer rows use
 // `Quantity`, invoice rows use `DeliveredQuantity`) — sending `Quantity` to /orders
 // returns 400 "Felaktigt fältnamn (Quantity)".
-export function buildOrderRows(lineItems: WorkOrderRow['line_items'], vatPercent: number, rotEnabled: boolean, reverseVat = false) {
+export function buildOrderRows(lineItems: WorkOrderRow['line_items'], vatPercent: number, rotEnabled: boolean, reverseVat = false): FortnoxOrderRow[] {
   if (!lineItems?.length) return [];
-  return lineItems.map((item) => {
+  return lineItems.flatMap((item) => {
     // parseDecimal handles Swedish comma input ("1,5") that plain parseFloat truncates.
     const price = item.unit_price ? parseDecimal(item.unit_price) : (item.article_price ?? 0);
     // For m³ rows the quantity is the computed volume, not the (empty) quantity field.
@@ -63,7 +85,7 @@ export function buildOrderRows(lineItems: WorkOrderRow['line_items'], vatPercent
     // Clamp to [0,100] to match the CRM pricing (lib/domains/crm/pricing.ts); otherwise a
     // discount > 100 makes the Fortnox row total diverge from the stored CRM total.
     const discount = Math.min(100, Math.max(0, item.discount_percent ? parseDecimal(item.discount_percent) : 0));
-    return {
+    const row: FortnoxOrderRow = {
       ...(item.article_number ? { ArticleNumber: item.article_number } : {}),
       Description: item.article_name || item.line_note || 'Artikel',
       // Fortnox invoices the DELIVERED quantity. A work order is the basis for invoicing
@@ -81,6 +103,11 @@ export function buildOrderRows(lineItems: WorkOrderRow['line_items'], vatPercent
       ...(discount > 0 ? { Discount: discount, DiscountType: 'PERCENT' as const } : {}),
       ...(rotEnabled && item.is_rot_work ? { HouseWork: true, HouseWorkType: item.house_work_type || DEFAULT_ROT_HOUSE_WORK_TYPE } : {}),
     };
+    // The per-row free text (Radtext) gets its own text row — only when an article name is
+    // present, since otherwise it is already the row Description (the fallback above).
+    const lineNote = item.line_note?.trim();
+    if (lineNote && item.article_name?.trim()) return [row, orderTextRow(lineNote)];
+    return [row];
   });
 }
 

--- a/lib/domains/fortnox/orders.ts
+++ b/lib/domains/fortnox/orders.ts
@@ -104,12 +104,12 @@ export function buildOrderRows(lineItems: WorkOrderRow['line_items'], vatPercent
       // DiscountType:'PERCENT' is required — Fortnox defaults to AMOUNT (kronor), which would
       // book discount_percent as a kronor discount and diverge from the CRM total.
       ...(discount > 0 ? { Discount: discount, DiscountType: 'PERCENT' as const } : {}),
-      // Explicit HouseWork on every row (incl. false) overrides an article-level husarbete
-      // default in Fortnox — otherwise a non-ROT order rejects an inherited OTHERCOSTS row
-      // (error 2004021). See offers.ts for the full rationale.
+      // Husarbete only on a ROT document. Do NOT send HouseWork:false on non-ROT rows — Fortnox
+      // stamps an empty husarbete type ('EMPTYHOUSEWORK') that a non-ROT document rejects
+      // (2004021). See offers.ts. A husarbete-configured article is fixed in Fortnox, not here.
       ...(rotEnabled && item.is_rot_work
         ? { HouseWork: true, HouseWorkType: item.house_work_type || DEFAULT_ROT_HOUSE_WORK_TYPE }
-        : { HouseWork: false }),
+        : {}),
     };
     // The per-row free text (Radtext) gets its own text row — only when an article name is
     // present, since otherwise it is already the row Description (the fallback above).

--- a/lib/domains/fortnox/partialInvoices.ts
+++ b/lib/domains/fortnox/partialInvoices.ts
@@ -124,9 +124,12 @@ export function buildInvoiceRows(
       VAT: reverseVat ? 0 : vatPercent,
       ...(item.article_unit_name ? { Unit: item.article_unit_name } : {}),
       ...(discount > 0 ? { Discount: discount, DiscountType: 'PERCENT' as const } : {}),
+      // Explicit HouseWork on every row (incl. false) overrides an article-level husarbete
+      // default in Fortnox — otherwise a non-ROT invoice rejects an inherited OTHERCOSTS row
+      // (error 2004021). See offers.ts for the full rationale.
       ...(rotEnabled && item.is_rot_work
         ? { HouseWork: true, HouseWorkType: item.house_work_type || DEFAULT_ROT_HOUSE_WORK_TYPE }
-        : {}),
+        : { HouseWork: false }),
     });
   });
   return rows;

--- a/lib/domains/fortnox/partialInvoices.ts
+++ b/lib/domains/fortnox/partialInvoices.ts
@@ -124,12 +124,12 @@ export function buildInvoiceRows(
       VAT: reverseVat ? 0 : vatPercent,
       ...(item.article_unit_name ? { Unit: item.article_unit_name } : {}),
       ...(discount > 0 ? { Discount: discount, DiscountType: 'PERCENT' as const } : {}),
-      // Explicit HouseWork on every row (incl. false) overrides an article-level husarbete
-      // default in Fortnox — otherwise a non-ROT invoice rejects an inherited OTHERCOSTS row
-      // (error 2004021). See offers.ts for the full rationale.
+      // Husarbete only on a ROT document. Do NOT send HouseWork:false on non-ROT rows — Fortnox
+      // stamps an empty husarbete type ('EMPTYHOUSEWORK') that a non-ROT document rejects
+      // (2004021). See offers.ts. A husarbete-configured article is fixed in Fortnox, not here.
       ...(rotEnabled && item.is_rot_work
         ? { HouseWork: true, HouseWorkType: item.house_work_type || DEFAULT_ROT_HOUSE_WORK_TYPE }
-        : { HouseWork: false }),
+        : {}),
     });
   });
   return rows;

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "oscar-webapp",
       "version": "0.1.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@supabase/auth-helpers-nextjs": "^0.10.0",
         "@supabase/supabase-js": "2.45.4",
         "class-variance-authority": "^0.7.1",
@@ -113,6 +116,59 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@emnapi/core": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@supabase/supabase-js": "2.45.4",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
-        "next": "14.2.5",
+        "next": "^14.2.35",
         "pdf-lib": "^1.17.1",
         "react": "18.3.1",
         "react-dom": "18.3.1",
@@ -208,15 +208,15 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "14.2.5",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.5.tgz",
-      "integrity": "sha512-/zZGkrTOsraVfYjGP8uM0p6r0BDT6xWpkjdVbcz66PJVSpwXX3yNiRycxAuDfBKGWBrZBXRuK/YVlkNgxHGwmA==",
+      "version": "14.2.35",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.35.tgz",
+      "integrity": "sha512-DuhvCtj4t9Gwrx80dmz2F4t/zKQ4ktN8WrMwOuVzkJfBilwAwGr6v16M5eI8yCuZ63H9TTuEU09Iu2HqkzFPVQ==",
       "license": "MIT"
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "14.2.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.5.tgz",
-      "integrity": "sha512-/9zVxJ+K9lrzSGli1///ujyRfon/ZneeZ+v4ptpiPoOU+GKZnm8Wj8ELWU1Pm7GHltYRBklmXMTUqM/DqQ99FQ==",
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.33.tgz",
+      "integrity": "sha512-HqYnb6pxlsshoSTubdXKu15g3iivcbsMXg4bYpjL2iS/V6aQot+iyF4BUc2qA/J/n55YtvE4PHMKWBKGCF/+wA==",
       "cpu": [
         "arm64"
       ],
@@ -230,9 +230,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "14.2.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.5.tgz",
-      "integrity": "sha512-vXHOPCwfDe9qLDuq7U1OYM2wUY+KQ4Ex6ozwsKxp26BlJ6XXbHleOUldenM67JRyBfVjv371oneEvYd3H2gNSA==",
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.33.tgz",
+      "integrity": "sha512-8HGBeAE5rX3jzKvF593XTTFg3gxeU4f+UWnswa6JPhzaR6+zblO5+fjltJWIZc4aUalqTclvN2QtTC37LxvZAA==",
       "cpu": [
         "x64"
       ],
@@ -246,9 +246,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "14.2.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.5.tgz",
-      "integrity": "sha512-vlhB8wI+lj8q1ExFW8lbWutA4M2ZazQNvMWuEDqZcuJJc78iUnLdPPunBPX8rC4IgT6lIx/adB+Cwrl99MzNaA==",
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.33.tgz",
+      "integrity": "sha512-JXMBka6lNNmqbkvcTtaX8Gu5by9547bukHQvPoLe9VRBx1gHwzf5tdt4AaezW85HAB3pikcvyqBToRTDA4DeLw==",
       "cpu": [
         "arm64"
       ],
@@ -262,9 +262,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "14.2.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.5.tgz",
-      "integrity": "sha512-NpDB9NUR2t0hXzJJwQSGu1IAOYybsfeB+LxpGsXrRIb7QOrYmidJz3shzY8cM6+rO4Aojuef0N/PEaX18pi9OA==",
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.33.tgz",
+      "integrity": "sha512-Bm+QulsAItD/x6Ih8wGIMfRJy4G73tu1HJsrccPW6AfqdZd0Sfm5Imhgkgq2+kly065rYMnCOxTBvmvFY1BKfg==",
       "cpu": [
         "arm64"
       ],
@@ -278,9 +278,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "14.2.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.5.tgz",
-      "integrity": "sha512-8XFikMSxWleYNryWIjiCX+gU201YS+erTUidKdyOVYi5qUQo/gRxv/3N1oZFCgqpesN6FPeqGM72Zve+nReVXQ==",
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.33.tgz",
+      "integrity": "sha512-FnFn+ZBgsVMbGDsTqo8zsnRzydvsGV8vfiWwUo1LD8FTmPTdV+otGSWKc4LJec0oSexFnCYVO4hX8P8qQKaSlg==",
       "cpu": [
         "x64"
       ],
@@ -294,9 +294,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "14.2.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.5.tgz",
-      "integrity": "sha512-6QLwi7RaYiQDcRDSU/os40r5o06b5ue7Jsk5JgdRBGGp8l37RZEh9JsLSM8QF0YDsgcosSeHjglgqi25+m04IQ==",
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.33.tgz",
+      "integrity": "sha512-345tsIWMzoXaQndUTDv1qypDRiebFxGYx9pYkhwY4hBRaOLt8UGfiWKr9FSSHs25dFIf8ZqIFaPdy5MljdoawA==",
       "cpu": [
         "x64"
       ],
@@ -310,9 +310,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "14.2.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.5.tgz",
-      "integrity": "sha512-1GpG2VhbspO+aYoMOQPQiqc/tG3LzmsdBH0LhnDS3JrtDx2QmzXe0B6mSZZiN3Bq7IOMXxv1nlsjzoS1+9mzZw==",
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.33.tgz",
+      "integrity": "sha512-nscpt0G6UCTkrT2ppnJnFsYbPDQwmum4GNXYTeoTIdsmMydSKFz9Iny2jpaRupTb+Wl298+Rh82WKzt9LCcqSQ==",
       "cpu": [
         "arm64"
       ],
@@ -326,9 +326,9 @@
       }
     },
     "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "14.2.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.5.tgz",
-      "integrity": "sha512-Igh9ZlxwvCDsu6438FXlQTHlRno4gFpJzqPjSIBZooD22tKeI4fE/YMRoHVJHmrQ2P5YL1DoZ0qaOKkbeFWeMg==",
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.33.tgz",
+      "integrity": "sha512-pc9LpGNKhJ0dXQhZ5QMmYxtARwwmWLpeocFmVG5Z0DzWq5Uf0izcI8tLc+qOpqxO1PWqZ5A7J1blrUIKrIFc7Q==",
       "cpu": [
         "ia32"
       ],
@@ -342,9 +342,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "14.2.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.5.tgz",
-      "integrity": "sha512-tEQ7oinq1/CjSG9uSTerca3v4AZ+dFa+4Yu6ihaG8Ud8ddqLQgFGcnwYls13H5X5CPDPZJdYxyeMui6muOLd4g==",
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.33.tgz",
+      "integrity": "sha512-nOjfZMy8B94MdisuzZo9/57xuFVLHJaDj5e/xrduJp9CV2/HrfxTRH2fbyLe+K9QT41WBLUd4iXX3R7jBp0EUg==",
       "cpu": [
         "x64"
       ],
@@ -2141,16 +2141,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -2316,9 +2316,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
-      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -3073,12 +3073,12 @@
       }
     },
     "node_modules/next": {
-      "version": "14.2.5",
-      "resolved": "https://registry.npmjs.org/next/-/next-14.2.5.tgz",
-      "integrity": "sha512-0f8aRfBVL+mpzfBjYfQuLWh2WyAwtJXCRfkPF4UJ5qd2YwrHczsrSzXU4tRMV0OAxR8ZJZWPFn6uhSC56UTsLA==",
+      "version": "14.2.35",
+      "resolved": "https://registry.npmjs.org/next/-/next-14.2.35.tgz",
+      "integrity": "sha512-KhYd2Hjt/O1/1aZVX3dCwGXM1QmOV4eNM2UTacK5gipDdPN/oHHK/4oVGy7X8GMfPMsUTUEmGlsy0EY1YGAkig==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "14.2.5",
+        "@next/env": "14.2.35",
         "@swc/helpers": "0.5.5",
         "busboy": "1.6.0",
         "caniuse-lite": "^1.0.30001579",
@@ -3093,15 +3093,15 @@
         "node": ">=18.17.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "14.2.5",
-        "@next/swc-darwin-x64": "14.2.5",
-        "@next/swc-linux-arm64-gnu": "14.2.5",
-        "@next/swc-linux-arm64-musl": "14.2.5",
-        "@next/swc-linux-x64-gnu": "14.2.5",
-        "@next/swc-linux-x64-musl": "14.2.5",
-        "@next/swc-win32-arm64-msvc": "14.2.5",
-        "@next/swc-win32-ia32-msvc": "14.2.5",
-        "@next/swc-win32-x64-msvc": "14.2.5"
+        "@next/swc-darwin-arm64": "14.2.33",
+        "@next/swc-darwin-x64": "14.2.33",
+        "@next/swc-linux-arm64-gnu": "14.2.33",
+        "@next/swc-linux-arm64-musl": "14.2.33",
+        "@next/swc-linux-x64-gnu": "14.2.33",
+        "@next/swc-linux-x64-musl": "14.2.33",
+        "@next/swc-win32-arm64-msvc": "14.2.33",
+        "@next/swc-win32-ia32-msvc": "14.2.33",
+        "@next/swc-win32-x64-msvc": "14.2.33"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",
@@ -4658,9 +4658,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@supabase/supabase-js": "2.45.4",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "next": "14.2.5",
+    "next": "^14.2.35",
     "pdf-lib": "^1.17.1",
     "react": "18.3.1",
     "react-dom": "18.3.1",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@supabase/auth-helpers-nextjs": "^0.10.0",
     "@supabase/supabase-js": "2.45.4",
     "class-variance-authority": "^0.7.1",

--- a/tests/crm/customers.route.test.ts
+++ b/tests/crm/customers.route.test.ts
@@ -327,8 +327,12 @@ describe('POST /api/crm/customers — framgång', () => {
 // GET /api/crm/customers/[id]
 // ---------------------------------------------------------------------------
 
+// Route [id] handlers now validate the path segment as a UUID (invalidUuidParam) before
+// touching the DB, so these fixtures use a real UUID instead of a placeholder like 'c1'.
+const CUSTOMER_ID = '11111111-1111-1111-1111-111111111111';
+
 describe('GET /api/crm/customers/[id]', () => {
-  const ctx = { params: { id: 'c1' } };
+  const ctx = { params: { id: CUSTOMER_ID } };
 
   it('returnerar 401 utan session', async () => {
     mockGetCurrentUser.mockResolvedValue(null);
@@ -347,7 +351,7 @@ describe('GET /api/crm/customers/[id]', () => {
 
     expect(res.status).toBe(200);
     expect(body.data.item).toEqual(customer);
-    expect(mockGet).toHaveBeenCalledWith(expect.anything(), 'c1');
+    expect(mockGet).toHaveBeenCalledWith(expect.anything(), CUSTOMER_ID);
   });
 
   it('returnerar 404 om kund inte hittas', async () => {
@@ -358,6 +362,16 @@ describe('GET /api/crm/customers/[id]', () => {
 
     expect(res.status).toBe(404);
   });
+
+  it('returnerar 400 vid ogiltigt (icke-UUID) id utan att röra DB', async () => {
+    mockGetCurrentUser.mockResolvedValue(salesUser);
+    mockGet.mockClear();
+
+    const res = await itemGET(makeRequest('/api/crm/customers/not-a-uuid'), { params: { id: 'not-a-uuid' } });
+
+    expect(res.status).toBe(400);
+    expect(mockGet).not.toHaveBeenCalled();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -365,7 +379,7 @@ describe('GET /api/crm/customers/[id]', () => {
 // ---------------------------------------------------------------------------
 
 describe('PATCH /api/crm/customers/[id]', () => {
-  const ctx = { params: { id: 'c1' } };
+  const ctx = { params: { id: CUSTOMER_ID } };
 
   it('returnerar 401 utan session', async () => {
     mockGetCurrentUser.mockResolvedValue(null);
@@ -407,6 +421,6 @@ describe('PATCH /api/crm/customers/[id]', () => {
 
     expect(res.status).toBe(200);
     expect(body.data.item).toEqual(updated);
-    expect(mockUpdate).toHaveBeenCalledWith(expect.anything(), 'c1', expect.objectContaining({ status: 'inactive' }));
+    expect(mockUpdate).toHaveBeenCalledWith(expect.anything(), CUSTOMER_ID, expect.objectContaining({ status: 'inactive' }));
   });
 });

--- a/tests/crm/customers.route.test.ts
+++ b/tests/crm/customers.route.test.ts
@@ -423,4 +423,37 @@ describe('PATCH /api/crm/customers/[id]', () => {
     expect(body.data.item).toEqual(updated);
     expect(mockUpdate).toHaveBeenCalledWith(expect.anything(), CUSTOMER_ID, expect.objectContaining({ status: 'inactive' }));
   });
+
+  it('blockerar tömning av personnummer på en Fortnox-synkad privatkund (409, ingen skrivning)', async () => {
+    mockGetCurrentUser.mockResolvedValue(salesUser);
+    mockGet.mockResolvedValue({
+      data: { id: CUSTOMER_ID, customer_type: 'private', personal_number: '900101-1234', fortnox_customer_id: '123' },
+      error: null,
+    } as any);
+
+    const res = await PATCH(
+      makeRequest('/api/crm/customers/c1', { method: 'PATCH', body: JSON.stringify({ personal_number: '' }) }),
+      ctx
+    );
+
+    expect(res.status).toBe(409);
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it('tillåter att SÄTTA personnummer på en synkad kund (inte en tömning)', async () => {
+    mockGetCurrentUser.mockResolvedValue(salesUser);
+    mockGet.mockResolvedValue({
+      data: { id: CUSTOMER_ID, customer_type: 'private', personal_number: null, fortnox_customer_id: '123' },
+      error: null,
+    } as any);
+    mockUpdate.mockResolvedValue({ data: { id: CUSTOMER_ID }, error: null } as any);
+
+    const res = await PATCH(
+      makeRequest('/api/crm/customers/c1', { method: 'PATCH', body: JSON.stringify({ personal_number: '900101-1234' }) }),
+      ctx
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockUpdate).toHaveBeenCalled();
+  });
 });

--- a/tests/crm/customers.schema.test.ts
+++ b/tests/crm/customers.schema.test.ts
@@ -68,13 +68,13 @@ describe('createCrmCustomerSchema', () => {
       expect(result.success).toBe(true);
     });
 
-    it('misslyckas utan personnummer', () => {
+    it('godkänner utan personnummer (krävs först vid orderskapande, inte vid kundskapande)', () => {
       const result = createCrmCustomerSchema.safeParse({
         customer_type: 'private',
         first_name: 'Anna',
         last_name: 'Svensson',
       });
-      expect(result.success).toBe(false);
+      expect(result.success).toBe(true);
     });
 
     it('misslyckas utan last_name', () => {

--- a/tests/crm/quotes.test.ts
+++ b/tests/crm/quotes.test.ts
@@ -101,6 +101,23 @@ describe('createCrmQuoteSchema', () => {
     ).toBe(false);
   });
 
+  it('godkänner privatkund UTAN personnummer när ROT inte används (krävs först vid order)', () => {
+    const result = createCrmQuoteSchema.safeParse({
+      ...validQuoteBase, quote_type: 'private', customer_name: 'Anna Svensson',
+      customer_snapshot: { customer_name: 'Anna Svensson' },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('kräver personnummer för privatkund NÄR ROT är på', () => {
+    const result = createCrmQuoteSchema.safeParse({
+      ...validQuoteBase, quote_type: 'private', customer_name: 'Anna Svensson',
+      customer_snapshot: { customer_name: 'Anna Svensson' },
+      rot_details: { enabled: true, property_designation: 'Kv 1', personal_number: '' },
+    });
+    expect(result.success).toBe(false);
+  });
+
   it('misslyckas med ogiltigt datumformat i quote_date', () => {
     expect(
       createCrmQuoteSchema.safeParse({ ...validQuoteBase, quote_date: '04-06-2026' }).success

--- a/tests/crm/work-orders.test.ts
+++ b/tests/crm/work-orders.test.ts
@@ -85,6 +85,22 @@ describe('createCrmWorkOrderFromQuote — fält-mappning', () => {
     expect(captured.insert!.notes).toBeNull();
   });
 
+  it('blockerar privatorder utan personnummer (varken snapshot eller kund)', async () => {
+    const { supabase } = makeSupabase(wonQuote({ quote_type: 'private', customer_id: null, customer_snapshot: { customer_name: 'Anna' } }));
+    const result = await createCrmWorkOrderFromQuote(supabase as any, 'q1', 'user-1');
+    expect(result.reason).toBe('missing_personal_number');
+    expect(result.data).toBeNull();
+  });
+
+  it('tillåter privatorder när snapshot har personnummer, och bevarar det på ordern', async () => {
+    const { supabase, captured } = makeSupabase(
+      wonQuote({ quote_type: 'private', customer_id: null, customer_snapshot: { customer_name: 'Anna', personal_number: '900101-1234' } }),
+    );
+    const result = await createCrmWorkOrderFromQuote(supabase as any, 'q1', 'user-1');
+    expect(result.error).toBeNull();
+    expect(captured.insert!.customer_snapshot.personal_number).toBe('900101-1234');
+  });
+
   it('seedar notes från offertens egna notes när de finns', async () => {
     const { supabase, captured } = makeSupabase(wonQuote({ notes: 'Internt orderunderlag' }));
 

--- a/tests/fortnox/offers.test.ts
+++ b/tests/fortnox/offers.test.ts
@@ -63,12 +63,18 @@ describe('buildOfferRows', () => {
     expect(rows[0].Description).toBe('Bara en fritextrad');
   });
 
-  it('emits the article row, then measurement, then Radtext, in order', () => {
+  it('combines measurement + Radtext into ONE text row under the article (not two)', () => {
+    // Two separate text rows make Fortnox treat the second as a priced product row, so the
+    // measurement and Radtext must share a single text row (newline-separated).
     const rows = buildOfferRows(
       [{ pricing_mode: 'm3', article_name: 'Lösull', m2: '100', thickness_mm: '200', unit_price: '700', line_note: 'Vindsbjälklag' }],
       25, false,
     );
-    expect(rows.map((r) => r.Description)).toEqual(['Lösull', 'Yta: 100 m², Tjocklek: 200 mm', 'Vindsbjälklag']);
+    expect(rows).toHaveLength(2);
+    expect(rows[0].Description).toBe('Lösull');
+    expect(rows[1].Description).toBe('Yta: 100 m², Tjocklek: 200 mm\nVindsbjälklag');
+    expect(rows[1].Quantity).toBeUndefined();
+    expect(rows[1].Price).toBeUndefined();
   });
 
   it('falls back to article_price when unit_price is empty', () => {

--- a/tests/fortnox/offers.test.ts
+++ b/tests/fortnox/offers.test.ts
@@ -48,6 +48,29 @@ describe('buildOfferRows', () => {
     expect(rows).toHaveLength(1);
   });
 
+  it('adds a separate text row for the per-row free text (Radtext) when an article is chosen', () => {
+    const rows = buildOfferRows([{ article_name: 'Lösull', unit_price: '100', quantity: '1', line_note: 'Extra tätning vid genomföringar' }], 25, false);
+    expect(rows).toHaveLength(2);
+    expect(rows[0].Description).toBe('Lösull');
+    expect(rows[1].Description).toBe('Extra tätning vid genomföringar');
+    expect(rows[1].Price).toBeUndefined();
+    expect(rows[1].Quantity).toBeUndefined();
+  });
+
+  it('does not duplicate the Radtext as a text row when it is already the row Description (no article name)', () => {
+    const rows = buildOfferRows([{ unit_price: '100', quantity: '1', line_note: 'Bara en fritextrad' }], 25, false);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].Description).toBe('Bara en fritextrad');
+  });
+
+  it('emits the article row, then measurement, then Radtext, in order', () => {
+    const rows = buildOfferRows(
+      [{ pricing_mode: 'm3', article_name: 'Lösull', m2: '100', thickness_mm: '200', unit_price: '700', line_note: 'Vindsbjälklag' }],
+      25, false,
+    );
+    expect(rows.map((r) => r.Description)).toEqual(['Lösull', 'Yta: 100 m², Tjocklek: 200 mm', 'Vindsbjälklag']);
+  });
+
   it('falls back to article_price when unit_price is empty', () => {
     const [row] = buildOfferRows([{ pricing_mode: 'item', unit_price: '', article_price: 900, quantity: '5' }], 25, false);
     expect(row.Price).toBe(900);

--- a/tests/fortnox/offers.test.ts
+++ b/tests/fortnox/offers.test.ts
@@ -107,19 +107,19 @@ describe('buildOfferRows', () => {
     expect(noDiscount.DiscountType).toBeUndefined();
   });
 
-  it('sets HouseWork true only for ROT rows, and explicit false otherwise (overrides article default)', () => {
+  it('sets HouseWork only for ROT rows, and OMITS it otherwise (never sends false)', () => {
     const [rotRow] = buildOfferRows([{ unit_price: '100', quantity: '1', is_rot_work: true }], 25, true);
     expect(rotRow.HouseWork).toBe(true);
     expect(rotRow.HouseWorkType).toBe('CONSTRUCTION');
 
-    // Non-ROT row on a ROT document → explicit false (not omitted) so Fortnox doesn't inherit a
-    // husarbete-configured article's default and reject the row on a non-ROT document (2004021).
+    // A non-ROT row must NOT carry HouseWork at all — sending false makes Fortnox stamp an empty
+    // husarbete type ('EMPTYHOUSEWORK') that a non-ROT document rejects (2004021).
     const [notRot] = buildOfferRows([{ unit_price: '100', quantity: '1', is_rot_work: false }], 25, true);
-    expect(notRot.HouseWork).toBe(false);
+    expect(notRot.HouseWork).toBeUndefined();
     expect(notRot.HouseWorkType).toBeUndefined();
 
     const [rotDisabled] = buildOfferRows([{ unit_price: '100', quantity: '1', is_rot_work: true }], 25, false);
-    expect(rotDisabled.HouseWork).toBe(false);
+    expect(rotDisabled.HouseWork).toBeUndefined();
   });
 
   it('uses each row\'s own HouseWorkType, defaulting to CONSTRUCTION', () => {

--- a/tests/fortnox/offers.test.ts
+++ b/tests/fortnox/offers.test.ts
@@ -107,16 +107,19 @@ describe('buildOfferRows', () => {
     expect(noDiscount.DiscountType).toBeUndefined();
   });
 
-  it('sets HouseWork only when ROT is enabled and the row is ROT work', () => {
+  it('sets HouseWork true only for ROT rows, and explicit false otherwise (overrides article default)', () => {
     const [rotRow] = buildOfferRows([{ unit_price: '100', quantity: '1', is_rot_work: true }], 25, true);
     expect(rotRow.HouseWork).toBe(true);
     expect(rotRow.HouseWorkType).toBe('CONSTRUCTION');
 
+    // Non-ROT row on a ROT document → explicit false (not omitted) so Fortnox doesn't inherit a
+    // husarbete-configured article's default and reject the row on a non-ROT document (2004021).
     const [notRot] = buildOfferRows([{ unit_price: '100', quantity: '1', is_rot_work: false }], 25, true);
-    expect(notRot.HouseWork).toBeUndefined();
+    expect(notRot.HouseWork).toBe(false);
+    expect(notRot.HouseWorkType).toBeUndefined();
 
     const [rotDisabled] = buildOfferRows([{ unit_price: '100', quantity: '1', is_rot_work: true }], 25, false);
-    expect(rotDisabled.HouseWork).toBeUndefined();
+    expect(rotDisabled.HouseWork).toBe(false);
   });
 
   it('uses each row\'s own HouseWorkType, defaulting to CONSTRUCTION', () => {

--- a/tests/fortnox/orders.test.ts
+++ b/tests/fortnox/orders.test.ts
@@ -49,8 +49,9 @@ describe('buildOrderRows', () => {
   it('marks HouseWork only when ROT is enabled and the row is rot work', () => {
     const [withRot] = buildOrderRows([{ pricing_mode: 'item', unit_price: '100', quantity: '1', is_rot_work: true }], 25, true);
     expect((withRot as any).HouseWork).toBe(true);
+    // Non-ROT → explicit false (overrides any article-level husarbete default; avoids 2004021).
     const [withoutRot] = buildOrderRows([{ pricing_mode: 'item', unit_price: '100', quantity: '1', is_rot_work: true }], 25, false);
-    expect((withoutRot as any).HouseWork).toBeUndefined();
+    expect((withoutRot as any).HouseWork).toBe(false);
   });
 
   // The per-row free text (Radtext) reaches Fortnox as its own text row (no amounts) after

--- a/tests/fortnox/orders.test.ts
+++ b/tests/fortnox/orders.test.ts
@@ -53,6 +53,23 @@ describe('buildOrderRows', () => {
     expect((withoutRot as any).HouseWork).toBeUndefined();
   });
 
+  // The per-row free text (Radtext) reaches Fortnox as its own text row (no amounts) after
+  // the article row — otherwise it is dropped whenever an article is chosen.
+  it('adds a text-only row for the Radtext when an article name is present', () => {
+    const rows = buildOrderRows([{ article_name: 'Lösull', unit_price: '100', quantity: '1', line_note: 'Extra tätning' }], 25, false);
+    expect(rows).toHaveLength(2);
+    expect(rows[0].Description).toBe('Lösull');
+    expect(rows[1].Description).toBe('Extra tätning');
+    expect((rows[1] as any).OrderedQuantity).toBeUndefined();
+    expect((rows[1] as any).Price).toBeUndefined();
+  });
+
+  it('does not duplicate the Radtext when it is already the row Description (no article name)', () => {
+    const rows = buildOrderRows([{ unit_price: '100', quantity: '1', line_note: 'Bara fritext' }], 25, false);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].Description).toBe('Bara fritext');
+  });
+
   it('forces 0 % VAT on rows for reverse charge (byggmoms), else the passed vatPercent', () => {
     const [reverse] = buildOrderRows([{ pricing_mode: 'item', unit_price: '100', quantity: '1' }], 25, false, true);
     expect((reverse as any).VAT).toBe(0);

--- a/tests/fortnox/orders.test.ts
+++ b/tests/fortnox/orders.test.ts
@@ -49,9 +49,9 @@ describe('buildOrderRows', () => {
   it('marks HouseWork only when ROT is enabled and the row is rot work', () => {
     const [withRot] = buildOrderRows([{ pricing_mode: 'item', unit_price: '100', quantity: '1', is_rot_work: true }], 25, true);
     expect((withRot as any).HouseWork).toBe(true);
-    // Non-ROT → explicit false (overrides any article-level husarbete default; avoids 2004021).
+    // Non-ROT → HouseWork omitted (never false — that stamps EMPTYHOUSEWORK and 2004021).
     const [withoutRot] = buildOrderRows([{ pricing_mode: 'item', unit_price: '100', quantity: '1', is_rot_work: true }], 25, false);
-    expect((withoutRot as any).HouseWork).toBe(false);
+    expect((withoutRot as any).HouseWork).toBeUndefined();
   });
 
   // The per-row free text (Radtext) reaches Fortnox as its own text row (no amounts) after

--- a/tests/fortnox/partialInvoices.test.ts
+++ b/tests/fortnox/partialInvoices.test.ts
@@ -103,9 +103,9 @@ describe('buildInvoiceRows', () => {
   it('marks HouseWork only when ROT is enabled and the row is rot work', () => {
     const on = buildInvoiceRows([itemLine({ is_rot_work: true })], new Map([[0, 1]]), 25, true);
     expect(on[0]).toMatchObject({ HouseWork: true, HouseWorkType: 'CONSTRUCTION' });
-    // Non-ROT → explicit false (overrides any article-level husarbete default; avoids 2004021).
+    // Non-ROT → HouseWork omitted (never false — that stamps EMPTYHOUSEWORK and 2004021).
     const off = buildInvoiceRows([itemLine({ is_rot_work: true })], new Map([[0, 1]]), 25, false);
-    expect((off[0] as any).HouseWork).toBe(false);
+    expect((off[0] as any).HouseWork).toBeUndefined();
   });
 
   it('forces 0 % VAT on rows for reverse charge (byggmoms), else the passed vatPercent', () => {

--- a/tests/fortnox/partialInvoices.test.ts
+++ b/tests/fortnox/partialInvoices.test.ts
@@ -103,8 +103,9 @@ describe('buildInvoiceRows', () => {
   it('marks HouseWork only when ROT is enabled and the row is rot work', () => {
     const on = buildInvoiceRows([itemLine({ is_rot_work: true })], new Map([[0, 1]]), 25, true);
     expect(on[0]).toMatchObject({ HouseWork: true, HouseWorkType: 'CONSTRUCTION' });
+    // Non-ROT → explicit false (overrides any article-level husarbete default; avoids 2004021).
     const off = buildInvoiceRows([itemLine({ is_rot_work: true })], new Map([[0, 1]]), 25, false);
-    expect((off[0] as any).HouseWork).toBeUndefined();
+    expect((off[0] as any).HouseWork).toBe(false);
   });
 
   it('forces 0 % VAT on rows for reverse charge (byggmoms), else the passed vatPercent', () => {

--- a/tests/offerter/quote-serializers.test.ts
+++ b/tests/offerter/quote-serializers.test.ts
@@ -28,6 +28,9 @@ function customer(overrides: Partial<QuoteCustomerFields> = {}): QuoteCustomerFi
     delivery_postal_code: '22233',
     delivery_city: 'Göteborg',
     invoice_address: 'Faktura 4',
+    end_contact_name: '',
+    end_contact_phone: '',
+    end_contact_email: '',
     ...overrides,
   };
 }
@@ -130,10 +133,19 @@ describe('buildCustomerSnapshot', () => {
       [
         'city', 'company_name', 'contact_name', 'customer_name', 'delivery_address',
         'delivery_city', 'delivery_postal_code',
-        'email', 'invoice_address', 'organization_number', 'personal_number', 'phone',
+        'email', 'end_contact_email', 'end_contact_name', 'end_contact_phone',
+        'invoice_address', 'organization_number', 'personal_number', 'phone',
         'postal_code', 'reverse_vat', 'street_address', 'visit_address',
       ].sort(),
     );
+  });
+
+  it('end_contact_*: null när inget anges, speglar fälten annars', () => {
+    expect(buildCustomerSnapshot(customer()).end_contact_name).toBeNull();
+    const snap = buildCustomerSnapshot(customer({ end_contact_name: 'Fastighetsägaren', end_contact_phone: '070-1' }));
+    expect(snap.end_contact_name).toBe('Fastighetsägaren');
+    expect(snap.end_contact_phone).toBe('070-1');
+    expect(snap.end_contact_email).toBeNull();
   });
 
   it('reverse_vat: null när inget anges, speglar opts annars', () => {


### PR DESCRIPTION
## Sammanfattning

Pre-launch-polish för CRM:et: gör säljflödet smidigare (personnummer krävs
först vid order, inte vid kund/offert), härdar Fortnox-synken mot kända
API-quirks, och stänger flera 500-läckor med medvetna 403/404-svar. Bygger
vidare på `crm-prelaunch-hardening` (delat kundregister, AO-kommentar-grant,
ROT, reverse VAT, AO-paginering).

**Inga migrationer.** Ren kod (API, domänlager, Fortnox, UI).

## Personnummer: valfritt → krävs vid order
- Personnummer är inte längre obligatoriskt vid kund-skapande eller offert
  (säljaren får det ofta först när jobbet bokas). Undantag: krävs på offert
  när **ROT** är på (kan inte beräknas utan det).
- Kravet flyttat till order-skapandet (`createStandaloneCrmWorkOrder` /
  `createCrmWorkOrderFromQuote`) – Fortnox behöver det som `OrganisationNumber`
  för fakturering. Saknas det svarar API:t `409` och klienten visar en
  personnummer-prompt (både "Ny order" och offert→order), sparar det på
  kundkortet och gör om försöket.
- Kan inte tömma personnr/org.nr på en Fortnox-synkad kund (`409`, skulle
  pusha tomt `OrganisationNumber` och bryta fakturering/ROT).

## Fortnox-synk
- **HouseWork skickas bara på ROT-dokument.** `HouseWork: false` på en icke-ROT-rad
  får Fortnox att stämpla `EMPTYHOUSEWORK`, vilket ett icke-ROT-dokument avvisar
  (2004021). Att utelämna fältet är det som synkar rent.
- **Mått + Radtext slås ihop till en textrad** under artikeln. Två på varandra
  följande textrader fick Fortnox att tolka den andra som en prissatt rad.
- **Separat kontaktperson på arbetsplatsen (slutkund)** utanför kundkortet →
  läggs som notering (`Remarks`) på offert/order och visas för installatören.
- Anti-orphan: `createCustomerInFortnox` länkar `customer_source` på offerten
  *först*, så ett fel i senare steg inte kan dubbla Fortnox-kunden vid retry.
- Push-fel vid offert-skapande ytas nu som `fortnox_error` istället för att
  misslyckas tyst.

## Robusthet / API
- UUID-guards på fler `[id]`-routes (undviker rå 500 från Postgres 22P02).
- `PGRST116` (0 rader) översätts medvetet till `403`/`404` på quote/work-order
  PATCH – en icke-ägare får ett tydligt meddelande, inte en rå 500.
- System-satt fakturastatus (`invoiced`/`partially_invoiced`) kan inte sättas
  eller regreseras manuellt via PATCH; övriga fältredigeringar på en fakturerad
  order fungerar fortfarande.

## UX
- Dra-och-släpp-ordning på offertens artikelrader (`@dnd-kit`).
- Kontaktväljare på offert + order (välj ansvarig kontakt när kunden har flera).
- Arbetsorder: bara arbetsadress redigeras här (faktura/övrigt ligger på
  kundkortet), adress-sök + kontaktväljare, "tillbaka till order"-nav med
  open-redirect-skydd (bara same-origin `/crm/...`).
- Personnummer-input maskas `######-####` i order/offert-prompterna.

## Beroenden
- `next` 14.2.5 → ^14.2.35 (säkerhetspatchar: next/ws/form-data).
- Nya: `@dnd-kit/core`, `@dnd-kit/sortable`, `@dnd-kit/utilities`.
