### PR TITLE
Feature/notifications followups

### DIFF
--- a/app/api/crm/work-orders/[id]/comments/route.ts
+++ b/app/api/crm/work-orders/[id]/comments/route.ts
@@ -75,10 +75,11 @@ async function fanOutMentions(input: {
 
   const admin = getSupabaseAdmin();
   // Validate the client-supplied ids are real profiles: recipient_user_id FKs to profiles, so one
-  // bogus id would otherwise fail the whole batch insert and nobody would be notified.
-  const { data: profs } = await admin.from('profiles').select('id').in('id', ids);
-  const validIds = (profs || []).map((p: { id: string }) => p.id);
-  if (validIds.length === 0) return;
+  // bogus id would otherwise fail the whole batch insert and nobody would be notified. We also read
+  // `role` to route each recipient's notification to a view they can open (see below).
+  const { data: profs } = await admin.from('profiles').select('id, role').in('id', ids);
+  const validProfiles = (profs || []) as { id: string; role: string | null }[];
+  if (validProfiles.length === 0) return;
 
   const { data: wo } = await admin
     .from('crm_work_orders')
@@ -86,11 +87,22 @@ async function fanOutMentions(input: {
     .eq('id', input.workOrderId)
     .maybeSingle();
 
-  const content = buildWorkOrderCommentMentionNotification({
+  // Split recipients by CRM access (mirrors the /crm layout gate: konsult == sales). Office roles
+  // link to the CRM detail view; everyone else to the open field view, so an installer isn't sent
+  // to a /crm/* page that would bounce them to '/'.
+  const hasCrmAccess = (role: string | null) => role === 'admin' || role === 'sales' || role === 'konsult';
+  const crmIds = validProfiles.filter((p) => hasCrmAccess(p.role)).map((p) => p.id);
+  const fieldIds = validProfiles.filter((p) => !hasCrmAccess(p.role)).map((p) => p.id);
+
+  const base = {
     workOrderId: input.workOrderId,
     orderNumber: (wo as { order_number?: string | null } | null)?.order_number ?? null,
     projectName: (wo as { project_name?: string | null } | null)?.project_name ?? null,
     commenterName: input.authorName,
-  });
-  await createNotifications(admin, expandNotificationToRecipients(content, validIds));
+  };
+  const rows = [
+    ...expandNotificationToRecipients(buildWorkOrderCommentMentionNotification({ ...base, audience: 'crm' }), crmIds),
+    ...expandNotificationToRecipients(buildWorkOrderCommentMentionNotification({ ...base, audience: 'field' }), fieldIds),
+  ];
+  if (rows.length > 0) await createNotifications(admin, rows);
 }

--- a/app/api/crm/work-orders/[id]/comments/route.ts
+++ b/app/api/crm/work-orders/[id]/comments/route.ts
@@ -3,7 +3,8 @@ import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
 import { createCrmWorkOrderComment, listCrmWorkOrderComments } from '@/lib/domains/crm/work-orders';
 import { getSupabaseAdmin } from '@/lib/supabase/server';
 import { buildWorkOrderCommentMentionNotification } from '@/lib/domains/notifications/payload';
-import { createNotifications, expandNotificationToRecipients } from '@/lib/domains/notifications/mutations';
+import { expandNotificationToRecipients } from '@/lib/domains/notifications/mutations';
+import { deliverNotifications } from '@/lib/domains/notifications/delivery';
 import { createWorkOrderCommentSchema, ok, requireSignedInUser, routeError, validationError } from '../../_lib';
 
 type RouteContext = {
@@ -104,5 +105,5 @@ async function fanOutMentions(input: {
     ...expandNotificationToRecipients(buildWorkOrderCommentMentionNotification({ ...base, audience: 'crm' }), crmIds),
     ...expandNotificationToRecipients(buildWorkOrderCommentMentionNotification({ ...base, audience: 'field' }), fieldIds),
   ];
-  if (rows.length > 0) await createNotifications(admin, rows);
+  if (rows.length > 0) await deliverNotifications(admin, rows);
 }

--- a/app/api/felanmalan/reports/[id]/route.ts
+++ b/app/api/felanmalan/reports/[id]/route.ts
@@ -9,7 +9,8 @@ import { updateFaultReport, addFaultReportUpdate } from '@/lib/domains/fault-rep
 import { mapFaultReportRow, mapFaultReportUpdateRows } from '@/lib/domains/fault-reports/mappers';
 import { statusLabel, type FaultReportRow, type FaultReportUpdateRow, type FaultReportView } from '@/lib/domains/fault-reports/types';
 import { buildFaultReportUpdatedNotification } from '@/lib/domains/notifications/payload';
-import { createNotifications, expandNotificationToRecipients } from '@/lib/domains/notifications/mutations';
+import { expandNotificationToRecipients } from '@/lib/domains/notifications/mutations';
+import { deliverNotifications } from '@/lib/domains/notifications/delivery';
 
 export async function GET(_req: Request, { params }: { params: { id: string } }) {
   try {
@@ -85,5 +86,5 @@ async function notifyReporter(report: FaultReportView) {
     reporterName: report.reporter_name,
     statusLabel: statusLabel[report.status],
   });
-  await createNotifications(admin, expandNotificationToRecipients(content, [report.reporter_id]));
+  await deliverNotifications(admin, expandNotificationToRecipients(content, [report.reporter_id]));
 }

--- a/app/api/felanmalan/reports/route.ts
+++ b/app/api/felanmalan/reports/route.ts
@@ -15,7 +15,8 @@ import { listActiveRecipients, resolveRecipientEmails, dedupeEmails } from '@/li
 import { buildFaultReportEmail } from '@/lib/domains/fault-reports/email';
 import type { FaultReportRow, FaultReportView } from '@/lib/domains/fault-reports/types';
 import { buildFaultReportCreatedNotification } from '@/lib/domains/notifications/payload';
-import { createNotifications, expandNotificationToRecipients } from '@/lib/domains/notifications/mutations';
+import { expandNotificationToRecipients } from '@/lib/domains/notifications/mutations';
+import { deliverNotifications } from '@/lib/domains/notifications/delivery';
 
 export async function GET(req: Request) {
   try {
@@ -85,7 +86,7 @@ async function fanOutNewReport(report: FaultReportView, req: Request) {
       categoryLabel: report.category_label,
       reporterName: report.reporter_name,
     });
-    await createNotifications(admin, expandNotificationToRecipients(content, notifyIds));
+    await deliverNotifications(admin, expandNotificationToRecipients(content, notifyIds));
   }
 
   // Email: resolved supervisor addresses + the FELANMALAN_NOTIFY_TO fallback/override. Runs even

--- a/app/arbetsorder/WorkOrderInstallerClient.tsx
+++ b/app/arbetsorder/WorkOrderInstallerClient.tsx
@@ -35,7 +35,7 @@ type InstallerWorkOrder = {
   status: WorkOrderStatus;
 };
 
-type InstallerTab = 'info' | 'articles' | 'time' | 'comments';
+type InstallerTab = 'info' | 'articles' | 'time';
 
 export default function WorkOrderInstallerClient({ workOrderId, currentUserId }: { workOrderId: string; currentUserId: string | null }) {
   const router = useRouter();
@@ -91,8 +91,10 @@ export default function WorkOrderInstallerClient({ workOrderId, currentUserId }:
   const workScope = workOrder.internal_handoff?.work_scope || '';
   const handoffNotes = workOrder.internal_handoff?.handoff_notes || '';
 
+  // Comments render at the bottom of the Info tab (not a separate tab) so an @-mention notification
+  // lands straight on the thread.
   const tabs: Array<[InstallerTab, string]> = [
-    ['info', 'Info'], ['articles', 'Artiklar'], ['time', 'Tid'], ['comments', 'Kommentarer'],
+    ['info', 'Info'], ['articles', 'Artiklar'], ['time', 'Tid'],
   ];
 
   return (
@@ -155,6 +157,17 @@ export default function WorkOrderInstallerClient({ workOrderId, currentUserId }:
               <p className="whitespace-pre-wrap text-sm leading-relaxed text-slate-700">{handoffNotes}</p>
             ) : (!workScope ? <p className="text-sm text-slate-400">Ingen arbetsbeskrivning angiven.</p> : null)}
           </div>
+
+          {/* Comments (write) — at the bottom of Info, no longer a separate tab */}
+          <WorkOrderCommentsTab
+            comments={activity.comments}
+            loading={activity.commentsLoading}
+            currentUserId={currentUserId}
+            mentionUsers={activity.mentionUsers}
+            onCreate={activity.createComment}
+            onUpdate={activity.updateComment}
+            onDelete={activity.deleteComment}
+          />
         </div>
       ) : null}
 
@@ -186,18 +199,6 @@ export default function WorkOrderInstallerClient({ workOrderId, currentUserId }:
         />
       ) : null}
 
-      {/* Comments (write) */}
-      {activeTab === 'comments' ? (
-        <WorkOrderCommentsTab
-          comments={activity.comments}
-          loading={activity.commentsLoading}
-          currentUserId={currentUserId}
-          mentionUsers={activity.mentionUsers}
-          onCreate={activity.createComment}
-          onUpdate={activity.updateComment}
-          onDelete={activity.deleteComment}
-        />
-      ) : null}
     </div>
   );
 }

--- a/app/crm/arbetsorder/WorkOrderCommentsTab.tsx
+++ b/app/crm/arbetsorder/WorkOrderCommentsTab.tsx
@@ -71,9 +71,26 @@ export default function WorkOrderCommentsTab({ comments, loading, currentUserId,
   }
 
   return (
-    <div className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_340px] lg:items-start">
-      <div className={cn(crm.cardInner, 'grid gap-3')}>
-        <p className={crm.sectionTitle}>Projektkommentarer</p>
+    <div className={cn(crm.cardInner, 'grid gap-4')}>
+      <p className={crm.sectionTitle}>Projektkommentarer</p>
+
+      {/* Composer — inline at the top of the same card as the thread. */}
+      <div className="grid gap-2">
+        <MentionTextarea
+          value={draft}
+          onChange={setDraft}
+          onMention={(u) => { if (u.full_name) mentionedRef.current.set(u.id, u.full_name); }}
+          users={mentionUsers}
+          rows={3}
+          placeholder="Skriv en kommentar… använd @ för att tagga någon"
+        />
+        <button type="button" onClick={submitCreate} disabled={creating || !draft.trim()} className={cn(crm.saveButton, 'h-9 w-auto justify-self-end px-5')}>
+          {creating ? 'Sparar kommentar…' : 'Spara kommentar'}
+        </button>
+      </div>
+
+      {/* Thread */}
+      <div className="grid gap-2 border-t border-[#e0e8dc] pt-4">
         {loading ? <div className="text-sm text-slate-500">Laddar kommentarer…</div> : null}
         {!loading && comments.length === 0 ? (
           <div className="rounded-xl border border-dashed border-[#cfdcc9] bg-[#f1f5ee] px-4 py-6 text-sm text-slate-500">Inga kommentarer ännu.</div>
@@ -119,21 +136,6 @@ export default function WorkOrderCommentsTab({ comments, loading, currentUserId,
             </div>
           );
         }) : null}
-      </div>
-
-      <div className={cn(crm.cardInner, 'grid gap-3 lg:content-start')}>
-        <p className={crm.sectionTitle}>Ny kommentar</p>
-        <MentionTextarea
-          value={draft}
-          onChange={setDraft}
-          onMention={(u) => { if (u.full_name) mentionedRef.current.set(u.id, u.full_name); }}
-          users={mentionUsers}
-          rows={8}
-          placeholder="Skriv en kommentar… använd @ för att tagga någon"
-        />
-        <button type="button" onClick={submitCreate} disabled={creating} className={crm.saveButton}>
-          {creating ? 'Sparar kommentar…' : 'Spara kommentar'}
-        </button>
       </div>
     </div>
   );

--- a/app/crm/arbetsorder/WorkOrderCommentsTab.tsx
+++ b/app/crm/arbetsorder/WorkOrderCommentsTab.tsx
@@ -74,23 +74,8 @@ export default function WorkOrderCommentsTab({ comments, loading, currentUserId,
     <div className={cn(crm.cardInner, 'grid gap-4')}>
       <p className={crm.sectionTitle}>Projektkommentarer</p>
 
-      {/* Composer — inline at the top of the same card as the thread. */}
+      {/* Thread first */}
       <div className="grid gap-2">
-        <MentionTextarea
-          value={draft}
-          onChange={setDraft}
-          onMention={(u) => { if (u.full_name) mentionedRef.current.set(u.id, u.full_name); }}
-          users={mentionUsers}
-          rows={3}
-          placeholder="Skriv en kommentar… använd @ för att tagga någon"
-        />
-        <button type="button" onClick={submitCreate} disabled={creating || !draft.trim()} className={cn(crm.saveButton, 'h-9 w-auto justify-self-end px-5')}>
-          {creating ? 'Sparar kommentar…' : 'Spara kommentar'}
-        </button>
-      </div>
-
-      {/* Thread */}
-      <div className="grid gap-2 border-t border-[#e0e8dc] pt-4">
         {loading ? <div className="text-sm text-slate-500">Laddar kommentarer…</div> : null}
         {!loading && comments.length === 0 ? (
           <div className="rounded-xl border border-dashed border-[#cfdcc9] bg-[#f1f5ee] px-4 py-6 text-sm text-slate-500">Inga kommentarer ännu.</div>
@@ -136,6 +121,21 @@ export default function WorkOrderCommentsTab({ comments, loading, currentUserId,
             </div>
           );
         }) : null}
+      </div>
+
+      {/* Composer at the bottom, below the thread. */}
+      <div className="grid gap-2 border-t border-[#e0e8dc] pt-4">
+        <MentionTextarea
+          value={draft}
+          onChange={setDraft}
+          onMention={(u) => { if (u.full_name) mentionedRef.current.set(u.id, u.full_name); }}
+          users={mentionUsers}
+          rows={2}
+          placeholder="Skriv en kommentar… använd @ för att tagga någon"
+        />
+        <button type="button" onClick={submitCreate} disabled={creating || !draft.trim()} className={cn(crm.saveButton, 'h-9 w-auto justify-self-end px-5')}>
+          {creating ? 'Sparar kommentar…' : 'Spara kommentar'}
+        </button>
       </div>
     </div>
   );

--- a/app/crm/arbetsorder/WorkOrderDetailClient.tsx
+++ b/app/crm/arbetsorder/WorkOrderDetailClient.tsx
@@ -26,7 +26,7 @@ import { openFortnoxPdf, postFortnoxEmail } from '@/app/crm/lib/fortnoxDoc';
 // ─── Types ──────────────────────────────────────────────────────────────────
 
 type WorkOrderStatus = 'draft' | 'scheduled' | 'ready' | 'in_progress' | 'completed' | 'partially_invoiced' | 'invoiced' | 'cancelled';
-type WorkOrderTab = 'overview' | 'economy' | 'articles' | 'time' | 'comments';
+type WorkOrderTab = 'overview' | 'economy' | 'articles' | 'time';
 type FortnoxSyncStatus = 'not_synced' | 'pending' | 'synced' | 'failed';
 
 // One delfakturering round: the per-article quantities billed + the Fortnox invoice it produced.
@@ -480,8 +480,10 @@ export default function WorkOrderDetailClient({ workOrderId, fortnoxConnected, c
   const ecoSubtotal = Number(workOrder.pricing_summary?.subtotal ?? 0);
   const ecoVat = Number(workOrder.pricing_summary?.vat ?? 0);
   const reverseCharge = workOrder.quote_type === 'business' && ecoVat === 0 && ecoSubtotal > 0;
+  // Comments live at the bottom of the overview (not a separate tab), so an @-mention notification
+  // lands you straight on the thread without hunting for a tab.
   const tabs: Array<[WorkOrderTab, string]> = [
-    ['overview', 'Översikt'], ['economy', 'Ekonomi'], ['articles', 'Artiklar'], ['time', 'Tid'], ['comments', 'Kommentarer'],
+    ['overview', 'Översikt'], ['economy', 'Ekonomi'], ['articles', 'Artiklar'], ['time', 'Tid'],
   ];
 
   // Read-only field display used when the overview is locked.
@@ -816,6 +818,19 @@ export default function WorkOrderDetailClient({ workOrderId, fortnoxConnected, c
         </div>
       ) : null}
 
+      {/* ─── Comments (on the overview, full width below the columns) ─── */}
+      {activeTab === 'overview' ? (
+        <WorkOrderCommentsTab
+          comments={comments}
+          loading={commentsLoading}
+          currentUserId={currentUserId}
+          mentionUsers={mentionUsers}
+          onCreate={createComment}
+          onUpdate={updateComment}
+          onDelete={deleteComment}
+        />
+      ) : null}
+
       {/* ─── Economy ─── */}
       {activeTab === 'economy' ? (
         <div className="grid gap-4">
@@ -970,19 +985,6 @@ export default function WorkOrderDetailClient({ workOrderId, fortnoxConnected, c
           onCreate={createTimeEntry}
           onUpdate={updateTimeEntry}
           onDelete={deleteTimeEntry}
-        />
-      ) : null}
-
-      {/* ─── Comments ─── */}
-      {activeTab === 'comments' ? (
-        <WorkOrderCommentsTab
-          comments={comments}
-          loading={commentsLoading}
-          currentUserId={currentUserId}
-          mentionUsers={mentionUsers}
-          onCreate={createComment}
-          onUpdate={updateComment}
-          onDelete={deleteComment}
         />
       ) : null}
 

--- a/components/notifications/NotificationBell.tsx
+++ b/components/notifications/NotificationBell.tsx
@@ -7,6 +7,7 @@ import { createClientComponentClient } from '@supabase/auth-helpers-nextjs';
 import { cn } from '@/lib/shared/cn';
 import { mapNotificationRow } from '@/lib/domains/notifications/mappers';
 import type { NotificationRow, NotificationView } from '@/lib/domains/notifications/types';
+import { usePushSubscription } from './usePushSubscription';
 
 // App-shell notification bell. Self-contained: fetches its own user + data, subscribes to
 // Realtime so the badge and list stay live. Reusable for any notification type. Rendered in
@@ -28,6 +29,8 @@ export default function NotificationBell({ className, collapsed = false }: { cla
   // Panelen visar OLÄSTA som standard; "Visa lästa" växlar till hela historiken (30 senaste).
   const [showRead, setShowRead] = useState(false);
   const showReadRef = useRef(false);
+  // Per-enhet push opt-in (samma /api/push-flöde som dashboardens påminnelser).
+  const push = usePushSubscription();
 
   useEffect(() => setMounted(true), []);
   useEffect(() => { showReadRef.current = showRead; }, [showRead]);
@@ -221,6 +224,41 @@ export default function NotificationBell({ className, collapsed = false }: { cla
                 </ul>
               )}
             </div>
+
+            {push.supported && (
+              <div className="border-t border-slate-100 px-4 py-3">
+                {push.enabled ? (
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="flex items-center gap-1.5 text-[12px] font-semibold text-emerald-700">
+                      <span className="h-2 w-2 rounded-full bg-emerald-500" aria-hidden />
+                      Notiser på för den här enheten
+                    </span>
+                    <button
+                      type="button"
+                      onClick={() => push.disable()}
+                      disabled={push.loading}
+                      className="text-[12px] font-semibold text-slate-500 hover:text-slate-700 disabled:opacity-50"
+                    >
+                      Stäng av
+                    </button>
+                  </div>
+                ) : push.permission === 'denied' ? (
+                  <p className="m-0 text-[12px] text-slate-500">
+                    Notiser är blockerade i enhetens inställningar. Tillåt dem där för att få notiser hit.
+                  </p>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={() => push.enable()}
+                    disabled={push.loading}
+                    className="flex w-full items-center justify-center gap-1.5 rounded-lg border border-emerald-200 bg-emerald-50 px-3 py-2 text-[12px] font-semibold text-emerald-700 transition hover:bg-emerald-100 disabled:opacity-50"
+                  >
+                    {push.loading ? 'Aktiverar…' : 'Aktivera notiser på den här enheten'}
+                  </button>
+                )}
+                {push.error && <p className="m-0 mt-1.5 text-[11px] text-red-600">{push.error}</p>}
+              </div>
+            )}
           </div>
         </div>,
         document.body,

--- a/components/notifications/usePushSubscription.ts
+++ b/components/notifications/usePushSubscription.ts
@@ -1,0 +1,136 @@
+"use client";
+
+import { useCallback, useEffect, useState } from 'react';
+
+// Shared web-push opt-in for the current device. Wraps the existing /api/push endpoints and the
+// service worker registered app-wide in app/register-sw.tsx. Used by the notification bell so any
+// user can enable phone notifications without going to the dashboard notes card.
+//
+// Per-device: each browser/PWA install registers its own subscription. iOS requires an installed
+// PWA (16.4+). No subscription → the bell still works, there's just no push.
+export type PushSubscriptionState = {
+  supported: boolean;
+  enabled: boolean;
+  permission: NotificationPermission;
+  loading: boolean;
+  error: string | null;
+  enable: () => Promise<void>;
+  disable: () => Promise<void>;
+};
+
+export function usePushSubscription(): PushSubscriptionState {
+  const [supported, setSupported] = useState(false);
+  const [enabled, setEnabled] = useState(false);
+  const [permission, setPermission] = useState<NotificationPermission>('default');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Reflect the device's current state: support, OS permission, and whether a subscription exists.
+  const sync = useCallback(async () => {
+    const isSupported =
+      typeof navigator !== 'undefined' &&
+      'serviceWorker' in navigator &&
+      typeof window !== 'undefined' &&
+      'PushManager' in window &&
+      'Notification' in window;
+    setSupported(isSupported);
+    if (!isSupported) return;
+    setPermission(Notification.permission);
+    try {
+      const registration = await navigator.serviceWorker.ready;
+      const subscription = await registration.pushManager.getSubscription();
+      setEnabled(Boolean(subscription));
+    } catch {
+      setEnabled(false);
+    }
+  }, []);
+
+  useEffect(() => { void sync(); }, [sync]);
+
+  const enable = useCallback(async () => {
+    if (!supported) {
+      setError('Den här enheten stöder inte pushnotiser.');
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      const registrationPromise = navigator.serviceWorker
+        .getRegistration('/sw.js')
+        .then((registration) => registration || navigator.serviceWorker.ready);
+
+      const keyRes = await fetch('/api/push/public-key');
+      const keyJson = await keyRes.json().catch(() => null);
+      if (!keyRes.ok) throw new Error(keyJson?.error || 'Kunde inte läsa push-nyckel.');
+      const publicKey = String(keyJson?.publicKey || '');
+      if (!publicKey) throw new Error('Push är inte konfigurerat.');
+
+      const perm = await Notification.requestPermission();
+      setPermission(perm);
+      if (perm !== 'granted') {
+        throw new Error('Notiser måste tillåtas för att de ska nå den här enheten.');
+      }
+
+      const registration = await registrationPromise;
+      let subscription = await registration.pushManager.getSubscription();
+      if (!subscription) {
+        subscription = await registration.pushManager.subscribe({
+          userVisibleOnly: true,
+          applicationServerKey: base64ToUint8Array(publicKey),
+        });
+      }
+
+      const saveRes = await fetch('/api/push/subscription', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ subscription: subscription.toJSON(), userAgent: navigator.userAgent }),
+      });
+      const saveJson = await saveRes.json().catch(() => null);
+      if (!saveRes.ok) throw new Error(saveJson?.error || 'Kunde inte aktivera notiser.');
+
+      setEnabled(true);
+    } catch (e: any) {
+      setEnabled(false);
+      setError(String(e?.message || e || 'Kunde inte aktivera notiser.'));
+    } finally {
+      setLoading(false);
+    }
+  }, [supported]);
+
+  const disable = useCallback(async () => {
+    if (!supported) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const registration = await navigator.serviceWorker.ready;
+      const subscription = await registration.pushManager.getSubscription();
+      if (subscription) {
+        await fetch('/api/push/subscription', {
+          method: 'DELETE',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ endpoint: subscription.endpoint }),
+        });
+        await subscription.unsubscribe();
+      }
+      setEnabled(false);
+    } catch (e: any) {
+      setError(String(e?.message || e || 'Kunde inte stänga av notiser.'));
+    } finally {
+      setLoading(false);
+    }
+  }, [supported]);
+
+  return { supported, enabled, permission, loading, error, enable, disable };
+}
+
+// VAPID public key (URL-safe base64) → Uint8Array for pushManager.subscribe.
+function base64ToUint8Array(value: string) {
+  const padding = '='.repeat((4 - (value.length % 4)) % 4);
+  const normalized = (value + padding).replace(/-/g, '+').replace(/_/g, '/');
+  const raw = atob(normalized);
+  const output = new Uint8Array(raw.length);
+  for (let index = 0; index < raw.length; index += 1) {
+    output[index] = raw.charCodeAt(index);
+  }
+  return output;
+}

--- a/lib/domains/notifications/delivery.ts
+++ b/lib/domains/notifications/delivery.ts
@@ -1,0 +1,103 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { NotificationInsert } from './types';
+import { createNotifications } from './mutations';
+import { isWebPushConfigured, sendWebPush } from '@/lib/webPush';
+
+// Deliver notifications: insert the rows (the bell is the source of truth) AND, best-effort, send a
+// web push to each recipient's registered devices so the notification also reaches phones. Push is a
+// pure enhancement — a push failure never affects the insert, and callers get the same result shape
+// as createNotifications. Service-role client required (fan-out writes rows for OTHER users).
+//
+// Because every notification row already carries title/body/href, routing all producers through this
+// single helper means every notification type gets push for free — no per-feature work, no SW change.
+export async function deliverNotifications(admin: SupabaseClient, rows: NotificationInsert[]) {
+  const result = await createNotifications(admin, rows);
+  // Never let push break the caller or the underlying insert.
+  try {
+    await pushToRecipients(admin, rows);
+  } catch (e) {
+    console.error('[notifications] push fan-out failed', e);
+  }
+  return result;
+}
+
+type PushSubscriptionRow = {
+  id: string;
+  user_id: string;
+  endpoint: string;
+  p256dh: string;
+  auth: string;
+};
+
+// Best-effort web push for a batch of notification rows. Loads each recipient's devices once and
+// fans a push out per device, pruning dead endpoints (404/410) exactly like the reminders dispatch.
+async function pushToRecipients(admin: SupabaseClient, rows: NotificationInsert[]) {
+  if (!isWebPushConfigured() || rows.length === 0) return;
+
+  // A recipient may receive several rows in one batch — group so we look up devices once per user.
+  const rowsByRecipient = new Map<string, NotificationInsert[]>();
+  for (const row of rows) {
+    const list = rowsByRecipient.get(row.recipient_user_id) ?? [];
+    list.push(row);
+    rowsByRecipient.set(row.recipient_user_id, list);
+  }
+
+  const { data: subscriptions, error } = await admin
+    .from('dashboard_push_subscriptions')
+    .select('id,user_id,endpoint,p256dh,auth')
+    .in('user_id', [...rowsByRecipient.keys()]);
+
+  if (error || !subscriptions?.length) return;
+
+  const subsByUser = new Map<string, PushSubscriptionRow[]>();
+  for (const sub of subscriptions as PushSubscriptionRow[]) {
+    const list = subsByUser.get(sub.user_id) ?? [];
+    list.push(sub);
+    subsByUser.set(sub.user_id, list);
+  }
+
+  const sends: Promise<void>[] = [];
+  for (const [userId, userRows] of rowsByRecipient) {
+    const devices = subsByUser.get(userId);
+    if (!devices?.length) continue; // no opted-in device → bell only, no push
+    for (const row of userRows) {
+      for (const device of devices) {
+        sends.push(sendToDevice(admin, device, row));
+      }
+    }
+  }
+
+  await Promise.all(sends);
+}
+
+async function sendToDevice(admin: SupabaseClient, device: PushSubscriptionRow, row: NotificationInsert) {
+  try {
+    await sendWebPush(
+      { endpoint: device.endpoint, keys: { p256dh: device.p256dh, auth: device.auth } },
+      {
+        title: row.title,
+        body: row.body ?? '',
+        url: row.href ?? '/',
+        // Collapse repeated push banners for the same thing (a new mention on the same order
+        // replaces the previous banner); the bell still lists every notification.
+        tag: `${row.type}:${row.entity_id ?? ''}`,
+      },
+    );
+    await admin
+      .from('dashboard_push_subscriptions')
+      .update({ last_success_at: new Date().toISOString(), last_error: null })
+      .eq('id', device.id);
+  } catch (error: any) {
+    const statusCode = Number(error?.statusCode || 0);
+    if (statusCode === 404 || statusCode === 410) {
+      // Endpoint is gone (unsubscribed / expired) — drop it so we stop trying.
+      await admin.from('dashboard_push_subscriptions').delete().eq('id', device.id);
+    } else {
+      const message = String(error?.body || error?.message || 'Push send failed');
+      await admin
+        .from('dashboard_push_subscriptions')
+        .update({ last_failure_at: new Date().toISOString(), last_error: message.slice(0, 1000) })
+        .eq('id', device.id);
+    }
+  }
+}

--- a/lib/domains/notifications/payload.ts
+++ b/lib/domains/notifications/payload.ts
@@ -23,19 +23,27 @@ export function buildFaultReportCreatedNotification(input: FaultReportNotificati
 }
 
 // Sent to each user @-mentioned in a work order comment.
+//
+// `audience` routes the link to a view the recipient can actually open: office roles (sales/admin/
+// konsult) get the full CRM detail view; everyone else (installers = member, leader, readonly) gets
+// the open field view at /arbetsorder/<id>. Both mount the same comments tab, so the mention is
+// readable either way. Without this split an installer would land on /crm/* and be bounced to '/'
+// by the CRM access gate. Defaults to 'crm' for callers that don't distinguish.
 export function buildWorkOrderCommentMentionNotification(input: {
   workOrderId: string;
   orderNumber?: string | null;
   projectName?: string | null;
   commenterName?: string | null;
+  audience?: 'crm' | 'field';
 }): NotificationContent {
   const ref = input.orderNumber ? `#${input.orderNumber}` : 'en arbetsorder';
   const where = input.projectName ? `${ref} · ${input.projectName}` : ref;
+  const basePath = input.audience === 'field' ? '/arbetsorder' : '/crm/arbetsorder';
   return {
     type: 'work_order.mention',
     title: `${input.commenterName || 'Någon'} nämnde dig i en kommentar`,
     body: `Arbetsorder ${where}`,
-    href: `/crm/arbetsorder/${input.workOrderId}`,
+    href: `${basePath}/${input.workOrderId}`,
     entity_type: 'work_order',
     entity_id: input.workOrderId,
   };

--- a/tests/notifications/delivery.test.ts
+++ b/tests/notifications/delivery.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { NotificationInsert } from '@/lib/domains/notifications/types';
+
+// The delivery helper does real I/O through the (mocked) service-role client and web-push module.
+vi.mock('@/lib/webPush', () => ({
+  isWebPushConfigured: vi.fn(() => true),
+  sendWebPush: vi.fn(async () => {}),
+}));
+
+import { deliverNotifications } from '@/lib/domains/notifications/delivery';
+import { isWebPushConfigured, sendWebPush } from '@/lib/webPush';
+
+type DeviceRow = { id: string; user_id: string; endpoint: string; p256dh: string; auth: string };
+
+// Minimal chainable stand-in for the Supabase service-role client covering exactly the calls the
+// delivery helper makes: notifications.insert().select(), subscriptions.select().in(),
+// subscriptions.update().eq(), subscriptions.delete().eq().
+function makeAdmin(subs: DeviceRow[] = []) {
+  const calls = {
+    inserted: null as NotificationInsert[] | null,
+    lookupIds: null as string[] | null,
+    deletes: [] as string[],
+    updates: [] as Array<{ id: string; payload: Record<string, unknown> }>,
+  };
+  const admin: any = {
+    from(table: string) {
+      if (table === 'notifications') {
+        return {
+          insert(rows: NotificationInsert[]) {
+            calls.inserted = rows;
+            return { select: async () => ({ data: rows.map((_, i) => ({ id: `n${i}` })), error: null }) };
+          },
+        };
+      }
+      // dashboard_push_subscriptions
+      return {
+        select() {
+          return {
+            in(_col: string, ids: string[]) {
+              calls.lookupIds = ids;
+              return Promise.resolve({ data: subs.filter((s) => ids.includes(s.user_id)), error: null });
+            },
+          };
+        },
+        update(payload: Record<string, unknown>) {
+          return {
+            eq: (_c: string, id: string) => {
+              calls.updates.push({ id, payload });
+              return Promise.resolve({ error: null });
+            },
+          };
+        },
+        delete() {
+          return {
+            eq: (_c: string, id: string) => {
+              calls.deletes.push(id);
+              return Promise.resolve({ error: null });
+            },
+          };
+        },
+      };
+    },
+  };
+  return { admin, calls };
+}
+
+const device = (id: string, user_id: string): DeviceRow => ({
+  id,
+  user_id,
+  endpoint: `https://push.example/${id}`,
+  p256dh: `p256-${id}`,
+  auth: `auth-${id}`,
+});
+
+const row = (recipient: string, over: Partial<NotificationInsert> = {}): NotificationInsert => ({
+  recipient_user_id: recipient,
+  type: 'work_order.mention',
+  title: 'Kalle nämnde dig',
+  body: 'Arbetsorder #1042',
+  href: '/crm/arbetsorder/wo1',
+  entity_type: 'work_order',
+  entity_id: 'wo1',
+  ...over,
+});
+
+beforeEach(() => {
+  vi.mocked(isWebPushConfigured).mockReturnValue(true);
+  vi.mocked(sendWebPush).mockReset();
+  vi.mocked(sendWebPush).mockResolvedValue(undefined as any);
+});
+
+describe('deliverNotifications', () => {
+  it('inserts the rows and returns the insert result', async () => {
+    const { admin, calls } = makeAdmin([]);
+    const rows = [row('u1'), row('u2')];
+    const result = await deliverNotifications(admin, rows);
+    expect(calls.inserted).toEqual(rows);
+    expect(result.error).toBeNull();
+    expect(result.data).toHaveLength(2);
+  });
+
+  it('skips push entirely when web push is not configured', async () => {
+    vi.mocked(isWebPushConfigured).mockReturnValue(false);
+    const { admin, calls } = makeAdmin([device('d1', 'u1')]);
+    await deliverNotifications(admin, [row('u1')]);
+    expect(calls.lookupIds).toBeNull(); // no subscription lookup
+    expect(sendWebPush).not.toHaveBeenCalled();
+  });
+
+  it('pushes to each opted-in device with the row content mapped to the SW payload', async () => {
+    const { admin } = makeAdmin([device('d1', 'u1')]);
+    await deliverNotifications(admin, [row('u1')]);
+    expect(sendWebPush).toHaveBeenCalledTimes(1);
+    const [subscription, payload] = vi.mocked(sendWebPush).mock.calls[0];
+    expect(subscription).toEqual({ endpoint: 'https://push.example/d1', keys: { p256dh: 'p256-d1', auth: 'auth-d1' } });
+    expect(payload).toMatchObject({
+      title: 'Kalle nämnde dig',
+      body: 'Arbetsorder #1042',
+      url: '/crm/arbetsorder/wo1',
+      tag: 'work_order.mention:wo1',
+    });
+  });
+
+  it('looks up devices once for the unique recipient set and fans out per device', async () => {
+    const { admin, calls } = makeAdmin([device('d1', 'u1'), device('d2', 'u1'), device('d3', 'u2')]);
+    await deliverNotifications(admin, [row('u1'), row('u2')]);
+    expect(calls.lookupIds).toEqual(['u1', 'u2']);
+    // u1 has 2 devices, u2 has 1 → 3 pushes total.
+    expect(sendWebPush).toHaveBeenCalledTimes(3);
+  });
+
+  it('recipients without a device get the bell row but no push', async () => {
+    const { admin } = makeAdmin([]); // nobody subscribed
+    await deliverNotifications(admin, [row('u1')]);
+    expect(sendWebPush).not.toHaveBeenCalled();
+  });
+
+  it('prunes a dead endpoint (410 Gone) and never throws', async () => {
+    vi.mocked(sendWebPush).mockRejectedValueOnce(Object.assign(new Error('gone'), { statusCode: 410 }));
+    const { admin, calls } = makeAdmin([device('d1', 'u1')]);
+    await expect(deliverNotifications(admin, [row('u1')])).resolves.toBeDefined();
+    expect(calls.deletes).toEqual(['d1']);
+  });
+
+  it('records a failure (non-404/410) without deleting the subscription', async () => {
+    vi.mocked(sendWebPush).mockRejectedValueOnce(Object.assign(new Error('boom'), { statusCode: 500 }));
+    const { admin, calls } = makeAdmin([device('d1', 'u1')]);
+    await deliverNotifications(admin, [row('u1')]);
+    expect(calls.deletes).toEqual([]);
+    expect(calls.updates.some((u) => u.id === 'd1' && 'last_failure_at' in u.payload)).toBe(true);
+  });
+});

--- a/tests/notifications/notifications.test.ts
+++ b/tests/notifications/notifications.test.ts
@@ -96,6 +96,16 @@ describe('buildWorkOrderCommentMentionNotification', () => {
     expect(n.title).toContain('Någon');
     expect(n.body).toContain('en arbetsorder');
   });
+
+  it('routes the field audience to the open installer view (not the office-only /crm route)', () => {
+    const n = buildWorkOrderCommentMentionNotification({ workOrderId: 'wo3', audience: 'field' });
+    expect(n.href).toBe('/arbetsorder/wo3');
+  });
+
+  it('routes the crm audience to the CRM detail view', () => {
+    const n = buildWorkOrderCommentMentionNotification({ workOrderId: 'wo4', audience: 'crm' });
+    expect(n.href).toBe('/crm/arbetsorder/wo4');
+  });
 });
 
 describe('expandNotificationToRecipients', () => {


### PR DESCRIPTION
## Notissystem-uppföljning

Bygger vidare på notissystemet (in-app klocka + @-mentions).

### Kommentarer på arbetsordern
- Kommentarstråden flyttad till AO:ns första sida i båda vyerna (CRM + installatör); separata fliken borttagen.
- Skrivfält + tråd ihopslaget till ett kort (tråd först, kompakt komposer sist).
- Rollmedveten mention-länk: installatörer landar på öppna fältvyn `/arbetsorder/<id>` istället för det office-låsta `/crm/*`.

### Push-notiser (nytt)
- `deliverNotifications()` på domän-nivå: skapar notis-raden **och** web-pushar mottagarens opt-in-enheter. Alla notistyper får push utan per-feature-arbete.
- Alla 3 producenter (felanmälan skapa/uppdatera, work-order mention) routade om.
- Återanvänder befintlig push-infra — ingen migration, ingen SW-ändring. Prunear döda endpoints (404/410); push påverkar aldrig sparningen.
- "Aktivera notiser på den här enheten"-opt-in i notisklockan (delad `usePushSubscription`-hook).

### Test
20 notis-tester gröna · type-check ✓ · build ✓.

### Kvar (separat)
- Riktig `favicon-192.png` (push-ikon).
- VAPID-nycklar i prod + E2E på enhet.