### PR TITLE
feat(felanmalan): felanmälan + in-app notiscenter

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,6 +43,15 @@ RESEND_API_KEY=
 MAIL_FROM=
 # Receiver for notifications (Andreas)
 OFFERT_CUSTOMER_NOTIFY_TO=
+# Optional extra email recipients for felanmälan (comma-separated). The primary recipients are
+# the arbetsledare in the fault_report_recipients table; this env is only a fallback/override.
+FELANMALAN_NOTIFY_TO=
+# Optional absolute app URL used to build deep links in felanmälan emails (falls back to the
+# request origin). E.g. https://app.ekovilla.se
+NEXT_PUBLIC_APP_URL=
+# Notifications auto-cleanup cron (/api/notifications/cleanup) — authorized by CRON_SECRET (Vercel
+# cron Bearer). NOTIFICATIONS_CLEANUP_SECRET is an optional manual override for x-cleanup-secret.
+NOTIFICATIONS_CLEANUP_SECRET=
 
 # Optional: extra pepper for hashing the token server-side
 OFFERT_CUSTOMER_TOKEN_PEPPER=

--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ Miljövariabler:
 - MAIL_FROM
 - OFFERT_CUSTOMER_NOTIFY_TO — mottagare (Andreas)
 - OFFERT_CUSTOMER_TOKEN_PEPPER — (valfri) extra “pepper” för token-hash
+- FELANMALAN_NOTIFY_TO — (valfri) extra e-postmottagare för felanmälan, kommaseparerat. Primära mottagare styrs av tabellen `fault_report_recipients`; denna env är bara fallback/override.
+- NEXT_PUBLIC_APP_URL — (valfri) absolut app-URL för djuplänkar i felanmälan-mejl (annars request-origin)
+
+Felanmälan-uppsättning (efter migrationer): kör `supabase/sql/20260703_notifications.sql` och sedan `supabase/sql/20260703_fault_reports.sql`, och seeda arbetsledarna i `fault_report_recipients` (se seed-blocket i slutet av fault_reports-filen, eller lägg till via admin senare).
 
 Supabase migrering:
 

--- a/app/_lib/appNav.ts
+++ b/app/_lib/appNav.ts
@@ -29,6 +29,7 @@ export const APP_NAV_ITEMS: AppNavItem[] = [
   { href: '/material-kvalitet', label: 'Materialkvalitet', roles: ['member', 'sales', 'admin'] },
 
   // Shared
+  { href: '/felanmalan', label: 'Felanmälan' },
   { href: '/mina-dokument', label: 'Mina dokument', roles: ['member', 'sales', 'admin'] },
   { href: '/crm/dokument', label: 'Dokument', roles: ['sales', 'admin'] },
   { href: '/kontakt-lista', label: 'Kontakt & adresser' },

--- a/app/api/crm/_shared.ts
+++ b/app/api/crm/_shared.ts
@@ -1,56 +1,10 @@
-import { NextResponse } from 'next/server';
-import { z } from 'zod';
 import { getCurrentUser } from '@/lib/auth/route';
 import { can, getEffectivePermissions, type PermissionKey } from '@/lib/auth/permissions';
+// Generic HTTP response helpers live in one place; re-exported here so the existing CRM route
+// imports (`from '../_shared'`) keep working unchanged.
+import { ok, routeError, validationError, invalidUuidParam, isNoRowsError } from '@/lib/api/responses';
 
-export function ok<T>(data: T, status = 200) {
-  return NextResponse.json({ ok: true, data }, { status, headers: { 'Cache-Control': 'no-store' } });
-}
-
-export function routeError(status: number, code: string, message: string, details?: unknown) {
-  return NextResponse.json(
-    {
-      ok: false,
-      error: message,
-      errorDetails: { code, message, ...(details !== undefined ? { details } : {}) },
-    },
-    { status, headers: { 'Cache-Control': 'no-store' } },
-  );
-}
-
-function getFirstValidationMessage(parsedError: z.ZodError) {
-  const flattened = parsedError.flatten();
-  const fieldErrorGroups = Object.values(flattened.fieldErrors);
-
-  for (const messages of fieldErrorGroups) {
-    const firstMessage = messages?.find(Boolean);
-    if (firstMessage) return firstMessage;
-  }
-
-  return flattened.formErrors.find(Boolean) || 'Invalid request';
-}
-
-export function validationError(parsedError: z.ZodError) {
-  return routeError(400, 'validation_error', getFirstValidationMessage(parsedError), parsedError.flatten());
-}
-
-const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-
-// Validates a dynamic [id] path segment as a UUID before it reaches a `.eq('id', …)` query.
-// A non-UUID id otherwise makes Postgres throw 22P02 ("invalid input syntax for type uuid"),
-// which surfaces as a 500 with a raw DB string. Returns the 400 response to return early, or
-// null when the id is valid.
-export function invalidUuidParam(id: string | undefined) {
-  return id && UUID_RE.test(id) ? null : routeError(400, 'invalid_id', 'Ogiltigt id.');
-}
-
-// PostgREST returns PGRST116 from `.single()` when a statement matched no rows. For a mutation
-// that means the row is either missing OR hidden from this user by RLS — e.g. a non-owner
-// updating a row whose UPDATE policy is owner/admin while its SELECT policy is open to all CRM
-// readers. Callers use this to answer 403/404 deliberately instead of leaking a raw 500.
-export function isNoRowsError(error: { code?: string } | null | undefined): boolean {
-  return error?.code === 'PGRST116';
-}
+export { ok, routeError, validationError, invalidUuidParam, isNoRowsError };
 
 // Keep only the fields the client actually sent. Zod schemas inject defaults for absent
 // fields; persisting those on a partial PATCH would overwrite untouched columns with

--- a/app/api/felanmalan/reports/[id]/route.ts
+++ b/app/api/felanmalan/reports/[id]/route.ts
@@ -1,0 +1,89 @@
+import { cookies } from 'next/headers';
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
+import { getCurrentUser, requireFaultReportRecipient } from '@/lib/auth/route';
+import { getSupabaseAdmin } from '@/lib/supabase/server';
+import { ok, routeError, validationError, invalidUuidParam, isNoRowsError } from '@/lib/api/responses';
+import { updateFaultReportSchema } from '@/lib/domains/fault-reports/schemas';
+import { getFaultReport, listFaultReportUpdates } from '@/lib/domains/fault-reports/queries';
+import { updateFaultReport, addFaultReportUpdate } from '@/lib/domains/fault-reports/mutations';
+import { mapFaultReportRow, mapFaultReportUpdateRows } from '@/lib/domains/fault-reports/mappers';
+import { statusLabel, type FaultReportRow, type FaultReportUpdateRow, type FaultReportView } from '@/lib/domains/fault-reports/types';
+import { buildFaultReportUpdatedNotification } from '@/lib/domains/notifications/payload';
+import { createNotifications, expandNotificationToRecipients } from '@/lib/domains/notifications/mutations';
+
+export async function GET(_req: Request, { params }: { params: { id: string } }) {
+  try {
+    const currentUser = await getCurrentUser();
+    if (!currentUser) return routeError(401, 'unauthorized', 'Unauthorized');
+
+    const badId = invalidUuidParam(params.id);
+    if (badId) return badId;
+
+    const supabase = createRouteHandlerClient({ cookies });
+    // RLS lets reporter OR recipient read; a hidden row returns null.
+    const { data, error } = await getFaultReport(supabase, params.id);
+    if (error) return routeError(500, 'fault_report_get_failed', error.message);
+    if (!data) return routeError(404, 'not_found', 'Ärendet hittades inte.');
+
+    const { data: updates } = await listFaultReportUpdates(supabase, params.id);
+
+    return ok({
+      item: mapFaultReportRow(data as FaultReportRow),
+      updates: mapFaultReportUpdateRows(updates as FaultReportUpdateRow[] | null),
+    });
+  } catch (e: any) {
+    return routeError(500, 'fault_reports_unexpected', e?.message || 'Failed to load fault report');
+  }
+}
+
+export async function PATCH(req: Request, { params }: { params: { id: string } }) {
+  try {
+    const recipient = await requireFaultReportRecipient();
+    if (recipient.response || !recipient.currentUser) return recipient.response;
+
+    const badId = invalidUuidParam(params.id);
+    if (badId) return badId;
+
+    const parsed = updateFaultReportSchema.safeParse(await req.json().catch(() => null));
+    if (!parsed.success) return validationError(parsed.error);
+
+    const supabase = createRouteHandlerClient({ cookies });
+    const { data, error } = await updateFaultReport(supabase, params.id, {
+      ...parsed.data,
+      responder_id: recipient.currentUser.id,
+      responder_name: recipient.currentUser.name || 'Arbetsledare',
+    });
+    if (isNoRowsError(error)) return routeError(404, 'not_found', 'Ärendet hittades inte.');
+    if (error || !data) return routeError(500, 'fault_report_update_failed', error?.message || 'Update failed');
+
+    // Parent row is committed → the save succeeded. Append history + notify the reporter
+    // best-effort; a transient failure here must not report a false error to the supervisor
+    // (which would prompt a retry and a duplicate history entry).
+    const { error: historyError } = await addFaultReportUpdate(supabase, {
+      report_id: data.id,
+      status: parsed.data.status,
+      reply: parsed.data.reply,
+      responder_id: recipient.currentUser.id,
+      responder_name: recipient.currentUser.name || 'Arbetsledare',
+    });
+    if (historyError) console.error('[felanmalan] history insert failed', historyError);
+
+    await notifyReporter(data).catch((e) => console.error('[felanmalan] reporter notify failed', e));
+
+    return ok({ item: data });
+  } catch (e: any) {
+    return routeError(500, 'fault_reports_unexpected', e?.message || 'Failed to update fault report');
+  }
+}
+
+async function notifyReporter(report: FaultReportView) {
+  if (!report.reporter_id) return;
+  const admin = getSupabaseAdmin();
+  const content = buildFaultReportUpdatedNotification({
+    reportId: report.id,
+    categoryLabel: report.category_label,
+    reporterName: report.reporter_name,
+    statusLabel: statusLabel[report.status],
+  });
+  await createNotifications(admin, expandNotificationToRecipients(content, [report.reporter_id]));
+}

--- a/app/api/felanmalan/reports/route.ts
+++ b/app/api/felanmalan/reports/route.ts
@@ -1,0 +1,112 @@
+import { cookies } from 'next/headers';
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
+import { getCurrentUser, requireFaultReportRecipient } from '@/lib/auth/route';
+import { getSupabaseAdmin } from '@/lib/supabase/server';
+import { sendEmail } from '@/lib/email';
+import { ok, routeError, validationError } from '@/lib/api/responses';
+import {
+  createFaultReportSchema,
+  listFaultReportsQuerySchema,
+} from '@/lib/domains/fault-reports/schemas';
+import { createFaultReport } from '@/lib/domains/fault-reports/mutations';
+import { listInboxFaultReports, listMyFaultReports } from '@/lib/domains/fault-reports/queries';
+import { mapFaultReportRows } from '@/lib/domains/fault-reports/mappers';
+import { listActiveRecipients, resolveRecipientEmails, dedupeEmails } from '@/lib/domains/fault-reports/recipients';
+import { buildFaultReportEmail } from '@/lib/domains/fault-reports/email';
+import type { FaultReportRow, FaultReportView } from '@/lib/domains/fault-reports/types';
+import { buildFaultReportCreatedNotification } from '@/lib/domains/notifications/payload';
+import { createNotifications, expandNotificationToRecipients } from '@/lib/domains/notifications/mutations';
+
+export async function GET(req: Request) {
+  try {
+    const currentUser = await getCurrentUser();
+    if (!currentUser) return routeError(401, 'unauthorized', 'Unauthorized');
+
+    const url = new URL(req.url);
+    const parsed = listFaultReportsQuerySchema.safeParse({
+      scope: url.searchParams.get('scope') ?? undefined,
+      status: url.searchParams.get('status') ?? undefined,
+    });
+    if (!parsed.success) return validationError(parsed.error);
+
+    const supabase = createRouteHandlerClient({ cookies });
+
+    if (parsed.data.scope === 'inbox') {
+      const recipient = await requireFaultReportRecipient();
+      if (recipient.response) return recipient.response;
+      const { data, error } = await listInboxFaultReports(supabase, { status: parsed.data.status });
+      if (error) return routeError(500, 'fault_reports_list_failed', error.message);
+      return ok({ items: mapFaultReportRows(data as FaultReportRow[] | null) });
+    }
+
+    const { data, error } = await listMyFaultReports(supabase, currentUser.id);
+    if (error) return routeError(500, 'fault_reports_list_failed', error.message);
+    return ok({ items: mapFaultReportRows(data as FaultReportRow[] | null) });
+  } catch (e: any) {
+    return routeError(500, 'fault_reports_unexpected', e?.message || 'Failed to list fault reports');
+  }
+}
+
+export async function POST(req: Request) {
+  try {
+    const currentUser = await getCurrentUser();
+    if (!currentUser) return routeError(401, 'unauthorized', 'Unauthorized');
+
+    const parsed = createFaultReportSchema.safeParse(await req.json().catch(() => null));
+    if (!parsed.success) return validationError(parsed.error);
+
+    const supabase = createRouteHandlerClient({ cookies });
+    const { data, error } = await createFaultReport(supabase, {
+      ...parsed.data,
+      reporter_id: currentUser.id,
+      reporter_name: currentUser.name || 'Okänd användare',
+    });
+    if (error || !data) return routeError(500, 'fault_report_create_failed', error?.message || 'Insert failed');
+
+    // Fan-out (best-effort — never fail the user's submission on notify errors).
+    await fanOutNewReport(data, req).catch((e) => console.error('[felanmalan] fan-out failed', e));
+
+    return ok({ item: data }, 201);
+  } catch (e: any) {
+    return routeError(500, 'fault_reports_unexpected', e?.message || 'Failed to create fault report');
+  }
+}
+
+async function fanOutNewReport(report: FaultReportView, req: Request) {
+  const admin = getSupabaseAdmin();
+  const recipientIds = await listActiveRecipients(admin);
+  // Don't notify the reporter about their own report (they may themselves be a supervisor).
+  const notifyIds = recipientIds.filter((id) => id !== report.reporter_id);
+
+  // In-app notifications (one per recipient), when there are any.
+  if (notifyIds.length > 0) {
+    const content = buildFaultReportCreatedNotification({
+      reportId: report.id,
+      categoryLabel: report.category_label,
+      reporterName: report.reporter_name,
+    });
+    await createNotifications(admin, expandNotificationToRecipients(content, notifyIds));
+  }
+
+  // Email: resolved supervisor addresses + the FELANMALAN_NOTIFY_TO fallback/override. Runs even
+  // when the recipients table is empty, so the env fallback still reaches someone.
+  const resolved = await resolveRecipientEmails(admin, notifyIds);
+  const envList = (process.env.FELANMALAN_NOTIFY_TO || '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+  const emails = dedupeEmails([...resolved, ...envList]);
+  if (emails.length === 0) return;
+
+  const origin = safeOrigin(req);
+  const { subject, html, text } = buildFaultReportEmail(report, origin);
+  await sendEmail({ to: emails, subject, html, text });
+}
+
+function safeOrigin(req: Request): string | undefined {
+  try {
+    return process.env.NEXT_PUBLIC_APP_URL || new URL(req.url).origin;
+  } catch {
+    return undefined;
+  }
+}

--- a/app/api/notifications/[id]/read/route.ts
+++ b/app/api/notifications/[id]/read/route.ts
@@ -1,0 +1,23 @@
+import { cookies } from 'next/headers';
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
+import { getCurrentUser } from '@/lib/auth/route';
+import { ok, routeError, invalidUuidParam } from '@/lib/api/responses';
+import { markNotificationRead } from '@/lib/domains/notifications/mutations';
+
+export async function POST(_req: Request, { params }: { params: { id: string } }) {
+  try {
+    const currentUser = await getCurrentUser();
+    if (!currentUser) return routeError(401, 'unauthorized', 'Unauthorized');
+
+    const badId = invalidUuidParam(params.id);
+    if (badId) return badId;
+
+    const supabase = createRouteHandlerClient({ cookies });
+    const { error } = await markNotificationRead(supabase, params.id);
+    if (error) return routeError(500, 'notification_read_failed', error.message);
+
+    return ok({ id: params.id });
+  } catch (e: any) {
+    return routeError(500, 'notifications_unexpected', e?.message || 'Failed to mark read');
+  }
+}

--- a/app/api/notifications/cleanup/route.ts
+++ b/app/api/notifications/cleanup/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getOptionalSupabaseAdmin } from '@/lib/supabase/server';
+import { pruneReadNotifications } from '@/lib/domains/notifications/mutations';
+
+export const dynamic = 'force-dynamic';
+
+// Auto-gallring av lästa notiser (D). Scheduled via vercel.json cron; Vercel sends
+// `Authorization: Bearer <CRON_SECRET>`. Deletes READ notifications older than 30 days so the
+// table stays tidy; unread rows are never touched. Allowlisted in middleware.ts.
+const RETENTION_DAYS = 30;
+
+function isAuthorizedCron(req: NextRequest): boolean {
+  const cronSecret = (process.env.CRON_SECRET || '').trim();
+  const custom = (process.env.NOTIFICATIONS_CLEANUP_SECRET || '').trim();
+  const authHeader = String(req.headers.get('authorization') || '').trim();
+  const bearer = authHeader.toLowerCase().startsWith('bearer ') ? authHeader.slice(7).trim() : '';
+  const headerSecret = String(req.headers.get('x-cleanup-secret') || '').trim();
+
+  if (cronSecret && bearer === cronSecret) return true;
+  if (custom && (bearer === custom || headerSecret === custom)) return true;
+  return false;
+}
+
+async function run(req: NextRequest) {
+  if (!isAuthorizedCron(req)) {
+    return NextResponse.json({ ok: false, error: 'unauthorized' }, { status: 401 });
+  }
+
+  const admin = getOptionalSupabaseAdmin();
+  if (!admin) {
+    return NextResponse.json({ ok: false, error: 'service_role_missing' }, { status: 500 });
+  }
+
+  const { data, error } = await pruneReadNotifications(admin, RETENTION_DAYS);
+  if (error) {
+    return NextResponse.json({ ok: false, error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ ok: true, data: { deleted: data?.length ?? 0, retentionDays: RETENTION_DAYS } });
+}
+
+export async function POST(req: NextRequest) {
+  return run(req);
+}
+
+export async function GET(req: NextRequest) {
+  return run(req);
+}

--- a/app/api/notifications/read-all/route.ts
+++ b/app/api/notifications/read-all/route.ts
@@ -1,0 +1,20 @@
+import { cookies } from 'next/headers';
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
+import { getCurrentUser } from '@/lib/auth/route';
+import { ok, routeError } from '@/lib/api/responses';
+import { markAllNotificationsRead } from '@/lib/domains/notifications/mutations';
+
+export async function POST() {
+  try {
+    const currentUser = await getCurrentUser();
+    if (!currentUser) return routeError(401, 'unauthorized', 'Unauthorized');
+
+    const supabase = createRouteHandlerClient({ cookies });
+    const { error } = await markAllNotificationsRead(supabase, currentUser.id);
+    if (error) return routeError(500, 'notifications_read_all_failed', error.message);
+
+    return ok({ ok: true });
+  } catch (e: any) {
+    return routeError(500, 'notifications_unexpected', e?.message || 'Failed to mark all read');
+  }
+}

--- a/app/api/notifications/route.ts
+++ b/app/api/notifications/route.ts
@@ -1,0 +1,31 @@
+import { cookies } from 'next/headers';
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
+import { getCurrentUser } from '@/lib/auth/route';
+import { ok, routeError, validationError } from '@/lib/api/responses';
+import { listNotificationsQuerySchema } from '@/lib/domains/notifications/schemas';
+import { listNotifications } from '@/lib/domains/notifications/queries';
+import { mapNotificationRows } from '@/lib/domains/notifications/mappers';
+import type { NotificationRow } from '@/lib/domains/notifications/types';
+
+export async function GET(req: Request) {
+  try {
+    const currentUser = await getCurrentUser();
+    if (!currentUser) return routeError(401, 'unauthorized', 'Unauthorized');
+
+    const url = new URL(req.url);
+    const parsed = listNotificationsQuerySchema.safeParse({
+      unreadOnly: url.searchParams.get('unreadOnly') ?? undefined,
+      limit: url.searchParams.get('limit') ?? undefined,
+      before: url.searchParams.get('before') ?? undefined,
+    });
+    if (!parsed.success) return validationError(parsed.error);
+
+    const supabase = createRouteHandlerClient({ cookies });
+    const { data, error } = await listNotifications(supabase, parsed.data);
+    if (error) return routeError(500, 'notifications_list_failed', error.message);
+
+    return ok({ items: mapNotificationRows(data as NotificationRow[] | null) });
+  } catch (e: any) {
+    return routeError(500, 'notifications_unexpected', e?.message || 'Failed to list notifications');
+  }
+}

--- a/app/api/notifications/unread-count/route.ts
+++ b/app/api/notifications/unread-count/route.ts
@@ -1,0 +1,20 @@
+import { cookies } from 'next/headers';
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
+import { getCurrentUser } from '@/lib/auth/route';
+import { ok, routeError } from '@/lib/api/responses';
+import { countUnreadNotifications } from '@/lib/domains/notifications/queries';
+
+export async function GET() {
+  try {
+    const currentUser = await getCurrentUser();
+    if (!currentUser) return routeError(401, 'unauthorized', 'Unauthorized');
+
+    const supabase = createRouteHandlerClient({ cookies });
+    const { count, error } = await countUnreadNotifications(supabase, currentUser.id);
+    if (error) return routeError(500, 'notifications_count_failed', error.message);
+
+    return ok({ count: count ?? 0 });
+  } catch (e: any) {
+    return routeError(500, 'notifications_unexpected', e?.message || 'Failed to count notifications');
+  }
+}

--- a/app/components/AppSidebar.tsx
+++ b/app/components/AppSidebar.tsx
@@ -8,6 +8,7 @@ import type { UserRole } from '@/lib/roles';
 import { getVisibleCrmNavItems } from '../crm/_lib/nav';
 import { getVisibleAppNavItems } from '../_lib/appNav';
 import ProfileMenu from './ProfileMenu';
+import NotificationBell from '@/components/notifications/NotificationBell';
 
 // Unified, context-aware app sidebar. Outside /crm it shows the app-level nav;
 // inside /crm it swaps to the CRM nav (plus a "back to start" item). Mirrors the
@@ -175,6 +176,11 @@ const navIcons: Record<string, JSX.Element> = {
       <path d="M4 4h13v16H6a2 2 0 01-2-2z" /><path d="M17 8h3v10a2 2 0 01-2 2" /><line x1="7" y1="8" x2="14" y2="8" /><line x1="7" y1="12" x2="14" y2="12" /><line x1="7" y1="16" x2="11" y2="16" />
     </svg>
   ),
+  '/felanmalan': (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" /><line x1="12" y1="9" x2="12" y2="13" /><line x1="12" y1="17" x2="12.01" y2="17" />
+    </svg>
+  ),
   '/admin': (
     <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
       <path d="M12 3l7 4v5c0 5-3.5 8-7 9-3.5-1-7-4-7-9V7l7-4z" /><path d="M10 11l2 2 4-4" />
@@ -286,6 +292,7 @@ export default function AppSidebar({
           <img src="/brand/Ekovilla_vit.png" alt="Ekovilla" className="h-5 w-auto" />
           <span className="text-[11px] font-medium" style={{ color: 'var(--crm-sidebar-text-muted)' }}>{brandSub}</span>
         </Link>
+        <NotificationBell className="ml-auto" />
         <button
           type="button"
           onClick={() => setMobileOpen(true)}
@@ -293,7 +300,7 @@ export default function AppSidebar({
           aria-haspopup="dialog"
           aria-expanded={mobileOpen}
           aria-controls="app-sidebar-nav"
-          className="ml-auto flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border border-white/25 bg-white/10 text-white transition-colors hover:bg-white/20"
+          className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border border-white/25 bg-white/10 text-white transition-colors hover:bg-white/20"
         >
           <svg width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
             <line x1="3" y1="6" x2="21" y2="6" /><line x1="3" y1="12" x2="21" y2="12" /><line x1="3" y1="18" x2="21" y2="18" />
@@ -346,16 +353,20 @@ export default function AppSidebar({
             {/* eslint-disable-next-line @next/next/no-img-element */}
             <img src="/brand/Ekovilla_logga_vit.png" alt="Ekovilla" className="h-6 w-6 object-contain" />
           </Link>
-          <button
-            type="button"
-            onClick={toggleCollapsed}
-            aria-label={collapsed ? 'Visa meny' : 'Fäll ihop meny'}
-            className="hidden h-8 w-8 shrink-0 place-items-center rounded-lg text-white/80 transition-colors hover:bg-white/10 hover:text-white lg:grid"
-          >
-            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.9" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true" className={cn('transition-transform', collapsed && 'rotate-180')}>
-              <polyline points="15 18 9 12 15 6" />
-            </svg>
-          </button>
+          {/* Desktop: notification bell + collapse toggle, grouped top-right (mobile has the bell in the top bar). */}
+          <div className={cn('ml-auto hidden items-center gap-1 lg:flex', collapsed ? 'lg:ml-0 lg:flex-col' : 'lg:self-start')}>
+            <NotificationBell collapsed={collapsed} className="!h-8 !w-8 !rounded-lg !border !border-white/20 !bg-transparent !p-0 !text-white/80 hover:!border-white/30 hover:!bg-white/10 hover:!text-white" />
+            <button
+              type="button"
+              onClick={toggleCollapsed}
+              aria-label={collapsed ? 'Visa meny' : 'Fäll ihop meny'}
+              className="grid h-8 w-8 shrink-0 place-items-center rounded-lg text-white/80 transition-colors hover:bg-white/10 hover:text-white"
+            >
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.9" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true" className={cn('transition-transform', collapsed && 'rotate-180')}>
+                <polyline points="15 18 9 12 15 6" />
+              </svg>
+            </button>
+          </div>
           <button
             type="button"
             onClick={() => setMobileOpen(false)}

--- a/app/felanmalan/FelanmalanClient.tsx
+++ b/app/felanmalan/FelanmalanClient.tsx
@@ -1,0 +1,430 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { cn } from '@/lib/shared/cn';
+import { crm } from '@/app/crm/lib/crmTokens';
+import CrmModal from '@/app/crm/components/CrmModal';
+import Select from '@/components/ui/Select';
+import Textarea from '@/components/ui/Textarea';
+import { useToast } from '@/lib/Toast';
+import {
+  FAULT_CATEGORIES,
+  FAULT_STATUSES,
+  categoryLabel,
+  statusLabel,
+  type FaultCategory,
+  type FaultStatus,
+  type FaultReportView,
+  type FaultReportUpdateView,
+} from '@/lib/domains/fault-reports/types';
+
+const NOTICE = 'Detta skickas till arbetsledare som tar vid och återkopplar sedan till dig i ärendet.';
+
+const statusMeta: Record<FaultStatus, { badge: string; accent: string }> = {
+  new: { badge: 'border-sky-200 bg-sky-50 text-sky-800', accent: 'bg-sky-400' },
+  in_progress: { badge: 'border-amber-200 bg-amber-50 text-amber-800', accent: 'bg-amber-400' },
+  resolved: { badge: 'border-emerald-200 bg-emerald-50 text-emerald-700', accent: 'bg-emerald-500' },
+};
+
+type Tab = 'new' | 'mine' | 'inbox';
+
+export default function FelanmalanClient({ isRecipient }: { isRecipient: boolean }) {
+  const searchParams = useSearchParams();
+  const deepLinkId = searchParams.get('arende');
+  const deepLinkScope = searchParams.get('scope');
+
+  const [tab, setTab] = useState<Tab>(deepLinkScope === 'inbox' && isRecipient ? 'inbox' : deepLinkId ? 'mine' : 'new');
+  const [detail, setDetail] = useState<FaultReportView | null>(null);
+  const [reloadToken, setReloadToken] = useState(0);
+
+  return (
+    <div className="grid grid-cols-1 gap-4">
+      <header className="grid gap-1">
+        <h1 className={crm.pageTitle}>Felanmälan</h1>
+        <p className={crm.pageSubtitle}>Anmäl trasig utrustning — arbetsledare tar vid och återkopplar i ärendet.</p>
+      </header>
+
+      <div role="tablist" aria-label="Felanmälan" className="flex flex-wrap gap-2">
+        <TabButton active={tab === 'new'} onClick={() => setTab('new')}>Ny felanmälan</TabButton>
+        <TabButton active={tab === 'mine'} onClick={() => setTab('mine')}>Mina ärenden</TabButton>
+        {isRecipient && <TabButton active={tab === 'inbox'} onClick={() => setTab('inbox')}>Inkorg</TabButton>}
+      </div>
+
+      {tab === 'new' && <NewReportForm onCreated={() => { setTab('mine'); setReloadToken((t) => t + 1); }} />}
+      {tab === 'mine' && <ReportList scope="mine" onOpen={setDetail} deepLinkId={deepLinkId} reloadToken={reloadToken} />}
+      {tab === 'inbox' && isRecipient && <ReportList scope="inbox" onOpen={setDetail} deepLinkId={deepLinkScope === 'inbox' ? deepLinkId : null} reloadToken={reloadToken} />}
+
+      {detail && (
+        <ReportDetailModal
+          reportId={detail.id}
+          initial={detail}
+          canRespond={isRecipient}
+          onClose={() => setDetail(null)}
+          onChanged={() => setReloadToken((t) => t + 1)}
+        />
+      )}
+    </div>
+  );
+}
+
+function TabButton({ active, onClick, children }: { active: boolean; onClick: () => void; children: React.ReactNode }) {
+  return (
+    <button
+      type="button"
+      role="tab"
+      aria-selected={active}
+      onClick={onClick}
+      className={cn(
+        'rounded-full border px-3.5 py-1.5 text-[13px] font-semibold transition-colors',
+        active
+          ? 'border-emerald-200 bg-emerald-50 text-emerald-700 shadow-[0_8px_20px_rgba(20,44,27,0.08)]'
+          : 'border-[#e0e8dc] bg-white text-slate-700 hover:border-emerald-200 hover:bg-[#f9fbf7]',
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
+function NewReportForm({ onCreated }: { onCreated: () => void }) {
+  const toast = useToast();
+  const [category, setCategory] = useState<FaultCategory | ''>('');
+  const [comment, setComment] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    if (!category) { setError('Välj vad felanmälan gäller.'); return; }
+    if (!comment.trim()) { setError('Beskriv vad som är fel.'); return; }
+    setSubmitting(true);
+    try {
+      const res = await fetch('/api/felanmalan/reports', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ category, comment: comment.trim() }),
+      });
+      const j = await res.json().catch(() => null);
+      if (!res.ok) throw new Error(j?.error || 'Kunde inte skicka felanmälan.');
+      toast.success('Felanmälan skickad — arbetsledare är notifierade.');
+      setCategory('');
+      setComment('');
+      onCreated();
+    } catch (err: any) {
+      setError(err?.message || 'Kunde inte skicka felanmälan.');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <form onSubmit={submit} className={cn(crm.cardInner, 'grid max-w-2xl gap-4')}>
+      <div className="grid gap-1.5">
+        <label htmlFor="fault-category" className={crm.label}>Vad gäller det?</label>
+        <Select
+          id="fault-category"
+          value={category}
+          onChange={(e) => setCategory(e.target.value as FaultCategory)}
+          disabled={submitting}
+        >
+          <option value="" disabled>Välj utrustning…</option>
+          {FAULT_CATEGORIES.map((c) => (
+            <option key={c} value={c}>{categoryLabel[c]}</option>
+          ))}
+        </Select>
+      </div>
+
+      <div className="grid gap-1.5">
+        <label htmlFor="fault-comment" className={crm.label}>Vad är fel?</label>
+        <Textarea
+          id="fault-comment"
+          value={comment}
+          onChange={(e) => setComment(e.target.value)}
+          placeholder="Beskriv felet så tydligt du kan…"
+          disabled={submitting}
+        />
+      </div>
+
+      {error && <p className="m-0 text-sm text-red-700">{error}</p>}
+
+      <p className="m-0 rounded-lg border border-[#e0e8dc] bg-[#eef4ea] px-3.5 py-2.5 text-[13px] text-slate-600">
+        {NOTICE}
+      </p>
+
+      <div>
+        <button
+          type="submit"
+          disabled={submitting}
+          className={cn(crm.primaryButton, 'disabled:cursor-not-allowed disabled:opacity-60')}
+          style={{ backgroundColor: 'var(--crm-primary)' }}
+        >
+          {submitting ? 'Skickar…' : 'Anmäl'}
+        </button>
+      </div>
+    </form>
+  );
+}
+
+function ReportList({ scope, onOpen, deepLinkId, reloadToken }: { scope: 'mine' | 'inbox'; onOpen: (r: FaultReportView) => void; deepLinkId: string | null; reloadToken: number }) {
+  const [items, setItems] = useState<FaultReportView[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [statusFilter, setStatusFilter] = useState<FaultStatus | 'all'>('all');
+
+  const load = useCallback(async () => {
+    setLoading(true); setError(null);
+    try {
+      const res = await fetch(`/api/felanmalan/reports?scope=${scope}`, { cache: 'no-store' });
+      const j = await res.json().catch(() => null);
+      if (!res.ok) throw new Error(j?.error || 'Kunde inte ladda ärenden.');
+      setItems((j?.data?.items || []) as FaultReportView[]);
+    } catch (err: any) {
+      setError(err?.message || 'Kunde inte ladda ärenden.');
+    } finally {
+      setLoading(false);
+    }
+  }, [scope]);
+
+  useEffect(() => { load(); }, [load, reloadToken]);
+
+  // Auto-open a deep-linked ärende ONCE per id — not on every subsequent reload (a reply save
+  // bumps reloadToken → load() toggles `loading`, which would otherwise re-open the modal).
+  const openedDeepLinkRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!deepLinkId || loading) return;
+    if (openedDeepLinkRef.current === deepLinkId) return;
+    const found = items.find((r) => r.id === deepLinkId);
+    if (found) {
+      openedDeepLinkRef.current = deepLinkId;
+      onOpen(found);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [deepLinkId, loading]);
+
+  const visible = useMemo(
+    () => (statusFilter === 'all' ? items : items.filter((r) => r.status === statusFilter)),
+    [items, statusFilter],
+  );
+
+  return (
+    <div className="grid gap-3">
+      {scope === 'inbox' && (
+        <div className="flex flex-wrap gap-2">
+          <FilterChip active={statusFilter === 'all'} onClick={() => setStatusFilter('all')}>Alla ({items.length})</FilterChip>
+          {FAULT_STATUSES.map((s) => (
+            <FilterChip key={s} active={statusFilter === s} onClick={() => setStatusFilter(s)}>
+              {statusLabel[s]} ({items.filter((r) => r.status === s).length})
+            </FilterChip>
+          ))}
+        </div>
+      )}
+
+      {loading && <p className="m-0 text-sm text-slate-500">Laddar…</p>}
+      {error && <p className="m-0 text-sm text-red-700">{error}</p>}
+      {!loading && !error && visible.length === 0 && (
+        <div className="rounded-2xl border border-dashed border-[#d5e0cf] bg-[#f4f8f1] px-4 py-8 text-center">
+          <p className="m-0 text-sm text-slate-500">
+            {scope === 'mine' ? 'Du har inga felanmälningar ännu.' : 'Inga felanmälningar här.'}
+          </p>
+        </div>
+      )}
+
+      {!loading && !error && visible.length > 0 && (
+        <ul role="list" className="m-0 grid list-none gap-1 p-0">
+          {visible.map((r) => (
+            <li key={r.id}>
+              <button
+                type="button"
+                onClick={() => onOpen(r)}
+                className="group flex w-full items-stretch overflow-hidden rounded-lg border border-[#e0e8dc] bg-white text-left shadow-[0_1px_2px_rgba(15,23,42,0.05)] transition-colors hover:border-[#cfdcc9]"
+              >
+                <span className={cn('w-1.5 shrink-0', statusMeta[r.status].accent)} aria-hidden />
+                <span className="grid flex-1 gap-0.5 px-3 py-2">
+                  <span className="flex items-center gap-2">
+                    <span className="text-[13px] font-bold text-slate-900">{r.category_label}</span>
+                    <span className={cn(crm.badge, statusMeta[r.status].badge)}>{r.status_label}</span>
+                  </span>
+                  <span className="line-clamp-1 text-[12px] text-slate-600">{r.comment}</span>
+                  <span className="text-[11px] text-slate-400">
+                    {scope === 'inbox' ? `${r.reporter_name} · ` : ''}{formatDate(r.created_at)}
+                    {r.reply ? ' · Besvarad' : ''}
+                  </span>
+                </span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function FilterChip({ active, onClick, children }: { active: boolean; onClick: () => void; children: React.ReactNode }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        'rounded-full border px-2.5 py-1 text-[13px] font-semibold transition-colors',
+        active ? 'border-emerald-200 bg-emerald-50 text-emerald-700' : 'border-[#e0e8dc] bg-white text-slate-600 hover:border-emerald-200',
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
+function ReportDetailModal({
+  reportId,
+  initial,
+  canRespond,
+  onClose,
+  onChanged,
+}: {
+  reportId: string;
+  initial: FaultReportView;
+  canRespond: boolean;
+  onClose: () => void;
+  onChanged: () => void;
+}) {
+  const toast = useToast();
+  const [report, setReport] = useState<FaultReportView>(initial);
+  const [history, setHistory] = useState<FaultReportUpdateView[]>([]);
+  const [loading, setLoading] = useState(true);
+  // Status defaults to the current one; the reply field starts EMPTY — each save is a NEW entry,
+  // never an edit of a previous reply (so we never accidentally resend the last one).
+  const [status, setStatus] = useState<FaultStatus>(initial.status);
+  const [reply, setReply] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadDetail = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/felanmalan/reports/${reportId}`, { cache: 'no-store' });
+      const j = await res.json().catch(() => null);
+      if (res.ok && j?.data) {
+        setReport(j.data.item as FaultReportView);
+        setHistory((j.data.updates || []) as FaultReportUpdateView[]);
+        setStatus((j.data.item as FaultReportView).status);
+      }
+    } catch { /* keep the initial snapshot */ } finally {
+      setLoading(false);
+    }
+  }, [reportId]);
+
+  useEffect(() => { loadDetail(); }, [loadDetail]);
+
+  const save = async () => {
+    setSaving(true); setError(null);
+    try {
+      const res = await fetch(`/api/felanmalan/reports/${reportId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status, reply: reply.trim() || null }),
+      });
+      const j = await res.json().catch(() => null);
+      if (!res.ok) throw new Error(j?.error || 'Kunde inte spara.');
+      toast.success('Ärendet uppdaterat — anmälaren är notifierad.');
+      setReply('');
+      await loadDetail();
+      onChanged();
+    } catch (err: any) {
+      setError(err?.message || 'Kunde inte spara.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <CrmModal
+      onClose={onClose}
+      ariaLabel="Felanmälan"
+      maxWidth="sm:max-w-[560px]"
+      header={
+        <div className="grid gap-0.5">
+          <div className="flex items-center gap-2">
+            <h2 className="m-0 text-base font-bold text-slate-900">{report.category_label}</h2>
+            <span className={cn(crm.badge, statusMeta[report.status].badge)}>{report.status_label}</span>
+          </div>
+          <p className="m-0 text-[12px] text-slate-500">{report.reporter_name} · {formatDate(report.created_at)}</p>
+        </div>
+      }
+      footer={
+        canRespond ? (
+          <>
+            <button type="button" onClick={onClose} className={cn(crm.ghostButton, 'flex-1 sm:flex-none sm:px-5')}>Stäng</button>
+            <button
+              type="button"
+              onClick={save}
+              disabled={saving}
+              className={cn(crm.primaryButton, 'flex-1 justify-center disabled:opacity-60 sm:flex-none sm:px-5')}
+              style={{ backgroundColor: 'var(--crm-primary)' }}
+            >
+              {saving ? 'Sparar…' : 'Spara & återkoppla'}
+            </button>
+          </>
+        ) : (
+          <button type="button" onClick={onClose} className={cn(crm.ghostButton, 'flex-1 sm:flex-none sm:px-5')}>Stäng</button>
+        )
+      }
+    >
+      <div className="grid gap-4">
+        <div className="grid gap-1">
+          <span className={crm.label}>Beskrivning</span>
+          <p className="m-0 whitespace-pre-wrap text-sm text-slate-800">{report.comment}</p>
+        </div>
+
+        {/* History timeline — everything a supervisor has sent, oldest first. */}
+        <div className="grid gap-1.5">
+          <span className={crm.label}>Historik</span>
+          {loading ? (
+            <p className="m-0 text-sm text-slate-400">Laddar…</p>
+          ) : history.length === 0 ? (
+            <p className="m-0 text-sm italic text-slate-400">Ingen återkoppling ännu.</p>
+          ) : (
+            <ul role="list" className="m-0 grid list-none gap-2 p-0">
+              {history.map((h) => (
+                <li key={h.id} className="grid gap-1 rounded-lg border border-[#e0e8dc] bg-white px-3 py-2">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className={cn(crm.badge, statusMeta[h.status].badge)}>{h.status_label}</span>
+                    <span className="text-[11px] text-slate-400">{h.responder_name} · {formatDate(h.created_at)}</span>
+                  </div>
+                  {h.reply && <p className="m-0 whitespace-pre-wrap text-sm text-slate-800">{h.reply}</p>}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+
+        {canRespond && (
+          <div className="grid gap-4 border-t border-slate-100 pt-4">
+            <div className="grid gap-1.5">
+              <label htmlFor="fault-status" className={crm.label}>Ny status</label>
+              <Select id="fault-status" value={status} onChange={(e) => setStatus(e.target.value as FaultStatus)} disabled={saving}>
+                {FAULT_STATUSES.map((s) => (
+                  <option key={s} value={s}>{statusLabel[s]}</option>
+                ))}
+              </Select>
+            </div>
+            <div className="grid gap-1.5">
+              <label htmlFor="fault-reply" className={crm.label}>Nytt svar till anmälaren</label>
+              <Textarea id="fault-reply" value={reply} onChange={(e) => setReply(e.target.value)} placeholder="Skriv en återkoppling…" disabled={saving} />
+            </div>
+            {error && <p className="m-0 text-sm text-red-700">{error}</p>}
+          </div>
+        )}
+      </div>
+    </CrmModal>
+  );
+}
+
+function formatDate(iso: string): string {
+  try {
+    return new Date(iso).toLocaleString('sv-SE', { day: 'numeric', month: 'short', hour: '2-digit', minute: '2-digit' });
+  } catch {
+    return '';
+  }
+}

--- a/app/felanmalan/page.tsx
+++ b/app/felanmalan/page.tsx
@@ -1,0 +1,29 @@
+import { Suspense } from 'react';
+import { cookies } from 'next/headers';
+import { createServerComponentClient } from '@supabase/auth-helpers-nextjs';
+import { redirect } from 'next/navigation';
+import FelanmalanClient from './FelanmalanClient';
+
+export const dynamic = 'force-dynamic';
+
+// Thin server wrapper: middleware already auth-gates this route, but we resolve the session to
+// determine whether the user is an arbetsledare (recipient) so the "Inkorg" tab is only shown to
+// them. Data loading happens in the client via /api/felanmalan/*.
+export default async function FelanmalanPage() {
+  const supabase = createServerComponentClient({ cookies });
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) redirect('/auth/sign-in');
+
+  const { data: recipient } = await supabase
+    .from('fault_report_recipients')
+    .select('user_id')
+    .eq('user_id', user.id)
+    .eq('active', true)
+    .maybeSingle();
+
+  return (
+    <Suspense fallback={null}>
+      <FelanmalanClient isRecipient={!!recipient} />
+    </Suspense>
+  );
+}

--- a/components/dashboard/ClientDashboard.tsx
+++ b/components/dashboard/ClientDashboard.tsx
@@ -110,6 +110,12 @@ const baseExtra: Record<string, Omit<QuickLink, 'href' | 'title'>> = {
       <path d="M8 9h8M8 12h8M8 15h5" strokeLinecap="round" />
     </svg>
   ) },
+  '/felanmalan': { desc: 'Anmäl trasig utrustning', icon: (
+    <svg width="28" height="28" viewBox="0 0 24 24" strokeWidth={1.7} stroke="currentColor" fill="none" aria-hidden>
+      <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" strokeLinecap="round" strokeLinejoin="round" />
+      <path d="M12 9v4M12 17h.01" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  ) },
 };
 
 const cardClass = cn(crm.cardInner, 'min-h-0');
@@ -162,11 +168,13 @@ export function ClientDashboard({ role }: { role: UserRole | null }) {
         { href: '/offert/kalkylator', title: 'Kalkylator Försäljning Privat', ...baseExtra['/offert/kalkylator'] },
         { href: '/crm/dokument', title: 'Dokument', ...baseExtra['/crm/dokument'] },
         { href: '/kontakt-lista', title: 'Kontakt', ...baseExtra['/kontakt-lista'] },
+        { href: '/felanmalan', title: 'Felanmälan', ...baseExtra['/felanmalan'] },
       ];
     }
     if (effectiveRole === 'member') {
       return [
         { href: '/egenkontroll', title: 'Skapa egenkontroll', ...baseExtra['/egenkontroll'] },
+        { href: '/felanmalan', title: 'Felanmälan', ...baseExtra['/felanmalan'] },
         { href: '/bestallning-klader', title: 'Beställ kläder & annat', ...baseExtra['/bestallning-klader'] },
         { href: '/tidrapport', title: 'Tidrapport', ...baseExtra['/tidrapport'] },
         { href: '/kontakt-lista', title: 'Kontakt', ...baseExtra['/kontakt-lista'] },
@@ -184,6 +192,7 @@ export function ClientDashboard({ role }: { role: UserRole | null }) {
         { href: '/mina-dokument', title: 'Mina dokument', ...baseExtra['/mina-dokument'] },
         { href: '/crm/dokument', title: 'Dokument', ...baseExtra['/crm/dokument'] },
         { href: '/offert/kalkylator', title: 'Kalkylator Försäljning Privat', ...baseExtra['/offert/kalkylator'] },
+        { href: '/felanmalan', title: 'Felanmälan', ...baseExtra['/felanmalan'] },
       ];
     }
     if (effectiveRole === 'admin') {
@@ -198,9 +207,13 @@ export function ClientDashboard({ role }: { role: UserRole | null }) {
         { href: '/crm/dokument', title: 'Dokument', ...baseExtra['/crm/dokument'] },
         { href: '/admin', title: 'Admin', ...baseExtra['/admin'] },
         { href: '/offert/kalkylator', title: 'Kalkylator Försäljning Privat', ...baseExtra['/offert/kalkylator'] },
+        { href: '/felanmalan', title: 'Felanmälan', ...baseExtra['/felanmalan'] },
       ];
     }
-    return [{ href: '/egenkontroll', title: 'Egenkontroll', ...baseExtra['/egenkontroll'] }];
+    return [
+      { href: '/egenkontroll', title: 'Egenkontroll', ...baseExtra['/egenkontroll'] },
+      { href: '/felanmalan', title: 'Felanmälan', ...baseExtra['/felanmalan'] },
+    ];
   }, [effectiveRole, role]);
 
   const [timeModalOpen, setTimeModalOpen] = useState(false);

--- a/components/notifications/NotificationBell.tsx
+++ b/components/notifications/NotificationBell.tsx
@@ -1,0 +1,242 @@
+"use client";
+
+import { useCallback, useEffect, useId, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { useRouter } from 'next/navigation';
+import { createClientComponentClient } from '@supabase/auth-helpers-nextjs';
+import { cn } from '@/lib/shared/cn';
+import { mapNotificationRow } from '@/lib/domains/notifications/mappers';
+import type { NotificationRow, NotificationView } from '@/lib/domains/notifications/types';
+
+// App-shell notification bell. Self-contained: fetches its own user + data, subscribes to
+// Realtime so the badge and list stay live. Reusable for any notification type. Rendered in
+// AppSidebar (mobile top bar + desktop account footer).
+export default function NotificationBell({ className, collapsed = false }: { className?: string; collapsed?: boolean }) {
+  const supabase = createClientComponentClient();
+  const router = useRouter();
+  // Unique per instance: the mobile top-bar bell and the desktop sidebar bell are BOTH mounted
+  // (CSS-hidden, not unmounted) on one singleton client, so a shared channel name would collide
+  // (duplicate subscribe → CHANNEL_ERROR) and break live updates.
+  const channelId = useId();
+  const [userId, setUserId] = useState<string | null>(null);
+  const [unread, setUnread] = useState(0);
+  const [items, setItems] = useState<NotificationView[]>([]);
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [mounted, setMounted] = useState(false);
+  // Panelen visar OLÄSTA som standard; "Visa lästa" växlar till hela historiken (30 senaste).
+  const [showRead, setShowRead] = useState(false);
+  const showReadRef = useRef(false);
+
+  useEffect(() => setMounted(true), []);
+  useEffect(() => { showReadRef.current = showRead; }, [showRead]);
+
+  // Resolve the current user + initial unread count.
+  useEffect(() => {
+    let alive = true;
+    (async () => {
+      try {
+        const { data: { user } } = await supabase.auth.getUser();
+        if (!alive || !user) return;
+        setUserId(user.id);
+        const res = await fetch('/api/notifications/unread-count', { cache: 'no-store' });
+        if (!alive || !res.ok) return;
+        const j = await res.json();
+        setUnread(j?.data?.count ?? 0);
+      } catch { /* ignore */ }
+    })();
+    return () => { alive = false; };
+  }, [supabase]);
+
+  // Realtime: keep the badge + open list live. Filter to our own rows client-side.
+  useEffect(() => {
+    if (!userId) return;
+    const channel = supabase
+      .channel(`realtime:notifications:${channelId}`)
+      .on('postgres_changes', { event: '*', schema: 'public', table: 'notifications' }, (payload) => {
+        const row: any = payload.eventType === 'DELETE' ? payload.old : payload.new;
+        if (!row || row.recipient_user_id !== userId) return;
+        if (payload.eventType === 'INSERT') {
+          setUnread((c) => c + 1);
+          setItems((prev) => (prev.some((n) => n.id === row.id) ? prev : [mapNotificationRow(row as NotificationRow), ...prev]));
+        } else if (payload.eventType === 'UPDATE') {
+          setItems((prev) => {
+            const next = prev.map((n) => (n.id === row.id ? mapNotificationRow(row as NotificationRow) : n));
+            // In unread-only mode a row that just became read leaves the list.
+            return showReadRef.current ? next : next.filter((n) => !n.read);
+          });
+          // Recompute badge from the freshest server truth rather than guessing deltas.
+          refreshCount();
+        } else if (payload.eventType === 'DELETE') {
+          setItems((prev) => prev.filter((n) => n.id !== row.id));
+          refreshCount();
+        }
+      })
+      .subscribe();
+    return () => { supabase.removeChannel(channel); };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [supabase, userId]);
+
+  const refreshCount = useCallback(async () => {
+    try {
+      const res = await fetch('/api/notifications/unread-count', { cache: 'no-store' });
+      if (!res.ok) return;
+      const j = await res.json();
+      setUnread(j?.data?.count ?? 0);
+    } catch { /* ignore */ }
+  }, []);
+
+  const loadList = useCallback(async () => {
+    setLoading(true); setError(null);
+    try {
+      const res = await fetch(`/api/notifications?limit=30&unreadOnly=${!showRead}`, { cache: 'no-store' });
+      if (!res.ok) throw new Error('failed');
+      const j = await res.json();
+      setItems((j?.data?.items || []) as NotificationView[]);
+    } catch {
+      setError('Kunde inte ladda notiser.');
+    } finally {
+      setLoading(false);
+    }
+  }, [showRead]);
+
+  const openPanel = () => { setOpen(true); loadList(); };
+
+  // Reload when the reader toggles between unread-only and all (only while the panel is open).
+  useEffect(() => { if (open) loadList(); /* eslint-disable-next-line react-hooks/exhaustive-deps */ }, [showRead]);
+
+  const onRowClick = async (n: NotificationView) => {
+    setOpen(false);
+    if (!n.read) {
+      // In unread-only mode the row leaves the list once read; otherwise it just greys out.
+      setItems((prev) => (showReadRef.current ? prev.map((x) => (x.id === n.id ? { ...x, read: true } : x)) : prev.filter((x) => x.id !== n.id)));
+      setUnread((c) => Math.max(0, c - 1));
+      try { await fetch(`/api/notifications/${n.id}/read`, { method: 'POST' }); } catch { /* ignore */ }
+    }
+    if (n.href) router.push(n.href);
+  };
+
+  const markAll = async () => {
+    // Unread-only view empties; "show read" view keeps rows but greys them.
+    setItems((prev) => (showReadRef.current ? prev.map((x) => ({ ...x, read: true })) : []));
+    setUnread(0);
+    try { await fetch('/api/notifications/read-all', { method: 'POST' }); } catch { /* ignore */ }
+  };
+
+  const badge = unread > 99 ? '99+' : String(unread);
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={openPanel}
+        aria-label={unread > 0 ? `Notiser (${unread} olästa)` : 'Notiser'}
+        className={cn(
+          'relative flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border border-white/25 bg-white/10 text-white transition-colors hover:bg-white/20',
+          className,
+        )}
+      >
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.9" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+          <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9" />
+          <path d="M13.73 21a2 2 0 0 1-3.46 0" />
+        </svg>
+        {unread > 0 && (
+          <span className="absolute -right-1 -top-1 flex min-w-[18px] items-center justify-center rounded-full bg-red-500 px-1 text-[10px] font-bold leading-[18px] text-white">
+            {badge}
+          </span>
+        )}
+      </button>
+
+      {mounted && open && createPortal(
+        <div
+          className="crm-overlay-in fixed inset-0 z-[2900] flex items-start justify-center bg-slate-950/50 px-3 [backdrop-filter:blur(4px)] lg:justify-start lg:px-0"
+          onClick={() => setOpen(false)}
+        >
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-label="Notiser"
+            onClick={(e) => e.stopPropagation()}
+            className={cn(
+              // Phone / tablet (< lg): a centred top dropdown below the top bar. Desktop (lg): a
+              // sheet anchored just right of the sidebar — offset follows the collapsed width.
+              'mt-[calc(3.75rem+env(safe-area-inset-top))] flex max-h-[75dvh] w-full flex-col overflow-hidden rounded-2xl bg-white shadow-[0_20px_50px_rgba(15,23,42,0.30)] sm:w-[380px] lg:mt-3 lg:max-h-[70vh] lg:shadow-[0_30px_80px_rgba(15,23,42,0.28)]',
+              collapsed ? 'lg:ml-[5rem]' : 'lg:ml-[14.75rem]',
+            )}
+          >
+            <div className="flex items-center justify-between gap-3 border-b border-slate-100 px-4 py-3">
+              <strong className="text-sm font-bold text-slate-900">Notiser</strong>
+              <div className="flex items-center gap-2">
+                {items.some((n) => !n.read) && (
+                  <button type="button" onClick={markAll} className="text-[12px] font-semibold text-emerald-700 hover:text-emerald-800">
+                    Markera alla som lästa
+                  </button>
+                )}
+                <button type="button" onClick={() => setShowRead((s) => !s)} className="text-[12px] font-semibold text-slate-500 hover:text-slate-700">
+                  {showRead ? 'Visa olästa' : 'Visa lästa'}
+                </button>
+                <button
+                  type="button"
+                  aria-label="Stäng"
+                  onClick={() => setOpen(false)}
+                  className="flex h-8 w-8 items-center justify-center !rounded-full !border !border-slate-200 !bg-slate-50 !p-0 text-slate-500 transition hover:!bg-slate-100 hover:text-slate-700"
+                >
+                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                    <path d="M18 6L6 18M6 6l12 12" />
+                  </svg>
+                </button>
+              </div>
+            </div>
+
+            <div className="flex-1 overflow-y-auto [padding-bottom:env(safe-area-inset-bottom)]">
+              {loading && <p className="m-0 px-4 py-6 text-center text-xs text-slate-500">Laddar…</p>}
+              {error && <p className="m-0 px-4 py-6 text-center text-xs text-red-700">{error}</p>}
+              {!loading && !error && items.length === 0 && (
+                <p className="m-0 px-4 py-8 text-center text-sm text-slate-500">
+                  {showRead ? 'Inga notiser ännu.' : 'Inga olästa notiser.'}
+                </p>
+              )}
+              {!loading && !error && items.length > 0 && (
+                <ul role="list" className="m-0 grid list-none gap-0 p-0">
+                  {items.map((n) => (
+                    <li key={n.id}>
+                      <button
+                        type="button"
+                        onClick={() => onRowClick(n)}
+                        className={cn(
+                          'grid w-full gap-0.5 border-b border-slate-100 px-4 py-3 text-left transition-colors hover:bg-slate-50',
+                          !n.read && 'bg-emerald-50/50',
+                        )}
+                      >
+                        <div className="flex items-center gap-2">
+                          {!n.read && <span className="h-2 w-2 shrink-0 rounded-full bg-emerald-500" aria-hidden />}
+                          <span className={cn('text-[13px] text-slate-900', !n.read ? 'font-bold' : 'font-semibold')}>{n.title}</span>
+                        </div>
+                        {n.body && <span className="text-[12px] text-slate-600">{n.body}</span>}
+                        <span className="text-[11px] text-slate-400">{formatWhen(n.created_at)}</span>
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          </div>
+        </div>,
+        document.body,
+      )}
+    </>
+  );
+}
+
+function formatWhen(iso: string): string {
+  try {
+    const d = new Date(iso);
+    const now = new Date();
+    const sameDay = d.toDateString() === now.toDateString();
+    if (sameDay) return d.toLocaleTimeString('sv-SE', { hour: '2-digit', minute: '2-digit' });
+    return d.toLocaleDateString('sv-SE', { day: 'numeric', month: 'short' });
+  } catch {
+    return '';
+  }
+}

--- a/lib/api/responses.ts
+++ b/lib/api/responses.ts
@@ -1,0 +1,53 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+
+// Shared HTTP response helpers for non-CRM API routes. Mirrors the shape used by the CRM
+// surface (app/api/crm/_shared.ts) exactly — `error` is the human string the client toasts,
+// `errorDetails` carries the machine-readable { code, message, details }. Kept identical so the
+// whole app parses one response shape; do not introduce a third variant.
+
+export function ok<T>(data: T, status = 200) {
+  return NextResponse.json({ ok: true, data }, { status, headers: { 'Cache-Control': 'no-store' } });
+}
+
+export function routeError(status: number, code: string, message: string, details?: unknown) {
+  return NextResponse.json(
+    {
+      ok: false,
+      error: message,
+      errorDetails: { code, message, ...(details !== undefined ? { details } : {}) },
+    },
+    { status, headers: { 'Cache-Control': 'no-store' } },
+  );
+}
+
+function getFirstValidationMessage(parsedError: z.ZodError) {
+  const flattened = parsedError.flatten();
+  const fieldErrorGroups = Object.values(flattened.fieldErrors);
+
+  for (const messages of fieldErrorGroups) {
+    const firstMessage = messages?.find(Boolean);
+    if (firstMessage) return firstMessage;
+  }
+
+  return flattened.formErrors.find(Boolean) || 'Invalid request';
+}
+
+export function validationError(parsedError: z.ZodError) {
+  return routeError(400, 'validation_error', getFirstValidationMessage(parsedError), parsedError.flatten());
+}
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+// Guards a dynamic [id] path segment before it reaches a `.eq('id', …)` query. A non-UUID id
+// otherwise makes Postgres throw 22P02, surfacing as a raw 500. Returns a 400 to return early,
+// or null when the id is valid.
+export function invalidUuidParam(id: string | undefined) {
+  return id && UUID_RE.test(id) ? null : routeError(400, 'invalid_id', 'Ogiltigt id.');
+}
+
+// PostgREST returns PGRST116 from `.single()` when a statement matched no rows — the row is
+// missing OR hidden by RLS. Lets callers answer 403/404 deliberately instead of leaking a 500.
+export function isNoRowsError(error: { code?: string } | null | undefined): boolean {
+  return error?.code === 'PGRST116';
+}

--- a/lib/auth/route.ts
+++ b/lib/auth/route.ts
@@ -43,6 +43,30 @@ export async function requireAdminUser() {
   return currentUser;
 }
 
+// Fault-report supervisor guard. Reads the SAME source as the fault_reports RLS
+// (is_fault_report_recipient) via the session client, so the route check and RLS agree. Returns
+// the { currentUser, response } shape the CRM guards use.
+export async function requireFaultReportRecipient() {
+  const currentUser = await getCurrentUser();
+  if (!currentUser) {
+    return { currentUser: null, response: NextResponse.json({ ok: false, error: 'Unauthorized' }, { status: 401 }) };
+  }
+
+  const supabase = createRouteHandlerClient({ cookies });
+  const { data, error } = await supabase
+    .from('fault_report_recipients')
+    .select('user_id')
+    .eq('user_id', currentUser.id)
+    .eq('active', true)
+    .maybeSingle();
+
+  if (error || !data) {
+    return { currentUser: null, response: NextResponse.json({ ok: false, error: 'Forbidden' }, { status: 403 }) };
+  }
+
+  return { currentUser, response: null as null };
+}
+
 export async function forbidIfReadonly() {
   const currentUser = await getCurrentUser();
   if (!currentUser) {

--- a/lib/domains/fault-reports/email.ts
+++ b/lib/domains/fault-reports/email.ts
@@ -1,0 +1,35 @@
+import type { FaultReportView } from './types';
+
+// Pure builder for the internal "ny felanmälan" email to arbetsledare (unit tested). No I/O —
+// the route resolves recipients and calls sendEmail with this.
+export function buildFaultReportEmail(report: FaultReportView, appBaseUrl?: string): { subject: string; html: string; text: string } {
+  const base = (appBaseUrl || '').replace(/\/$/, '');
+  const link = `${base}/felanmalan?arende=${report.id}&scope=inbox`;
+  const subject = `Ny felanmälan: ${report.category_label}`;
+
+  const text = [
+    'En ny felanmälan har registrerats.',
+    '',
+    `Utrustning: ${report.category_label}`,
+    `Anmäld av: ${report.reporter_name}`,
+    '',
+    'Beskrivning:',
+    report.comment,
+    '',
+    base ? `Öppna ärendet: ${link}` : 'Öppna Felanmälan i appen för att ta vid.',
+  ].join('\n');
+
+  const esc = (s: string) => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  const html = `
+    <div style="font-family:Arial,Helvetica,sans-serif;color:#0f172a;line-height:1.5">
+      <h2 style="margin:0 0 12px">Ny felanmälan</h2>
+      <p style="margin:0 0 4px"><strong>Utrustning:</strong> ${esc(report.category_label)}</p>
+      <p style="margin:0 0 12px"><strong>Anmäld av:</strong> ${esc(report.reporter_name)}</p>
+      <p style="margin:0 0 4px"><strong>Beskrivning:</strong></p>
+      <p style="margin:0 0 16px;white-space:pre-wrap">${esc(report.comment)}</p>
+      ${base ? `<p style="margin:0"><a href="${link}" style="color:#1a3f26;font-weight:bold">Öppna ärendet</a></p>` : '<p style="margin:0">Öppna Felanmälan i appen för att ta vid.</p>'}
+    </div>
+  `.trim();
+
+  return { subject, html, text };
+}

--- a/lib/domains/fault-reports/mappers.ts
+++ b/lib/domains/fault-reports/mappers.ts
@@ -1,0 +1,50 @@
+import {
+  categoryLabel,
+  statusLabel,
+  toFaultCategory,
+  toFaultStatus,
+  type FaultReportRow,
+  type FaultReportView,
+  type FaultReportUpdateRow,
+  type FaultReportUpdateView,
+} from './types';
+
+export function mapFaultReportRow(row: FaultReportRow): FaultReportView {
+  const category = toFaultCategory(row.category) ?? 'maskiner';
+  const status = toFaultStatus(row.status);
+  return {
+    id: row.id,
+    reporter_id: row.reporter_id,
+    reporter_name: row.reporter_name,
+    category,
+    category_label: categoryLabel[category],
+    comment: row.comment,
+    status,
+    status_label: statusLabel[status],
+    reply: row.reply,
+    responder_name: row.responder_name,
+    responded_at: row.responded_at,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+  };
+}
+
+export function mapFaultReportRows(rows: FaultReportRow[] | null | undefined): FaultReportView[] {
+  return (rows || []).map(mapFaultReportRow);
+}
+
+export function mapFaultReportUpdateRow(row: FaultReportUpdateRow): FaultReportUpdateView {
+  const status = toFaultStatus(row.status);
+  return {
+    id: row.id,
+    status,
+    status_label: statusLabel[status],
+    reply: row.reply,
+    responder_name: row.responder_name,
+    created_at: row.created_at,
+  };
+}
+
+export function mapFaultReportUpdateRows(rows: FaultReportUpdateRow[] | null | undefined): FaultReportUpdateView[] {
+  return (rows || []).map(mapFaultReportUpdateRow);
+}

--- a/lib/domains/fault-reports/mutations.ts
+++ b/lib/domains/fault-reports/mutations.ts
@@ -1,0 +1,67 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { CreateFaultReportInput, UpdateFaultReportInput } from './schemas';
+import { mapFaultReportRow } from './mappers';
+import type { FaultReportRow, FaultReportView } from './types';
+
+const faultReportSelect =
+  'id, reporter_id, reporter_name, category, comment, status, reply, responder_id, responder_name, responded_at, created_at, updated_at';
+
+type MutationResult = { data: FaultReportView | null; error: { message: string; code?: string } | null };
+
+// Create a fault report as the current user (session client — RLS enforces reporter_id).
+export async function createFaultReport(
+  supabase: SupabaseClient,
+  input: CreateFaultReportInput & { reporter_id: string; reporter_name: string },
+): Promise<MutationResult> {
+  const result = await supabase
+    .from('fault_reports')
+    .insert({
+      reporter_id: input.reporter_id,
+      reporter_name: input.reporter_name,
+      category: input.category,
+      comment: input.comment,
+    })
+    .select(faultReportSelect)
+    .single();
+
+  return { data: result.data ? mapFaultReportRow(result.data as FaultReportRow) : null, error: result.error };
+}
+
+// Append one immutable history entry (status + reply at this moment). Called alongside
+// updateFaultReport so the ärende keeps a timeline of everything a supervisor has sent.
+export async function addFaultReportUpdate(
+  supabase: SupabaseClient,
+  input: { report_id: string; status: string; reply: string | null; responder_id: string; responder_name: string },
+) {
+  return supabase.from('fault_report_updates').insert({
+    report_id: input.report_id,
+    status: input.status,
+    reply: input.reply,
+    responder_id: input.responder_id,
+    responder_name: input.responder_name,
+  });
+}
+
+// Supervisor update: set status + reply, stamp responder + responded_at + updated_at.
+export async function updateFaultReport(
+  supabase: SupabaseClient,
+  id: string,
+  input: UpdateFaultReportInput & { responder_id: string; responder_name: string },
+): Promise<MutationResult> {
+  const now = new Date().toISOString();
+  const result = await supabase
+    .from('fault_reports')
+    .update({
+      status: input.status,
+      reply: input.reply,
+      responder_id: input.responder_id,
+      responder_name: input.responder_name,
+      responded_at: now,
+      updated_at: now,
+    })
+    .eq('id', id)
+    .select(faultReportSelect)
+    .single();
+
+  return { data: result.data ? mapFaultReportRow(result.data as FaultReportRow) : null, error: result.error };
+}

--- a/lib/domains/fault-reports/queries.ts
+++ b/lib/domains/fault-reports/queries.ts
@@ -1,0 +1,46 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { FaultStatus } from './types';
+
+const faultReportSelect =
+  'id, reporter_id, reporter_name, category, comment, status, reply, responder_id, responder_name, responded_at, created_at, updated_at';
+
+// The caller's own reports ("Mina ärenden"). Small set (one user) — no pagination needed.
+export async function listMyFaultReports(supabase: SupabaseClient, reporterId: string) {
+  return supabase
+    .from('fault_reports')
+    .select(faultReportSelect)
+    .eq('reporter_id', reporterId)
+    .order('created_at', { ascending: false })
+    .limit(100);
+}
+
+// Supervisor inbox. Constrained (optional status filter) + capped well under the PostgREST row
+// cap. Unresolved-first isn't expressible in one order, so order by recency; the UI filters.
+export async function listInboxFaultReports(supabase: SupabaseClient, options: { status?: FaultStatus } = {}) {
+  let query = supabase
+    .from('fault_reports')
+    .select(faultReportSelect)
+    .order('created_at', { ascending: false })
+    .limit(200);
+
+  if (options.status) {
+    query = query.eq('status', options.status);
+  }
+
+  return query;
+}
+
+export async function getFaultReport(supabase: SupabaseClient, id: string) {
+  return supabase.from('fault_reports').select(faultReportSelect).eq('id', id).maybeSingle();
+}
+
+// The append-only reply/status history for a report, oldest first (a timeline). RLS scopes it to
+// the reporter or a supervisor.
+export async function listFaultReportUpdates(supabase: SupabaseClient, reportId: string) {
+  return supabase
+    .from('fault_report_updates')
+    .select('id, report_id, status, reply, responder_id, responder_name, created_at')
+    .eq('report_id', reportId)
+    .order('created_at', { ascending: true })
+    .limit(100);
+}

--- a/lib/domains/fault-reports/recipients.ts
+++ b/lib/domains/fault-reports/recipients.ts
@@ -1,0 +1,54 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+// The fixed, admin-managed set of arbetsledare who receive fault reports (in-app + email).
+
+// List active recipient user_ids. Call with the service-role client (getSupabaseAdmin()) from the
+// fan-out path so it sees every recipient regardless of the caller's RLS scope.
+export async function listActiveRecipients(admin: SupabaseClient): Promise<string[]> {
+  const { data, error } = await admin.from('fault_report_recipients').select('user_id').eq('active', true);
+  if (error) return [];
+  return dedupeRecipients((data || []).map((r: { user_id: string }) => r.user_id));
+}
+
+// Resolve emails for the given user_ids. Emails live on the auth user, not profiles, so this uses
+// the admin auth API (service-role only). Tolerates missing/blank emails.
+export async function resolveRecipientEmails(admin: SupabaseClient, userIds: string[]): Promise<string[]> {
+  const emails: string[] = [];
+  for (const id of dedupeRecipients(userIds)) {
+    try {
+      const { data } = await admin.auth.admin.getUserById(id);
+      const email = data?.user?.email?.trim();
+      if (email) emails.push(email);
+    } catch {
+      /* skip an unresolvable recipient rather than failing the whole send */
+    }
+  }
+  return dedupeEmails(emails);
+}
+
+// Pure helpers (unit tested).
+export function dedupeRecipients(ids: Array<string | null | undefined>): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const id of ids) {
+    const v = (id || '').trim();
+    if (!v || seen.has(v)) continue;
+    seen.add(v);
+    out.push(v);
+  }
+  return out;
+}
+
+export function dedupeEmails(emails: Array<string | null | undefined>): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const raw of emails) {
+    const v = (raw || '').trim();
+    if (!v) continue;
+    const key = v.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(v);
+  }
+  return out;
+}

--- a/lib/domains/fault-reports/schemas.ts
+++ b/lib/domains/fault-reports/schemas.ts
@@ -1,0 +1,29 @@
+import { z } from 'zod';
+import { FAULT_CATEGORIES, FAULT_STATUSES } from './types';
+
+export const createFaultReportSchema = z.object({
+  category: z.enum(FAULT_CATEGORIES, { errorMap: () => ({ message: 'Välj vad felanmälan gäller' }) }),
+  comment: z.string().trim().min(1, 'Beskriv vad som är fel'),
+});
+
+export type CreateFaultReportInput = z.infer<typeof createFaultReportSchema>;
+
+// Supervisor update: status is required, reply optional (empty → null).
+export const updateFaultReportSchema = z.object({
+  status: z.enum(FAULT_STATUSES, { errorMap: () => ({ message: 'Ogiltig status' }) }),
+  reply: z.preprocess((v) => {
+    if (v == null) return null;
+    const t = String(v).trim();
+    return t.length > 0 ? t : null;
+  }, z.string().nullable()).optional().default(null),
+});
+
+export type UpdateFaultReportInput = z.infer<typeof updateFaultReportSchema>;
+
+// Query for the list route.
+export const listFaultReportsQuerySchema = z.object({
+  scope: z.enum(['mine', 'inbox']).optional().default('mine'),
+  status: z.enum(FAULT_STATUSES).optional(),
+});
+
+export type ListFaultReportsQuery = z.infer<typeof listFaultReportsQuerySchema>;

--- a/lib/domains/fault-reports/types.ts
+++ b/lib/domains/fault-reports/types.ts
@@ -1,0 +1,81 @@
+// Felanmälan domain types. DB stores stable English keys (text + CHECK); Swedish labels live
+// here so the UI and notifications render consistently.
+
+export const FAULT_CATEGORIES = ['truck', 'lager', 'lastbil', 'isoleringsmaskin', 'maskiner'] as const;
+export type FaultCategory = (typeof FAULT_CATEGORIES)[number];
+
+export const FAULT_STATUSES = ['new', 'in_progress', 'resolved'] as const;
+export type FaultStatus = (typeof FAULT_STATUSES)[number];
+
+export const categoryLabel: Record<FaultCategory, string> = {
+  truck: 'Truck',
+  lager: 'Lager',
+  lastbil: 'Lastbil',
+  isoleringsmaskin: 'Isoleringsmaskin',
+  maskiner: 'Maskiner',
+};
+
+export const statusLabel: Record<FaultStatus, string> = {
+  new: 'Ny',
+  in_progress: 'Pågår',
+  resolved: 'Åtgärdad',
+};
+
+export function toFaultCategory(value: unknown): FaultCategory | null {
+  return FAULT_CATEGORIES.includes(value as FaultCategory) ? (value as FaultCategory) : null;
+}
+
+export function toFaultStatus(value: unknown): FaultStatus {
+  return FAULT_STATUSES.includes(value as FaultStatus) ? (value as FaultStatus) : 'new';
+}
+
+export type FaultReportRow = {
+  id: string;
+  reporter_id: string | null;
+  reporter_name: string;
+  category: string;
+  comment: string;
+  status: string;
+  reply: string | null;
+  responder_id: string | null;
+  responder_name: string | null;
+  responded_at: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+// One append-only history entry (a supervisor status/reply at a point in time).
+export type FaultReportUpdateRow = {
+  id: string;
+  report_id: string;
+  status: string;
+  reply: string | null;
+  responder_id: string | null;
+  responder_name: string;
+  created_at: string;
+};
+
+export type FaultReportUpdateView = {
+  id: string;
+  status: FaultStatus;
+  status_label: string;
+  reply: string | null;
+  responder_name: string;
+  created_at: string;
+};
+
+export type FaultReportView = {
+  id: string;
+  reporter_id: string | null;
+  reporter_name: string;
+  category: FaultCategory;
+  category_label: string;
+  comment: string;
+  status: FaultStatus;
+  status_label: string;
+  reply: string | null;
+  responder_name: string | null;
+  responded_at: string | null;
+  created_at: string;
+  updated_at: string;
+};

--- a/lib/domains/notifications/mappers.ts
+++ b/lib/domains/notifications/mappers.ts
@@ -1,0 +1,21 @@
+import type { NotificationRow, NotificationView } from './types';
+
+// Row → view model. Derives the `read` boolean so the client doesn't reason about read_at.
+export function mapNotificationRow(row: NotificationRow): NotificationView {
+  return {
+    id: row.id,
+    type: row.type,
+    title: row.title,
+    body: row.body,
+    href: row.href,
+    entity_type: row.entity_type,
+    entity_id: row.entity_id,
+    read: row.read_at != null,
+    read_at: row.read_at,
+    created_at: row.created_at,
+  };
+}
+
+export function mapNotificationRows(rows: NotificationRow[] | null | undefined): NotificationView[] {
+  return (rows || []).map(mapNotificationRow);
+}

--- a/lib/domains/notifications/mutations.ts
+++ b/lib/domains/notifications/mutations.ts
@@ -1,0 +1,46 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { NotificationContent, NotificationInsert } from './types';
+
+// Mark one of the caller's notifications read (session client — RLS enforces ownership).
+export async function markNotificationRead(supabase: SupabaseClient, id: string) {
+  return supabase
+    .from('notifications')
+    .update({ read_at: new Date().toISOString() })
+    .eq('id', id)
+    .is('read_at', null)
+    .select('id')
+    .maybeSingle();
+}
+
+// Mark all the caller's unread notifications read.
+export async function markAllNotificationsRead(supabase: SupabaseClient, recipientId: string) {
+  return supabase
+    .from('notifications')
+    .update({ read_at: new Date().toISOString() })
+    .eq('recipient_user_id', recipientId)
+    .is('read_at', null);
+}
+
+// Bulk insert notifications for OTHER users (fan-out). Must be called with the service-role
+// client (getSupabaseAdmin()) — there is no INSERT policy for authenticated users.
+export async function createNotifications(admin: SupabaseClient, rows: NotificationInsert[]) {
+  if (rows.length === 0) return { data: [], error: null };
+  return admin.from('notifications').insert(rows).select('id');
+}
+
+// Auto-gallring: delete READ notifications older than `olderThanDays`. Unread rows are always
+// kept. Service-role only (cron). Returns the deleted rows so the caller can log a count.
+export async function pruneReadNotifications(admin: SupabaseClient, olderThanDays = 30) {
+  const cutoff = new Date(Date.now() - olderThanDays * 24 * 60 * 60 * 1000).toISOString();
+  return admin
+    .from('notifications')
+    .delete()
+    .not('read_at', 'is', null)
+    .lt('read_at', cutoff)
+    .select('id');
+}
+
+// Convenience: expand one content object to one insert per recipient id.
+export function expandNotificationToRecipients(content: NotificationContent, recipientIds: string[]): NotificationInsert[] {
+  return recipientIds.map((recipient_user_id) => ({ recipient_user_id, ...content }));
+}

--- a/lib/domains/notifications/payload.ts
+++ b/lib/domains/notifications/payload.ts
@@ -1,0 +1,36 @@
+import type { NotificationContent } from './types';
+
+// Pure notification-content builders (no I/O — unit tested). The fault-reports fan-out passes
+// the minimal fields these need; the recipient is attached per-recipient at insert time.
+
+export type FaultReportNotificationInput = {
+  reportId: string;
+  categoryLabel: string; // Swedish label, e.g. "Isoleringsmaskin"
+  reporterName: string;
+  statusLabel?: string; // Swedish status label, e.g. "Pågår" (for the updated builder)
+};
+
+// Sent to each supervisor when a new fault report is filed.
+export function buildFaultReportCreatedNotification(input: FaultReportNotificationInput): NotificationContent {
+  return {
+    type: 'fault_report.created',
+    title: `Ny felanmälan: ${input.categoryLabel}`,
+    body: `${input.reporterName} har gjort en felanmälan.`,
+    href: `/felanmalan?arende=${input.reportId}&scope=inbox`,
+    entity_type: 'fault_report',
+    entity_id: input.reportId,
+  };
+}
+
+// Sent to the reporter when a supervisor updates status / writes a reply.
+export function buildFaultReportUpdatedNotification(input: FaultReportNotificationInput): NotificationContent {
+  const status = input.statusLabel ? ` (${input.statusLabel})` : '';
+  return {
+    type: 'fault_report.updated',
+    title: `Din felanmälan har uppdaterats${status}`,
+    body: `${input.categoryLabel}: en arbetsledare har återkopplat.`,
+    href: `/felanmalan?arende=${input.reportId}`,
+    entity_type: 'fault_report',
+    entity_id: input.reportId,
+  };
+}

--- a/lib/domains/notifications/queries.ts
+++ b/lib/domains/notifications/queries.ts
@@ -1,0 +1,33 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { ListNotificationsQuery } from './schemas';
+
+const notificationSelect = 'id, recipient_user_id, type, title, body, href, entity_type, entity_id, read_at, created_at';
+
+// List the caller's notifications (RLS scopes to recipient_user_id = auth.uid()). Keyset
+// paginated on created_at so it stays under the PostgREST row cap.
+export async function listNotifications(supabase: SupabaseClient, options: ListNotificationsQuery) {
+  let query = supabase
+    .from('notifications')
+    .select(notificationSelect)
+    .order('created_at', { ascending: false })
+    .order('id', { ascending: false })
+    .limit(options.limit);
+
+  if (options.unreadOnly) {
+    query = query.is('read_at', null);
+  }
+  if (options.before) {
+    query = query.lt('created_at', options.before);
+  }
+
+  return query;
+}
+
+// Unread count for the badge. head+count avoids materialising rows.
+export async function countUnreadNotifications(supabase: SupabaseClient, recipientId: string) {
+  return supabase
+    .from('notifications')
+    .select('id', { count: 'exact', head: true })
+    .eq('recipient_user_id', recipientId)
+    .is('read_at', null);
+}

--- a/lib/domains/notifications/schemas.ts
+++ b/lib/domains/notifications/schemas.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod';
+
+// Query for GET /api/notifications. Keep the page small (well under the PostgREST row cap) and
+// paginate with a created_at cursor.
+export const listNotificationsQuerySchema = z.object({
+  unreadOnly: z
+    .preprocess((v) => (v === 'true' || v === true ? true : v === 'false' || v === false ? false : v), z.boolean())
+    .optional()
+    .default(false),
+  limit: z.coerce.number().int().min(1).max(50).optional().default(30),
+  // ISO timestamp; return rows strictly older than this (keyset pagination on created_at).
+  before: z.string().datetime().optional(),
+});
+
+export type ListNotificationsQuery = z.infer<typeof listNotificationsQuerySchema>;

--- a/lib/domains/notifications/types.ts
+++ b/lib/domains/notifications/types.ts
@@ -1,0 +1,53 @@
+// Generic in-app notification types. Kept feature-agnostic — `type`/`entity_type` are open
+// strings so any feature can emit notifications. Felanmälan is the first producer.
+
+export type NotificationType = 'fault_report.created' | 'fault_report.updated' | (string & {});
+
+// Raw row as stored in public.notifications.
+export type NotificationRow = {
+  id: string;
+  recipient_user_id: string;
+  type: string;
+  title: string;
+  body: string | null;
+  href: string | null;
+  entity_type: string | null;
+  entity_id: string | null;
+  read_at: string | null;
+  created_at: string;
+};
+
+// View model returned to the client. `read` is derived from read_at.
+export type NotificationView = {
+  id: string;
+  type: string;
+  title: string;
+  body: string | null;
+  href: string | null;
+  entity_type: string | null;
+  entity_id: string | null;
+  read: boolean;
+  read_at: string | null;
+  created_at: string;
+};
+
+// Payload for a new notification (recipient set by the fan-out caller, one row per recipient).
+export type NotificationInsert = {
+  recipient_user_id: string;
+  type: string;
+  title: string;
+  body?: string | null;
+  href?: string | null;
+  entity_type?: string | null;
+  entity_id?: string | null;
+};
+
+// Shape produced by the pure payload builders (recipient is added per-recipient at fan-out).
+export type NotificationContent = {
+  type: string;
+  title: string;
+  body: string | null;
+  href: string | null;
+  entity_type: string | null;
+  entity_id: string | null;
+};

--- a/middleware.ts
+++ b/middleware.ts
@@ -14,12 +14,14 @@ export async function middleware(req: NextRequest) {
   const isApiAuth = pathname.startsWith('/api/auth');
   const isApi = pathname.startsWith('/api');
   const isReminderDispatchApi = pathname === '/api/dashboard-notes/reminders/dispatch';
+  const isNotificationsCleanupApi = pathname === '/api/notifications/cleanup';
   const isTwilioSmsStatusApi = pathname === '/api/twilio/sms-status';
   const isPublicCustomerOffertPage = pathname.startsWith('/kund/offert/');
   const isPublicCustomerOffertApi = pathname.startsWith('/api/kund/offert/');
 
   if (isApiAuth) return NextResponse.next();
   if (isReminderDispatchApi) return NextResponse.next();
+  if (isNotificationsCleanupApi) return NextResponse.next();
   if (isTwilioSmsStatusApi) return NextResponse.next();
   if (isPublicCustomerOffertPage || isPublicCustomerOffertApi) return NextResponse.next();
 

--- a/supabase/sql/20260703_fault_report_updates.sql
+++ b/supabase/sql/20260703_fault_report_updates.sql
@@ -1,0 +1,44 @@
+-- Felanmälan — append-only reply/status history.
+--
+-- fault_reports.reply/status only ever hold the LATEST value (a supervisor overwrites them each
+-- time). This table logs every supervisor update as an immutable row so the ärende shows the full
+-- history of replies + status changes over time — not a chat thread, just "what I sent, when".
+--
+-- The parent fault_reports row keeps the current status + latest reply (for list previews); this
+-- table is the timeline. Insert-only: no UPDATE/DELETE policy.
+--
+-- DEPLOY ORDER: run AFTER 20260703_fault_reports.sql. Run in the Supabase SQL editor. Idempotent.
+
+create table if not exists public.fault_report_updates (
+  id             uuid primary key default gen_random_uuid(),
+  report_id      uuid not null references public.fault_reports(id) on delete cascade,
+  -- The status set at this update, and the reply written (nullable — a pure status change logs too).
+  status         text not null,
+  reply          text,
+  responder_id   uuid references public.profiles(id) on delete set null,
+  responder_name text not null,
+  created_at     timestamptz not null default now(),
+  constraint fault_report_updates_status_chk check (status in ('new', 'in_progress', 'resolved'))
+);
+
+create index if not exists fault_report_updates_report_idx
+  on public.fault_report_updates (report_id, created_at);
+
+alter table public.fault_report_updates enable row level security;
+grant select, insert on public.fault_report_updates to authenticated;
+
+-- Read the history if you can read the parent report: the reporter (own report) or a supervisor.
+-- The subquery is itself RLS-scoped, so a reporter only matches their own report rows.
+drop policy if exists fault_report_updates_select on public.fault_report_updates;
+create policy fault_report_updates_select on public.fault_report_updates
+  for select to authenticated
+  using (
+    public.is_fault_report_recipient()
+    or exists (select 1 from public.fault_reports fr where fr.id = report_id and fr.reporter_id = auth.uid())
+  );
+
+-- Only supervisors append, and only as themselves.
+drop policy if exists fault_report_updates_insert on public.fault_report_updates;
+create policy fault_report_updates_insert on public.fault_report_updates
+  for insert to authenticated
+  with check (public.is_fault_report_recipient() and responder_id = auth.uid());

--- a/supabase/sql/20260703_fault_reports.sql
+++ b/supabase/sql/20260703_fault_reports.sql
@@ -1,0 +1,114 @@
+-- Felanmälan (equipment fault reporting).
+--
+-- Any signed-in user files a report (category + free-text comment). A fixed, admin-managed list
+-- of "arbetsledare" (fault_report_recipients) receives it — both as an in-app notification (see
+-- 20260703_notifications.sql) and as an email (fan-out happens in the route handler). Supervisors
+-- set status + write a reply; the reporter sees it on their ärende and gets an update notification.
+--
+-- There is no "arbetsledare" role in the app, so recipients are a data-managed set of user_ids.
+-- A single user_id row gives both the id (in-app notification) and — via auth.admin.getUserById
+-- server-side — the always-current email. is_fault_report_recipient() is the single source both
+-- RLS and the route guard read (same pattern as has_permission()).
+--
+-- DEPLOY ORDER: run AFTER 20260703_notifications.sql. Run in the Supabase SQL editor. Idempotent.
+-- After running, seed the supervisor(s) — see the seed block at the end.
+
+-- ---------------------------------------------------------------------------
+-- Recipients (arbetsledare) + membership helper
+-- ---------------------------------------------------------------------------
+
+create table if not exists public.fault_report_recipients (
+  user_id    uuid primary key references public.profiles(id) on delete cascade,
+  active     boolean not null default true,
+  created_at timestamptz not null default now()
+);
+
+alter table public.fault_report_recipients enable row level security;
+grant select, insert, update, delete on public.fault_report_recipients to authenticated;
+
+-- A user must be able to see whether THEY are a recipient (drives the "Inkorg" tab); admins
+-- manage the whole list.
+drop policy if exists fault_report_recipients_select on public.fault_report_recipients;
+create policy fault_report_recipients_select on public.fault_report_recipients
+  for select to authenticated
+  using (
+    user_id = auth.uid()
+    or exists (select 1 from public.profiles p where p.id = auth.uid() and p.role = 'admin')
+  );
+
+-- Only admins add/remove/toggle recipients.
+drop policy if exists fault_report_recipients_write on public.fault_report_recipients;
+create policy fault_report_recipients_write on public.fault_report_recipients
+  for all to authenticated
+  using (exists (select 1 from public.profiles p where p.id = auth.uid() and p.role = 'admin'))
+  with check (exists (select 1 from public.profiles p where p.id = auth.uid() and p.role = 'admin'));
+
+-- SECURITY DEFINER so RLS policies on fault_reports can call it without recursion and every
+-- caller reads the same source. STABLE → evaluated ~once per query.
+create or replace function public.is_fault_report_recipient() returns boolean
+language sql stable security definer set search_path = public as $$
+  select exists (
+    select 1 from public.fault_report_recipients r
+    where r.user_id = auth.uid() and r.active
+  );
+$$;
+grant execute on function public.is_fault_report_recipient() to authenticated;
+
+-- ---------------------------------------------------------------------------
+-- Fault reports
+-- ---------------------------------------------------------------------------
+
+create table if not exists public.fault_reports (
+  id             uuid primary key default gen_random_uuid(),
+  -- Nullable to match ON DELETE SET NULL (a NOT NULL column + SET NULL would abort profile
+  -- deletion). reporter_name is the durable display snapshot (profiles are self-read-only, so
+  -- supervisors can't re-read the reporter's name) — mirrors ops_activity_events.actor_name.
+  reporter_id    uuid references public.profiles(id) on delete set null,
+  reporter_name  text not null,
+  category       text not null,
+  comment        text not null,
+  status         text not null default 'new',
+  reply          text,
+  responder_id   uuid references public.profiles(id) on delete set null,
+  responder_name text,
+  responded_at   timestamptz,
+  created_at     timestamptz not null default now(),
+  updated_at     timestamptz not null default now(),
+  constraint fault_reports_category_chk
+    check (category in ('truck', 'lager', 'lastbil', 'isoleringsmaskin', 'maskiner')),
+  constraint fault_reports_status_chk
+    check (status in ('new', 'in_progress', 'resolved'))
+);
+
+create index if not exists fault_reports_reporter_idx on public.fault_reports (reporter_id, created_at desc);
+create index if not exists fault_reports_status_idx   on public.fault_reports (status, created_at desc);
+
+alter table public.fault_reports enable row level security;
+grant select, insert, update on public.fault_reports to authenticated;
+
+-- Anyone signed in files their own report (reporter_id = auth.uid()).
+drop policy if exists fault_reports_insert on public.fault_reports;
+create policy fault_reports_insert on public.fault_reports
+  for insert to authenticated
+  with check (reporter_id = auth.uid());
+
+-- Reporters see their own; supervisors see all.
+drop policy if exists fault_reports_select on public.fault_reports;
+create policy fault_reports_select on public.fault_reports
+  for select to authenticated
+  using (reporter_id = auth.uid() or public.is_fault_report_recipient());
+
+-- Only supervisors set status/reply. A matching SELECT policy exists above (UPDATE⇒SELECT rule).
+drop policy if exists fault_reports_update on public.fault_reports;
+create policy fault_reports_update on public.fault_reports
+  for update to authenticated
+  using (public.is_fault_report_recipient())
+  with check (public.is_fault_report_recipient());
+
+-- ---------------------------------------------------------------------------
+-- Seed the arbetsledare (EDIT the emails/ids before running, or manage in admin later).
+-- Resolves the two supervisors by email from auth.users. Safe to re-run.
+-- ---------------------------------------------------------------------------
+-- insert into public.fault_report_recipients (user_id)
+-- select id from auth.users where lower(email) in ('arbetsledare1@example.se', 'arbetsledare2@example.se')
+-- on conflict (user_id) do update set active = true;

--- a/supabase/sql/20260703_notifications.sql
+++ b/supabase/sql/20260703_notifications.sql
@@ -1,0 +1,69 @@
+-- Generic in-app notification center (first notification system in the app).
+--
+-- One row = one notification delivered to one user. Deliberately generic (type + entity_type/
+-- entity_id + href) so future features can reuse it, not just felanmälan. The bell in the app
+-- shell reads the caller's own rows (RLS) and streams new ones over Realtime.
+--
+-- Writes fan out server-side: a user never inserts a notification for ANOTHER user, so there is
+-- no INSERT policy — the fan-out routes use the service-role client (getSupabaseAdmin()). Users
+-- may only SELECT and UPDATE (mark-as-read) their own rows.
+--
+-- Run in the Supabase SQL editor. Idempotent.
+
+create table if not exists public.notifications (
+  id                uuid primary key default gen_random_uuid(),
+  recipient_user_id uuid not null references public.profiles(id) on delete cascade,
+  -- Dotted type key, e.g. 'fault_report.created' | 'fault_report.updated'.
+  type              text not null,
+  title             text not null,
+  body              text,
+  -- In-app link the row navigates to when clicked, e.g. '/felanmalan?arende=<id>'.
+  href              text,
+  -- What the notification is about, for grouping/filtering. entity_id is not FK-constrained
+  -- (the referenced row may be deleted; the notification is a point-in-time message).
+  entity_type       text,
+  entity_id         uuid,
+  read_at           timestamptz,               -- null = unread
+  created_at        timestamptz not null default now()
+);
+
+create index if not exists notifications_recipient_created_idx
+  on public.notifications (recipient_user_id, created_at desc);
+
+-- Fast unread count/badge: partial index over just the unread rows.
+create index if not exists notifications_recipient_unread_idx
+  on public.notifications (recipient_user_id) where read_at is null;
+
+alter table public.notifications enable row level security;
+
+-- INSERT is service-role only (fan-out) → no insert grant/policy for authenticated.
+grant select, update on public.notifications to authenticated;
+
+-- Read only your own notifications.
+drop policy if exists notifications_select on public.notifications;
+create policy notifications_select on public.notifications
+  for select to authenticated
+  using (recipient_user_id = auth.uid());
+
+-- Mark your own notifications read (UPDATE). A matching SELECT policy exists above, satisfying
+-- the "UPDATE requires SELECT" rule. Row-scoped, not column-scoped — a user can only touch their
+-- own rows; mark-as-read only ever sets read_at.
+drop policy if exists notifications_update on public.notifications;
+create policy notifications_update on public.notifications
+  for update to authenticated
+  using (recipient_user_id = auth.uid())
+  with check (recipient_user_id = auth.uid());
+
+-- Stream INSERT (new notification) + UPDATE (read_at) to the open bell. replica identity full so
+-- DELETE/UPDATE payloads carry the old row for client-side reconciliation.
+alter table public.notifications replica identity full;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_publication_tables
+    where pubname = 'supabase_realtime' and schemaname = 'public' and tablename = 'notifications'
+  ) then
+    execute 'alter publication supabase_realtime add table public.notifications';
+  end if;
+end $$;

--- a/tests/fault-reports/faultReports.test.ts
+++ b/tests/fault-reports/faultReports.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect } from 'vitest';
+import {
+  createFaultReportSchema,
+  updateFaultReportSchema,
+  listFaultReportsQuerySchema,
+} from '@/lib/domains/fault-reports/schemas';
+import { mapFaultReportRow, mapFaultReportUpdateRow } from '@/lib/domains/fault-reports/mappers';
+import {
+  FAULT_CATEGORIES,
+  FAULT_STATUSES,
+  categoryLabel,
+  statusLabel,
+  type FaultReportRow,
+} from '@/lib/domains/fault-reports/types';
+import { dedupeRecipients, dedupeEmails } from '@/lib/domains/fault-reports/recipients';
+import { buildFaultReportEmail } from '@/lib/domains/fault-reports/email';
+
+describe('createFaultReportSchema', () => {
+  it('accepts each of the five categories', () => {
+    for (const c of FAULT_CATEGORIES) {
+      expect(createFaultReportSchema.parse({ category: c, comment: 'trasig' }).category).toBe(c);
+    }
+  });
+
+  it('rejects an unknown category', () => {
+    expect(() => createFaultReportSchema.parse({ category: 'gaffeltruck', comment: 'x' })).toThrow();
+  });
+
+  it('rejects empty / whitespace comment and trims', () => {
+    expect(() => createFaultReportSchema.parse({ category: 'truck', comment: '' })).toThrow();
+    expect(() => createFaultReportSchema.parse({ category: 'truck', comment: '   ' })).toThrow();
+    expect(createFaultReportSchema.parse({ category: 'truck', comment: '  fel  ' }).comment).toBe('fel');
+  });
+});
+
+describe('updateFaultReportSchema', () => {
+  it('requires a valid status and defaults reply to null', () => {
+    expect(updateFaultReportSchema.parse({ status: 'in_progress' })).toEqual({ status: 'in_progress', reply: null });
+    expect(() => updateFaultReportSchema.parse({ status: 'closed' })).toThrow();
+  });
+
+  it('normalises blank reply to null and trims a real reply', () => {
+    expect(updateFaultReportSchema.parse({ status: 'resolved', reply: '   ' }).reply).toBeNull();
+    expect(updateFaultReportSchema.parse({ status: 'resolved', reply: ' fixat ' }).reply).toBe('fixat');
+  });
+});
+
+describe('listFaultReportsQuerySchema', () => {
+  it('defaults scope to mine', () => {
+    expect(listFaultReportsQuerySchema.parse({}).scope).toBe('mine');
+  });
+  it('rejects an unknown scope', () => {
+    expect(() => listFaultReportsQuerySchema.parse({ scope: 'all' })).toThrow();
+  });
+});
+
+describe('category / status label completeness', () => {
+  it('every category has a Swedish label', () => {
+    for (const c of FAULT_CATEGORIES) expect(categoryLabel[c]).toBeTruthy();
+    expect(categoryLabel.isoleringsmaskin).toBe('Isoleringsmaskin');
+  });
+  it('every status has a Swedish label', () => {
+    for (const s of FAULT_STATUSES) expect(statusLabel[s]).toBeTruthy();
+    expect(statusLabel.in_progress).toBe('Pågår');
+  });
+});
+
+describe('mapFaultReportRow', () => {
+  const row: FaultReportRow = {
+    id: 'r1',
+    reporter_id: 'u1',
+    reporter_name: 'Anna',
+    category: 'lastbil',
+    comment: 'Punktering',
+    status: 'in_progress',
+    reply: null,
+    responder_id: null,
+    responder_name: null,
+    responded_at: null,
+    created_at: '2026-07-03T09:00:00.000Z',
+    updated_at: '2026-07-03T09:00:00.000Z',
+  };
+
+  it('maps category/status to labels', () => {
+    const v = mapFaultReportRow(row);
+    expect(v.category).toBe('lastbil');
+    expect(v.category_label).toBe('Lastbil');
+    expect(v.status).toBe('in_progress');
+    expect(v.status_label).toBe('Pågår');
+  });
+
+  it('falls back to a safe status for an unknown DB value', () => {
+    expect(mapFaultReportRow({ ...row, status: 'weird' }).status).toBe('new');
+  });
+});
+
+describe('mapFaultReportUpdateRow', () => {
+  it('maps a history entry status to its label and keeps reply/responder', () => {
+    const v = mapFaultReportUpdateRow({
+      id: 'h1',
+      report_id: 'r1',
+      status: 'resolved',
+      reply: 'Bytte filter',
+      responder_id: 'u2',
+      responder_name: 'Kalle',
+      created_at: '2026-07-03T12:00:00.000Z',
+    });
+    expect(v.status).toBe('resolved');
+    expect(v.status_label).toBe('Åtgärdad');
+    expect(v.reply).toBe('Bytte filter');
+    expect(v.responder_name).toBe('Kalle');
+  });
+});
+
+describe('dedupeRecipients / dedupeEmails', () => {
+  it('dedupes user ids and drops blanks', () => {
+    expect(dedupeRecipients(['a', 'a', ' b ', '', null, undefined])).toEqual(['a', 'b']);
+  });
+  it('dedupes emails case-insensitively but keeps first casing', () => {
+    expect(dedupeEmails(['A@x.se', 'a@x.se', ' b@x.se ', ''])).toEqual(['A@x.se', 'b@x.se']);
+  });
+});
+
+describe('buildFaultReportEmail', () => {
+  const report = mapFaultReportRow({
+    id: 'r9',
+    reporter_id: 'u1',
+    reporter_name: 'Bertil',
+    category: 'isoleringsmaskin',
+    comment: 'Läcker olja',
+    status: 'new',
+    reply: null,
+    responder_id: null,
+    responder_name: null,
+    responded_at: null,
+    created_at: '2026-07-03T09:00:00.000Z',
+    updated_at: '2026-07-03T09:00:00.000Z',
+  });
+
+  it('includes category, reporter and a deep link when a base url is given', () => {
+    const { subject, html, text } = buildFaultReportEmail(report, 'https://app.example.se/');
+    expect(subject).toContain('Isoleringsmaskin');
+    expect(text).toContain('Bertil');
+    expect(text).toContain('Läcker olja');
+    expect(html).toContain('https://app.example.se/felanmalan?arende=r9&scope=inbox');
+  });
+
+  it('escapes HTML in user content', () => {
+    const evil = mapFaultReportRow({
+      id: 'r9', reporter_id: 'u1', reporter_name: '<b>x</b>', category: 'truck', comment: '<script>',
+      status: 'new', reply: null, responder_id: null, responder_name: null, responded_at: null,
+      created_at: '2026-07-03T09:00:00.000Z', updated_at: '2026-07-03T09:00:00.000Z',
+    });
+    const { html } = buildFaultReportEmail(evil);
+    expect(html).not.toContain('<script>');
+    expect(html).toContain('&lt;script&gt;');
+  });
+});

--- a/tests/notifications/notifications.test.ts
+++ b/tests/notifications/notifications.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import { listNotificationsQuerySchema } from '@/lib/domains/notifications/schemas';
+import { mapNotificationRow } from '@/lib/domains/notifications/mappers';
+import { expandNotificationToRecipients } from '@/lib/domains/notifications/mutations';
+import {
+  buildFaultReportCreatedNotification,
+  buildFaultReportUpdatedNotification,
+} from '@/lib/domains/notifications/payload';
+import type { NotificationRow } from '@/lib/domains/notifications/types';
+
+describe('listNotificationsQuerySchema', () => {
+  it('defaults: unreadOnly=false, limit=30', () => {
+    const parsed = listNotificationsQuerySchema.parse({});
+    expect(parsed.unreadOnly).toBe(false);
+    expect(parsed.limit).toBe(30);
+    expect(parsed.before).toBeUndefined();
+  });
+
+  it('coerces string unreadOnly + limit and clamps limit range', () => {
+    expect(listNotificationsQuerySchema.parse({ unreadOnly: 'true', limit: '10' })).toMatchObject({ unreadOnly: true, limit: 10 });
+    expect(() => listNotificationsQuerySchema.parse({ limit: '0' })).toThrow();
+    expect(() => listNotificationsQuerySchema.parse({ limit: '999' })).toThrow();
+  });
+
+  it('rejects a non-ISO before cursor', () => {
+    expect(() => listNotificationsQuerySchema.parse({ before: 'igår' })).toThrow();
+  });
+});
+
+describe('mapNotificationRow', () => {
+  const base: NotificationRow = {
+    id: 'n1',
+    recipient_user_id: 'u1',
+    type: 'fault_report.created',
+    title: 'Ny felanmälan',
+    body: 'text',
+    href: '/felanmalan?arende=r1',
+    entity_type: 'fault_report',
+    entity_id: 'r1',
+    read_at: null,
+    created_at: '2026-07-03T10:00:00.000Z',
+  };
+
+  it('derives read=false when read_at is null', () => {
+    expect(mapNotificationRow(base).read).toBe(false);
+  });
+
+  it('derives read=true when read_at is set', () => {
+    expect(mapNotificationRow({ ...base, read_at: '2026-07-03T11:00:00.000Z' }).read).toBe(true);
+  });
+});
+
+describe('fault report notification payload builders', () => {
+  const input = { reportId: 'r1', categoryLabel: 'Isoleringsmaskin', reporterName: 'Anna' };
+
+  it('created: correct type, entity ref and href carrying the report id', () => {
+    const n = buildFaultReportCreatedNotification(input);
+    expect(n.type).toBe('fault_report.created');
+    expect(n.entity_type).toBe('fault_report');
+    expect(n.entity_id).toBe('r1');
+    expect(n.href).toContain('r1');
+    expect(n.href).toContain('scope=inbox');
+    expect(n.title).toContain('Isoleringsmaskin');
+  });
+
+  it('updated: includes status label and points at the reporter view (no inbox scope)', () => {
+    const n = buildFaultReportUpdatedNotification({ ...input, statusLabel: 'Pågår' });
+    expect(n.type).toBe('fault_report.updated');
+    expect(n.title).toContain('Pågår');
+    expect(n.href).toContain('r1');
+    expect(n.href).not.toContain('scope=inbox');
+  });
+});
+
+describe('expandNotificationToRecipients', () => {
+  it('produces one insert per recipient carrying the content', () => {
+    const content = buildFaultReportCreatedNotification({ reportId: 'r1', categoryLabel: 'Truck', reporterName: 'A' });
+    const rows = expandNotificationToRecipients(content, ['a', 'b']);
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toMatchObject({ recipient_user_id: 'a', type: 'fault_report.created', entity_id: 'r1' });
+    expect(rows[1].recipient_user_id).toBe('b');
+  });
+
+  it('empty recipient list → no rows', () => {
+    const content = buildFaultReportCreatedNotification({ reportId: 'r1', categoryLabel: 'Truck', reporterName: 'A' });
+    expect(expandNotificationToRecipients(content, [])).toEqual([]);
+  });
+});

--- a/vercel.json
+++ b/vercel.json
@@ -4,6 +4,10 @@
     {
       "path": "/api/dashboard-notes/reminders/dispatch",
       "schedule": "*/5 * * * *"
+    },
+    {
+      "path": "/api/notifications/cleanup",
+      "schedule": "0 3 * * *"
     }
   ]
 }


### PR DESCRIPTION
Ny felanmälan-yta (/felanmalan) där alla inloggade kan anmäla trasig utrustning (truck/lager/lastbil/isoleringsmaskin/maskiner) med kommentar. En fast, admin-hanterbar grupp arbetsledare får varje anmälan både som in-app-notis och mejl, sätter status (Ny/Pågår/Åtgärdad) och skriver svar som anmälaren ser på sitt ärende.

Fas A — generellt notiscenter (återanvändbart):
- notifications-tabell (RLS: läs/markera-läst egna rader, insert server-side)
  + realtime; domänlager i lib/domains/notifications/*
- /api/notifications (lista, oläst-antal, markera läst, markera-alla)
- NotificationBell i app-skalet (AppSidebar): oläst-badge, realtidsuppdaterad, visar olästa som standard med "Visa lästa"-växel; unik realtidskanal per instans; panelen auto-positioneras efter sidomenyns läge
- auto-gallring av lästa notiser >30 dagar via cron (/api/notifications/cleanup, vercel.json + CRON_SECRET, allowlistad i middleware)

Fas B — felanmälan:
- fault_reports + fault_report_recipients + is_fault_report_recipient() (SECURITY DEFINER, en källa för RLS + route-guard); append-only fault_report_updates som historik-tidslinje
- domänlager i lib/domains/fault-reports/*; requireFaultReportRecipient()
- /api/felanmalan/reports (skapa + lista mine/inbox + hämta + PATCH) med best-effort fan-out (notis + mejl via Resend), reporter exkluderas
- app/felanmalan (tunn page + FelanmalanClient): formulär, Mina ärenden, Inkorg, detalj-modal med status/svar + historik
- entrépunkter: snabb genväg (alla roller) + sidebar-nav + ikon

Delade helpers: lib/api/responses.ts (crm/_shared.ts re-exporterar dem nu,
avdup). Tester: tests/notifications + tests/fault-reports (585 gröna).

Deploy: kör supabase/sql/20260703_notifications.sql, _fault_reports.sql, _fault_report_updates.sql; seeda arbetsledare i fault_report_recipients. Env: RESEND_API_KEY + MAIL_FROM (mejl), valfri FELANMALAN_NOTIFY_TO / NEXT_PUBLIC_APP_URL / NOTIFICATIONS_CLEANUP_SECRET.