### PR TITLE
feat(crm): notifiera @-taggade i arbetsorder-kommentarer

### DIFF
--- a/app/api/crm/work-orders/[id]/comments/route.ts
+++ b/app/api/crm/work-orders/[id]/comments/route.ts
@@ -1,6 +1,9 @@
 import { cookies } from 'next/headers';
 import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
 import { createCrmWorkOrderComment, listCrmWorkOrderComments } from '@/lib/domains/crm/work-orders';
+import { getSupabaseAdmin } from '@/lib/supabase/server';
+import { buildWorkOrderCommentMentionNotification } from '@/lib/domains/notifications/payload';
+import { createNotifications, expandNotificationToRecipients } from '@/lib/domains/notifications/mutations';
 import { createWorkOrderCommentSchema, ok, requireSignedInUser, routeError, validationError } from '../../_lib';
 
 type RouteContext = {
@@ -46,8 +49,48 @@ export async function POST(req: Request, context: RouteContext) {
       return routeError(500, 'crm_work_order_comment_create_failed', error.message);
     }
 
+    // Notify @-mentioned users (best-effort — never fail the comment on a notify error).
+    await fanOutMentions({
+      workOrderId: context.params.id,
+      authorId: currentUser.currentUser.id,
+      authorName: currentUser.currentUser.name ?? null,
+      mentionedIds: parsedBody.data.mentioned_user_ids,
+    }).catch((e) => console.error('[work-order-comment] mention fan-out failed', e));
+
     return ok({ item: data }, 201);
   } catch (e: any) {
     return routeError(500, 'crm_work_order_comment_unexpected', e?.message || 'Failed to create work order comment');
   }
+}
+
+async function fanOutMentions(input: {
+  workOrderId: string;
+  authorId: string;
+  authorName: string | null;
+  mentionedIds: string[];
+}) {
+  // Dedupe + drop the author (no self-mention notification).
+  const ids = Array.from(new Set(input.mentionedIds)).filter((id) => id && id !== input.authorId);
+  if (ids.length === 0) return;
+
+  const admin = getSupabaseAdmin();
+  // Validate the client-supplied ids are real profiles: recipient_user_id FKs to profiles, so one
+  // bogus id would otherwise fail the whole batch insert and nobody would be notified.
+  const { data: profs } = await admin.from('profiles').select('id').in('id', ids);
+  const validIds = (profs || []).map((p: { id: string }) => p.id);
+  if (validIds.length === 0) return;
+
+  const { data: wo } = await admin
+    .from('crm_work_orders')
+    .select('order_number, project_name')
+    .eq('id', input.workOrderId)
+    .maybeSingle();
+
+  const content = buildWorkOrderCommentMentionNotification({
+    workOrderId: input.workOrderId,
+    orderNumber: (wo as { order_number?: string | null } | null)?.order_number ?? null,
+    projectName: (wo as { project_name?: string | null } | null)?.project_name ?? null,
+    commenterName: input.authorName,
+  });
+  await createNotifications(admin, expandNotificationToRecipients(content, validIds));
 }

--- a/app/api/crm/work-orders/_lib.ts
+++ b/app/api/crm/work-orders/_lib.ts
@@ -45,6 +45,8 @@ export const createWorkOrderTimeEntrySchema = z.object({
 
 export const createWorkOrderCommentSchema = z.object({
   body: z.string().trim().min(1, 'Kommentar krävs'),
+  // Ids of users @-mentioned in the body (client-supplied; validated server-side before notifying).
+  mentioned_user_ids: z.array(z.string().uuid()).optional().default([]),
 });
 
 export const listCrmWorkOrdersQuerySchema = z.object({

--- a/app/crm/arbetsorder/WorkOrderCommentsTab.tsx
+++ b/app/crm/arbetsorder/WorkOrderCommentsTab.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { cn } from '@/lib/shared/cn';
 import { crm } from '@/app/crm/lib/crmTokens';
 import { formatDateTime } from '@/app/crm/lib/format';
@@ -20,7 +20,7 @@ type Props = {
   loading: boolean;
   currentUserId: string | null;
   mentionUsers: MentionUser[];
-  onCreate: (body: string) => Promise<boolean>;
+  onCreate: (body: string, mentionedUserIds: string[]) => Promise<boolean>;
   onUpdate: (id: string, body: string) => Promise<boolean>;
   onDelete: (id: string) => Promise<boolean>;
 };
@@ -28,6 +28,9 @@ type Props = {
 export default function WorkOrderCommentsTab({ comments, loading, currentUserId, mentionUsers, onCreate, onUpdate, onDelete }: Props) {
   const [draft, setDraft] = useState('');
   const [creating, setCreating] = useState(false);
+  // Ids picked from the @-autocomplete for the new comment (id → full_name). The id is otherwise
+  // lost (the body only has plain "@Name" text); at submit we keep only those still present.
+  const mentionedRef = useRef<Map<string, string>>(new Map());
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editBody, setEditBody] = useState('');
   const [busyId, setBusyId] = useState<string | null>(null);
@@ -35,8 +38,15 @@ export default function WorkOrderCommentsTab({ comments, loading, currentUserId,
 
   async function submitCreate() {
     setCreating(true);
-    const ok = await onCreate(draft);
-    if (ok) setDraft('');
+    // Only notify people whose @mention is still in the text (a removed mention shouldn't notify).
+    const mentionedIds = [...mentionedRef.current.entries()]
+      .filter(([, name]) => draft.includes(`@${name}`))
+      .map(([id]) => id);
+    const ok = await onCreate(draft, mentionedIds);
+    if (ok) {
+      setDraft('');
+      mentionedRef.current.clear();
+    }
     setCreating(false);
   }
 
@@ -113,7 +123,14 @@ export default function WorkOrderCommentsTab({ comments, loading, currentUserId,
 
       <div className={cn(crm.cardInner, 'grid gap-3 lg:content-start')}>
         <p className={crm.sectionTitle}>Ny kommentar</p>
-        <MentionTextarea value={draft} onChange={setDraft} users={mentionUsers} rows={8} placeholder="Skriv en kommentar… använd @ för att tagga någon" />
+        <MentionTextarea
+          value={draft}
+          onChange={setDraft}
+          onMention={(u) => { if (u.full_name) mentionedRef.current.set(u.id, u.full_name); }}
+          users={mentionUsers}
+          rows={8}
+          placeholder="Skriv en kommentar… använd @ för att tagga någon"
+        />
         <button type="button" onClick={submitCreate} disabled={creating} className={crm.saveButton}>
           {creating ? 'Sparar kommentar…' : 'Spara kommentar'}
         </button>

--- a/app/crm/arbetsorder/useWorkOrderActivity.ts
+++ b/app/crm/arbetsorder/useWorkOrderActivity.ts
@@ -83,12 +83,12 @@ export function useWorkOrderActivity(workOrderId: string) {
     } catch { toast.error('Kunde inte ta bort tidrad'); return false; }
   }
 
-  async function createComment(body: string): Promise<boolean> {
+  async function createComment(body: string, mentionedUserIds: string[] = []): Promise<boolean> {
     if (!body.trim()) { toast.error('Kommentar krävs'); return false; }
     try {
       const res = await fetch(`/api/crm/work-orders/${workOrderId}/comments`, {
         method: 'POST', headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ body }),
+        body: JSON.stringify({ body, mentioned_user_ids: mentionedUserIds }),
       });
       const json = await res.json().catch(() => ({}));
       if (!res.ok || !json.ok) { toast.error(json?.error || 'Kunde inte spara kommentar'); return false; }

--- a/app/crm/components/MentionTextarea.tsx
+++ b/app/crm/components/MentionTextarea.tsx
@@ -45,6 +45,7 @@ function caretCoordinates(el: HTMLTextAreaElement, index: number): { top: number
 export default function MentionTextarea({
   value,
   onChange,
+  onMention,
   users,
   rows,
   placeholder,
@@ -52,6 +53,9 @@ export default function MentionTextarea({
 }: {
   value: string;
   onChange: (next: string) => void;
+  // Fires when a user is picked from the autocomplete, so the caller can collect mentioned ids
+  // (the id is otherwise discarded — the body only carries the plain "@Name" text).
+  onMention?: (user: MentionUser) => void;
   users: MentionUser[];
   rows?: number;
   placeholder?: string;
@@ -102,6 +106,7 @@ export default function MentionTextarea({
     const after = value.slice(caret);
     const insert = `@${name} `;
     onChange(`${before}${insert}${after}`);
+    onMention?.(user);
     setOpen(false);
     const nextCaret = before.length + insert.length;
     requestAnimationFrame(() => {

--- a/lib/domains/notifications/payload.ts
+++ b/lib/domains/notifications/payload.ts
@@ -22,6 +22,25 @@ export function buildFaultReportCreatedNotification(input: FaultReportNotificati
   };
 }
 
+// Sent to each user @-mentioned in a work order comment.
+export function buildWorkOrderCommentMentionNotification(input: {
+  workOrderId: string;
+  orderNumber?: string | null;
+  projectName?: string | null;
+  commenterName?: string | null;
+}): NotificationContent {
+  const ref = input.orderNumber ? `#${input.orderNumber}` : 'en arbetsorder';
+  const where = input.projectName ? `${ref} · ${input.projectName}` : ref;
+  return {
+    type: 'work_order.mention',
+    title: `${input.commenterName || 'Någon'} nämnde dig i en kommentar`,
+    body: `Arbetsorder ${where}`,
+    href: `/crm/arbetsorder/${input.workOrderId}`,
+    entity_type: 'work_order',
+    entity_id: input.workOrderId,
+  };
+}
+
 // Sent to the reporter when a supervisor updates status / writes a reply.
 export function buildFaultReportUpdatedNotification(input: FaultReportNotificationInput): NotificationContent {
   const status = input.statusLabel ? ` (${input.statusLabel})` : '';

--- a/tests/notifications/notifications.test.ts
+++ b/tests/notifications/notifications.test.ts
@@ -5,6 +5,7 @@ import { expandNotificationToRecipients } from '@/lib/domains/notifications/muta
 import {
   buildFaultReportCreatedNotification,
   buildFaultReportUpdatedNotification,
+  buildWorkOrderCommentMentionNotification,
 } from '@/lib/domains/notifications/payload';
 import type { NotificationRow } from '@/lib/domains/notifications/types';
 
@@ -69,6 +70,31 @@ describe('fault report notification payload builders', () => {
     expect(n.title).toContain('Pågår');
     expect(n.href).toContain('r1');
     expect(n.href).not.toContain('scope=inbox');
+  });
+});
+
+describe('buildWorkOrderCommentMentionNotification', () => {
+  it('links to the work order and carries the entity ref + order number', () => {
+    const n = buildWorkOrderCommentMentionNotification({
+      workOrderId: 'wo1',
+      orderNumber: 'AO-1042',
+      projectName: 'Villa Ek',
+      commenterName: 'Kalle',
+    });
+    expect(n.type).toBe('work_order.mention');
+    expect(n.entity_type).toBe('work_order');
+    expect(n.entity_id).toBe('wo1');
+    expect(n.href).toBe('/crm/arbetsorder/wo1');
+    expect(n.title).toContain('Kalle');
+    expect(n.body).toContain('AO-1042');
+    expect(n.body).toContain('Villa Ek');
+  });
+
+  it('degrades gracefully when order number / project / commenter are missing', () => {
+    const n = buildWorkOrderCommentMentionNotification({ workOrderId: 'wo2' });
+    expect(n.href).toBe('/crm/arbetsorder/wo2');
+    expect(n.title).toContain('Någon');
+    expect(n.body).toContain('en arbetsorder');
   });
 });
 


### PR DESCRIPTION
Kopplar den befintliga @-taggningen i arbetsorder-kommentarer till det generella notissystemet — en taggad person får nu en in-app-notis (klocka + realtime) med länk till arbetsordern. Ingen ny migration: notistypen 'work_order.mention' är en öppen sträng i notifications-tabellen.

- MentionTextarea: valfri onMention(user)-callback fångar upp user.id vid val (kastades bort tidigare; bakåtkompatibelt)
- WorkOrderCommentsTab: samlar taggade id:n för nya kommentaren och skickar bara med dem vars @Namn fortfarande finns kvar i texten vid submit
- useWorkOrderActivity.createComment(body, mentionedUserIds) → POST:ar ids
- createWorkOrderCommentSchema validerar mentioned_user_ids (uuid-array)
- comments-POST: best-effort fan-out efter insert — dedupar, exkluderar författaren, validerar ids mot riktiga profiler, hämtar order_number/ project_name för notistexten, skapar notiser via service-role
- ny payload-byggare buildWorkOrderCommentMentionNotification (+ tester)

Täcker både CRM-detaljvyn och installatörens fältvy (delar WorkOrderCommentsTab). MVP: bara nya kommentarer notifierar (ej redigering). 587 tester gröna.