### PR TITLE
Feature/crm golive followups

### DIFF
--- a/PERMISSIONS.md
+++ b/PERMISSIONS.md
@@ -138,6 +138,41 @@ seed equals the role set the old predicate admitted, so behavior is identical):
 
 ---
 
+### Crew access — the one path that is NOT permission-based ⚠️
+
+`supabase/sql/20260810_crm_work_order_crew_access.sql` (field/CRM cutover).
+
+Installers (`member`) have **no CRM permission keys, deliberately** — and that must stay true.
+But they have to reach the work order they are scheduled on. That access is **derived from data,
+not granted by a key**: `is_user_on_work_order(uid, work_order_id)` asks the planning crew tables
+(`ops_segment_crew` / `ops_truck_crew` / `ops_truck_default_crew`, joined to the order through
+`ops_segments.work_order_id`) whether this person is on this job.
+
+| | |
+| --- | --- |
+| **Tables** | `crm_work_orders` (SELECT), `crm_work_order_time_entries` (SELECT + INSERT), `crm_work_order_comments` (SELECT + INSERT) |
+| **Policies** | `*_crew`, **additive** — Postgres OR-combines permissive policies, so the existing `assigned_to` / `has_permission` policies are untouched and nobody loses access |
+| **Resolution** | Weekly truck crew **overrides** the standing default crew, resolved per **ISO week** to match `crewForTruckInRange` in `app/crm/planering/WeekBoard.tsx` |
+| **Helper** | `security definer` (the caller has no `planning.schedule.read`), `revoke from public`, `grant execute to authenticated` |
+
+Two consequences worth remembering:
+
+- **RLS is row-level and cannot narrow columns.** `crmWorkOrderSelect` carries
+  `customer_snapshot.personal_number` and `rot_details.personal_number`, so a crew SELECT policy
+  alone would hand personnummer to installers. The column-level line is drawn in
+  `redactWorkOrderForField` (`lib/domains/crm/work-orders.ts`), applied in
+  `GET /api/crm/work-orders/[id]` for `role === 'member'`. **Any new field-facing route on a CRM
+  table must do the same.**
+- **The time-entry policies are dormant on purpose.** The field view has no time tab while Blikk
+  still owns payroll; the policies exist because they are correct and are what the CRM time
+  migration needs.
+
+`is_user_on_work_order` is callable by any authenticated user with an arbitrary uid, so an
+employee can probe who is on which job. Accepted: employees-only, and the planning board already
+shows crew to anyone with `planning.schedule.read`.
+
+---
+
 ## Managing permissions (admin UI)
 
 **Admin → Behörigheter** (`app/admin/permissions/AdminPermissions.tsx`):
@@ -249,6 +284,9 @@ yet), and coach. Swap them to granular keys once those are reconciled.
   `crm_customers` with `customer_stage = 'prospect'`; `crm_calls`/`crm_quotes` join
   `crm_customers` via `prospect_id`.
 - **Keep the catalog in sync** between the SQL `permissions` table and `PERMISSION_KEYS`.
+- **Not all access is a permission key.** Crew access to work orders is derived from the planning
+  tables (see above), so "member has no CRM keys" does *not* mean "member cannot read a work
+  order". Grep for `is_user_on_work_order` before reasoning about who can see what.
 
 ---
 
@@ -259,6 +297,7 @@ yet), and coach. Swap them to granular keys once those are reconciled.
 | Model + resolver + seed | `supabase/sql/20260608_permissions_model.sql`, `…_parity_assert.sql` |
 | RLS swaps | `supabase/sql/20260609_rls_permissions_crm_{core,quotes_workorders,admin}.sql`, `…_verify.sql` |
 | Lockout guard | `supabase/sql/20260609_permissions_admin_lockout_guard.sql` |
+| Crew access (non-key) | `supabase/sql/20260810_crm_work_order_crew_access.sql`, `redactWorkOrderForField` in `lib/domains/crm/work-orders.ts` |
 | App layer | `lib/auth/permissions.ts`, `app/api/crm/_shared.ts` (`requirePermission` + guard wrappers) |
 | Admin UI | `app/admin/permissions/AdminPermissions.tsx`, `app/api/admin/permissions/**` |
 

--- a/PERMISSIONS.md
+++ b/PERMISSIONS.md
@@ -171,6 +171,17 @@ Two consequences worth remembering:
 employee can probe who is on which job. Accepted: employees-only, and the planning board already
 shows crew to anyone with `planning.schedule.read`.
 
+**What it costs (measured 2026-08-11, question closed).** A row-dependent predicate can be evaluated
+once per row, which would have made the CRM work-order list — and especially the six `count(*)` chip
+queries, which have no `LIMIT` to stop early — scale badly. It doesn't: the plan's filter evaluates
+`assigned_to = auth.uid()` → `has_permission(...)` → `is_user_on_work_order(...)`, and for
+sales/admin the middle arm is true, so the OR short-circuits and the crew function is **never called
+on the office path**, at any table size. A `member` has no permission key, so their read does fall
+through to the crew branch — correct, it's their only way in, and it is scoped to their own jobs.
+Re-measure after PostgreSQL upgrades: arm order is not guaranteed. Probe and method:
+`supabase/sql/20260811_crm_work_order_rls_perf_probe.sql`, `SUPABASE_CONVENTIONS.md` →
+"Measuring what a policy costs".
+
 ---
 
 ## Managing permissions (admin UI)
@@ -298,6 +309,7 @@ yet), and coach. Swap them to granular keys once those are reconciled.
 | RLS swaps | `supabase/sql/20260609_rls_permissions_crm_{core,quotes_workorders,admin}.sql`, `…_verify.sql` |
 | Lockout guard | `supabase/sql/20260609_permissions_admin_lockout_guard.sql` |
 | Crew access (non-key) | `supabase/sql/20260810_crm_work_order_crew_access.sql`, `redactWorkOrderForField` in `lib/domains/crm/work-orders.ts` |
+| Policy cost probe | `supabase/sql/20260811_crm_work_order_rls_perf_probe.sql` (create → run → drop; measures under impersonation) |
 | App layer | `lib/auth/permissions.ts`, `app/api/crm/_shared.ts` (`requirePermission` + guard wrappers) |
 | Admin UI | `app/admin/permissions/AdminPermissions.tsx`, `app/api/admin/permissions/**` |
 

--- a/app/api/crm/quotes/[id]/work-order/route.ts
+++ b/app/api/crm/quotes/[id]/work-order/route.ts
@@ -30,6 +30,13 @@ export async function POST(_req: Request, context: RouteContext) {
         return routeError(409, 'crm_work_order_missing_personal_number', result.error?.message || 'Personnummer krävs för privatkund innan order kan skapas');
       }
 
+      // ROT without fastighetsbeteckning/BRF org.nr. Its own code so the quote form can open the
+      // prompt that collects it; the quote list (no prompt there) just shows the message, which
+      // says where to fill it in.
+      if (result.reason === 'missing_rot_property') {
+        return routeError(409, 'crm_work_order_missing_rot_property', result.error?.message || 'Fastighetsbeteckning krävs för ROT innan order kan skapas');
+      }
+
       if (result.reason === 'quote_not_won' || result.reason === 'already_created') {
         return routeError(409, result.reason, result.error?.message || 'Arbetsorder kunde inte skapas');
       }

--- a/app/crm/offerter/QuoteFormClient.tsx
+++ b/app/crm/offerter/QuoteFormClient.tsx
@@ -1707,6 +1707,10 @@ export default function QuoteFormClient({ quoteId }: { quoteId?: string }) {
     const property = draft.rot_property_designation.trim();
     const brf = draft.rot_brf_org_number.trim();
     if (!property && !brf) { toast.error('Fyll i fastighetsbeteckning eller BRF org.nr'); return; }
+    // Re-saving means the whole quote is validated again, and an older quote can be missing
+    // something today's schema requires (Er referens, t.ex.). Say which field it is here instead of
+    // letting the PATCH answer with a generic valideringsfel the seller can't act on.
+    if (issues.length > 0) { toast.error(`Offerten måste kompletteras först: ${issues[0]}`); return; }
     setCreatingWorkOrder(true);
     try {
       const res = await fetch(`/api/crm/quotes/${quoteId}`, {

--- a/app/crm/offerter/QuoteFormClient.tsx
+++ b/app/crm/offerter/QuoteFormClient.tsx
@@ -356,8 +356,9 @@ function getValidationIssues(draft: QuoteDraft, effectiveRows: EffectiveRow[]) {
   if (!draft.contact_name.trim()) issues.push('Er referens krävs');
   if (draft.quote_type === 'business' && draft.rot_enabled) issues.push('ROT är bara tillåtet för privatkund');
   // Fastighetsbeteckning is NOT required on the quote — it's only mandatory once the offer becomes a
-  // work order (customer-approved), so it's enforced at order creation, not here. The field stays
-  // available so it can be filled early when known.
+  // work order (customer-approved), so it's enforced at order creation, not here (the gate lives in
+  // createCrmWorkOrderFromQuote and answers `missing_rot_property`; a BRF org.nr identifies a
+  // bostadsrätt just as well). The field stays available so it can be filled early when known.
   // Every offer is built from article rows (there is no manual lump-sum amount field), so at least
   // one configured row is required.
   if (!hasAnyLineItemInput) issues.push('Lägg till minst en rad');
@@ -987,6 +988,10 @@ export default function QuoteFormClient({ quoteId }: { quoteId?: string }) {
   // Private customer without personnummer (optional at create) → the work-order route rejects
   // with 409; we prompt for it, save it on the customer, then retry the conversion.
   const [pnPromptOpen, setPnPromptOpen] = useState(false);
+  // Same shape for the ROT property: optional while quoting, required once the customer approves
+  // and the offer becomes an order (the route rejects with 409). Prompt → re-save the quote →
+  // retry the conversion.
+  const [rotPropertyPromptOpen, setRotPropertyPromptOpen] = useState(false);
   // Custom "leave with unsaved changes?" confirm for in-app navigation (the browser's own
   // beforeunload text can't be customised, so we show our own dialog where we can). Holds the
   // intended destination so the same dialog serves the back button AND intercepted link clicks.
@@ -1536,6 +1541,56 @@ export default function QuoteFormClient({ quoteId }: { quoteId?: string }) {
     return res.ok && json.ok;
   }
 
+  // The quote save payload, built from the current draft. Extracted so the ROT-property prompt can
+  // re-save the quote through the exact same shape the ordinary save uses — a partial PATCH won't
+  // do: the update schema requires the core fields, and only a body carrying `line_items` triggers
+  // the Fortnox auto-sync, which is what gets the fastighetsbeteckning onto the offer before it is
+  // converted to an order.
+  function buildQuotePayload() {
+    const effectiveCustomerName = getEffectiveCustomerName(draft);
+
+    // The offer's amount/summary always derive from the article rows — there is no manual amount
+    // field, and validation requires at least one row.
+    const amountNumber = totals.total;
+    const vatPercentNumber = parseDecimal(draft.vat_percent);
+
+    return {
+      prospect_id: draft.prospect_id || null,
+      customer_id: draft.customer_id || null,
+      customer_name: effectiveCustomerName,
+      quote_type: draft.quote_type,
+      customer_source: {
+        kind: draft.customer_source.kind,
+        sync_intent: draft.customer_source.kind === 'fortnox' ? 'linked' : draft.customer_source.sync_intent,
+        fortnox_customer_id: draft.customer_source.fortnox_customer_id || null,
+        fortnox_customer_name: draft.customer_source.fortnox_customer_name || null,
+      },
+      // Business quote at 0 % VAT = omvänd skattskyldighet (byggmoms) — the app's canonical
+      // signal (see quoteAmountDisplay). Captured point-in-time so the Fortnox push resolves
+      // the VAT regime even for snapshot-only quotes with no linked customer.
+      customer_snapshot: buildCustomerSnapshot(draft, {
+        reverseVat: draft.quote_type === 'business' && parseDecimal(draft.vat_percent) === 0,
+      }),
+      pricing_summary: {
+        subtotal: totals.subtotal,
+        vat: totals.vat,
+        total: totals.total,
+      },
+      line_items: draft.items,
+      rot_details: buildRotDetails(draft),
+      internal_handoff: buildInternalHandoff(draft),
+      project_name: draft.project_name,
+      description: draft.description,
+      amount: amountNumber,
+      vat_percent: vatPercentNumber,
+      valid_until: draft.valid_until || null,
+      status: draft.status,
+      quote_date: draft.quote_date,
+      follow_up_date: draft.follow_up_date || null,
+      notes: draft.notes,
+    };
+  }
+
   async function saveQuote() {
     setSubmitAttempted(true);
     if (submitting) return;
@@ -1552,48 +1607,7 @@ export default function QuoteFormClient({ quoteId }: { quoteId?: string }) {
     setSubmitting(true);
 
     try {
-      const effectiveCustomerName = getEffectiveCustomerName(draft);
-
-      // The offer's amount/summary always derive from the article rows — there is no manual amount
-      // field, and validation requires at least one row.
-      const amountNumber = totals.total;
-      const vatPercentNumber = parseDecimal(draft.vat_percent);
-
-      const payload = {
-        prospect_id: draft.prospect_id || null,
-        customer_id: draft.customer_id || null,
-        customer_name: effectiveCustomerName,
-        quote_type: draft.quote_type,
-        customer_source: {
-          kind: draft.customer_source.kind,
-          sync_intent: draft.customer_source.kind === 'fortnox' ? 'linked' : draft.customer_source.sync_intent,
-          fortnox_customer_id: draft.customer_source.fortnox_customer_id || null,
-          fortnox_customer_name: draft.customer_source.fortnox_customer_name || null,
-        },
-        // Business quote at 0 % VAT = omvänd skattskyldighet (byggmoms) — the app's canonical
-        // signal (see quoteAmountDisplay). Captured point-in-time so the Fortnox push resolves
-        // the VAT regime even for snapshot-only quotes with no linked customer.
-        customer_snapshot: buildCustomerSnapshot(draft, {
-          reverseVat: draft.quote_type === 'business' && parseDecimal(draft.vat_percent) === 0,
-        }),
-        pricing_summary: {
-          subtotal: totals.subtotal,
-          vat: totals.vat,
-          total: totals.total,
-        },
-        line_items: draft.items,
-        rot_details: buildRotDetails(draft),
-        internal_handoff: buildInternalHandoff(draft),
-        project_name: draft.project_name,
-        description: draft.description,
-        amount: amountNumber,
-        vat_percent: vatPercentNumber,
-        valid_until: draft.valid_until || null,
-        status: draft.status,
-        quote_date: draft.quote_date,
-        follow_up_date: draft.follow_up_date || null,
-        notes: draft.notes,
-      };
+      const payload = buildQuotePayload();
 
       const res = await fetch(isEditing ? `/api/crm/quotes/${quoteId}` : '/api/crm/quotes', {
         method: isEditing ? 'PATCH' : 'POST',
@@ -1649,6 +1663,10 @@ export default function QuoteFormClient({ quoteId }: { quoteId?: string }) {
           setPnPromptOpen(true);
           return;
         }
+        if (json?.errorDetails?.code === 'crm_work_order_missing_rot_property') {
+          setRotPropertyPromptOpen(true);
+          return;
+        }
         toast.error(json?.error || 'Kunde inte skapa arbetsorder');
         return;
       }
@@ -1677,6 +1695,43 @@ export default function QuoteFormClient({ quoteId }: { quoteId?: string }) {
       setCreatingWorkOrder(false);
     }
     // Retry the conversion now that the customer has a personnummer.
+    await createWorkOrderFromQuote();
+  }
+
+  // Save the ROT property identification on the quote, then retry the quote→order conversion.
+  // The quote is re-saved in full (not a partial PATCH): that is what re-syncs the Fortnox offer,
+  // and the offer is what `createorder` copies the order from — writing the designation only to our
+  // own row would leave Fortnox without it, which is the whole point of collecting it here.
+  async function saveRotPropertyAndCreateOrder() {
+    if (!quoteId) return;
+    const property = draft.rot_property_designation.trim();
+    const brf = draft.rot_brf_org_number.trim();
+    if (!property && !brf) { toast.error('Fyll i fastighetsbeteckning eller BRF org.nr'); return; }
+    setCreatingWorkOrder(true);
+    try {
+      const res = await fetch(`/api/crm/quotes/${quoteId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(buildQuotePayload()),
+      });
+      const json = await res.json().catch(() => ({}));
+      if (!res.ok || !json.ok) { toast.error(json?.error || 'Kunde inte spara fastighetsbeteckning'); return; }
+      if (json?.data?.fortnox_error) {
+        // The offer didn't re-sync, so converting it now would produce a Fortnox order without the
+        // designation — exactly what this gate exists to prevent. Stop and let them retry.
+        toast.error(`Sparat, men offerten kunde inte synkas till Fortnox: ${json.data.fortnox_error}`);
+        return;
+      }
+      // Saved → same bookkeeping as the ordinary save, so no phantom "resume draft?" banner.
+      clearPersistedDraft();
+      baselineRef.current = draftJson;
+      setRotPropertyPromptOpen(false);
+    } catch {
+      toast.error('Kunde inte spara fastighetsbeteckning');
+      return;
+    } finally {
+      setCreatingWorkOrder(false);
+    }
     await createWorkOrderFromQuote();
   }
 
@@ -2607,6 +2662,61 @@ export default function QuoteFormClient({ quoteId }: { quoteId?: string }) {
           <Field label="Personnummer">
             <Input value={pnValue} onChange={(e) => setPnValue(formatSwedishIdNumber(e.target.value))} placeholder="ÅÅMMDD-XXXX" autoFocus />
           </Field>
+        </CrmModal>
+      ) : null}
+
+      {rotPropertyPromptOpen ? (
+        <CrmModal
+          onClose={() => setRotPropertyPromptOpen(false)}
+          ariaLabel="Fastighetsbeteckning krävs"
+          maxWidth="sm:max-w-[460px]"
+          header={
+            <>
+              <h2 className="text-lg font-bold text-slate-900">Fastighetsbeteckning krävs</h2>
+              <p className="m-0 mt-0.5 text-sm text-slate-500">
+                ROT-avdraget kan inte begäras utan att fastigheten är identifierad. Fyll i fastighetsbeteckningen — eller
+                BRF:ens org.nr om kunden bor i bostadsrätt. Uppgiften sparas på offerten och följer med till Fortnox.
+              </p>
+            </>
+          }
+          footer={
+            <>
+              <button
+                type="button"
+                onClick={() => setRotPropertyPromptOpen(false)}
+                className="flex-1 rounded-xl border border-slate-200 bg-white py-2.5 text-sm font-semibold text-slate-600 transition hover:border-slate-300 sm:flex-none sm:px-5"
+              >
+                Avbryt
+              </button>
+              <button
+                type="button"
+                onClick={() => void saveRotPropertyAndCreateOrder()}
+                disabled={creatingWorkOrder || (!draft.rot_property_designation.trim() && !draft.rot_brf_org_number.trim())}
+                className="flex-1 rounded-xl py-2.5 text-sm font-semibold text-white shadow-sm transition hover:brightness-95 disabled:cursor-not-allowed disabled:opacity-60 sm:ml-auto sm:flex-none sm:px-5"
+                style={{ backgroundColor: 'var(--crm-primary)' }}
+              >
+                {creatingWorkOrder ? 'Sparar…' : 'Spara och skapa order'}
+              </button>
+            </>
+          }
+        >
+          <div className="grid gap-3">
+            <Field label="Fastighetsbeteckning">
+              <Input
+                value={draft.rot_property_designation}
+                onChange={(e) => setDraft((d) => ({ ...d, rot_property_designation: e.target.value }))}
+                placeholder="T.ex. Gläntan 1:14"
+                autoFocus
+              />
+            </Field>
+            <Field label="BRF org.nr">
+              <Input
+                value={draft.rot_brf_org_number}
+                onChange={(e) => setDraft((d) => ({ ...d, rot_brf_org_number: e.target.value }))}
+                placeholder="Om bostadsrätt"
+              />
+            </Field>
+          </div>
         </CrmModal>
       ) : null}
     </div>

--- a/lib/domains/crm/work-orders.ts
+++ b/lib/domains/crm/work-orders.ts
@@ -288,6 +288,24 @@ export async function createCrmWorkOrderFromQuote(supabase: SupabaseClient, quot
     orderSnapshot = { ...orderSnapshot, personal_number: personalNumber };
   }
 
+  // ROT can only be filed with the property identified: fastighetsbeteckning for a småhus, or the
+  // BRF's org.nr for a bostadsrätt (Skatteverket takes either — never both). It is deliberately
+  // OPTIONAL on the quote: nothing is approved yet and the seller often doesn't have it while
+  // quoting. The order is where it becomes mandatory, because the order is the point of no return —
+  // the route auto-pushes to Fortnox the moment the order exists, and Fortnox has NO API field for
+  // the designation (whoever finalizes the invoice types it into the husarbete dialog, reading it
+  // off the text row / YourOrderNumber we send). An order created without it therefore reaches the
+  // invoice with nothing to type in, and the deduction can't be filed. This is the last point where
+  // a human is still in the loop.
+  const rot = (quote.rot_details || {}) as { enabled?: boolean | null; property_designation?: string | null; brf_org_number?: string | null };
+  if (rot.enabled === true && !rot.property_designation?.trim() && !rot.brf_org_number?.trim()) {
+    return {
+      data: null,
+      error: { message: 'Fastighetsbeteckning (eller BRF org.nr för bostadsrätt) krävs för ROT innan order kan skapas. Öppna offerten och fyll i den.' },
+      reason: 'missing_rot_property' as const,
+    };
+  }
+
   const orderNumber = buildWorkOrderNumber(quote.id);
 
   const createResult = await supabase

--- a/supabase/sql/20260811_crm_work_order_rls_perf_probe.sql
+++ b/supabase/sql/20260811_crm_work_order_rls_perf_probe.sql
@@ -1,0 +1,186 @@
+-- CRM-arbetsorderlistan under besättnings-RLS:en — MÄTNING, inga ändringar sparas.
+--
+-- Den enda punkten i fält/CRM-cutovern som ingen mätte innan go-live. `crm_work_orders_select_crew`
+-- (20260810_crm_work_order_crew_access.sql) anropar `is_user_on_work_order(auth.uid(), id)` — ett
+-- predikat som beror på RADEN och därför i värsta fall körs en gång per arbetsorder. Frågan filen
+-- svarar på: kostar det något för kontoret, som läser hela listan?
+--
+-- VARFÖR DET ANTAGLIGEN ÄR BILLIGT — och varför det ändå måste mätas: policyerna är permissiva och
+-- OR:as ihop. För en säljare/admin är `has_permission('crm.workorder.read')` sann, och en OR
+-- kortsluter så fort en gren är sann — men PostgreSQL garanterar INTE i vilken ordning grenarna
+-- utvärderas. Väljer planeraren besättningsgrenen först betalar kontoret full kostnad per rad.
+-- Mätningen avgör vilket som faktiskt händer i er databas, med er datamängd.
+--
+-- VÄRST BELASTADE STÄLLET är inte listan utan chip-räknarna: getCrmWorkOrderFilterCounts kör SEX
+-- `count(*)`-frågor per sidladdning (CRM_WORK_ORDER_BOARD_FILTERS), och en count har ingen LIMIT att
+-- sluta tidigt på — varje rad måste igenom policyn. Därför mäts count_all separat och jämförs × 6.
+--
+-- KÖRS SOM EN TRANSAKTION SOM RULLAS TILLBAKA. Hjälpfunktionen skapas i pg_temp och existerar bara
+-- under körningen; inga rader, policyer eller funktioner i public rörs. Kör hela filen på en gång.
+--
+-- Supabase SQL-editorn visar bara SISTA resultatet — därför samlas allt i en temptabell som sista
+-- satsen läser. EXPLAIN-delen (avsnitt 2, längst ned) är avkommenterad och körs separat.
+--
+-- Kör mätningen när systemet används som vanligt. En helt kall databas ger missvisande siffror åt
+-- båda håll: första körningen betalar disk-I/O, andra körningen läser allt ur cachen. Kör två
+-- gånger och läs den andra.
+
+begin;
+
+-- ── Uppsamling ───────────────────────────────────────────────────────────────
+create temp table probe_out (
+  sort      int,
+  persona   text,
+  prob      text,
+  rader     bigint,
+  ms        numeric,
+  bedomning text
+);
+
+-- ── Testpersoner ─────────────────────────────────────────────────────────────
+-- Väljs ut medan vi fortfarande är privilegierade (efter rollbytet går profiles inte att läsa).
+-- Byt ut selecten mot en hårdkodad uuid om du vill mäta en specifik person.
+select set_config(
+  'probe.office_uid',
+  coalesce((select id::text from public.profiles where role::text in ('admin', 'sales') order by role::text, id limit 1), ''),
+  true
+);
+-- En installatör som faktiskt står på en bil — annars mäter vi en tom besättningsgren.
+select set_config(
+  'probe.field_uid',
+  coalesce(
+    (select member_id::text from public.ops_truck_default_crew limit 1),
+    (select member_id::text from public.ops_truck_crew limit 1),
+    (select member_id::text from public.ops_segment_crew limit 1),
+    ''
+  ),
+  true
+);
+
+-- ── Sonden ───────────────────────────────────────────────────────────────────
+-- Byter roll till `authenticated` och sätter JWT-claims så auth.uid() svarar rätt, kör frågorna, och
+-- återgår innan den returnerar. Utan rollbytet körs allt som tabellägare och RLS hoppas över helt —
+-- då mäter vi ingenting. Rollen sätts med set_config(...,true) = SET LOCAL: den överlever inte
+-- transaktionen även om något går sönder mitt i.
+create function pg_temp.rls_probe(p_persona text, p_uid text)
+returns table(persona text, prob text, rader bigint, ms numeric, bedomning text)
+language plpgsql
+as $fn$
+declare
+  t0 timestamptz;
+  n  bigint;
+  elapsed numeric;
+begin
+  if p_uid = '' then
+    persona := p_persona; prob := '(ingen testperson hittad)'; rader := null; ms := null;
+    bedomning := 'HOPPAD ÖVER'; return next; return;
+  end if;
+
+  perform set_config('role', 'authenticated', true);
+  perform set_config('request.jwt.claims', json_build_object('sub', p_uid, 'role', 'authenticated')::text, true);
+
+  -- 1) Listsidan: exakt vad listCrmWorkOrdersWithFilters begär (sida 1, 100 rader).
+  t0 := clock_timestamp();
+  execute '
+    select count(*) from (
+      select * from public.crm_work_orders
+      order by desired_installation_date asc nulls last, created_at desc
+      limit 100
+    ) t' into n;
+  elapsed := round((extract(epoch from clock_timestamp() - t0) * 1000)::numeric, 1);
+  persona := p_persona; prob := '1. listsida (100 rader)'; rader := n; ms := elapsed;
+  bedomning := case when elapsed < 150 then 'OK' when elapsed < 500 then 'VARNING' else 'ÅTGÄRDA' end;
+  return next;
+
+  -- 2) En chip-räknare. Sidan kör SEX sådana, så tröskeln jämförs mot ms × 6.
+  t0 := clock_timestamp();
+  execute 'select count(*) from public.crm_work_orders' into n;
+  elapsed := round((extract(epoch from clock_timestamp() - t0) * 1000)::numeric, 1);
+  persona := p_persona; prob := '2. count_all (sidan kör 6 st → ms × 6)'; rader := n; ms := elapsed;
+  bedomning := case when elapsed * 6 < 150 then 'OK' when elapsed * 6 < 500 then 'VARNING' else 'ÅTGÄRDA' end;
+  return next;
+
+  -- 3) Enskild order — fältvyns väg, den som måste vara snabb för besättningen.
+  t0 := clock_timestamp();
+  execute '
+    select count(*) from (
+      select * from public.crm_work_orders
+      order by created_at desc limit 1
+    ) t' into n;
+  elapsed := round((extract(epoch from clock_timestamp() - t0) * 1000)::numeric, 1);
+  persona := p_persona; prob := '3. senaste ordern (1 rad)'; rader := n; ms := elapsed;
+  bedomning := case when elapsed < 50 then 'OK' when elapsed < 200 then 'VARNING' else 'ÅTGÄRDA' end;
+  return next;
+
+  -- 4) Taket: tvinga besättningsgrenen att köras för VARJE rad, utan OR att kortsluta på.
+  --    Ligger den nära (1) betyder det att kontoret redan betalar full kostnad — då är det
+  --    ordningen på OR-grenarna som räddar er idag, och det är inget att förlita sig på.
+  t0 := clock_timestamp();
+  execute format(
+    'select count(*) from public.crm_work_orders where public.is_user_on_work_order(%L::uuid, id)', p_uid
+  ) into n;
+  elapsed := round((extract(epoch from clock_timestamp() - t0) * 1000)::numeric, 1);
+  persona := p_persona; prob := '4. is_user_on_work_order per rad (tak)'; rader := n; ms := elapsed;
+  bedomning := 'INFO';
+  return next;
+
+  perform set_config('role', 'none', true);
+end;
+$fn$;
+
+-- ── Körning ──────────────────────────────────────────────────────────────────
+-- Kontexten först, medan rollen fortfarande är privilegierad: annars räknas raderna genom RLS och
+-- säger något helt annat än "så här många arbetsordrar finns det".
+insert into probe_out
+select 0, 'kontext', 'antal arbetsordrar', count(*), null, 'INFO' from public.crm_work_orders
+union all
+select 0, 'kontext', 'antal ops_segments', count(*), null, 'INFO' from public.ops_segments;
+
+insert into probe_out
+select 1, p.* from pg_temp.rls_probe('kontor (sälj/admin)', current_setting('probe.office_uid')) p;
+
+insert into probe_out
+select 2, p.* from pg_temp.rls_probe('fält (besättning)', current_setting('probe.field_uid')) p;
+
+select persona, prob, rader, ms, bedomning from probe_out order by sort, prob;
+
+rollback;
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- AVSNITT 2 — kör separat när en siffra ovan ser fel ut
+--
+-- Visar planen. Leta efter `Filter: is_user_on_work_order(...)` på crm_work_orders: står funktionen
+-- kvar som radfilter körs den per rad, och `Rows Removed by Filter` visar hur många gånger.
+--
+--   begin;
+--   set local role authenticated;
+--   select set_config('request.jwt.claims', '{"sub":"<uuid-på-en-säljare>","role":"authenticated"}', true);
+--   explain (analyze, buffers, verbose)
+--     select * from public.crm_work_orders
+--     order by desired_installation_date asc nulls last, created_at desc
+--     limit 100;
+--   rollback;
+--
+-- ─────────────────────────────────────────────────────────────────────────────
+-- OM DET ÄR FÖR LÅNGSAMT — åtgärden, INTE applicerad
+--
+-- Indexen finns redan (ops_segments(work_order_id), ops_segment_crew(segment_id),
+-- ops_truck_crew(truck_id, start_day, end_day), ops_truck_default_crew(truck_id)), så ett nytt index
+-- löser ingenting. Problemet är i så fall att predikatet är per rad. Formulera om det till en mängd
+-- PostgreSQL kan räkna ut EN gång per fråga (InitPlan) i stället för en gång per rad:
+--
+--   create or replace function public.my_crew_work_order_ids()
+--   returns setof uuid language sql stable security definer set search_path = public as $$
+--     select distinct s.work_order_id
+--     from public.ops_segments s
+--     where public.is_user_on_work_order(auth.uid(), s.work_order_id)
+--   $$;
+--   revoke all on function public.my_crew_work_order_ids() from public;
+--   grant execute on function public.my_crew_work_order_ids() to authenticated;
+--
+--   drop policy if exists crm_work_orders_select_crew on public.crm_work_orders;
+--   create policy crm_work_orders_select_crew on public.crm_work_orders for select to authenticated
+--     using (id in (select public.my_crew_work_order_ids()));
+--
+-- Samma åtkomst, annan form. Kör om mätningen efteråt: bytet är bara värt något om siffrorna säger
+-- det, och det gör åtkomstregeln ett steg svårare att läsa. Mät först.

--- a/supabase/sql/20260811_crm_work_order_rls_perf_probe.sql
+++ b/supabase/sql/20260811_crm_work_order_rls_perf_probe.sql
@@ -25,6 +25,18 @@
 --
 -- Kör mätningen när systemet används som vanligt, och kör den TVÅ gånger — första körningen betalar
 -- disk-I/O, andra läser ur cachen. Läs den andra.
+--
+-- ── MÄTT 2026-08-11 (14 arbetsordrar, 25 segment) ──────────────────────────
+-- Inget problem: allt under 8 ms, RLS bekräftat påslagen och gällande.
+--
+-- MEN datamängden är för liten för att säga något om skalning, och det syns i siffrorna: mätning 3
+-- läser EN rad på 7,6 ms medan mätning 1 läser fjorton på 3,9 ms. Den inversionen betyder att allt
+-- man ser är fast overhead och första-anrops-cache, inte radarbete. Läs "OK" som "inget problem nu",
+-- aldrig som "skalar".
+--
+-- Skalningsfrågan avgörs därför av mätning 5 (grenordningen), inte av millisekunderna. Mät om när
+-- tabellen vuxit en storleksordning — vid några hundra ordrar börjar radkostnaden gå att se, och då
+-- säger siffrorna något på riktigt.
 
 -- ═══════════════════════════════════════════════════════════════════════════
 -- STEG 1 — skapa probfunktionen. Kör den här filen som den är.
@@ -46,6 +58,11 @@ declare
   kor_som  text;
   uid_syns text;
   plan_json json;
+  plan_txt  text;
+  filter_txt text;
+  pos_perm  int;
+  pos_crew  int;
+  max_synliga bigint;
 begin
   -- ── Kontext ────────────────────────────────────────────────────────────────
   -- Körs som anroparen, alltså utan RLS. Med RLS hade de här räknats genom policyn och svarat på
@@ -75,12 +92,34 @@ begin
    order by p.role::text, p.id
    limit 1;
 
-  -- En installatör som faktiskt står på en bil — annars mäter vi en tom besättningsgren.
-  v_field := coalesce(
-    (select dc.member_id from public.ops_truck_default_crew dc limit 1),
-    (select tc.member_id from public.ops_truck_crew tc limit 1),
-    (select sc.member_id from public.ops_segment_crew sc limit 1)
-  );
+  -- En installatör som faktiskt SER något. Första bästa raden ur standardbesättningen duger inte:
+  -- att stå på en bil betyder inte att bilen har ett CRM-jobb den här veckan, och en persona som
+  -- ser noll rader mäter ingenting (den varianten valde först en person med 0 jobb, och hela
+  -- fälthalvan blev nollor). Välj den som löser upp till flest arbetsordrar — då mäter vi den dyra
+  -- vägen med data i.
+  select c.member_id into v_field
+    from (
+      select member_id from public.ops_truck_default_crew
+      union
+      select member_id from public.ops_truck_crew
+      union
+      select member_id from public.ops_segment_crew
+    ) c
+   order by (select count(*) from public.crm_work_orders w
+              where public.is_user_on_work_order(c.member_id, w.id)) desc,
+            c.member_id
+   limit 1;
+
+  -- Ser den flitigaste besättningsmedlemmen noll jobb är det inte en prestandasiffra utan ett
+  -- innehållsfynd: ingen i fält når någon CRM-arbetsorder alls.
+  select count(*) into max_synliga
+    from public.crm_work_orders w
+   where v_field is not null and public.is_user_on_work_order(v_field, w.id);
+  persona := 'kontext'; prob := 'flest arbetsordrar en besättningsmedlem ser';
+  rader := max_synliga; ms := null;
+  bedomning := case when coalesce(max_synliga, 0) = 0
+                    then 'NOLL — ingen i fält når någon CRM-order' else 'INFO' end;
+  return next;
 
   for rec in
     select * from (values ('kontor (sälj/admin)', v_office), ('fält (besättning)', v_field)) as v(label, uid)
@@ -159,22 +198,37 @@ begin
     bedomning := 'INFO';
     return next;
 
-    -- 5) Svaret på själva frågan, direkt ur planen i stället för att gissa: står funktionen kvar som
-    --    radfilter på crm_work_orders utvärderas den per rad. För KONTORET betyder JA att
-    --    OR-kortslutningen inte räddar er och att siffrorna ovan är den kostnaden. För FÄLTET är JA
-    --    förväntat — besättningsgrenen är deras enda väg in.
+    -- 5) Frågan som timingen inte kan besvara på ett litet dataset: betalar kontoret besättnings-
+    --    grenen per rad? Att funktionen SYNS i planen räcker inte som svar — de två policyerna OR:as
+    --    ihop, och en OR kortsluter, så står behörighetsgrenen först anropas besättningsfunktionen
+    --    aldrig trots att den står där. (Den tidigare varianten mätte närvaro och rapporterade
+    --    utvärdering — två olika saker, och just de två vi försöker skilja på.)
+    --
+    --    Det som avgör är ORDNINGEN i filteruttrycket, och den står i planen. Kommer has_permission
+    --    först kortsluter kontoret på varje rad och besättningsgrenen kostar dem ingenting.
     execute '
       explain (analyze, format json)
       select * from public.crm_work_orders
       order by desired_installation_date asc nulls last, created_at desc
       limit 100' into plan_json;
-    prob := '5. plan — besättningsfiltret kvar som radfilter?';
-    rader := null;
+    plan_txt := plan_json::text;
+    pos_perm := strpos(plan_txt, 'has_permission');
+    pos_crew := strpos(plan_txt, 'is_user_on_work_order');
     ms := round((plan_json->0->>'Execution Time')::numeric, 1);
+    rader := null;
+    prob := '5. plan — vilken gren står först i filtret?';
     bedomning := case
-      when plan_json::text like '%is_user_on_work_order%' then 'JA — utvärderas per rad'
-      else 'NEJ — kortsluts av behörighetsgrenen'
+      when pos_crew = 0 then 'besättningsgrenen saknas i planen'
+      when pos_perm = 0 then 'ENDA GRENEN — inget att kortsluta mot (väntat i fält)'
+      when pos_perm < pos_crew then 'OK — behörighetsgrenen först, kortsluter per rad'
+      else 'DYRT — besättningsgrenen först, körs för varje rad'
     end;
+    return next;
+
+    -- 6) Filteruttrycket i klartext, så slutsatsen ovan går att granska i stället för att litas på.
+    filter_txt := substring(plan_txt from '"Filter":\s*"(.*?)"');
+    prob := '6. filteruttryck: ' || coalesce(left(filter_txt, 180), '(inget filter i planen)');
+    rader := null; ms := null; bedomning := 'INFO';
     return next;
 
     perform set_config('role', 'none', true);

--- a/supabase/sql/20260811_crm_work_order_rls_perf_probe.sql
+++ b/supabase/sql/20260811_crm_work_order_rls_perf_probe.sql
@@ -1,4 +1,4 @@
--- CRM-arbetsorderlistan under besättnings-RLS:en — MÄTNING, inga ändringar sparas.
+-- CRM-arbetsorderlistan under besättnings-RLS:en — MÄTNING.
 --
 -- KORT: alla andra läsregler på crm_work_orders ger SAMMA svar för varje rad ("har du
 -- crm.workorder.read?") — databasen frågar en gång och är klar. Besättningsregeln ger OLIKA svar per
@@ -7,200 +7,199 @@
 --
 -- VARFÖR DEN BYTER ROLL. Som databasägare gäller RLS inte alls — mäter man därifrån mäter man en
 -- fråga utan policy på och lär sig ingenting. `set role authenticated` + JWT-claims är det som gör
--- mätningen verklig. Uppslagen (vilka testpersoner finns, hur många rader) körs medvetet UTAN RLS;
--- mätningarna körs medvetet MED. Rad "0. kontroll" i utdatan bevisar vilket som gällde — säger den
--- FEL är resten skräp.
+-- mätningen verklig. Rad "0. kontroll" i utdatan bevisar vilket som gällde: säger den FEL är resten
+-- skräp.
 --
--- FARLIGT? Nej: inget skrivs (begin…rollback, hjälpfunktion i pg_temp, temporär tabell), rollen och
--- claimsen sätts med SET LOCAL och dör med transaktionen även om något kraschar mitt i, och utdatan
--- är antal + millisekunder — ingen kunddata. Den reella kostnaden är CPU: proben scannar tabellen
--- flera gånger och sista mätningen är långsam med flit. Kör den inte mitt i högtrafik.
+-- ⚠️ VARFÖR ALLT LIGGER I EN FUNKTION — läs det här innan du "förenklar" filen:
+-- Supabase SQL-editorn kan lägga varje sats på en EGEN uppkoppling. Då finns ingen delad session:
+-- en temptabell från sats 1 är borta i sats 2 (det felet, `relation "probe_out" does not exist`,
+-- är hur den här filen upptäcktes), `begin`/`rollback` gör ingenting, och — värre — ett
+-- `set local role authenticated` i en sats når INTE nästa sats. Mätningen hade då körts som ägare,
+-- utan RLS, och gett låga siffror som ser utmärkta ut. Ett tyst fel, inte ett felmeddelande.
+-- Därför: rollbyte, mätning och avläsning sker inuti EN sats — funktionsanropet.
 --
--- Den enda punkten i fält/CRM-cutovern som ingen mätte innan go-live. `crm_work_orders_select_crew`
--- (20260810_crm_work_order_crew_access.sql) anropar `is_user_on_work_order(auth.uid(), id)` — ett
--- predikat som beror på RADEN och därför i värsta fall körs en gång per arbetsorder. Frågan filen
--- svarar på: kostar det något för kontoret, som läser hela listan?
+-- FARLIGT? Inget skrivs till någon tabell, utdatan är antal + millisekunder (ingen kunddata), och
+-- rollbytet sätts med SET LOCAL inuti funktionen så det dör när satsen är klar. Det enda som lämnas
+-- kvar är själva funktionen — därför steg 3. Den reella kostnaden är CPU: proben scannar tabellen
+-- flera gånger och mätning 4 är långsam med flit. Kör den inte mitt i högtrafik.
 --
--- VARFÖR DET ANTAGLIGEN ÄR BILLIGT — och varför det ändå måste mätas: policyerna är permissiva och
--- OR:as ihop. För en säljare/admin är `has_permission('crm.workorder.read')` sann, och en OR
--- kortsluter så fort en gren är sann — men PostgreSQL garanterar INTE i vilken ordning grenarna
--- utvärderas. Väljer planeraren besättningsgrenen först betalar kontoret full kostnad per rad.
--- Mätningen avgör vilket som faktiskt händer i er databas, med er datamängd.
---
--- VÄRST BELASTADE STÄLLET är inte listan utan chip-räknarna: getCrmWorkOrderFilterCounts kör SEX
--- `count(*)`-frågor per sidladdning (CRM_WORK_ORDER_BOARD_FILTERS), och en count har ingen LIMIT att
--- sluta tidigt på — varje rad måste igenom policyn. Därför mäts count_all separat och jämförs × 6.
---
--- KÖRS SOM EN TRANSAKTION SOM RULLAS TILLBAKA. Hjälpfunktionen skapas i pg_temp och existerar bara
--- under körningen; inga rader, policyer eller funktioner i public rörs. Kör hela filen på en gång.
---
--- Supabase SQL-editorn visar bara SISTA resultatet — därför samlas allt i en temptabell som sista
--- satsen läser. EXPLAIN-delen (avsnitt 2, längst ned) är avkommenterad och körs separat.
---
--- Kör mätningen när systemet används som vanligt. En helt kall databas ger missvisande siffror åt
--- båda håll: första körningen betalar disk-I/O, andra körningen läser allt ur cachen. Kör två
--- gånger och läs den andra.
+-- Kör mätningen när systemet används som vanligt, och kör den TVÅ gånger — första körningen betalar
+-- disk-I/O, andra läser ur cachen. Läs den andra.
 
-begin;
+-- ═══════════════════════════════════════════════════════════════════════════
+-- STEG 1 — skapa probfunktionen. Kör den här filen som den är.
+-- ═══════════════════════════════════════════════════════════════════════════
 
--- ── Uppsamling ───────────────────────────────────────────────────────────────
-create temp table probe_out (
-  sort      int,
-  persona   text,
-  prob      text,
-  rader     bigint,
-  ms        numeric,
-  bedomning text
-);
-
--- ── Testpersoner ─────────────────────────────────────────────────────────────
--- Väljs ut medan vi fortfarande är privilegierade (efter rollbytet går profiles inte att läsa).
--- Byt ut selecten mot en hårdkodad uuid om du vill mäta en specifik person.
-select set_config(
-  'probe.office_uid',
-  coalesce((select id::text from public.profiles where role::text in ('admin', 'sales') order by role::text, id limit 1), ''),
-  true
-);
--- En installatör som faktiskt står på en bil — annars mäter vi en tom besättningsgren.
-select set_config(
-  'probe.field_uid',
-  coalesce(
-    (select member_id::text from public.ops_truck_default_crew limit 1),
-    (select member_id::text from public.ops_truck_crew limit 1),
-    (select member_id::text from public.ops_segment_crew limit 1),
-    ''
-  ),
-  true
-);
-
--- ── Sonden ───────────────────────────────────────────────────────────────────
--- Byter roll till `authenticated` och sätter JWT-claims så auth.uid() svarar rätt, kör frågorna, och
--- återgår innan den returnerar. Utan rollbytet körs allt som tabellägare och RLS hoppas över helt —
--- då mäter vi ingenting. Rollen sätts med set_config(...,true) = SET LOCAL: den överlever inte
--- transaktionen även om något går sönder mitt i.
-create function pg_temp.rls_probe(p_persona text, p_uid text)
+create or replace function public.crm_rls_probe()
 returns table(persona text, prob text, rader bigint, ms numeric, bedomning text)
 language plpgsql
+volatile
+security invoker
 as $fn$
 declare
-  t0 timestamptz;
-  n  bigint;
-  elapsed numeric;
-  kor_som text;
+  v_office uuid;
+  v_field  uuid;
+  rec      record;
+  t0       timestamptz;
+  n        bigint;
+  elapsed  numeric;
+  kor_som  text;
   uid_syns text;
+  plan_json json;
 begin
-  if p_uid = '' then
-    persona := p_persona; prob := '(ingen testperson hittad)'; rader := null; ms := null;
-    bedomning := 'HOPPAD ÖVER'; return next; return;
-  end if;
+  -- ── Kontext ────────────────────────────────────────────────────────────────
+  -- Körs som anroparen, alltså utan RLS. Med RLS hade de här räknats genom policyn och svarat på
+  -- något helt annat än "så här många arbetsordrar finns det".
+  persona := 'kontext'; ms := null; bedomning := 'INFO';
 
-  perform set_config('role', 'authenticated', true);
-  perform set_config('request.jwt.claims', json_build_object('sub', p_uid, 'role', 'authenticated')::text, true);
+  select count(*) into n from public.crm_work_orders;
+  prob := 'antal arbetsordrar'; rader := n; return next;
 
-  -- 0) Beviset att mätningen mäter något. Tar rollbytet inte — fel rollnamn, ändrad Supabase-uppsättning
-  --    — körs allt nedan som tabellägare, och då gäller RLS inte alls: siffrorna blir strålande och
-  --    betyder ingenting. En mätning man inte kan skilja från en no-op är ingen mätning, så läs den
-  --    här raden FÖRST och kasta resten om den säger FEL.
-  select current_user::text into kor_som;
-  select coalesce(auth.uid()::text, '(null)') into uid_syns;
-  persona := p_persona;
-  prob := format('0. kontroll — kör som %s, auth.uid() = %s', kor_som, uid_syns);
-  rader := null; ms := null;
-  bedomning := case
-    when kor_som = 'authenticated' and uid_syns = p_uid then 'OK — RLS gäller'
-    else 'FEL — allt nedan mäter en fråga utan policy'
-  end;
+  select count(*) into n from public.ops_segments;
+  prob := 'antal ops_segments'; rader := n; return next;
+
+  -- Är RLS avslaget på tabellen finns ingen policy att mäta kostnaden för, och allt nedan är fritt
+  -- fall. (Ägaren kringgår RLS ändå — därför rollbytet — men är den AV kringgår ALLA den.)
+  prob := 'RLS på crm_work_orders'; rader := null;
+  select case when c.relrowsecurity then 'PÅ' else 'AV — inget nedan betyder något' end
+    into bedomning
+    from pg_class c where c.oid = 'public.crm_work_orders'::regclass;
   return next;
 
-  -- 1) Listsidan: exakt vad listCrmWorkOrdersWithFilters begär (sida 1, 100 rader).
-  t0 := clock_timestamp();
-  execute '
-    select count(*) from (
+  -- ── Testpersoner ───────────────────────────────────────────────────────────
+  -- Väljs ut innan rollbytet: efteråt går profiles inte att läsa. Byt mot en hårdkodad uuid om du
+  -- vill mäta en bestämd person.
+  select p.id into v_office
+    from public.profiles p
+   where p.role::text in ('admin', 'sales')
+   order by p.role::text, p.id
+   limit 1;
+
+  -- En installatör som faktiskt står på en bil — annars mäter vi en tom besättningsgren.
+  v_field := coalesce(
+    (select dc.member_id from public.ops_truck_default_crew dc limit 1),
+    (select tc.member_id from public.ops_truck_crew tc limit 1),
+    (select sc.member_id from public.ops_segment_crew sc limit 1)
+  );
+
+  for rec in
+    select * from (values ('kontor (sälj/admin)', v_office), ('fält (besättning)', v_field)) as v(label, uid)
+  loop
+    persona := rec.label;
+
+    if rec.uid is null then
+      prob := '(ingen testperson hittad)'; rader := null; ms := null; bedomning := 'HOPPAD ÖVER';
+      return next;
+      continue;
+    end if;
+
+    perform set_config('role', 'authenticated', true);
+    perform set_config('request.jwt.claims',
+                       json_build_object('sub', rec.uid::text, 'role', 'authenticated')::text, true);
+
+    -- 0) Beviset att mätningen mäter något. Tar rollbytet inte körs allt nedan som tabellägare, och
+    --    då gäller ingen policy: siffrorna blir strålande och betyder ingenting. En mätning man inte
+    --    kan skilja från en no-op är ingen mätning — läs den här raden FÖRST.
+    kor_som  := current_user::text;
+    uid_syns := coalesce(auth.uid()::text, '(null)');
+    prob := format('0. kontroll — kör som %s, auth.uid() = %s', kor_som, uid_syns);
+    rader := null; ms := null;
+    bedomning := case
+      when kor_som = 'authenticated' and uid_syns = rec.uid::text then 'OK — RLS gäller'
+      else 'FEL — allt nedan mäter en fråga utan policy'
+    end;
+    return next;
+
+    -- Alla mätfrågor körs med EXECUTE, alltså dynamiskt. Statisk SQL i plpgsql cachar planen, och en
+    -- plan gjord för en roll säger ingenting om nästa — vi vill planera om varje gång.
+
+    -- 1) Listsidan: exakt vad listCrmWorkOrdersWithFilters begär (sida 1, 100 rader).
+    t0 := clock_timestamp();
+    execute '
+      select count(*) from (
+        select * from public.crm_work_orders
+        order by desired_installation_date asc nulls last, created_at desc
+        limit 100
+      ) t' into n;
+    elapsed := round((extract(epoch from clock_timestamp() - t0) * 1000)::numeric, 1);
+    prob := '1. listsida (100 rader)'; rader := n; ms := elapsed;
+    bedomning := case when elapsed < 150 then 'OK' when elapsed < 500 then 'VARNING' else 'ÅTGÄRDA' end;
+    return next;
+
+    -- 2) En chip-räknare. getCrmWorkOrderFilterCounts kör SEX sådana per sidladdning, och en count
+    --    har ingen LIMIT att sluta tidigt på — varje rad måste igenom policyn. Värsta stället.
+    t0 := clock_timestamp();
+    execute 'select count(*) from public.crm_work_orders' into n;
+    elapsed := round((extract(epoch from clock_timestamp() - t0) * 1000)::numeric, 1);
+    prob := '2. count_all (sidan kör 6 st → ms × 6)'; rader := n; ms := elapsed;
+    bedomning := case when elapsed * 6 < 150 then 'OK' when elapsed * 6 < 500 then 'VARNING' else 'ÅTGÄRDA' end;
+    return next;
+
+    -- 3) Enskild order — fältvyns väg, den som måste vara snabb för besättningen.
+    t0 := clock_timestamp();
+    execute '
+      select count(*) from (
+        select * from public.crm_work_orders
+        order by created_at desc limit 1
+      ) t' into n;
+    elapsed := round((extract(epoch from clock_timestamp() - t0) * 1000)::numeric, 1);
+    prob := '3. senaste ordern (1 rad)'; rader := n; ms := elapsed;
+    bedomning := case when elapsed < 50 then 'OK' when elapsed < 200 then 'VARNING' else 'ÅTGÄRDA' end;
+    return next;
+
+    -- 4) Taket: tvinga besättningsgrenen att köras för VARJE rad, utan OR att kortsluta på.
+    --    Ligger den nära (1) betyder det att kontoret redan betalar full kostnad.
+    t0 := clock_timestamp();
+    execute format(
+      'select count(*) from public.crm_work_orders where public.is_user_on_work_order(%L::uuid, id)',
+      rec.uid
+    ) into n;
+    elapsed := round((extract(epoch from clock_timestamp() - t0) * 1000)::numeric, 1);
+    prob := '4. is_user_on_work_order per rad (tak)'; rader := n; ms := elapsed;
+    bedomning := 'INFO';
+    return next;
+
+    -- 5) Svaret på själva frågan, direkt ur planen i stället för att gissa: står funktionen kvar som
+    --    radfilter på crm_work_orders utvärderas den per rad. För KONTORET betyder JA att
+    --    OR-kortslutningen inte räddar er och att siffrorna ovan är den kostnaden. För FÄLTET är JA
+    --    förväntat — besättningsgrenen är deras enda väg in.
+    execute '
+      explain (analyze, format json)
       select * from public.crm_work_orders
       order by desired_installation_date asc nulls last, created_at desc
-      limit 100
-    ) t' into n;
-  elapsed := round((extract(epoch from clock_timestamp() - t0) * 1000)::numeric, 1);
-  persona := p_persona; prob := '1. listsida (100 rader)'; rader := n; ms := elapsed;
-  bedomning := case when elapsed < 150 then 'OK' when elapsed < 500 then 'VARNING' else 'ÅTGÄRDA' end;
-  return next;
+      limit 100' into plan_json;
+    prob := '5. plan — besättningsfiltret kvar som radfilter?';
+    rader := null;
+    ms := round((plan_json->0->>'Execution Time')::numeric, 1);
+    bedomning := case
+      when plan_json::text like '%is_user_on_work_order%' then 'JA — utvärderas per rad'
+      else 'NEJ — kortsluts av behörighetsgrenen'
+    end;
+    return next;
 
-  -- 2) En chip-räknare. Sidan kör SEX sådana, så tröskeln jämförs mot ms × 6.
-  t0 := clock_timestamp();
-  execute 'select count(*) from public.crm_work_orders' into n;
-  elapsed := round((extract(epoch from clock_timestamp() - t0) * 1000)::numeric, 1);
-  persona := p_persona; prob := '2. count_all (sidan kör 6 st → ms × 6)'; rader := n; ms := elapsed;
-  bedomning := case when elapsed * 6 < 150 then 'OK' when elapsed * 6 < 500 then 'VARNING' else 'ÅTGÄRDA' end;
-  return next;
-
-  -- 3) Enskild order — fältvyns väg, den som måste vara snabb för besättningen.
-  t0 := clock_timestamp();
-  execute '
-    select count(*) from (
-      select * from public.crm_work_orders
-      order by created_at desc limit 1
-    ) t' into n;
-  elapsed := round((extract(epoch from clock_timestamp() - t0) * 1000)::numeric, 1);
-  persona := p_persona; prob := '3. senaste ordern (1 rad)'; rader := n; ms := elapsed;
-  bedomning := case when elapsed < 50 then 'OK' when elapsed < 200 then 'VARNING' else 'ÅTGÄRDA' end;
-  return next;
-
-  -- 4) Taket: tvinga besättningsgrenen att köras för VARJE rad, utan OR att kortsluta på.
-  --    Ligger den nära (1) betyder det att kontoret redan betalar full kostnad — då är det
-  --    ordningen på OR-grenarna som räddar er idag, och det är inget att förlita sig på.
-  t0 := clock_timestamp();
-  execute format(
-    'select count(*) from public.crm_work_orders where public.is_user_on_work_order(%L::uuid, id)', p_uid
-  ) into n;
-  elapsed := round((extract(epoch from clock_timestamp() - t0) * 1000)::numeric, 1);
-  persona := p_persona; prob := '4. is_user_on_work_order per rad (tak)'; rader := n; ms := elapsed;
-  bedomning := 'INFO';
-  return next;
-
-  perform set_config('role', 'none', true);
+    perform set_config('role', 'none', true);
+  end loop;
 end;
 $fn$;
 
--- ── Körning ──────────────────────────────────────────────────────────────────
--- Kontexten först, medan rollen fortfarande är privilegierad: annars räknas raderna genom RLS och
--- säger något helt annat än "så här många arbetsordrar finns det".
-insert into probe_out
-select 0, 'kontext', 'antal arbetsordrar', count(*), null::numeric, 'INFO' from public.crm_work_orders
-union all
-select 0, 'kontext', 'antal ops_segments', count(*), null::numeric, 'INFO' from public.ops_segments
-union all
--- Är RLS avslaget på tabellen finns det ingen policy att mäta kostnaden för, och alla siffror nedan
--- är fritt fall. (Ägaren kringgår RLS ändå — därför rollbytet — men är den AV kringgår ALLA den.)
-select 0, 'kontext', 'RLS på crm_work_orders', null::bigint, null::numeric,
-       case when relrowsecurity then 'PÅ' else 'AV — inget nedan betyder något' end
-from pg_class where oid = 'public.crm_work_orders'::regclass;
+-- Diagnostik, inte en app-funktion: den impersonerar och ska bara kunna köras av den som redan är
+-- privilegierad. authenticated ska aldrig komma åt den.
+revoke all on function public.crm_rls_probe() from public;
 
-insert into probe_out
-select 1, p.* from pg_temp.rls_probe('kontor (sälj/admin)', current_setting('probe.office_uid')) p;
-
-insert into probe_out
-select 2, p.* from pg_temp.rls_probe('fält (besättning)', current_setting('probe.field_uid')) p;
-
-select persona, prob, rader, ms, bedomning from probe_out order by sort, prob;
-
-rollback;
-
--- ─────────────────────────────────────────────────────────────────────────────
--- AVSNITT 2 — kör separat när en siffra ovan ser fel ut
+-- ═══════════════════════════════════════════════════════════════════════════
+-- STEG 2 — kör mätningen. Markera raden och kör den ENSAM (annars visar editorn
+--          resultatet av nästa sats i stället).
+-- ═══════════════════════════════════════════════════════════════════════════
 --
--- Visar planen. Leta efter `Filter: is_user_on_work_order(...)` på crm_work_orders: står funktionen
--- kvar som radfilter körs den per rad, och `Rows Removed by Filter` visar hur många gånger.
+--   select * from public.crm_rls_probe();
 --
---   begin;
---   set local role authenticated;
---   select set_config('request.jwt.claims', '{"sub":"<uuid-på-en-säljare>","role":"authenticated"}', true);
---   explain (analyze, buffers, verbose)
---     select * from public.crm_work_orders
---     order by desired_installation_date asc nulls last, created_at desc
---     limit 100;
---   rollback;
+-- ═══════════════════════════════════════════════════════════════════════════
+-- STEG 3 — städa när du är klar. Funktionen behöver inte ligga kvar.
+-- ═══════════════════════════════════════════════════════════════════════════
 --
--- ─────────────────────────────────────────────────────────────────────────────
+--   drop function public.crm_rls_probe();
+--
+-- ═══════════════════════════════════════════════════════════════════════════
 -- OM DET ÄR FÖR LÅNGSAMT — åtgärden, INTE applicerad
 --
 -- Indexen finns redan (ops_segments(work_order_id), ops_segment_crew(segment_id),

--- a/supabase/sql/20260811_crm_work_order_rls_perf_probe.sql
+++ b/supabase/sql/20260811_crm_work_order_rls_perf_probe.sql
@@ -26,17 +26,26 @@
 -- Kör mätningen när systemet används som vanligt, och kör den TVÅ gånger — första körningen betalar
 -- disk-I/O, andra läser ur cachen. Läs den andra.
 --
--- ── MÄTT 2026-08-11 (14 arbetsordrar, 25 segment) ──────────────────────────
--- Inget problem: allt under 8 ms, RLS bekräftat påslagen och gällande.
+-- ── MÄTT 2026-08-11 (14 arbetsordrar, 25 segment) — FRÅGAN ÄR BESVARAD ─────
+-- **Kontoret betalar ingenting för besättningsregeln.** Grenordningen i planen är
 --
--- MEN datamängden är för liten för att säga något om skalning, och det syns i siffrorna: mätning 3
--- läser EN rad på 7,6 ms medan mätning 1 läser fjorton på 3,9 ms. Den inversionen betyder att allt
--- man ser är fast overhead och första-anrops-cache, inte radarbete. Läs "OK" som "inget problem nu",
--- aldrig som "skalar".
+--     assigned_to=auth.uid()  →  has_permission  →  is_user_on_work_order
 --
--- Skalningsfrågan avgörs därför av mätning 5 (grenordningen), inte av millisekunderna. Mät om när
--- tabellen vuxit en storleksordning — vid några hundra ordrar börjar radkostnaden gå att se, och då
--- säger siffrorna något på riktigt.
+-- och för en säljare/admin är has_permission sann. OR:en kortsluter där, så besättningsfunktionen
+-- anropas aldrig på deras väg — oavsett hur många arbetsordrar tabellen växer till. Risken som stod
+-- öppen efter cutovern finns alltså inte, och åtgärden längst ned i filen behöver inte göras.
+--
+-- Millisekunderna säger däremot ingenting, och det ska de inte läsas som att de gör. Vid 14 rader är
+-- allt fast overhead: i första körningen tog EN rad 7,6 ms medan fjorton tog 3,9 ms. Läs "OK" som
+-- "inget problem nu". Skalningssvaret kommer från mätning 5, inte från tiderna.
+--
+-- Grenordningen är den planen faktiskt utvärderar i, men den är inte garanterad över
+-- PostgreSQL-uppgraderingar eller ändrad statistik. Mät om efter större ingrepp, och när tabellen
+-- vuxit en storleksordning — då börjar tiderna också betyda något.
+--
+-- SIDOFYND, inte prestanda: den mest uppkopplade besättningsmedlemmen nådde 1 av 14 arbetsordrar.
+-- Kontextraden 'flest arbetsordrar en besättningsmedlem ser' finns kvar just för att den siffran ska
+-- gå att se. Är den låg är det planeringsdata som saknar besättning, inte RLS som stänger ute.
 
 -- ═══════════════════════════════════════════════════════════════════════════
 -- STEG 1 — skapa probfunktionen. Kör den här filen som den är.
@@ -62,6 +71,8 @@ declare
   filter_txt text;
   pos_perm  int;
   pos_crew  int;
+  pos_agare int;
+  har_perm  boolean;
   max_synliga bigint;
 begin
   -- ── Kontext ────────────────────────────────────────────────────────────────
@@ -212,22 +223,42 @@ begin
       order by desired_installation_date asc nulls last, created_at desc
       limit 100' into plan_json;
     plan_txt := plan_json::text;
-    pos_perm := strpos(plan_txt, 'has_permission');
-    pos_crew := strpos(plan_txt, 'is_user_on_work_order');
+    pos_agare := strpos(plan_txt, 'request.jwt.claim.sub');  -- auth.uid() inlinat = ägargrenen
+    pos_perm  := strpos(plan_txt, 'has_permission');
+    pos_crew  := strpos(plan_txt, 'is_user_on_work_order');
+    -- Ordningen räcker inte som slutsats: kortslutningen inträffar bara om den tidigare grenen är
+    -- SANN för just den här personen. En installatör har inte crm.workorder.read, så för hen faller
+    -- filtret alltid igenom till besättningsgrenen — helt riktigt, det är deras enda väg in. Fråga
+    -- i stället för att anta.
+    execute 'select public.has_permission(''crm.workorder.read'')' into har_perm;
     ms := round((plan_json->0->>'Execution Time')::numeric, 1);
     rader := null;
-    prob := '5. plan — vilken gren står först i filtret?';
+    prob := '5. plan — betalar den här personen besättningsgrenen per rad?';
     bedomning := case
       when pos_crew = 0 then 'besättningsgrenen saknas i planen'
-      when pos_perm = 0 then 'ENDA GRENEN — inget att kortsluta mot (väntat i fält)'
-      when pos_perm < pos_crew then 'OK — behörighetsgrenen först, kortsluter per rad'
-      else 'DYRT — besättningsgrenen först, körs för varje rad'
+      when har_perm and pos_perm > 0 and pos_perm < pos_crew
+        then 'NEJ — behörighetsgrenen är sann och står först, kortsluter'
+      when har_perm then 'JA — behörighetsgrenen är sann men står EFTER besättningsgrenen'
+      else 'JA — ingen behörighetsgren att kortsluta på (väntat i fält)'
     end;
     return next;
 
-    -- 6) Filteruttrycket i klartext, så slutsatsen ovan går att granska i stället för att litas på.
+    -- 6) Grenordningen i läsbar form, så slutsatsen ovan går att granska i stället för att litas på.
+    --    Ordningen är den planen faktiskt utvärderar i, men den är inte garanterad över uppgraderingar
+    --    eller ändrad statistik — mät om efter större ingrepp.
+    prob := '6. grenordning: ' || coalesce((
+      select string_agg(v.namn, '  →  ' order by v.pos)
+        from (values ('assigned_to=auth.uid()', pos_agare),
+                     ('has_permission',        pos_perm),
+                     ('is_user_on_work_order', pos_crew)) v(namn, pos)
+       where v.pos > 0), '(inget filter i planen)');
+    rader := null; ms := null; bedomning := 'INFO';
+    return next;
+
+    -- 7) Råa filtret, slutet av uttrycket — det är där grenarna sitter. Början är bara auth.uid()
+    --    utskrivet i sin fulla längd och säger ingenting.
     filter_txt := substring(plan_txt from '"Filter":\s*"(.*?)"');
-    prob := '6. filteruttryck: ' || coalesce(left(filter_txt, 180), '(inget filter i planen)');
+    prob := '7. filtrets slut: …' || coalesce(right(filter_txt, 170), '(inget filter i planen)');
     rader := null; ms := null; bedomning := 'INFO';
     return next;
 

--- a/supabase/sql/20260811_crm_work_order_rls_perf_probe.sql
+++ b/supabase/sql/20260811_crm_work_order_rls_perf_probe.sql
@@ -1,5 +1,21 @@
 -- CRM-arbetsorderlistan under besättnings-RLS:en — MÄTNING, inga ändringar sparas.
 --
+-- KORT: alla andra läsregler på crm_work_orders ger SAMMA svar för varje rad ("har du
+-- crm.workorder.read?") — databasen frågar en gång och är klar. Besättningsregeln ger OLIKA svar per
+-- rad ("står du på det här jobbets besättning?") och gräver genom planeringstabellerna varje gång.
+-- Det är den enda regeln i systemet som kostar per rad. Frågan här: märks det?
+--
+-- VARFÖR DEN BYTER ROLL. Som databasägare gäller RLS inte alls — mäter man därifrån mäter man en
+-- fråga utan policy på och lär sig ingenting. `set role authenticated` + JWT-claims är det som gör
+-- mätningen verklig. Uppslagen (vilka testpersoner finns, hur många rader) körs medvetet UTAN RLS;
+-- mätningarna körs medvetet MED. Rad "0. kontroll" i utdatan bevisar vilket som gällde — säger den
+-- FEL är resten skräp.
+--
+-- FARLIGT? Nej: inget skrivs (begin…rollback, hjälpfunktion i pg_temp, temporär tabell), rollen och
+-- claimsen sätts med SET LOCAL och dör med transaktionen även om något kraschar mitt i, och utdatan
+-- är antal + millisekunder — ingen kunddata. Den reella kostnaden är CPU: proben scannar tabellen
+-- flera gånger och sista mätningen är långsam med flit. Kör den inte mitt i högtrafik.
+--
 -- Den enda punkten i fält/CRM-cutovern som ingen mätte innan go-live. `crm_work_orders_select_crew`
 -- (20260810_crm_work_order_crew_access.sql) anropar `is_user_on_work_order(auth.uid(), id)` — ett
 -- predikat som beror på RADEN och därför i värsta fall körs en gång per arbetsorder. Frågan filen
@@ -70,6 +86,8 @@ declare
   t0 timestamptz;
   n  bigint;
   elapsed numeric;
+  kor_som text;
+  uid_syns text;
 begin
   if p_uid = '' then
     persona := p_persona; prob := '(ingen testperson hittad)'; rader := null; ms := null;
@@ -78,6 +96,21 @@ begin
 
   perform set_config('role', 'authenticated', true);
   perform set_config('request.jwt.claims', json_build_object('sub', p_uid, 'role', 'authenticated')::text, true);
+
+  -- 0) Beviset att mätningen mäter något. Tar rollbytet inte — fel rollnamn, ändrad Supabase-uppsättning
+  --    — körs allt nedan som tabellägare, och då gäller RLS inte alls: siffrorna blir strålande och
+  --    betyder ingenting. En mätning man inte kan skilja från en no-op är ingen mätning, så läs den
+  --    här raden FÖRST och kasta resten om den säger FEL.
+  select current_user::text into kor_som;
+  select coalesce(auth.uid()::text, '(null)') into uid_syns;
+  persona := p_persona;
+  prob := format('0. kontroll — kör som %s, auth.uid() = %s', kor_som, uid_syns);
+  rader := null; ms := null;
+  bedomning := case
+    when kor_som = 'authenticated' and uid_syns = p_uid then 'OK — RLS gäller'
+    else 'FEL — allt nedan mäter en fråga utan policy'
+  end;
+  return next;
 
   -- 1) Listsidan: exakt vad listCrmWorkOrdersWithFilters begär (sida 1, 100 rader).
   t0 := clock_timestamp();
@@ -132,9 +165,15 @@ $fn$;
 -- Kontexten först, medan rollen fortfarande är privilegierad: annars räknas raderna genom RLS och
 -- säger något helt annat än "så här många arbetsordrar finns det".
 insert into probe_out
-select 0, 'kontext', 'antal arbetsordrar', count(*), null, 'INFO' from public.crm_work_orders
+select 0, 'kontext', 'antal arbetsordrar', count(*), null::numeric, 'INFO' from public.crm_work_orders
 union all
-select 0, 'kontext', 'antal ops_segments', count(*), null, 'INFO' from public.ops_segments;
+select 0, 'kontext', 'antal ops_segments', count(*), null::numeric, 'INFO' from public.ops_segments
+union all
+-- Är RLS avslaget på tabellen finns det ingen policy att mäta kostnaden för, och alla siffror nedan
+-- är fritt fall. (Ägaren kringgår RLS ändå — därför rollbytet — men är den AV kringgår ALLA den.)
+select 0, 'kontext', 'RLS på crm_work_orders', null::bigint, null::numeric,
+       case when relrowsecurity then 'PÅ' else 'AV — inget nedan betyder något' end
+from pg_class where oid = 'public.crm_work_orders'::regclass;
 
 insert into probe_out
 select 1, p.* from pg_temp.rls_probe('kontor (sälj/admin)', current_setting('probe.office_uid')) p;

--- a/supabase/sql/20260811_rot_orders_missing_property_audit.sql
+++ b/supabase/sql/20260811_rot_orders_missing_property_audit.sql
@@ -1,0 +1,46 @@
+-- ROT-ordrar som saknar fastighetsbeteckning — READ ONLY, ändrar ingenting.
+--
+-- Grinden i `createCrmWorkOrderFromQuote` (V3, 2026-08-11) gäller bara ordrar som skapas FRÅN OCH
+-- MED nu. Den här frågan listar de som redan fanns: ROT är påslaget, men varken fastighetsbeteckning
+-- eller BRF org.nr är ifyllt, så den som slutför fakturan i Fortnox har inget att skriva in i
+-- husarbete-dialogen (fältet går inte att sätta via API:t — se FORTNOX_INTEGRATION.md 4b).
+--
+-- Läs `källa`: pushen läser ROT-uppgifterna från den KOPPLADE OFFERTEN (`linkedQuote.rot_details` i
+-- orders.ts), inte från ordern. En order vars egen kopia är tom men vars offert har beteckningen är
+-- alltså i sin ordning — därför särskiljs de.
+--
+-- Åtgärd per rad: fyll i beteckningen på offerten och spara om den (då re-synkas Fortnox-offerten),
+-- eller skriv in den för hand i Fortnox innan fakturan slutförs. Ordrar som redan är fakturerade är
+-- historik — kontrollera bara att ROT gick igenom.
+
+select
+  wo.order_number,
+  wo.client_name,
+  wo.status,
+  wo.fortnox_order_number,
+  wo.fortnox_invoice_number,
+  wo.created_at::date as skapad,
+  q.id as offert_id,
+  case
+    when q.id is null then 'ordern har ingen offert (standalone) — ROT pushas aldrig, kontrollera manuellt'
+    else 'offertens rot_details saknar både beteckning och BRF org.nr'
+  end as kalla,
+  case
+    when wo.fortnox_invoice_number is not null then 'FAKTURERAD — kontrollera om ROT gick igenom'
+    when wo.fortnox_order_number is not null then 'LIGGER I FORTNOX — fyll i före fakturering'
+    else 'EJ PUSHAD — fyll i på offerten och spara om'
+  end as atgard
+from public.crm_work_orders wo
+left join public.crm_quotes q on q.id = wo.quote_id
+where wo.status <> 'cancelled'
+  -- ROT påslaget någonstans: på ordern (kopian) eller på offerten (det pushen faktiskt läser).
+  and (coalesce(wo.rot_details->>'enabled', 'false') = 'true' or coalesce(q.rot_details->>'enabled', 'false') = 'true')
+  -- ...och ingen av identifieringarna finns, varken på offerten eller på ordern.
+  and coalesce(nullif(btrim(coalesce(q.rot_details->>'property_designation', '')), ''), '') = ''
+  and coalesce(nullif(btrim(coalesce(q.rot_details->>'brf_org_number', '')), ''), '') = ''
+  and coalesce(nullif(btrim(coalesce(wo.rot_details->>'property_designation', '')), ''), '') = ''
+  and coalesce(nullif(btrim(coalesce(wo.rot_details->>'brf_org_number', '')), ''), '') = ''
+order by
+  (wo.fortnox_invoice_number is not null) desc,
+  (wo.fortnox_order_number is not null) desc,
+  wo.created_at desc;

--- a/tests/crm/work-orders.test.ts
+++ b/tests/crm/work-orders.test.ts
@@ -101,6 +101,62 @@ describe('createCrmWorkOrderFromQuote — fält-mappning', () => {
     expect(captured.insert!.customer_snapshot.personal_number).toBe('900101-1234');
   });
 
+  // V3: ROT-avdraget kan inte begäras utan att fastigheten är identifierad, och Fortnox har inget
+  // API-fält för beteckningen — den skrivs för hand i husarbete-dialogen utifrån textraden vi
+  // skickar. Kravet ligger därför på ORDERN (kundgodkänd), inte på offerten. Routen auto-pushar
+  // till Fortnox i samma andetag som ordern skapas, så det här är sista stället en människa hinner
+  // stoppas.
+  const rotQuote = (rot: Record<string, unknown>) =>
+    wonQuote({
+      quote_type: 'private',
+      customer_id: null,
+      customer_snapshot: { customer_name: 'Anna', personal_number: '900101-1234' },
+      rot_details: { enabled: true, personal_number: '900101-1234', ...rot },
+    });
+
+  it('blockerar ROT-order utan fastighetsbeteckning och BRF org.nr', async () => {
+    const { supabase, captured } = makeSupabase(rotQuote({ property_designation: null, brf_org_number: null }));
+    const result = await createCrmWorkOrderFromQuote(supabase as any, 'q1', 'user-1');
+    expect(result.reason).toBe('missing_rot_property');
+    expect(result.data).toBeNull();
+    // Ordern får inte ha hunnit skapas — annars auto-pushas den till Fortnox.
+    expect(captured.insert).toBeNull();
+  });
+
+  it('blockerar när beteckningen bara är blanksteg', async () => {
+    const { supabase } = makeSupabase(rotQuote({ property_designation: '   ' }));
+    const result = await createCrmWorkOrderFromQuote(supabase as any, 'q1', 'user-1');
+    expect(result.reason).toBe('missing_rot_property');
+  });
+
+  it('släpper igenom ROT-order med fastighetsbeteckning', async () => {
+    const { supabase, captured } = makeSupabase(rotQuote({ property_designation: 'Gläntan 1:14' }));
+    const result = await createCrmWorkOrderFromQuote(supabase as any, 'q1', 'user-1');
+    expect(result.error).toBeNull();
+    expect(captured.insert!.rot_details.property_designation).toBe('Gläntan 1:14');
+  });
+
+  // Bostadsrätt: fastigheten identifieras med föreningens org.nr i stället, så BRF-numret räcker.
+  it('släpper igenom ROT-order med bara BRF org.nr', async () => {
+    const { supabase } = makeSupabase(rotQuote({ property_designation: null, brf_org_number: '769606-1234' }));
+    const result = await createCrmWorkOrderFromQuote(supabase as any, 'q1', 'user-1');
+    expect(result.error).toBeNull();
+    expect(result.reason).toBeNull();
+  });
+
+  // Grinden gäller bara ROT. En vanlig order (eller en offert där ROT slagits av) rörs inte.
+  it('kräver ingen beteckning när ROT är av', async () => {
+    const { supabase } = makeSupabase(wonQuote({ rot_details: { enabled: false, property_designation: null } }));
+    const result = await createCrmWorkOrderFromQuote(supabase as any, 'q1', 'user-1');
+    expect(result.error).toBeNull();
+  });
+
+  it('kräver ingen beteckning för äldre offerter utan rot_details', async () => {
+    const { supabase } = makeSupabase(wonQuote({ rot_details: null }));
+    const result = await createCrmWorkOrderFromQuote(supabase as any, 'q1', 'user-1');
+    expect(result.error).toBeNull();
+  });
+
   it('seedar notes från offertens egna notes när de finns', async () => {
     const { supabase, captured } = makeSupabase(wonQuote({ notes: 'Internt orderunderlag' }));
 


### PR DESCRIPTION
## Go-live-efterarbete efter fält/CRM-cutovern

Tre punkter som stod öppna efter PR #53.

### 1. Docs-commit som aldrig nådde main
`519849a` skrevs efter att #53 mergats och blev kvar på grenen. PERMISSIONS.md saknade
därför hela sektionen om besättningsåtkomst — inklusive gotchan att "member har inga
CRM-nycklar" inte betyder "member kan inte läsa en arbetsorder".

### 2. V3 — fastighetsbeteckning krävs när en ROT-offert blir order
Fortnox har inget API-fält för beteckningen; den skrivs för hand i husarbete-dialogen
utifrån textraden vi skickar. Saknas den när ordern skapas finns inget att skriva av.

Kravet ligger medvetet på **ordern**, inte offerten: säljaren har sällan uppgiften medan
hen offererar. Ordern är däremot ingen återvändo — routen auto-pushar till Fortnox direkt.

- `createCrmWorkOrderFromQuote` → `reason: 'missing_rot_property'` när ROT är på och både
  `property_designation` och `brf_org_number` saknas. **Endera räcker** — en bostadsrätt
  identifieras med föreningens org.nr.
- Routen svarar 409 `crm_work_order_missing_rot_property`.
- Offertformuläret öppnar en prompt och **sparar om hela offerten** innan den gör om ordern.
  Avsiktligt: bara en payload med `line_items` triggar Fortnox-synken, och utan den ärver
  `createorder` en offert utan beteckningen.
- Gäller bara nya ordrar. Befintliga blockeras inte vid push eller delfakturering —
  `20260811_rot_orders_missing_property_audit.sql` listar dem för manuell uppföljning.

### 3. RLS-prestandan mätt — risken avskriven
`is_user_on_work_order` är radberoende och kunde ha kostat per rad, värst i de sex
`count(*)` chip-frågorna som saknar `LIMIT`. Mätt: filtret utvärderar
`assigned_to=auth.uid()` → `has_permission` → `is_user_on_work_order`, och för sälj/admin
är mittengrenen sann. OR:en kortsluter — besättningsfunktionen anropas aldrig på kontorets
väg, oavsett tabellstorlek. Ingen omskrivning behövs.

Proben ligger kvar som `20260811_crm_work_order_rls_perf_probe.sql` (skapa → kör → droppa)
för omkörning när tabellen vuxit.

### Verifiering
`npm run type-check` ren · 718 tester gröna (6 nya) · `npm run build` exit 0 ·
proben körd skarpt mot produktionsdata.

