### PR TITLE
feat(order): skilj Er referens från kundkontakten

### DIFF
--- a/app/api/crm/work-orders/[id]/route.ts
+++ b/app/api/crm/work-orders/[id]/route.ts
@@ -9,10 +9,15 @@ import { isNoRowsError, ok, pickProvidedFields, requireCrmUser, requirePermissio
 // by hand — so a crafted PATCH can't fake a billed order or regress one back to a manual state.
 const SYSTEM_MANAGED_WO_STATUSES: string[] = ['invoiced', 'partially_invoiced'];
 
-// The edited fields that Fortnox mirrors on the order header: contact person → YourReference,
+// The edited fields that Fortnox mirrors on the order header: Er referens → YourReference,
 // work address → delivery address, ansvarig → OurReference. Gating on these keeps a status-only
 // PATCH — the board sends one on every drag — from becoming a Fortnox write.
-const FORTNOX_MIRRORED_FIELDS = ['contact', 'work_address', 'assigned_to'] as const;
+//
+// `contact` is deliberately ABSENT. The customer contact is who we and the installers call; it may
+// be re-pointed at a site foreman mid-job and must never touch the customer's document. It used to
+// share a field with Er referens, which meant fixing a phone number silently rewrote the reference
+// that routes the customer's invoice for approval.
+const FORTNOX_MIRRORED_FIELDS = ['your_reference', 'work_address', 'assigned_to'] as const;
 
 type RouteContext = {
   params: {
@@ -63,28 +68,38 @@ export async function PATCH(req: Request, context: RouteContext) {
     // change) doesn't wipe untouched columns (internal_handoff, work_address) with defaults.
     const updateInput = pickProvidedFields(parsedBody.data, rawBody);
 
-    // Read before the merge below deletes `contact` off updateInput.
+    // Read before the merges below strip `contact`/`your_reference` off updateInput.
     const touchesFortnox = FORTNOX_MIRRORED_FIELDS.some((field) => field in updateInput);
 
-    // Load the current row once — both the contact-snapshot merge and the status guard need it.
+    // Load the current row once — the snapshot merges and the status guard all need it.
     type WoCurrent = { status?: string | null; customer_snapshot?: Record<string, unknown> | null };
     let current: WoCurrent | null = null;
-    if (updateInput.contact || updateInput.status) {
+    if (updateInput.contact || updateInput.your_reference !== undefined || updateInput.status) {
       current = (await getCrmWorkOrder(supabase, context.params.id)).data as WoCurrent | null;
     }
 
-    // Contact override: merge into the (jsonb) customer_snapshot with a read-merge-write so the
-    // other snapshot fields (personnummer, addresses, reverse_vat, end-contact) are preserved.
-    // Lets a seller fix the responsible contact if it changed after the offer.
-    if (updateInput.contact) {
+    // Both overrides merge into the (jsonb) customer_snapshot with a read-merge-write so the other
+    // snapshot fields (personnummer, addresses, reverse_vat) survive. Built as one object so a PATCH
+    // carrying both doesn't have the second merge drop the first.
+    if (updateInput.contact || updateInput.your_reference !== undefined) {
       const snapshot = (current?.customer_snapshot ?? {}) as Record<string, unknown>;
-      (updateInput as Record<string, unknown>).customer_snapshot = {
-        ...snapshot,
-        contact_name: updateInput.contact.contact_name ?? null,
-        email: updateInput.contact.email ?? null,
-        phone: updateInput.contact.phone ?? null,
-      };
+      const merged: Record<string, unknown> = { ...snapshot };
+
+      if (updateInput.contact) {
+        // Freeze the pre-edit contact_name as Er referens on any order created before the two were
+        // split. Without this, editing the customer contact on such an order would still change what
+        // the Fortnox header falls back to — the exact bug the split exists to remove.
+        if (merged.your_reference == null) merged.your_reference = snapshot.contact_name ?? null;
+        merged.contact_name = updateInput.contact.contact_name ?? null;
+        merged.email = updateInput.contact.email ?? null;
+        merged.phone = updateInput.contact.phone ?? null;
+      }
+      // Sent explicitly (including null to clear) → wins over the freeze above.
+      if (updateInput.your_reference !== undefined) merged.your_reference = updateInput.your_reference;
+
+      (updateInput as Record<string, unknown>).customer_snapshot = merged;
       delete (updateInput as { contact?: unknown }).contact;
+      delete (updateInput as { your_reference?: unknown }).your_reference;
     }
 
     // System-managed status guard — only a real TRANSITION is blocked. The client always sends

--- a/app/api/crm/work-orders/_lib.ts
+++ b/app/api/crm/work-orders/_lib.ts
@@ -83,8 +83,12 @@ export const updateCrmWorkOrderSchema = z.object({
     delivery_address: z.preprocess((value) => normalizeOptionalText(value), z.string().nullable()).optional().default(null),
     invoice_address: z.preprocess((value) => normalizeOptionalText(value), z.string().nullable()).optional().default(null),
   }).optional().default({}),
-  // Responsible contact override — merged into customer_snapshot by the route so a contact that
-  // changed between offer→order flows to the installer view and the Fortnox YourReference.
+  // "Er referens" — kundens formella referens, det enda kontaktvärdet som når Fortnox
+  // (YourReference). Skilt från `contact` nedan med flit: den som rättar en kundkontakt ska inte
+  // råka skriva om referensen som styr kundens faktura till rätt attestant.
+  your_reference: z.preprocess((value) => normalizeOptionalText(value), z.string().nullable()).optional(),
+  // Kundkontakten — vem vi och installatörerna ringer. Merged into customer_snapshot by the route.
+  // Når ALDRIG Fortnox; se FORTNOX_MIRRORED_FIELDS i routen.
   contact: z.object({
     contact_name: z.preprocess((value) => normalizeOptionalText(value), z.string().nullable()).optional().default(null),
     email: z.preprocess((value) => normalizeOptionalText(value), z.string().nullable()).optional().default(null),

--- a/app/crm/arbetsorder/WorkOrderDetailClient.tsx
+++ b/app/crm/arbetsorder/WorkOrderDetailClient.tsx
@@ -105,6 +105,7 @@ type WorkOrderDraft = {
   contact_name: string;
   contact_phone: string;
   contact_email: string;
+  your_reference: string;
   work_scope: string;
   handoff_notes: string;
   notes: string;
@@ -266,6 +267,9 @@ export default function WorkOrderDetailClient({ workOrderId, fortnoxConnected, c
       contact_name: item.customer_snapshot?.contact_name || '',
       contact_phone: item.customer_snapshot?.phone || '',
       contact_email: item.customer_snapshot?.email || '',
+      // Ordrar skapade innan Er referens blev ett eget fält har den kvar i contact_name — visa den
+      // därifrån, annars ser fältet tomt ut fast Fortnox har ett värde.
+      your_reference: item.customer_snapshot?.your_reference ?? item.customer_snapshot?.contact_name ?? '',
       work_scope: item.internal_handoff?.work_scope || '',
       handoff_notes: item.internal_handoff?.handoff_notes || '',
       notes: item.notes || '',
@@ -317,8 +321,9 @@ export default function WorkOrderDetailClient({ workOrderId, fortnoxConnected, c
             postal_code: draft.postal_code,
             city: draft.city,
           },
-          // Responsible contact (merged into the snapshot server-side) — lets us fix it if it
-          // changed between offer→order.
+          // Er referens — kundens formella referens, det ENDA kontaktvärdet som når Fortnox.
+          your_reference: draft.your_reference || null,
+          // Kundkontakten: vem vi och installatörerna ringer. Rör aldrig Fortnox.
           contact: {
             contact_name: draft.contact_name,
             phone: draft.contact_phone,
@@ -710,10 +715,32 @@ export default function WorkOrderDetailClient({ workOrderId, fortnoxConnected, c
           {/* Sidebar */}
           <div className="grid gap-5 lg:content-start">
 
+            {/* Er referens — kundens formella referens. Eget kort med flit: den ligger bredvid
+                Kundkontakt men betyder något helt annat, och den är den enda av de två som
+                kunden ser. Delade tidigare fält med kontaktpersonen, vilket gjorde att en rättad
+                telefonkontakt skrev om referensen som styr kundens faktura till rätt attestant. */}
+            {editingOverview ? (
+              <Card className="grid gap-2">
+                <p className={crm.sectionTitle}>Er referens</p>
+                <Input
+                  value={draft.your_reference}
+                  onChange={(e) => setField('your_reference', e.target.value)}
+                  placeholder="Kundens referens"
+                />
+                <p className="text-xs text-slate-500">Kundens egen referens — följer med till Fortnox och syns på order och faktura.</p>
+              </Card>
+            ) : draft?.your_reference ? (
+              <Card className="grid gap-1">
+                <p className={crm.sectionTitle}>Er referens</p>
+                <p className="text-sm font-semibold text-slate-900">{draft.your_reference}</p>
+              </Card>
+            ) : null}
+
             {/* Customer contact */}
             {editingOverview ? (
               <Card className="grid gap-3">
                 <p className={crm.sectionTitle}>Kundkontakt</p>
+                <p className="text-xs text-slate-500">För er och installatörerna. Skickas inte till Fortnox.</p>
                 {/* Pick a different contact if the responsible person changed offer→order. */}
                 {customerContacts.length > 0 ? (
                   <Select

--- a/lib/domains/crm/work-orders.ts
+++ b/lib/domains/crm/work-orders.ts
@@ -171,6 +171,12 @@ export async function createStandaloneCrmWorkOrder(supabase: SupabaseClient, inp
     contact_name: contact.name || null,
     email: contact.email || null,
     phone: contact.phone || null,
+    // "Er referens" — kundens formella referens, den som hamnar på Fortnox-dokumenten och styr
+    // fakturan rätt hos kunden. SKILD från contact_name ovan: det fältet är kundkontakten, alltså
+    // vem vi och installatörerna ringer, och den får ändras fritt utan att röra Fortnox. På en
+    // standalone-order finns ingen offert att ärva referensen från, så den seedas från samma
+    // kontakt och kan sedan sättas för hand i ordervyn.
+    your_reference: contact.name || null,
     street_address: visit.street || visit.street_address || null,
     postal_code: visit.postal_code || null,
     city: visit.city || null,
@@ -274,7 +280,15 @@ export async function createCrmWorkOrderFromQuote(supabase: SupabaseClient, quot
   // predate it (the quote was saved before the number was known), so fall back to the customer's
   // current value and bake it into the order snapshot. If neither has it, block — the caller
   // collects it and saves it on the customer before retrying.
+  // "Er referens" blir ett EGET fält på arbetsordern. På offerten är den samma sak som
+  // contact_name (fältet heter "Er referens (kontaktperson)" och är obligatoriskt där), men från
+  // och med ordern skiljer sig de två: contact_name blir kundkontakten — vem vi ringer — och får
+  // ändras fritt, medan your_reference är det som går till Fortnox YourReference. Utan den här
+  // frysningen vid orderskapandet skulle en rättad kontaktperson skriva om kundens fakturareferens.
   let orderSnapshot = (quote.customer_snapshot || {}) as Record<string, unknown>;
+  if (orderSnapshot.your_reference == null) {
+    orderSnapshot = { ...orderSnapshot, your_reference: orderSnapshot.contact_name ?? null };
+  }
   if (quote.quote_type === 'private' && !orderSnapshot.personal_number) {
     let personalNumber: string | null = null;
     if (quote.customer_id) {

--- a/lib/domains/fortnox/helpers.ts
+++ b/lib/domains/fortnox/helpers.ts
@@ -145,20 +145,6 @@ export async function resolveReverseVat(
   return (data as { reverse_vat?: boolean | null } | null)?.reverse_vat === true;
 }
 
-// Builds the Fortnox Remarks line for a separate on-site contact (slutkund) captured on the
-// quote/order outside the customer card. Returns null when no on-site contact was entered, so
-// the caller can conditionally include it. Kept document-level (Remarks) rather than a line-item
-// row — it's not a priced row and reads better as a note.
-export function buildEndContactNote(
-  snapshot: { end_contact_name?: string | null; end_contact_phone?: string | null; end_contact_email?: string | null } | null | undefined,
-): string | null {
-  const name = snapshot?.end_contact_name?.trim();
-  const phone = snapshot?.end_contact_phone?.trim();
-  const email = snapshot?.end_contact_email?.trim();
-  const parts = [name, phone, email].filter(Boolean);
-  return parts.length ? `Kontaktperson på arbetsplatsen: ${parts.join(', ')}` : null;
-}
-
 // Builds a ROT property note (Fastighetsbeteckning + BRF org.nr) for a text row on the
 // offer/order/invoice. Fortnox has NO API field for the ROT property designation — it must be
 // typed manually into the husarbete dialog — so we surface it as a plain comment line for whoever

--- a/lib/domains/fortnox/offers.ts
+++ b/lib/domains/fortnox/offers.ts
@@ -2,7 +2,7 @@ import { getSupabaseAdmin } from '@/lib/supabase/server';
 import { lineItemQuantity } from '@/lib/domains/crm/lineItems';
 import { lineItemUnitPrice, lineItemDiscountPercent, lineItemRowTotal } from '@/lib/domains/crm/pricing';
 import { fortnoxPost, fortnoxPut, fortnoxGetBinary, FortnoxApiError, FortnoxNotConnectedError, FortnoxPushInProgressError } from './client';
-import { appendFortnoxTextNote, buildEndContactNote, buildRotPropertyNote, claimFortnoxPush, resolveOurReference, resolveReverseVat, rotLaborRow, rowRotLaborCarveout, splitRotMaterialRow } from './helpers';
+import { appendFortnoxTextNote, buildRotPropertyNote, claimFortnoxPush, resolveOurReference, resolveReverseVat, rotLaborRow, rowRotLaborCarveout, splitRotMaterialRow } from './helpers';
 import { buildFortnoxCustomerPayload, createFortnoxCustomer, splitSwedishName, buildFortnoxAddress, type FortnoxCustomerSource } from './customers';
 import { DEFAULT_ROT_HOUSE_WORK_TYPE } from './types';
 
@@ -465,11 +465,12 @@ export async function pushQuoteToFortnox(quoteId: string): Promise<PushOfferResu
     const deliveryZip = snapshot?.delivery_postal_code;
     const deliveryCity = snapshot?.delivery_city;
 
-    // Remarks now carries ONLY the on-site contact note. The quote's free-text `description` and
-    // the ROT property designation / BRF org.nr are deliberately kept OUT of Remarks — Fortnox's
-    // Remarks field renders as the offer's body text and would overwrite the company's standard
-    // offerttext. Description stays CRM-internal; the ROT property info rides as a text row instead.
-    const remarks = buildEndContactNote(snapshot) || undefined;
+    // Remarks is NOT sent at all. It renders as the offer's body text, so anything we put there
+    // overwrites the company's standard offerttext — which is why the quote's `description` and the
+    // ROT property designation were already kept out of it (the latter rides as a text row).
+    // The customer contact was the last thing using it and is now deliberately CRM-internal: it is
+    // who we and the installers call, not something the customer's document should carry. Fortnox
+    // rewrites Remarks per document type on createorder anyway, so it never survived offer→order.
 
     const offerBody = {
       Offer: {
@@ -485,7 +486,6 @@ export async function pushQuoteToFortnox(quoteId: string): Promise<PushOfferResu
         // customer card (kept in sync with our reverse_vat), and we send rows at the MATCHING VAT
         // (0 % for reverse charge, else vatPercent) so header and rows are always consistent.
         ...(rotEnabled ? { TaxReductionType: 'rot' } : {}),
-        ...(remarks ? { Remarks: remarks } : {}),
         ...(deliveryAddress
           ? {
               DeliveryAddress1: deliveryAddress,

--- a/lib/domains/fortnox/orders.ts
+++ b/lib/domains/fortnox/orders.ts
@@ -2,13 +2,14 @@ import { getSupabaseAdmin } from '@/lib/supabase/server';
 import { lineItemQuantity } from '@/lib/domains/crm/lineItems';
 import { lineItemUnitPrice, lineItemDiscountPercent, lineItemRowTotal } from '@/lib/domains/crm/pricing';
 import { fortnoxGet, fortnoxGetBinary, fortnoxPost, fortnoxPut, FortnoxApiError, FortnoxNotConnectedError, FortnoxPushInProgressError } from './client';
-import { appendFortnoxTextNote, buildEndContactNote, claimFortnoxPush, resolveOurReference, resolveReverseVat, resolveRotReference, rotLaborRow, rowRotLaborCarveout, splitRotMaterialRow } from './helpers';
+import { appendFortnoxTextNote, claimFortnoxPush, resolveOurReference, resolveReverseVat, resolveRotReference, rotLaborRow, rowRotLaborCarveout, splitRotMaterialRow } from './helpers';
 import { DEFAULT_ROT_HOUSE_WORK_TYPE } from './types';
 
 // The point-in-time customer data carried on both the quote and the work order. Named once
 // because the header builder below has to read the same shape off either of them.
 type CustomerSnapshot = {
   contact_name?: string | null;
+  your_reference?: string | null;
   street_address?: string | null;
   delivery_address?: string | null;
   delivery_postal_code?: string | null;
@@ -231,6 +232,21 @@ export function buildOrderDeliveryFields(
   };
 }
 
+// "Er referens" for the Fortnox header. It is its OWN snapshot field on a work order, deliberately
+// NOT the customer contact: contact_name is who we and the installers call and may be re-pointed at
+// a site foreman mid-job, while YourReference is the customer's formal reference and is what routes
+// their invoice for approval. The two start out as the same person, which is why one field used to
+// serve both — and why fixing a phone number silently rewrote the customer's invoice reference.
+//
+// The contact_name fallback covers orders created before the split: dropping it would blank their
+// YourReference on the next sync. The PATCH route freezes the old value into your_reference the
+// first time such an order's contact is edited, so the fallback only ever reads an untouched row.
+export function resolveYourReference(
+  snapshot: { your_reference?: string | null; contact_name?: string | null } | null | undefined,
+): string | null {
+  return snapshot?.your_reference?.trim() || snapshot?.contact_name?.trim() || null;
+}
+
 type OrderHeaderWorkOrder = {
   assigned_to: string | null;
   customer_snapshot: CustomerSnapshot | null;
@@ -264,16 +280,19 @@ async function buildOrderHeader(
   const snapshot = workOrder.customer_snapshot ?? linkedQuote?.customer_snapshot ?? null;
   const ourReference = await resolveOurReference(workOrder.assigned_to ?? linkedQuote?.assigned_to ?? null, supabase);
   const { referenceNumber, propertyNote } = resolveRotReference(linkedQuote?.rot_details, snapshot?.label, rotEnabled);
-  const endContactNote = buildEndContactNote(snapshot);
+
+  const yourReference = resolveYourReference(snapshot);
 
   return {
     header: {
       ...(ourReference ? { OurReference: ourReference } : {}),
-      ...(snapshot?.contact_name ? { YourReference: snapshot.contact_name } : {}),
+      ...(yourReference ? { YourReference: yourReference } : {}),
       // "Ert referensnummer" — the order field is YourOrderNumber (the offer uses
       // YourReferenceNumber; sending the wrong one is a 2001399 "Felaktigt fältnamn").
       ...(referenceNumber ? { YourOrderNumber: referenceNumber } : {}),
-      ...(endContactNote ? { Remarks: endContactNote } : {}),
+      // No Remarks: it is Fortnox's own per-document body text (it rewrites it on createorder
+      // anyway), and the customer contact is deliberately CRM-internal — see the removal of
+      // buildEndContactNote.
       ...buildOrderDeliveryFields(workOrder.work_address, snapshot),
     },
     rotPropertyNote: propertyNote,

--- a/tests/crm/work-orders.test.ts
+++ b/tests/crm/work-orders.test.ts
@@ -174,3 +174,42 @@ describe('createCrmWorkOrderFromQuote — fält-mappning', () => {
     expect(captured.insert!.notes).toBe('Offertbeskrivning');
   });
 });
+
+// "Er referens" och kundkontakten delade tidigare fält (customer_snapshot.contact_name). Det
+// betydde att en säljare som rättade kontaktpersonen på ordern samtidigt skrev om kundens
+// formella referens — den som styr fakturan till rätt attestant hos kunden. Från och med
+// orderskapandet är de två skilda: your_reference går till Fortnox, contact_name gör det inte.
+describe('createCrmWorkOrderFromQuote — Er referens fryses vid orderskapandet', () => {
+  it('seedar your_reference från offertens contact_name', async () => {
+    const { supabase, captured } = makeSupabase(wonQuote({
+      customer_snapshot: { customer_name: 'Bygg AB', contact_name: 'Emil' },
+    }));
+
+    const result = await createCrmWorkOrderFromQuote(supabase as any, 'q1', 'user-1');
+
+    expect(result.error).toBeNull();
+    expect(captured.insert!.customer_snapshot.your_reference).toBe('Emil');
+    // Kundkontakten finns kvar som egen uppgift — de börjar som samma person.
+    expect(captured.insert!.customer_snapshot.contact_name).toBe('Emil');
+  });
+
+  it('skriver inte över en your_reference som offerten redan bär', async () => {
+    const { supabase, captured } = makeSupabase(wonQuote({
+      customer_snapshot: { customer_name: 'Bygg AB', contact_name: 'Emil', your_reference: 'Inköp/Anna' },
+    }));
+
+    await createCrmWorkOrderFromQuote(supabase as any, 'q1', 'user-1');
+
+    expect(captured.insert!.customer_snapshot.your_reference).toBe('Inköp/Anna');
+  });
+
+  it('sätter your_reference till null när offerten saknar kontaktperson', async () => {
+    const { supabase, captured } = makeSupabase(wonQuote({
+      customer_snapshot: { customer_name: 'Bygg AB' },
+    }));
+
+    await createCrmWorkOrderFromQuote(supabase as any, 'q1', 'user-1');
+
+    expect(captured.insert!.customer_snapshot.your_reference).toBeNull();
+  });
+});

--- a/tests/fortnox/orders.test.ts
+++ b/tests/fortnox/orders.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildOrderRows, buildOrderDeliveryFields } from '@/lib/domains/fortnox/orders';
+import { buildOrderRows, buildOrderDeliveryFields, resolveYourReference } from '@/lib/domains/fortnox/orders';
 import { ROT_LABOR_ARTICLE_NUMBER } from '@/lib/domains/fortnox/helpers';
 
 describe('buildOrderRows', () => {
@@ -205,5 +205,30 @@ describe('buildOrderDeliveryFields — rensad adress', () => {
       DeliveryZipCode: '11111',
       DeliveryCity: 'Solna',
     });
+  });
+});
+
+// Er referens och kundkontakten delade tidigare ETT fält, så en rättad kontaktperson skrev om
+// kundens formella referens i Fortnox — den som styr fakturan till rätt attestant.
+describe('resolveYourReference', () => {
+  it('uses the dedicated Er referens field when set', () => {
+    expect(resolveYourReference({ your_reference: 'Inköp/Anna', contact_name: 'Platschef Emil' })).toBe('Inköp/Anna');
+  });
+
+  // De 15 ordrar som fanns när fältet delades saknar your_reference. Utan fallbacken hade deras
+  // YourReference nollats i Fortnox vid nästa headersynk.
+  it('falls back to contact_name for orders created before the split', () => {
+    expect(resolveYourReference({ contact_name: 'Emil' })).toBe('Emil');
+    expect(resolveYourReference({ your_reference: null, contact_name: 'Emil' })).toBe('Emil');
+  });
+
+  it('treats blanks as absent so a whitespace value never reaches Fortnox', () => {
+    expect(resolveYourReference({ your_reference: '   ', contact_name: 'Emil' })).toBe('Emil');
+    expect(resolveYourReference({ your_reference: '  ', contact_name: ' ' })).toBeNull();
+  });
+
+  it('returns null when there is nothing to send', () => {
+    expect(resolveYourReference({})).toBeNull();
+    expect(resolveYourReference(null)).toBeNull();
   });
 });


### PR DESCRIPTION
## Problemet

"Er referens" och kundkontakten var **samma fält** (`customer_snapshot.contact_name`), men hette olika i de två vyerna:

| Vy | Etikett | Krav |
|---|---|---|
| Offert | **Er referens (kontaktperson)** | obligatorisk |
| Order | **Kundkontakt → Namn** (platshållare "Kontaktperson") | fri |

Ordervyn bjuder alltså in till att ändra *vem man ringer*, medan effekten var att skriva om *kundens formella referens*. Sedan headersynken (#58) mergades propagerade det värdet till Fortnox `YourReference` — så en säljare som rättade ett telefonnummer skrev samtidigt om referensen som styr fakturan till rätt attestant hos kunden. Hos en byggkund kan det stoppa betalningen.

Konflationen fanns redan innan #58; den synken gjorde den bara skarp.

## Lösningen — två fält

| Fält | Lagras i | Källa | Till Fortnox |
|---|---|---|---|
| **Er referens** | `customer_snapshot.your_reference` | ärvs från offertens kontaktperson; seedas från kundkontakten på standalone-order | ✅ `YourReference` |
| **Kundkontakt** | `contact_name` / `phone` / `email` | som tidigare | ❌ aldrig |

Er referens är redigerbar på ordern och har ett eget kort i ordervyn. Kundkontakten är oförändrad, med en rad under rubriken om att den inte skickas till Fortnox.

`FORTNOX_MIRRORED_FIELDS` bytte `contact` → `your_reference`: **en kontaktändring är inte längre en Fortnox-skrivning över huvud taget.**

Ingen migration — `customer_snapshot` är JSONB.

## Bakåtkompatibilitet (den känsliga biten)

De 15 arbetsordrar som redan finns saknar `your_reference`. Två skydd:

1. **`resolveYourReference` faller tillbaka på `contact_name`.** Utan det hade deras Er referens nollats i Fortnox vid nästa headersynk.
2. **Routen fryser det gamla värdet** in i `your_reference` första gången en sådan orders kontakt redigeras — annars hade den gamla buggen levt kvar för just de ordrarna, eftersom fallbacken då läst det nyss ändrade kontaktnamnet.

Ordervyns fält visar också `your_reference ?? contact_name`, så en gammal order inte ser tom ut fast Fortnox har ett värde.

## Bonus: `Remarks` skickas inte längre

`end_contact_*` ("kontaktperson på arbetsplatsen") gick till Fortnox `Remarks` på offert och standalone-order. Borttaget, eftersom:

- `Remarks` renderar som dokumentets **brödtext** och skriver över företagets standardtext (samma skäl som `description` och ROT-beteckningen redan hölls utanför).
- Fortnox skriver **ändå** om `Remarks` per dokumenttyp vid `createorder` — det överlevde aldrig offert→order. Verifierat på fyra riktiga par: *"Vi tackar för förtroendet…"* → *"Vi tackar för beställningen…"*.
- Fältet användes **0 av 35** offerter och **0 av 15** arbetsordrar.

Regeln "kundkontakt rör aldrig Fortnox" är därmed undantagslös. `buildEndContactNote` hade inga kvarvarande användare och är borttagen.

## Att verifiera

- [ ] Gammal order: "Er referens" visar kontaktpersonen, inte tomt
- [ ] Ändra **kundkontakt** → ingen Fortnox-skrivning, dokumentet orört
- [ ] Ändra **Er referens** → uppdateras på Fortnox-ordern
- [ ] Ny order från offert → Er referens ärvd från offerten
- [ ] Standalone-order → Er referens ifylld och redigerbar

## Testning

`npm run type-check`, `npm run build` och `npm test` (898 tester) gröna. Nya tester: `resolveYourReference` (nytt fält vinner, legacy-fallback, blanksteg, tomt) och seedningen i `createCrmWorkOrderFromQuote`.