### PR TITLE
fix(order): synka orderns header till Fortnox + rotorsaken till 2004021

### DIFF
--- a/app/api/crm/work-orders/[id]/line-items/route.ts
+++ b/app/api/crm/work-orders/[id]/line-items/route.ts
@@ -3,7 +3,7 @@ import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
 import { getCrmWorkOrder, updateCrmWorkOrderLineItems } from '@/lib/domains/crm/work-orders';
 import { computePricing, type PricingLineItem } from '@/lib/domains/crm/pricing';
 import { updateWorkOrderInFortnox } from '@/lib/domains/fortnox/orders';
-import { FortnoxNotConnectedError } from '@/lib/domains/fortnox/client';
+import { FortnoxNotConnectedError, friendlyFortnoxMessage } from '@/lib/domains/fortnox/client';
 import { ok, requirePermission, routeError, updateWorkOrderLineItemsSchema, validationError, invalidUuidParam } from '../../_lib';
 
 type RouteContext = {
@@ -61,8 +61,11 @@ export async function PATCH(req: Request, context: RouteContext) {
       await updateWorkOrderInFortnox(context.params.id);
     } catch (e) {
       if (!(e instanceof FortnoxNotConnectedError)) {
-        fortnoxError = (e as any)?.message || 'Fortnox-synk misslyckades';
-        console.error('[fortnox] Arbetsorder-raduppdatering misslyckades:', fortnoxError);
+        // friendlyFortnoxMessage, inte e.message: FortnoxApiError.message ÄR den tekniska
+        // loggsträngen ("Fortnox POST /orders (400): {…}") och den hamnade rakt i säljarens toast.
+        // Samma översättning som manuella "Synka om"-knappen redan gör.
+        fortnoxError = friendlyFortnoxMessage(e);
+        console.error('[fortnox] Arbetsorder-raduppdatering misslyckades:', (e as Error)?.message);
       }
     }
 

--- a/app/api/crm/work-orders/[id]/route.ts
+++ b/app/api/crm/work-orders/[id]/route.ts
@@ -1,11 +1,18 @@
 import { cookies } from 'next/headers';
 import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
 import { getCrmWorkOrder, updateCrmWorkOrder, listWorkOrderInvoiceRounds, redactWorkOrderForField } from '@/lib/domains/crm/work-orders';
+import { syncWorkOrderHeaderToFortnox } from '@/lib/domains/fortnox/orders';
+import { FortnoxNotConnectedError, friendlyFortnoxMessage } from '@/lib/domains/fortnox/client';
 import { isNoRowsError, ok, pickProvidedFields, requireCrmUser, requirePermission, requireSignedInUser, routeError, updateCrmWorkOrderSchema, validationError } from '../_lib';
 
 // Fakturastatus is system-managed (set by the invoice/delfakturering flow), never chosen
 // by hand — so a crafted PATCH can't fake a billed order or regress one back to a manual state.
 const SYSTEM_MANAGED_WO_STATUSES: string[] = ['invoiced', 'partially_invoiced'];
+
+// The edited fields that Fortnox mirrors on the order header: contact person → YourReference,
+// work address → delivery address, ansvarig → OurReference. Gating on these keeps a status-only
+// PATCH — the board sends one on every drag — from becoming a Fortnox write.
+const FORTNOX_MIRRORED_FIELDS = ['contact', 'work_address', 'assigned_to'] as const;
 
 type RouteContext = {
   params: {
@@ -55,6 +62,9 @@ export async function PATCH(req: Request, context: RouteContext) {
     // Persist only fields the client actually sent, so a partial PATCH (e.g. a status-only
     // change) doesn't wipe untouched columns (internal_handoff, work_address) with defaults.
     const updateInput = pickProvidedFields(parsedBody.data, rawBody);
+
+    // Read before the merge below deletes `contact` off updateInput.
+    const touchesFortnox = FORTNOX_MIRRORED_FIELDS.some((field) => field in updateInput);
 
     // Load the current row once — both the contact-snapshot merge and the status guard need it.
     type WoCurrent = { status?: string | null; customer_snapshot?: Record<string, unknown> | null };
@@ -107,7 +117,30 @@ export async function PATCH(req: Request, context: RouteContext) {
       return routeError(500, 'crm_work_order_update_failed', error.message);
     }
 
-    return ok({ item: data });
+    // Mirror the edit onto the Fortnox order header. Non-fatal, exactly like the article route:
+    // the save has already succeeded, and a Fortnox outage must not make it look like it didn't.
+    // The reason is handed back so the UI can say the save landed but the sync didn't.
+    let fortnoxError: string | null = null;
+    let synced = false;
+    if (touchesFortnox) {
+      try {
+        synced = (await syncWorkOrderHeaderToFortnox(context.params.id)) !== null;
+      } catch (e) {
+        if (!(e instanceof FortnoxNotConnectedError)) {
+          fortnoxError = friendlyFortnoxMessage(e);
+          console.error('[fortnox] Arbetsorder-headersynk misslyckades:', (e as Error)?.message);
+        }
+      }
+    }
+
+    // Re-read only when Fortnox was actually touched, so the returned row carries the fresh
+    // sync status/timestamp instead of the pre-sync one the update returned.
+    if (synced || fortnoxError) {
+      const fresh = await getCrmWorkOrder(supabase, context.params.id);
+      return ok({ item: fresh.data ?? data, fortnox_error: fortnoxError });
+    }
+
+    return ok({ item: data, fortnox_error: null });
   } catch (e: any) {
     return routeError(500, 'crm_work_order_update_unexpected', e?.message || 'Failed to update work order');
   }

--- a/app/crm/arbetsorder/WorkOrderDetailClient.tsx
+++ b/app/crm/arbetsorder/WorkOrderDetailClient.tsx
@@ -330,7 +330,14 @@ export default function WorkOrderDetailClient({ workOrderId, fortnoxConnected, c
       if (!res.ok || !json.ok) { toast.error(json?.error || 'Kunde inte spara arbetsorder'); return; }
       if (json.data?.item) applyWorkOrder(json.data.item as WorkOrderItem);
       setEditingOverview(false);
-      toast.success('Arbetsorder sparad');
+      // Kontaktperson/arbetsadress/ansvarig speglas på Fortnox-ordern. Synken är icke-fatal —
+      // sparningen har redan lyckats — men den får inte misslyckas tyst: det var precis så en
+      // ändrad kontakt kunde ligga rätt i CRM och fel i Fortnox utan att någon märkte det.
+      if (json.data?.fortnox_error) {
+        toast.error(`Arbetsorder sparad men Fortnox-synk misslyckades: ${json.data.fortnox_error}`);
+      } else {
+        toast.success('Arbetsorder sparad');
+      }
     } catch { toast.error('Kunde inte spara arbetsorder'); }
     finally { setSaving(false); }
   }

--- a/lib/domains/fortnox/client.ts
+++ b/lib/domains/fortnox/client.ts
@@ -100,6 +100,14 @@ const FRIENDLY_FORTNOX_MESSAGES: Record<number, string> = {
   2000310: 'Posten används redan i Fortnox och kan inte ändras eller tas bort.',
   2000204: 'En obligatorisk uppgift saknas i Fortnox. Komplettera kund-/offertuppgifterna och försök igen.',
   1000030: 'Kunde inte hämta dokumentet från Fortnox. Försök igen om en stund.',
+  // Fortnox säger bara "skattereduktionstypen 'none' får inte innehålla rader med husarbetestypen
+  // X" — sant, men det pekar ut fel ställe. Vi skickar aldrig husarbete på ett icke-ROT-dokument;
+  // flaggan ÄRVS från artikeln i Fortnox och går inte att överrösta från raden. Åtgärden ligger
+  // alltså i artikelregistret, inte i CRM. Se FORTNOX_INTEGRATION.md sekt. 4 punkt 3.
+  2004021: 'En av artiklarna är markerad som husarbete i Fortnox, men dokumentet har inte ROT. '
+    + 'Öppna artikeln i Fortnox (Register → Artiklar) och stäng av husarbete — det är oftast en '
+    + 'arbets-, etablerings- eller fraktartikel som blivit husarbete-flaggad av misstag. '
+    + 'Flaggan sitter på artikeln och kan inte stängas av från raden här.',
 };
 
 // Turn any thrown Fortnox error into a message safe to show a non-technical user.

--- a/lib/domains/fortnox/client.ts
+++ b/lib/domains/fortnox/client.ts
@@ -100,14 +100,16 @@ const FRIENDLY_FORTNOX_MESSAGES: Record<number, string> = {
   2000310: 'Posten används redan i Fortnox och kan inte ändras eller tas bort.',
   2000204: 'En obligatorisk uppgift saknas i Fortnox. Komplettera kund-/offertuppgifterna och försök igen.',
   1000030: 'Kunde inte hämta dokumentet från Fortnox. Försök igen om en stund.',
-  // Fortnox säger bara "skattereduktionstypen 'none' får inte innehålla rader med husarbetestypen
-  // X" — sant, men det pekar ut fel ställe. Vi skickar aldrig husarbete på ett icke-ROT-dokument;
-  // flaggan ÄRVS från artikeln i Fortnox och går inte att överrösta från raden. Åtgärden ligger
-  // alltså i artikelregistret, inte i CRM. Se FORTNOX_INTEGRATION.md sekt. 4 punkt 3.
+  // Fortnox säger "skattereduktionstypen 'none' får inte innehålla rader med husarbetestypen X" —
+  // sant, men det pekar ut dokumentet när felet sitter på ARTIKELN. Vi skickar aldrig husarbete på
+  // ett icke-ROT-dokument; flaggan (`Housework` på artikeln i Fortnox) ärvs ner på raden och går
+  // inte att överrösta därifrån — `HouseWork: false` stämplar EMPTYHOUSEWORK och nekas likaså.
+  // Åtgärden ligger i artikelregistret. Se FORTNOX_INTEGRATION.md sekt. 4 punkt 3.
   2004021: 'En av artiklarna är markerad som husarbete i Fortnox, men dokumentet har inte ROT. '
-    + 'Öppna artikeln i Fortnox (Register → Artiklar) och stäng av husarbete — det är oftast en '
-    + 'arbets-, etablerings- eller fraktartikel som blivit husarbete-flaggad av misstag. '
-    + 'Flaggan sitter på artikeln och kan inte stängas av från raden här.',
+    + 'Flaggan sitter på ARTIKELN (Register → Artiklar i Fortnox) och ärvs ner på raden — den går '
+    + 'inte att stänga av härifrån. Typiskt arbets-, monterings- eller framkörningsartiklar. '
+    + 'Kontakta en administratör: artikelflaggan behöver stängas av, eftersom CRM sätter husarbete '
+    + 'per rad på ROT-dokument ändå.',
 };
 
 // Turn any thrown Fortnox error into a message safe to show a non-technical user.

--- a/lib/domains/fortnox/client.ts
+++ b/lib/domains/fortnox/client.ts
@@ -105,11 +105,11 @@ const FRIENDLY_FORTNOX_MESSAGES: Record<number, string> = {
   // ett icke-ROT-dokument; flaggan (`Housework` på artikeln i Fortnox) ärvs ner på raden och går
   // inte att överrösta därifrån — `HouseWork: false` stämplar EMPTYHOUSEWORK och nekas likaså.
   // Åtgärden ligger i artikelregistret. Se FORTNOX_INTEGRATION.md sekt. 4 punkt 3.
-  2004021: 'En av artiklarna är markerad som husarbete i Fortnox, men dokumentet har inte ROT. '
-    + 'Flaggan sitter på ARTIKELN (Register → Artiklar i Fortnox) och ärvs ner på raden — den går '
-    + 'inte att stänga av härifrån. Typiskt arbets-, monterings- eller framkörningsartiklar. '
-    + 'Kontakta en administratör: artikelflaggan behöver stängas av, eftersom CRM sätter husarbete '
-    + 'per rad på ROT-dokument ändå.',
+  2004021: 'En av artiklarna har en husarbetestyp satt i Fortnox, men dokumentet har inte ROT. '
+    + 'Typen sitter på ARTIKELN och ärvs ner på raden — den går inte att stänga av härifrån. '
+    + 'Obs: den syns oftast INTE i Fortnox artikelvy, eftersom en urkryssad husarbetesruta lämnar '
+    + 'kvar typen. Kontakta en administratör — den behöver rensas via API:t '
+    + '(PUT /articles/{nr} med HouseworkType: null).',
 };
 
 // Turn any thrown Fortnox error into a message safe to show a non-technical user.

--- a/lib/domains/fortnox/helpers.ts
+++ b/lib/domains/fortnox/helpers.ts
@@ -176,6 +176,30 @@ export function buildRotPropertyNote(
   return parts.length ? parts.join('  ') : null;
 }
 
+// "Ert referensnummer" and the ROT property text row are two halves of ONE rule, so they are
+// resolved together instead of by two parallel copies of the same condition. A villa's
+// fastighetsbeteckning IS the customer's reference for the house and fits the single reference
+// field; a bostadsrätt needs two values (BRF org.nr + lägenhetsnr) that don't fit, so those ride
+// as a text row instead. A företag's märkning (customer_snapshot.label) uses the same reference
+// field — the two can never collide, since ROT is always a private customer.
+//
+// Returns exactly one of the two populated for a ROT document (never both), and the märkning as
+// referenceNumber for everything else. See FORTNOX_INTEGRATION.md 4b for why Fortnox can't take
+// the designation as a real field.
+export function resolveRotReference(
+  rot: { property_designation?: string | null; brf_org_number?: string | null } | null | undefined,
+  label: string | null | undefined,
+  rotEnabled: boolean,
+): { referenceNumber: string | null; propertyNote: string | null } {
+  const hasProperty = rotEnabled && !!rot?.property_designation?.trim();
+  const hasBrf = rotEnabled && !!rot?.brf_org_number?.trim();
+  const propertyAsRef = hasProperty && !hasBrf;
+  return {
+    referenceNumber: propertyAsRef ? rot!.property_designation!.trim() : (label?.trim() || null),
+    propertyNote: propertyAsRef ? null : (rotEnabled ? buildRotPropertyNote(rot) : null),
+  };
+}
+
 // Appends a document-level text note to a Fortnox row list WITHOUT creating two consecutive
 // text rows — Fortnox treats a second consecutive text row (Description only, no amounts) as a
 // new priced product row. If the last row is already a text row we merge the note into it

--- a/lib/domains/fortnox/orders.ts
+++ b/lib/domains/fortnox/orders.ts
@@ -202,16 +202,23 @@ export function buildOrderDeliveryFields(
   workAddress: WorkOrderAddress | null | undefined,
   snapshot: CustomerSnapshot | null | undefined,
 ): Pick<FortnoxOrderHeaderFields, 'DeliveryAddress1' | 'DeliveryZipCode' | 'DeliveryCity'> {
-  const fromColumn = workAddress?.street_address?.trim();
-  const site = fromColumn
-    ? { street: fromColumn, zip: workAddress?.postal_code?.trim(), city: workAddress?.city?.trim() }
-    : snapshot?.delivery_address?.trim()
-      ? {
-          street: snapshot.delivery_address!.trim(),
-          zip: snapshot.delivery_postal_code?.trim(),
-          city: snapshot.delivery_city?.trim(),
-        }
-      : null;
+  // Which source is AUTHORITATIVE is decided by whether the column exists at all — not by whether
+  // it happens to hold a street. A row that HAS a work_address owns its job site, so an emptied
+  // street means "no separate job site", not "look in the snapshot". Falling back on a blank street
+  // would re-push the address the seller just deleted, and would do it on a first create push too.
+  // Only a row with no work_address at all (legacy: getWorkAddress and the standalone create both
+  // always write one) may fall back to the snapshot's delivery_*.
+  const site = workAddress
+    ? (workAddress.street_address?.trim()
+        ? { street: workAddress.street_address.trim(), zip: workAddress.postal_code?.trim(), city: workAddress.city?.trim() }
+        : null)
+    : (snapshot?.delivery_address?.trim()
+        ? {
+            street: snapshot.delivery_address.trim(),
+            zip: snapshot.delivery_postal_code?.trim(),
+            city: snapshot.delivery_city?.trim(),
+          }
+        : null);
   if (!site) return {};
 
   const customerStreet = snapshot?.street_address?.trim();
@@ -657,15 +664,22 @@ export async function syncWorkOrderHeaderToFortnox(workOrderId: string): Promise
     const rotEnabled = linkedQuote?.rot_details?.enabled === true && !reverseVat;
     const { header } = await buildOrderHeader(workOrder, linkedQuote, rotEnabled, supabase);
 
-    // An empty header would be a PUT that says nothing — skip the round trip.
-    if (Object.keys(header).length === 0) return { fortnox_order_number: workOrder.fortnox_order_number };
+    // An empty header would be a PUT that says nothing — skip the round trip. null, not a result:
+    // nothing was sent, so the caller must not report a completed sync (and must not re-read the
+    // row expecting a fresh timestamp).
+    if (Object.keys(header).length === 0) return null;
 
     await fortnoxPut(`/orders/${workOrder.fortnox_order_number}`, { Order: header });
 
+    // `neq('failed')`: this path sends NO rows, so it cannot vouch for them. Stamping 'synced'
+    // unconditionally would clear a failed article sync, hide the "Försök igen"-knapp, and leave
+    // the order looking complete while Fortnox still holds the pre-edit rows. A failed row sync
+    // stays failed until the row path itself succeeds.
     await supabase
       .from('crm_work_orders')
       .update({ fortnox_order_sync_status: 'synced', fortnox_order_synced_at: new Date().toISOString() })
-      .eq('id', workOrderId);
+      .eq('id', workOrderId)
+      .neq('fortnox_order_sync_status', 'failed');
 
     return { fortnox_order_number: workOrder.fortnox_order_number };
   } catch (e) {

--- a/lib/domains/fortnox/orders.ts
+++ b/lib/domains/fortnox/orders.ts
@@ -2,27 +2,47 @@ import { getSupabaseAdmin } from '@/lib/supabase/server';
 import { lineItemQuantity } from '@/lib/domains/crm/lineItems';
 import { lineItemUnitPrice, lineItemDiscountPercent, lineItemRowTotal } from '@/lib/domains/crm/pricing';
 import { fortnoxGet, fortnoxGetBinary, fortnoxPost, fortnoxPut, FortnoxApiError, FortnoxNotConnectedError, FortnoxPushInProgressError } from './client';
-import { appendFortnoxTextNote, buildEndContactNote, buildRotPropertyNote, claimFortnoxPush, resolveOurReference, resolveReverseVat, rotLaborRow, rowRotLaborCarveout, splitRotMaterialRow } from './helpers';
+import { appendFortnoxTextNote, buildEndContactNote, claimFortnoxPush, resolveOurReference, resolveReverseVat, resolveRotReference, rotLaborRow, rowRotLaborCarveout, splitRotMaterialRow } from './helpers';
 import { DEFAULT_ROT_HOUSE_WORK_TYPE } from './types';
+
+// The point-in-time customer data carried on both the quote and the work order. Named once
+// because the header builder below has to read the same shape off either of them.
+type CustomerSnapshot = {
+  contact_name?: string | null;
+  street_address?: string | null;
+  delivery_address?: string | null;
+  delivery_postal_code?: string | null;
+  delivery_city?: string | null;
+  postal_code?: string | null;
+  city?: string | null;
+  reverse_vat?: boolean | null;
+  end_contact_name?: string | null;
+  end_contact_phone?: string | null;
+  end_contact_email?: string | null;
+  label?: string | null;
+};
+
+// The work order's OWN address column — what the order detail page edits, and (since
+// getWorkAddress seeds it) where the job site lives once an order exists.
+type WorkOrderAddress = {
+  street_address?: string | null;
+  postal_code?: string | null;
+  city?: string | null;
+};
+
+type RotDetails = {
+  enabled?: boolean | null;
+  property_designation?: string | null;
+  brf_org_number?: string | null;
+};
 
 type WorkOrderRow = {
   id: string;
   quote_id: string | null;
   customer_id: string | null;
   assigned_to: string | null;
-  customer_snapshot: {
-    contact_name?: string | null;
-    delivery_address?: string | null;
-    delivery_postal_code?: string | null;
-    delivery_city?: string | null;
-    postal_code?: string | null;
-    city?: string | null;
-    reverse_vat?: boolean | null;
-    end_contact_name?: string | null;
-    end_contact_phone?: string | null;
-    end_contact_email?: string | null;
-    label?: string | null;
-  } | null;
+  customer_snapshot: CustomerSnapshot | null;
+  work_address: WorkOrderAddress | null;
   project_name: string;
   client_name: string | null;
   amount: number;
@@ -151,6 +171,123 @@ export function buildOrderRows(lineItems: WorkOrderRow['line_items'], vatPercent
   return appendFortnoxTextNote(rows, rotPropertyNote);
 }
 
+// The header fields we own on a Fortnox order. Everything else on the document (customer, dates,
+// totals) is either set once at creation or computed by Fortnox, and is deliberately absent here:
+// a PUT only touches the fields it carries, so an omitted key leaves Fortnox's value alone.
+export type FortnoxOrderHeaderFields = {
+  OurReference?: string;
+  YourReference?: string;
+  YourOrderNumber?: string;
+  Remarks?: string;
+  DeliveryAddress1?: string;
+  DeliveryZipCode?: string;
+  DeliveryCity?: string;
+};
+
+// The job site as Fortnox delivery address — or nothing, when the job happens at the customer's
+// own address.
+//
+// Two sources, in order: the work order's `work_address` column (what the order detail page edits)
+// and, for a row that never got one, the snapshot's `delivery_*`. They hold the same value at
+// creation (getWorkAddress copies snapshot → column), so reading the column first changes nothing
+// for an untouched order and is the whole point for an edited one — the edit used to land only in
+// the column while the push kept reading the snapshot.
+//
+// The "only when it differs from the customer address" rule is preserved deliberately: sending a
+// delivery address unconditionally would print a delivery block on every order confirmation that
+// doesn't have one today. Street is the anchor (same rule as buildCustomerSnapshot); postal/city
+// go as entered and are never borrowed from the customer address, since a job in another town
+// would otherwise get the wrong ort.
+export function buildOrderDeliveryFields(
+  workAddress: WorkOrderAddress | null | undefined,
+  snapshot: CustomerSnapshot | null | undefined,
+): Pick<FortnoxOrderHeaderFields, 'DeliveryAddress1' | 'DeliveryZipCode' | 'DeliveryCity'> {
+  const fromColumn = workAddress?.street_address?.trim();
+  const site = fromColumn
+    ? { street: fromColumn, zip: workAddress?.postal_code?.trim(), city: workAddress?.city?.trim() }
+    : snapshot?.delivery_address?.trim()
+      ? {
+          street: snapshot.delivery_address!.trim(),
+          zip: snapshot.delivery_postal_code?.trim(),
+          city: snapshot.delivery_city?.trim(),
+        }
+      : null;
+  if (!site) return {};
+
+  const customerStreet = snapshot?.street_address?.trim();
+  if (customerStreet && site.street.toLowerCase() === customerStreet.toLowerCase()) return {};
+
+  return {
+    DeliveryAddress1: site.street,
+    ...(site.zip ? { DeliveryZipCode: site.zip } : {}),
+    ...(site.city ? { DeliveryCity: site.city } : {}),
+  };
+}
+
+type OrderHeaderWorkOrder = {
+  assigned_to: string | null;
+  customer_snapshot: CustomerSnapshot | null;
+  work_address: WorkOrderAddress | null;
+};
+
+type OrderHeaderQuote = {
+  assigned_to?: string | null;
+  customer_snapshot?: CustomerSnapshot | null;
+  rot_details?: RotDetails | null;
+} | null;
+
+// Builds the order header (and the ROT text-row note that belongs with it) from the work order.
+//
+// ONE builder for all three push paths — create, the row re-sync after an article edit, and the
+// header-only sync after a contact/address edit. They used to disagree: only the create path ever
+// set OurReference/YourReference/delivery, so a contact person or work address corrected on the
+// order stayed in CRM and Fortnox kept the offer's original values with nothing to signal it.
+//
+// The WORK ORDER's snapshot leads and the quote's is a whole-object fallback, not a per-field one.
+// The two are identical at creation (createCrmWorkOrderFromQuote copies the quote's), and the order
+// is what gets edited afterwards — a per-field fallback would resurrect a value the seller
+// deliberately cleared. Same reasoning for assigned_to, which the detail page re-assigns and which
+// only ever holds an office role (listAssignableCrmUsers is sales/admin/konsult), never an installer.
+async function buildOrderHeader(
+  workOrder: OrderHeaderWorkOrder,
+  linkedQuote: OrderHeaderQuote,
+  rotEnabled: boolean,
+  supabase: ReturnType<typeof getSupabaseAdmin>,
+): Promise<{ header: FortnoxOrderHeaderFields; rotPropertyNote: string | null }> {
+  const snapshot = workOrder.customer_snapshot ?? linkedQuote?.customer_snapshot ?? null;
+  const ourReference = await resolveOurReference(workOrder.assigned_to ?? linkedQuote?.assigned_to ?? null, supabase);
+  const { referenceNumber, propertyNote } = resolveRotReference(linkedQuote?.rot_details, snapshot?.label, rotEnabled);
+  const endContactNote = buildEndContactNote(snapshot);
+
+  return {
+    header: {
+      ...(ourReference ? { OurReference: ourReference } : {}),
+      ...(snapshot?.contact_name ? { YourReference: snapshot.contact_name } : {}),
+      // "Ert referensnummer" — the order field is YourOrderNumber (the offer uses
+      // YourReferenceNumber; sending the wrong one is a 2001399 "Felaktigt fältnamn").
+      ...(referenceNumber ? { YourOrderNumber: referenceNumber } : {}),
+      ...(endContactNote ? { Remarks: endContactNote } : {}),
+      ...buildOrderDeliveryFields(workOrder.work_address, snapshot),
+    },
+    rotPropertyNote: propertyNote,
+  };
+}
+
+// The quote fields the header builder falls back on (an order created from a quote inherits its
+// ROT details, which never live on the work order itself). Null for a standalone order.
+async function fetchLinkedQuoteForHeader(
+  supabase: ReturnType<typeof getSupabaseAdmin>,
+  quoteId: string | null,
+): Promise<OrderHeaderQuote> {
+  if (!quoteId) return null;
+  const { data } = await supabase
+    .from('crm_quotes')
+    .select('assigned_to, customer_snapshot, rot_details')
+    .eq('id', quoteId)
+    .maybeSingle();
+  return (data as OrderHeaderQuote) ?? null;
+}
+
 // Resolves the Fortnox customer number from an already-fetched linked quote.
 // Checks customer_source first, then falls back to crm_customers.fortnox_customer_id.
 async function resolveCustomerNumberFromQuote(
@@ -192,7 +329,7 @@ export async function pushWorkOrderToFortnox(workOrderId: string): Promise<PushO
 
   const { data: workOrder, error } = await supabase
     .from('crm_work_orders')
-    .select('id, quote_id, customer_id, assigned_to, customer_snapshot, project_name, client_name, amount, vat_percent, currency_code, line_items, fortnox_order_number')
+    .select('id, quote_id, customer_id, assigned_to, customer_snapshot, work_address, project_name, client_name, amount, vat_percent, currency_code, line_items, fortnox_order_number')
     .eq('id', workOrderId)
     .single<WorkOrderRow>();
 
@@ -227,20 +364,8 @@ export async function pushWorkOrderToFortnox(workOrderId: string): Promise<PushO
       customer_id: string | null;
       customer_source: { kind?: string; fortnox_customer_id?: string } | null;
       assigned_to: string | null;
-      customer_snapshot: {
-        contact_name?: string | null;
-        delivery_address?: string | null;
-        delivery_postal_code?: string | null;
-        delivery_city?: string | null;
-        postal_code?: string | null;
-        city?: string | null;
-        reverse_vat?: boolean | null;
-        end_contact_name?: string | null;
-        end_contact_phone?: string | null;
-        end_contact_email?: string | null;
-        label?: string | null;
-      } | null;
-      rot_details: { enabled?: boolean | null; property_designation?: string | null; brf_org_number?: string | null } | null;
+      customer_snapshot: CustomerSnapshot | null;
+      rot_details: RotDetails | null;
     };
 
     const linkedQuote: LinkedQuote | null = workOrder.quote_id
@@ -295,55 +420,29 @@ export async function pushWorkOrderToFortnox(workOrderId: string): Promise<PushO
         );
       }
 
-      const ourReference = await resolveOurReference(linkedQuote?.assigned_to ?? workOrder.assigned_to ?? null, supabase);
-
-      const snapshot = linkedQuote?.customer_snapshot ?? workOrder.customer_snapshot;
-      // Work/job address (Fortnox delivery): street is the anchor; postal/city sent as
-      // entered, not borrowed from the customer address. Matches the work order's address.
-      const deliveryAddress = snapshot?.delivery_address;
-      const deliveryZip = snapshot?.delivery_postal_code;
-      const deliveryCity = snapshot?.delivery_city;
-
       const vatPercent = typeof workOrder.vat_percent === 'number' ? workOrder.vat_percent : 25;
       // Reverse charge (byggmoms) excludes ROT and forces 0 % rows + SEREVERSEDVAT on the order.
       const reverseVat = await resolveReverseVat(
         supabase,
-        snapshot?.reverse_vat,
+        workOrder.customer_snapshot?.reverse_vat ?? linkedQuote?.customer_snapshot?.reverse_vat,
         linkedQuote?.customer_id ?? workOrder.customer_id,
       );
       const rotEnabled = linkedQuote?.rot_details?.enabled === true && !reverseVat;
-      // "Ert referensnummer" (order field = YourOrderNumber): ROT villa fastighetsbeteckning, else
-      // the företag märkning (snapshot.label). Mirrors offers.ts; standalone ROT is a rare path.
-      // Bostadsrätt (BRF) can't use one field → text row via buildRotPropertyNote.
-      const hasProperty = rotEnabled && !!linkedQuote?.rot_details?.property_designation?.trim();
-      const hasBrf = rotEnabled && !!linkedQuote?.rot_details?.brf_org_number?.trim();
-      const propertyAsRef = hasProperty && !hasBrf;
-      const referenceNumber = propertyAsRef
-        ? linkedQuote!.rot_details!.property_designation!.trim()
-        : (snapshot?.label?.trim() || null);
-      const rotPropertyNote = propertyAsRef ? null : (rotEnabled ? buildRotPropertyNote(linkedQuote?.rot_details) : null);
+      const { header, rotPropertyNote } = await buildOrderHeader(workOrder, linkedQuote, rotEnabled, supabase);
       const orderRows = buildOrderRows(workOrder.line_items, vatPercent, rotEnabled, reverseVat, rotPropertyNote);
 
       const response = await fortnoxPost<{ Order: { DocumentNumber: string } }>('/orders', {
         Order: {
           CustomerNumber: customerNumber,
           OrderDate: new Date().toISOString().slice(0, 10),
-          ...(ourReference ? { OurReference: ourReference } : {}),
-          ...(snapshot?.contact_name ? { YourReference: snapshot.contact_name } : {}),
-          // "Ert referensnummer" — order field is YourOrderNumber (offer uses YourReferenceNumber).
-          ...(referenceNumber ? { YourOrderNumber: referenceNumber } : {}),
+          ...header,
           // No VATType on the payload (Fortnox rejects it on offers; we keep orders consistent):
           // the customer card drives the VAT regime, and rows carry the matching VAT (0 % for
           // reverse charge, see buildOrderRows) so header and rows never diverge.
+          //
+          // TaxReductionType is set HERE only. The ROT regime of an order never changes after it
+          // exists, and re-sending it on an update would add a rejection path for no gain.
           ...(rotEnabled ? { TaxReductionType: 'rot' } : {}),
-          ...(buildEndContactNote(snapshot) ? { Remarks: buildEndContactNote(snapshot) } : {}),
-          ...(deliveryAddress
-            ? {
-                DeliveryAddress1: deliveryAddress,
-                ...(deliveryZip ? { DeliveryZipCode: deliveryZip } : {}),
-                ...(deliveryCity ? { DeliveryCity: deliveryCity } : {}),
-              }
-            : {}),
           OrderRows: orderRows,
         },
       });
@@ -457,17 +556,18 @@ export async function createInvoiceFromWorkOrder(workOrderId: string): Promise<C
   }
 }
 
-// Push edited article rows to an already-synced Fortnox order (PUT replaces all rows).
-// If the order was never synced, falls back to the create path. Used after the work
-// order's line_items are edited so Fortnox reflects the corrected areas/articles before
-// invoicing. Fortnox rejects edits to an invoiced/cancelled order — that surfaces as the
-// thrown error and the sync status flips to 'failed'.
+// Re-sync an already-synced Fortnox order: header AND article rows (PUT replaces all rows).
+// If the order was never synced, falls back to the create path. Used after the work order's
+// line_items are edited, and by the manual "Synka om" button — which is why the header goes
+// too: it used to send rows only, so "Synka om" could not repair a contact person or work
+// address no matter how many times a seller pressed it. Fortnox rejects edits to an
+// invoiced/cancelled order — that surfaces as the thrown error and sync status flips to 'failed'.
 export async function updateWorkOrderInFortnox(workOrderId: string): Promise<PushOrderResult> {
   const supabase = getSupabaseAdmin();
 
   const { data: workOrder, error } = await supabase
     .from('crm_work_orders')
-    .select('id, quote_id, customer_id, customer_snapshot, vat_percent, fortnox_order_number, line_items')
+    .select('id, quote_id, customer_id, assigned_to, customer_snapshot, work_address, vat_percent, fortnox_order_number, line_items')
     .eq('id', workOrderId)
     .single<WorkOrderRow>();
 
@@ -484,27 +584,83 @@ export async function updateWorkOrderInFortnox(workOrderId: string): Promise<Pus
     .eq('id', workOrderId);
 
   try {
-    type EditRotDetails = { enabled?: boolean | null; property_designation?: string | null; brf_org_number?: string | null };
-    const { data: linkedQuote } = workOrder.quote_id
-      ? await supabase.from('crm_quotes').select('rot_details').eq('id', workOrder.quote_id).maybeSingle()
-      : { data: null as { rot_details: EditRotDetails | null } | null };
+    const linkedQuote = await fetchLinkedQuoteForHeader(supabase, workOrder.quote_id);
 
     const vatPercent = typeof workOrder.vat_percent === 'number' ? workOrder.vat_percent : 25;
     // Reverse charge (byggmoms) must be honoured on the edit-resync too, else editing an article
     // re-PUTs the order at 25 % VAT and silently un-does the 0 %-rate push. ROT is excluded then.
     const reverseVat = await resolveReverseVat(supabase, workOrder.customer_snapshot?.reverse_vat, workOrder.customer_id);
-    const rotDetails = (linkedQuote as { rot_details?: EditRotDetails | null } | null)?.rot_details ?? null;
-    const rotEnabled = rotDetails?.enabled === true && !reverseVat;
+    const rotEnabled = linkedQuote?.rot_details?.enabled === true && !reverseVat;
     // This PUT replaces ALL OrderRows, so a ROT property note that rides as a text ROW (bostadsrätt)
-    // would be WIPED unless we regenerate it here. Villa/företag put it in YourOrderNumber (header),
-    // which this rows-only PUT doesn't touch, so their note stays null here. Mirrors the create path.
-    const hasProperty = rotEnabled && !!rotDetails?.property_designation?.trim();
-    const hasBrf = rotEnabled && !!rotDetails?.brf_org_number?.trim();
-    const propertyAsRef = hasProperty && !hasBrf;
-    const rotPropertyNote = propertyAsRef ? null : (rotEnabled ? buildRotPropertyNote(rotDetails) : null);
+    // would be WIPED unless we regenerate it here. Villa/företag put it in YourOrderNumber, which
+    // the header below carries. Same builder as the create path, so the two can't diverge.
+    const { header, rotPropertyNote } = await buildOrderHeader(workOrder, linkedQuote, rotEnabled, supabase);
     const orderRows = buildOrderRows(workOrder.line_items, vatPercent, rotEnabled, reverseVat, rotPropertyNote);
 
-    await fortnoxPut(`/orders/${workOrder.fortnox_order_number}`, { Order: { OrderRows: orderRows } });
+    await fortnoxPut(`/orders/${workOrder.fortnox_order_number}`, { Order: { ...header, OrderRows: orderRows } });
+
+    await supabase
+      .from('crm_work_orders')
+      .update({ fortnox_order_sync_status: 'synced', fortnox_order_synced_at: new Date().toISOString() })
+      .eq('id', workOrderId);
+
+    return { fortnox_order_number: workOrder.fortnox_order_number };
+  } catch (e) {
+    const syncStatus = e instanceof FortnoxNotConnectedError ? 'not_synced' : 'failed';
+    await supabase.from('crm_work_orders').update({ fortnox_order_sync_status: syncStatus }).eq('id', workOrderId);
+    throw e;
+  }
+}
+
+// Push ONLY the header (references, on-site contact note, delivery address) of an already-synced
+// Fortnox order. Called after the order's contact person, work address or ansvarig is edited.
+//
+// Rows are deliberately NOT sent. A contact correction has to be possible on an order whose rows
+// are frozen by delfakturering, and re-PUTting rows there would break the array-index match that
+// tracks invoiced-vs-remaining per article. Rows have their own path (updateWorkOrderInFortnox).
+//
+// Returns null — quietly, not as an error — when there is nothing to push:
+//   • the order isn't in Fortnox yet. A contact edit must never CREATE the Fortnox document; that
+//     belongs to the article push or the seller's explicit "Skicka till Fortnox".
+//   • the order is fully invoiced. Fortnox refuses edits to an invoiced order, and a closed order
+//     must not flip to sync_status 'failed' every time someone corrects a phone number.
+//     `partially_invoiced` is NOT excluded: under Model B those invoices are standalone documents,
+//     so the Fortnox order itself is still open and accepts a header update.
+export async function syncWorkOrderHeaderToFortnox(workOrderId: string): Promise<PushOrderResult | null> {
+  const supabase = getSupabaseAdmin();
+
+  // Narrower than WorkOrderRow on purpose: this path reads no rows and no pricing, and typing it
+  // as the full row would claim fields the select doesn't fetch.
+  type HeaderSyncRow = OrderHeaderWorkOrder & {
+    quote_id: string | null;
+    customer_id: string | null;
+    status: string;
+    fortnox_order_number: string | null;
+    fortnox_invoice_number: string | null;
+  };
+
+  const { data: workOrder, error } = await supabase
+    .from('crm_work_orders')
+    .select('id, quote_id, customer_id, assigned_to, customer_snapshot, work_address, status, fortnox_order_number, fortnox_invoice_number')
+    .eq('id', workOrderId)
+    .single<HeaderSyncRow>();
+
+  if (error || !workOrder) throw new Error(`Arbetsorder ${workOrderId} hittades inte`);
+  if (!workOrder.fortnox_order_number) return null;
+  if (workOrder.status === 'invoiced' || workOrder.fortnox_invoice_number) return null;
+
+  try {
+    const linkedQuote = await fetchLinkedQuoteForHeader(supabase, workOrder.quote_id);
+    // ROT only decides which of the two "Ert referensnummer" values the header carries; the note
+    // half of resolveRotReference is a ROW and belongs to the row path, so it's dropped here.
+    const reverseVat = await resolveReverseVat(supabase, workOrder.customer_snapshot?.reverse_vat, workOrder.customer_id);
+    const rotEnabled = linkedQuote?.rot_details?.enabled === true && !reverseVat;
+    const { header } = await buildOrderHeader(workOrder, linkedQuote, rotEnabled, supabase);
+
+    // An empty header would be a PUT that says nothing — skip the round trip.
+    if (Object.keys(header).length === 0) return { fortnox_order_number: workOrder.fortnox_order_number };
+
+    await fortnoxPut(`/orders/${workOrder.fortnox_order_number}`, { Order: header });
 
     await supabase
       .from('crm_work_orders')

--- a/tests/fortnox/friendlyMessage.test.ts
+++ b/tests/fortnox/friendlyMessage.test.ts
@@ -15,13 +15,15 @@ describe('friendlyFortnoxMessage', () => {
     expect(friendlyFortnoxMessage(e)).not.toContain('400');
   });
 
-  // 2004021 pekar ut fel ställe i Fortnox egen text: felet sitter på ARTIKELN (husarbete-flaggan
-  // ärvs och kan inte överröstas från raden), inte på dokumentet man just försökte spara.
+  // 2004021 pekar ut fel ställe i Fortnox egen text: typen sitter på ARTIKELN (ärvs ner på raden,
+  // kan inte överröstas därifrån), inte på dokumentet man just försökte spara. Texten måste också
+  // säga att den är OSYNLIG i Fortnox artikelvy — annars letar man förgäves, vilket hände 2026-08-12.
   it('translates 2004021 into an actionable instruction about the article', () => {
     const e = new FortnoxApiError(400, 'teknisk sträng', 2004021, "Dokument med skattereduktionstypen 'none' får inte innehålla rader med husarbetestypen 'CONSTRUCTION'.");
     const message = friendlyFortnoxMessage(e);
-    expect(message).toContain('husarbete');
-    expect(message).toContain('Register → Artiklar');
+    expect(message).toContain('husarbetestyp');
+    expect(message).toContain('ARTIKELN');
+    expect(message).toContain('HouseworkType: null');
   });
 
   // Okända koder ska falla tillbaka på Fortnox egen svenska text — den är oftast läsbar och

--- a/tests/fortnox/friendlyMessage.test.ts
+++ b/tests/fortnox/friendlyMessage.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// client.ts importerar getSupabaseAdmin i toppen (för tokenlagringen). Mocka bort den så testet
+// inte drar in env-beroenden — samma mönster som helpers.test.ts.
+vi.mock('@/lib/supabase/server', () => ({ getSupabaseAdmin: vi.fn() }));
+
+import { FortnoxApiError, FortnoxNotConnectedError, friendlyFortnoxMessage } from '@/lib/domains/fortnox/client';
+
+describe('friendlyFortnoxMessage', () => {
+  // FortnoxApiError.message ÄR den tekniska loggsträngen. Den får aldrig nå en säljare —
+  // rutter som visade e.message rakt av läckte "Fortnox POST /orders (400): {…}" i en toast.
+  it('never returns the technical log string', () => {
+    const e = new FortnoxApiError(400, 'Fortnox POST /orders (400): {"ErrorInformation":{...}}', 2004021, 'Dokument med skattereduktionstypen \'none\'…');
+    expect(friendlyFortnoxMessage(e)).not.toContain('Fortnox POST');
+    expect(friendlyFortnoxMessage(e)).not.toContain('400');
+  });
+
+  // 2004021 pekar ut fel ställe i Fortnox egen text: felet sitter på ARTIKELN (husarbete-flaggan
+  // ärvs och kan inte överröstas från raden), inte på dokumentet man just försökte spara.
+  it('translates 2004021 into an actionable instruction about the article', () => {
+    const e = new FortnoxApiError(400, 'teknisk sträng', 2004021, "Dokument med skattereduktionstypen 'none' får inte innehålla rader med husarbetestypen 'CONSTRUCTION'.");
+    const message = friendlyFortnoxMessage(e);
+    expect(message).toContain('husarbete');
+    expect(message).toContain('Register → Artiklar');
+  });
+
+  // Okända koder ska falla tillbaka på Fortnox egen svenska text — den är oftast läsbar och
+  // alltid bättre än den tekniska strängen.
+  it('falls back to the Fortnox message for an unmapped code', () => {
+    const e = new FortnoxApiError(400, 'teknisk sträng', 999999, 'Något specifikt från Fortnox.');
+    expect(friendlyFortnoxMessage(e)).toBe('Något specifikt från Fortnox.');
+  });
+
+  it('explains a missing Fortnox connection instead of failing cryptically', () => {
+    expect(friendlyFortnoxMessage(new FortnoxNotConnectedError())).toContain('Fortnox är inte kopplat');
+  });
+
+  it('has a safe generic answer for a non-Fortnox error', () => {
+    expect(friendlyFortnoxMessage(new Error('boom'))).toBe('Något gick fel. Försök igen.');
+  });
+});

--- a/tests/fortnox/helpers.test.ts
+++ b/tests/fortnox/helpers.test.ts
@@ -4,7 +4,7 @@ import { describe, it, expect, vi } from 'vitest';
 // '@/lib/supabase/server' (i typposition). Mocka den så testet inte drar in env-beroenden.
 vi.mock('@/lib/supabase/server', () => ({ getSupabaseAdmin: vi.fn() }));
 
-import { claimFortnoxPush, buildRotPropertyNote, appendFortnoxTextNote } from '@/lib/domains/fortnox/helpers';
+import { claimFortnoxPush, buildRotPropertyNote, appendFortnoxTextNote, resolveRotReference } from '@/lib/domains/fortnox/helpers';
 
 // Mock av supabase-kedjan. claimFortnoxPush gör upp till TVÅ försök, vart och ett:
 //   .from().update().eq().neq()/.eq().lt().select() → { data, error }
@@ -111,5 +111,48 @@ describe('appendFortnoxTextNote', () => {
     const rows = [{ Description: 'Lösull', Price: 100 }];
     expect(appendFortnoxTextNote(rows, null)).toHaveLength(1);
     expect(appendFortnoxTextNote(rows, '')).toHaveLength(1);
+  });
+});
+
+// "Ert referensnummer" och ROT-textraden är två halvor av en regel. De låg tidigare som två
+// parallella kopior i offers.ts och orders.ts (create + update) — testet låser att exakt EN av
+// dem fylls i, så en villa aldrig får både referensfält och rad, och en BRF aldrig tappar båda.
+describe('resolveRotReference', () => {
+  it('puts a villa fastighetsbeteckning in the reference field, not a row', () => {
+    expect(resolveRotReference({ property_designation: 'Haggården 6:3' }, null, true)).toEqual({
+      referenceNumber: 'Haggården 6:3',
+      propertyNote: null,
+    });
+  });
+
+  // Bostadsrätt = two values that can't share one field → they ride as a text row instead, and
+  // the reference field falls back to the märkning (normally empty for a private ROT customer).
+  it('puts a bostadsrätt on a text row and leaves the reference field to the märkning', () => {
+    expect(resolveRotReference({ property_designation: 'Haggården 6:3', brf_org_number: '769600-1234' }, null, true)).toEqual({
+      referenceNumber: null,
+      propertyNote: 'Fastighetsbeteckning: Haggården 6:3  BRF org.nr: 769600-1234',
+    });
+  });
+
+  it('uses the företag märkning as the reference number on a non-ROT document', () => {
+    expect(resolveRotReference(null, 'Projekt 4711', false)).toEqual({
+      referenceNumber: 'Projekt 4711',
+      propertyNote: null,
+    });
+  });
+
+  // ROT details left on a quote whose ROT was later switched off must not leak onto the document.
+  it('ignores ROT details when ROT is disabled', () => {
+    expect(resolveRotReference({ property_designation: 'Haggården 6:3' }, null, false)).toEqual({
+      referenceNumber: null,
+      propertyNote: null,
+    });
+  });
+
+  it('treats blank values as absent', () => {
+    expect(resolveRotReference({ property_designation: '   ' }, '  ', true)).toEqual({
+      referenceNumber: null,
+      propertyNote: null,
+    });
   });
 });

--- a/tests/fortnox/orders.test.ts
+++ b/tests/fortnox/orders.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildOrderRows } from '@/lib/domains/fortnox/orders';
+import { buildOrderRows, buildOrderDeliveryFields } from '@/lib/domains/fortnox/orders';
 import { ROT_LABOR_ARTICLE_NUMBER } from '@/lib/domains/fortnox/helpers';
 
 describe('buildOrderRows', () => {
@@ -118,5 +118,60 @@ describe('buildOrderRows – ROT labour carve-out', () => {
     expect(rows).toHaveLength(1);
     expect((rows[0] as any).Price).toBe(100);
     expect((rows[0] as any).HouseWork).toBe(true);
+  });
+});
+
+// Regressionsvakt för buggen som gjorde att en säljares ändrade arbetsadress aldrig nådde
+// Fortnox: adressen redigeras i kolumnen `work_address`, men pushen läste
+// `customer_snapshot.delivery_*`. Installatören såg den nya adressen, Fortnox den gamla.
+describe('buildOrderDeliveryFields', () => {
+  const customer = { street_address: 'Storgatan 1', postal_code: '11122', city: 'Stockholm' };
+
+  it('sends nothing when the job is at the customer address', () => {
+    expect(buildOrderDeliveryFields({ street_address: 'Storgatan 1', postal_code: '11122', city: 'Stockholm' }, customer)).toEqual({});
+  });
+
+  it('ignores case and surrounding whitespace when comparing the street', () => {
+    expect(buildOrderDeliveryFields({ street_address: '  storgatan 1 ' }, customer)).toEqual({});
+  });
+
+  it('sends the delivery address when the job site differs', () => {
+    expect(buildOrderDeliveryFields({ street_address: 'Verkstadsvägen 8', postal_code: '43900', city: 'Onsala' }, customer)).toEqual({
+      DeliveryAddress1: 'Verkstadsvägen 8',
+      DeliveryZipCode: '43900',
+      DeliveryCity: 'Onsala',
+    });
+  });
+
+  // The bug itself: an edited work_address must win over the snapshot the order was created with.
+  it('prefers the edited work_address column over the snapshot delivery address', () => {
+    const snapshot = { ...customer, delivery_address: 'Gamla vägen 2', delivery_postal_code: '11111', delivery_city: 'Solna' };
+    expect(buildOrderDeliveryFields({ street_address: 'Nya vägen 4', postal_code: '22222', city: 'Lund' }, snapshot)).toEqual({
+      DeliveryAddress1: 'Nya vägen 4',
+      DeliveryZipCode: '22222',
+      DeliveryCity: 'Lund',
+    });
+  });
+
+  // Legacy rows created before work_address was seeded still have to push their job site.
+  it('falls back to the snapshot delivery address when the column has no street', () => {
+    const snapshot = { ...customer, delivery_address: 'Gamla vägen 2', delivery_postal_code: '11111', delivery_city: 'Solna' };
+    expect(buildOrderDeliveryFields({ street_address: '  ' }, snapshot)).toEqual({
+      DeliveryAddress1: 'Gamla vägen 2',
+      DeliveryZipCode: '11111',
+      DeliveryCity: 'Solna',
+    });
+  });
+
+  // Postal/city are sent as entered — borrowing the customer's would put the job in the wrong ort.
+  it('omits postal code and city rather than borrowing the customer address', () => {
+    expect(buildOrderDeliveryFields({ street_address: 'Verkstadsvägen 8' }, customer)).toEqual({
+      DeliveryAddress1: 'Verkstadsvägen 8',
+    });
+  });
+
+  it('sends nothing when there is no job site at all', () => {
+    expect(buildOrderDeliveryFields(null, customer)).toEqual({});
+    expect(buildOrderDeliveryFields({}, null)).toEqual({});
   });
 });

--- a/tests/fortnox/orders.test.ts
+++ b/tests/fortnox/orders.test.ts
@@ -153,10 +153,12 @@ describe('buildOrderDeliveryFields', () => {
     });
   });
 
-  // Legacy rows created before work_address was seeded still have to push their job site.
-  it('falls back to the snapshot delivery address when the column has no street', () => {
+  // Legacy rows created before work_address was seeded still have to push their job site. Keyed on
+  // the COLUMN being absent — a present-but-blank street means the seller cleared it (see the
+  // "rensad adress" block below), not that we should go looking in the snapshot.
+  it('falls back to the snapshot delivery address for a row with no work_address at all', () => {
     const snapshot = { ...customer, delivery_address: 'Gamla vägen 2', delivery_postal_code: '11111', delivery_city: 'Solna' };
-    expect(buildOrderDeliveryFields({ street_address: '  ' }, snapshot)).toEqual({
+    expect(buildOrderDeliveryFields(null, snapshot)).toEqual({
       DeliveryAddress1: 'Gamla vägen 2',
       DeliveryZipCode: '11111',
       DeliveryCity: 'Solna',
@@ -173,5 +175,35 @@ describe('buildOrderDeliveryFields', () => {
   it('sends nothing when there is no job site at all', () => {
     expect(buildOrderDeliveryFields(null, customer)).toEqual({});
     expect(buildOrderDeliveryFields({}, null)).toEqual({});
+  });
+});
+
+// Fynd ur kodgranskningen: fallbacken kunde inte skilja "aldrig satt" från "medvetet tömd", så en
+// raderad arbetsadress lämnade snapshotens gamla adress kvar — och pushade den igen.
+describe('buildOrderDeliveryFields — rensad adress', () => {
+  const snapshot = {
+    street_address: 'Storgatan 1', postal_code: '11122', city: 'Stockholm',
+    delivery_address: 'Gamla vägen 2', delivery_postal_code: '11111', delivery_city: 'Solna',
+  };
+
+  it('does not resurrect the snapshot address when the work address was cleared', () => {
+    // Kolumnen FINNS men gatan är tömd → ingen separat arbetsplats, inte "leta i snapshoten".
+    expect(buildOrderDeliveryFields({ street_address: '', postal_code: '', city: '' }, snapshot)).toEqual({});
+    expect(buildOrderDeliveryFields({ street_address: '   ' }, snapshot)).toEqual({});
+    expect(buildOrderDeliveryFields({}, snapshot)).toEqual({});
+  });
+
+  // Bakåtkompatibiliteten som fallbacken fanns för: rader som aldrig fick en work_address alls.
+  it('still falls back for a legacy row that has no work_address column value', () => {
+    expect(buildOrderDeliveryFields(null, snapshot)).toEqual({
+      DeliveryAddress1: 'Gamla vägen 2',
+      DeliveryZipCode: '11111',
+      DeliveryCity: 'Solna',
+    });
+    expect(buildOrderDeliveryFields(undefined, snapshot)).toEqual({
+      DeliveryAddress1: 'Gamla vägen 2',
+      DeliveryZipCode: '11111',
+      DeliveryCity: 'Solna',
+    });
   });
 });


### PR DESCRIPTION
## Vad och varför

En säljare redigerade en skarp arbetsorder och **allt utom artiklarna stannade i CRM**. Grenen rättar det, plus rotorsaken till ett Fortnox-fel som slog till när man la in artiklar på en tom order.

## 1. Orderns header nådde aldrig Fortnox

Två fel som förstärkte varandra:

- **`PATCH /api/crm/work-orders/[id]` rörde aldrig Fortnox.** Kontaktperson, arbetsadress, ansvarig och anteckningar sparades och routen returnerade. Avsikten stod redan i schemat (`_lib.ts`, `contact`-fältet: *"flows to … the Fortnox YourReference"*) — koden skrevs bara aldrig.
- **`updateWorkOrderInFortnox` PUT:ade bara `OrderRows`.** Alltså kunde inte ens "Synka om"-knappen laga en felaktig kontakt, hur många gånger man än tryckte. `OurReference` sattes dessutom bara i create-branchen, så ett byte av ansvarig gick aldrig fram.

Plus en tredje, som gjorde att en fix på den första ensam inte hade räckt: **adressen säljaren redigerar är kolumnen `work_address`, men pushen läste `customer_snapshot.delivery_*`.** Installatören såg den nya adressen, Fortnox den gamla, utan någon signal.

### Lösning — en header-byggare, tre vägar

| Väg | Skickar | När |
|-----|---------|-----|
| `pushWorkOrderToFortnox` | header + rader + `TaxReductionType` | ordern skapas |
| `updateWorkOrderInFortnox` | header + rader | artikelredigering, "Synka om" |
| `syncWorkOrderHeaderToFortnox` (**ny**) | **bara** header | kontakt/adress/ansvarig redigeras |

`buildOrderHeader()` är enda källan för `OurReference` / `YourReference` / `YourOrderNumber` / `Remarks` / leveransadress. Duplicerad ROT-referenslogik lyftes till `resolveRotReference()` i `helpers.ts`.

**Header-only är avsiktligt.** En kontakträttning måste gå att göra på en **delfakturerad** order, där raderna är frysta — en rad-PUT där hade spräckt arrayindex-matchningen delfaktureringen spårar fakturerat-vs-kvar med. `partially_invoiced` släpps därför igenom (Model B → Fortnox-ordern är fortfarande öppen), medan `invoiced` hoppas över tyst: Fortnox nekar ändå, och en stängd order ska inte flippa till `failed` för att någon rättar ett telefonnummer.

**Designval som medvetet bevarar befintligt beteende:**
- Leveransadressen läses ur `work_address`, men behåller regeln *"skicka bara när den skiljer sig från kundadressen"* — annars hade **alla** orderbekräftelser fått ett adressblock de inte har idag.
- `TaxReductionType` sätts fortsatt bara vid create. ROT-läget ändras inte efter att ordern finns, och att skicka om det hade lagt till en avvisningsväg utan vinst.
- Synken triggas bara när ett speglat fält faktiskt skickats (`FORTNOX_MIRRORED_FIELDS` + `pickProvidedFields`), så en status-only-PATCH aldrig blir en Fortnox-skrivning.
- Icke-fatal + `fortnox_error` i svaret → varnings-toast, samma mönster som artikelfliken.

## 2. Fortnox-felet 2004021 på tom order

En tom order nekades med *"Dokument med skattereduktionstypen 'none' får inte innehålla rader med husarbetestypen 'CONSTRUCTION'"* så fort första artikeln sparades.

**Felet låg inte i koden.** En skanning av alla 289 artiklar live mot Fortnox gav:

| Tillstånd | Antal | Beteende |
|---|---|---|
| `HouseworkType` saknas helt | 281 |  fungerar överallt |
| `Housework=true` + typ satt | 8 |  men bara på ROT-dokument |
| **`Housework=false` men typ ändå satt** | **5** |  nekas på **alla** icke-ROT-dokument |

De fem — `2410509`, `2410510`, `1010` (`EMPTYHOUSEWORK`) samt `10059`, `2410557` (`CONSTRUCTION`) — **rättades direkt i Fortnox** via `PUT /articles/{nr}` med `{"Article":{"HouseworkType":null}}`. Benämning och pris orörda; de åtta äkta ROT-artiklarna lämnades ifred.

Mekanismen är vår egen dokumenterade fälla (sekt. 4 punkt 2) fast på **artikeln** i stället för på raden: ett icke-ROT-dokument nekar *vilken* husarbetestyp som helst, även den tomma, och typen ärvs ner på raden oavsett vad vi skickar.

**Två fällor värda att känna till:**
- Att kryssa **ur** husarbetesrutan i Fortnox nollställer inte typen — den blir kvar. Artikeln ser orörd ut i gränssnittet, så det går inte att felsöka visuellt.
- `GET /articles` (listan) returnerar inte `HouseworkType`, bara `Housework`. Artikelcachen rapporterade 0 trasiga medan API:t rapporterade 5. Ett förebyggande skydd i CRM kräver ett live-anrop per artikel.

**Kodändringen här** är att felet nu översätts till något handlingsbart, och att line-items-routen slutade läcka den tekniska loggsträngen (`FortnoxApiError.message` **är** `Fortnox POST /orders (400): {…}`) rakt in i säljarens toast.

## 3. Fynd ur kodgranskningen

Granskningen hittade en gemensam rot: synken var enkelriktad — den propagerade satta värden men aldrig rensade, eftersom Fortnox PUT lämnar utelämnade fält orörda.

- **Tömd arbetsadress återuppstod.** Fallbacken kunde inte skilja "aldrig satt" (gamla rader) från "medvetet raderad", så en borttagen adress pushades igen — även på en förstagångspush. Nu avgör om **kolumnen** finns, inte om den råkar innehålla en gata. Ett av mina egna tester låste in det felaktiga beteendet och är rättat.
- **Synken påstod "synkad" utan att ha skickat något.** Tom header hoppade över anropet men returnerade ändå ett resultat. Returnerar `null` nu.
- **Header-synken stämplade `synced` fast den medvetet inte skickar rader.** Ett misslyckat artikelsynk nollställdes alltså av att någon rättade en kontaktperson: "Försök igen" försvann och ordern såg komplett ut medan Fortnox hade kvar de gamla raderna. Uppdateringen är nu villkorad med `neq('failed')`.

## Att verifiera före merge

**Inget är kört skarpt mot Fortnox än.** På en synkad order:

- [ ] Ändra kontaktperson → "Er referens" uppdateras i Fortnox
- [ ] Ändra arbetsadress → leveransadressen följer med
- [ ] Byt ansvarig → "Vår referens" byter namn
- [ ] Rätta en kontakt på en **delfakturerad** order → går igenom, raderna orörda
- [ ] Status-only-ändring → ingen Fortnox-skrivning

## Känd begränsning (medveten)

Fortnox PUT är partiell — ett fält vi inte skickar lämnas orört. Det skyddar offertens `YourReferenceNumber`-arv, men betyder att ett **tömt** värde (kontaktperson raderad, ansvarig borttagen, arbetsadress ändrad tillbaka till kundens) inte kan nollas i Fortnox, bara skrivas över. Att skicka tom sträng är oprövat mot testbolaget och skulle träffa varje order, så det byggdes inte blint.

## Öppna beslut (ej i denna PR)

1. **`rot_details` läses från två ställen.** Artikelfliken och prissättningen läser arbetsorderns `rot_details`; Fortnox-pushen läser offertens. Lika idag eftersom orderskapandet kopierar — men konsekvensen är att en **standalone-order aldrig kan bli ROT i Fortnox**.
2. **Standalone-order + kund som inte finns i Fortnox = hårt fel.** Offertvägen auto-skapar kunden, ordervägen kastar `Ingen Fortnox-kundkoppling hittades`. Ordern har alltid ett `customer_id`, så fixen är samma delade `createFortnoxCustomer()`.

## Testning

`npm run type-check`, `npm run build` och `npm test` (891 tester) gröna. Nya tester: `buildOrderDeliveryFields` (inkl. regression för den rensade adressen), `resolveRotReference`, `friendlyFortnoxMessage`.

**Obs:** `FORTNOX_INTEGRATION.md` är gitignorerad, så dokumentationen av allt ovan finns bara lokalt och syns inte i diffen.

