### PR TITLE
feat(support): ticketsystem för appen — buggar och önskemål i en backlog

### DIFF
--- a/app/_lib/supportTokens.ts
+++ b/app/_lib/supportTokens.ts
@@ -1,0 +1,32 @@
+import type { TicketKind, TicketStatus } from '@/lib/domains/support/types';
+
+// Visuella tokens för appärenden. Delade mellan rapportera-formuläret (app/components) och
+// backloggen (app/admin/support) så ett ärende ser likadant ut var man än möter det. Ligger i
+// app/_lib eftersom båda ytorna behöver dem men ingen äger dem — samma plats som appNav.
+//
+// FÄRGEN BETYDER STATUS, INGET ANNAT. Typen (bugg/förslag) visas med ett tecken och sitt ord i
+// stället för en egen färgskala. Två färgskalor på samma rad gör att ingen av dem går att läsa
+// snabbt — och statusen är det man skannar en backlog efter. Samma grepp som arbetsorderlistan,
+// där railen alltid betyder status.
+
+export const ticketStatusMeta: Record<TicketStatus, { badge: string; accent: string }> = {
+  new: { badge: 'border-sky-200 bg-sky-50 text-sky-800', accent: 'bg-sky-400' },
+  planned: { badge: 'border-violet-200 bg-violet-50 text-violet-700', accent: 'bg-violet-400' },
+  in_progress: { badge: 'border-amber-200 bg-amber-50 text-amber-900', accent: 'bg-amber-400' },
+  done: { badge: 'border-emerald-200 bg-emerald-50 text-emerald-800', accent: 'bg-emerald-500' },
+  // Slate, inte rosa: "blir inte av" är ett beslut, inte ett fel. Rött hade läst som att något
+  // gick sönder.
+  declined: { badge: 'border-slate-200 bg-slate-50 text-slate-500', accent: 'bg-slate-300' },
+};
+
+// Ett tecken räcker för att skilja de två typerna åt i en lista, och skalar till radhöjd utan en
+// ikonuppsättning att underhålla.
+export const ticketKindGlyph: Record<TicketKind, string> = {
+  bug: '!',
+  idea: '+',
+};
+
+export const ticketKindGlyphClass: Record<TicketKind, string> = {
+  bug: 'bg-rose-100 text-rose-700',
+  idea: 'bg-[#e4efe0] text-emerald-800',
+};

--- a/app/admin/AdminTabsClient.tsx
+++ b/app/admin/AdminTabsClient.tsx
@@ -15,8 +15,9 @@ const AdminNews = dynamic(() => import('./news/AdminNews'), { ssr: false });
 const AdminPermissions = dynamic(() => import('./permissions/AdminPermissions'), { ssr: false });
 const AdminTimeReference = dynamic(() => import('./tid/AdminTimeReference'), { ssr: false });
 const AdminTimeApprovals = dynamic(() => import('./tid/AdminTimeApprovals'), { ssr: false });
+const AdminSupportTickets = dynamic(() => import('./support/AdminSupportTickets'), { ssr: false });
 
-type AdminTab = 'users'|'permissions'|'contacts'|'depots'|'blikk'|'tid'|'attest'|'news';
+type AdminTab = 'users'|'permissions'|'contacts'|'depots'|'blikk'|'tid'|'attest'|'news'|'arenden';
 
 const tabs: Array<{ id: AdminTab; label: string; summary: string }> = [
   { id: 'users', label: 'Användare', summary: 'Konton, roller och taggar' },
@@ -27,6 +28,7 @@ const tabs: Array<{ id: AdminTab; label: string; summary: string }> = [
   { id: 'tid', label: 'Tidkoder', summary: 'Tidkoder, internprojekt och frånvarotyper för tidrapporteringen' },
   { id: 'attest', label: 'Attest', summary: 'Lås tidrapporteringen per person och kalendermånad' },
   { id: 'news', label: 'Nyheter', summary: 'Skapa och publicera dashboardnyheter' },
+  { id: 'arenden', label: 'Ärenden', summary: 'Buggar och önskemål som rapporterats i appen' },
 ];
 
 function resolveAdminTab(fromQuery: string | null, fromStorage: string | null): AdminTab | null {
@@ -96,6 +98,7 @@ export default function AdminTabsClient() {
         {tab==='tid' && <AdminTimeReference />}
         {tab==='attest' && <AdminTimeApprovals />}
         {tab==='news' && <AdminNews />}
+        {tab==='arenden' && <AdminSupportTickets />}
       </section>
     </PageShell>
   );

--- a/app/admin/support/AdminSupportTickets.tsx
+++ b/app/admin/support/AdminSupportTickets.tsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import { cn } from '../../../lib/shared/cn';
 import { crm } from '../../crm/lib/crmTokens';
+import CrmModal from '../../crm/components/CrmModal';
 import Textarea from '../../../components/ui/Textarea';
 import Select from '../../../components/ui/Select';
 import { ticketKindGlyph, ticketKindGlyphClass, ticketStatusMeta } from '../../_lib/supportTokens';
@@ -22,6 +23,11 @@ import {
 // VAD VYN ÄR TILL FÖR: att svara på "vad är kvar" utan att någon behöver minnas. Därför öppnar den
 // på det som ÄR kvar (state=open) i stället för allt — en lista där klart och blir-inte-av ligger
 // blandat med nytt blir en logg, inte en backlog. Klara ärenden finns ett klick bort.
+//
+// LISTA → MODAL, inte en infälld panel. Ett ärende har beskrivning, skärmbild, status, svar och
+// changelog-text; allt det inuti en listrad trycker resten av backloggen ur bild precis när man vill
+// jämföra ärenden med varandra. Modalen är dessutom mönstret på varje annan CRM-yta (offert, kund,
+// felanmälan), så den är redan inlärd.
 //
 // OBS preflight är av (tailwind.config.js): `border` på en <div>/<span> ritar ingen linje utan
 // `border-solid`. <button> får däremot `border: 1px solid transparent` från globals.css, så
@@ -72,7 +78,7 @@ export default function AdminSupportTickets() {
   React.useEffect(() => { load(); }, [load]);
 
   // Djuplänk ur notisen: /admin?tab=arenden&arende=<id>. Öppnas en gång per id, inte vid varje
-  // omladdning — en sparning laddar om listan och hade annars slagit upp panelen igen.
+  // omladdning — en sparning laddar om listan och hade annars slagit upp modalen igen.
   const openedDeepLink = React.useRef<string | null>(null);
   React.useEffect(() => {
     if (typeof window === 'undefined') return;
@@ -80,21 +86,17 @@ export default function AdminSupportTickets() {
     if (!id || openedDeepLink.current === id) return;
     openedDeepLink.current = id;
     setOpenId(id);
-    // Ett djuplänkat ärende kan vara avslutat — visa allt, annars öppnas en panel för en rad som
+    // Ett djuplänkat ärende kan vara avslutat — visa allt, annars öppnas en modal för en rad som
     // inte finns i urvalet.
     setStateFilter('any');
   }, []);
 
-  const counts = React.useMemo(() => {
-    const byStatus = new Map<TicketStatus, number>();
-    for (const t of items) byStatus.set(t.status, (byStatus.get(t.status) || 0) + 1);
-    return byStatus;
-  }, [items]);
+  const openTicket = React.useMemo(() => items.find((t) => t.id === openId) ?? null, [items, openId]);
 
   return (
     // p-5 matchar de andra adminflikarna (Behörigheter, Tidkoder) — AdminTabsClient lägger inget
     // innerutrymme i sitt kort.
-    <div className="grid gap-4 p-5">
+    <div className="grid grid-cols-1 gap-4 p-5">
       <div className="grid gap-1">
         <h2 className="m-0 text-lg font-bold text-slate-900">Ärenden</h2>
         <p className="m-0 text-sm text-slate-600">
@@ -124,16 +126,6 @@ export default function AdminSupportTickets() {
         <div className="rounded-xl border border-solid border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700">{error}</div>
       ) : null}
 
-      {!loading && !error && items.length > 0 ? (
-        <div className="flex flex-wrap gap-1.5">
-          {TICKET_STATUSES.filter((s) => (counts.get(s) || 0) > 0).map((s) => (
-            <span key={s} className={cn(crm.badge, 'border-solid', ticketStatusMeta[s].badge)}>
-              {counts.get(s)} {statusLabel[s].toLowerCase()}
-            </span>
-          ))}
-        </div>
-      ) : null}
-
       {loading ? (
         <p className="m-0 text-sm text-slate-400">Laddar…</p>
       ) : items.length === 0 && !error ? (
@@ -146,16 +138,23 @@ export default function AdminSupportTickets() {
         <ul role="list" className="m-0 grid list-none gap-1 p-0">
           {items.map((ticket) => (
             <li key={ticket.id}>
-              <TicketRow
-                ticket={ticket}
-                open={openId === ticket.id}
-                onToggle={() => setOpenId(openId === ticket.id ? null : ticket.id)}
-                onSaved={load}
-              />
+              <TicketRow ticket={ticket} onOpen={() => setOpenId(ticket.id)} />
             </li>
           ))}
         </ul>
       )}
+
+      {openTicket ? (
+        <TicketModal
+          ticket={openTicket}
+          onClose={() => setOpenId(null)}
+          onChanged={load}
+          onDeleted={() => {
+            setOpenId(null);
+            load();
+          }}
+        />
+      ) : null}
     </div>
   );
 }
@@ -177,66 +176,65 @@ function FilterChip({ active, onClick, children }: { active: boolean; onClick: (
   );
 }
 
-function TicketRow({
-  ticket,
-  open,
-  onToggle,
-  onSaved,
-}: {
-  ticket: AppTicketView;
-  open: boolean;
-  onToggle: () => void;
-  onSaved: () => void;
-}) {
+function TicketRow({ ticket, onOpen }: { ticket: AppTicketView; onOpen: () => void }) {
   return (
-    <div className="overflow-hidden rounded-lg border border-solid border-[#e0e8dc] bg-white">
-      <button
-        type="button"
-        onClick={onToggle}
-        aria-expanded={open}
-        className="flex w-full items-stretch !border-0 bg-white text-left transition-colors hover:bg-[#f9fbf7]"
-      >
-        <span className={cn('w-1.5 shrink-0', ticketStatusMeta[ticket.status].accent)} aria-hidden />
-        <span className="grid flex-1 gap-0.5 px-3 py-2">
-          <span className="flex flex-wrap items-center gap-2">
-            <span
-              aria-hidden
-              className={cn(
-                'grid h-4 w-4 shrink-0 place-items-center rounded-full text-[11px] font-bold',
-                ticketKindGlyphClass[ticket.kind],
-              )}
-            >
-              {ticketKindGlyph[ticket.kind]}
-            </span>
-            <span className="text-[13px] font-bold text-slate-900">{ticket.title}</span>
-            <span className={cn(crm.badge, 'border-solid', ticketStatusMeta[ticket.status].badge)}>
-              {ticket.status_label}
-            </span>
-            {ticket.changelog_published_at ? (
-              <span className={cn(crm.badge, 'border-solid border-emerald-200 bg-white text-emerald-700')}>
-                I changeloggen
-              </span>
-            ) : null}
+    <button
+      type="button"
+      onClick={onOpen}
+      className="flex w-full items-stretch overflow-hidden rounded-lg border border-[#e0e8dc] bg-white p-0 text-left transition-colors hover:border-[#cfdcc9] hover:bg-[#f9fbf7]"
+    >
+      <span className={cn('w-1.5 shrink-0', ticketStatusMeta[ticket.status].accent)} aria-hidden />
+      <span className="grid flex-1 gap-0.5 px-3 py-2">
+        <span className="flex flex-wrap items-center gap-2">
+          <span
+            aria-hidden
+            className={cn(
+              'grid h-4 w-4 shrink-0 place-items-center rounded-full text-[11px] font-bold',
+              ticketKindGlyphClass[ticket.kind],
+            )}
+          >
+            {ticketKindGlyph[ticket.kind]}
           </span>
-          <span className="text-[11px] text-slate-400">
-            {ticket.reporter_name} · {ticket.area_label} · {formatDate(ticket.created_at)}
-            {ticket.has_screenshot ? ' · Skärmbild' : ''}
+          <span className="text-[13px] font-bold text-slate-900">{ticket.title}</span>
+          <span className={cn(crm.badge, 'border-solid', ticketStatusMeta[ticket.status].badge)}>
+            {ticket.status_label}
           </span>
+          {ticket.changelog_published_at ? (
+            <span className={cn(crm.badge, 'border-solid border-emerald-200 bg-white text-emerald-700')}>
+              I changeloggen
+            </span>
+          ) : null}
         </span>
-      </button>
-
-      {open ? <TicketPanel ticket={ticket} onSaved={onSaved} /> : null}
-    </div>
+        <span className="text-[11px] text-slate-400">
+          {ticket.reporter_name} · {ticket.area_label} · {formatDate(ticket.created_at)}
+          {ticket.has_screenshot ? ' · Skärmbild' : ''}
+        </span>
+      </span>
+    </button>
   );
 }
 
-function TicketPanel({ ticket, onSaved }: { ticket: AppTicketView; onSaved: () => void }) {
+function TicketModal({
+  ticket,
+  onClose,
+  onChanged,
+  onDeleted,
+}: {
+  ticket: AppTicketView;
+  onClose: () => void;
+  onChanged: () => void;
+  onDeleted: () => void;
+}) {
   const [detail, setDetail] = React.useState<AppTicketDetailView | null>(null);
   const [status, setStatus] = React.useState<TicketStatus>(ticket.status);
   const [resolution, setResolution] = React.useState(ticket.resolution || '');
   const [changelogNote, setChangelogNote] = React.useState(ticket.changelog_note || '');
   const [publish, setPublish] = React.useState(!!ticket.changelog_published_at);
   const [saving, setSaving] = React.useState(false);
+  const [deleting, setDeleting] = React.useState(false);
+  // Två steg för raderingen. Ingen nästlad dialog inuti modalen — knappen byter till "Säker?" och
+  // tillbaka igen, så en felträff aldrig raderar något.
+  const [confirmDelete, setConfirmDelete] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
   const [notice, setNotice] = React.useState<string | null>(null);
 
@@ -250,13 +248,13 @@ function TicketPanel({ ticket, onSaved }: { ticket: AppTicketView; onSaved: () =
         if (!alive || !res.ok || !body?.ok) return;
         const item = body.data.item as AppTicketDetailView;
         setDetail(item);
-        // Formulärets fält synkas mot det färska svaret — listraden kan vara någon minut gammal.
+        // Fälten synkas mot det färska svaret — listraden kan vara någon minut gammal.
         setStatus(item.status);
         setResolution(item.resolution || '');
         setChangelogNote(item.changelog_note || '');
         setPublish(!!item.changelog_published_at);
       } catch {
-        /* listradens data räcker för att visa panelen */
+        /* listradens data räcker för att visa modalen */
       }
     })();
     return () => { alive = false; };
@@ -281,7 +279,7 @@ function TicketPanel({ ticket, onSaved }: { ticket: AppTicketView; onSaved: () =
       const body = await res.json().catch(() => null);
       if (!res.ok || !body?.ok) throw new Error(body?.error || `Fel (${res.status})`);
       setNotice('Sparat.');
-      onSaved();
+      onChanged();
     } catch (e) {
       setError((e as Error).message);
     } finally {
@@ -289,116 +287,213 @@ function TicketPanel({ ticket, onSaved }: { ticket: AppTicketView; onSaved: () =
     }
   };
 
+  const remove = async () => {
+    setDeleting(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/support/tickets/${ticket.id}`, {
+        method: 'DELETE',
+        credentials: 'same-origin',
+      });
+      const body = await res.json().catch(() => null);
+      if (!res.ok || !body?.ok) throw new Error(body?.error || `Fel (${res.status})`);
+      // Modalen stängs av föräldern — ärendet finns inte kvar att visa.
+      onDeleted();
+    } catch (e) {
+      setError((e as Error).message);
+      setDeleting(false);
+      setConfirmDelete(false);
+    }
+  };
+
+  const busy = saving || deleting;
   const description = detail?.description ?? ticket.description;
   const pagePath = detail?.page_path ?? ticket.page_path;
+  const handledName = detail?.handled_by_name ?? ticket.handled_by_name;
+  const handledAt = detail?.handled_at ?? ticket.handled_at;
 
   return (
-    <div className="grid gap-4 border-t border-solid border-slate-100 bg-[#f9fbf7] px-3 py-3">
-      <div className="grid gap-1">
-        <span className={crm.label}>{ticket.kind === 'bug' ? 'Vad händer' : 'Önskemål'}</span>
-        <p className="m-0 whitespace-pre-wrap text-sm text-slate-800">{description}</p>
-      </div>
-
-      {pagePath ? (
+    <CrmModal
+      onClose={onClose}
+      ariaLabel={`Ärende: ${ticket.title}`}
+      maxWidth="sm:max-w-[620px]"
+      header={
         <div className="grid gap-1">
-          <span className={crm.label}>Rapporterat från</span>
-          <code className="w-fit max-w-full overflow-x-auto rounded border border-solid border-[#dce4d8] bg-white px-1.5 py-0.5 font-mono text-[11px] text-slate-600">
-            {pagePath}
-          </code>
+          <div className="flex flex-wrap items-center gap-2">
+            <span
+              aria-hidden
+              className={cn(
+                'grid h-5 w-5 shrink-0 place-items-center rounded-full text-[12px] font-bold',
+                ticketKindGlyphClass[ticket.kind],
+              )}
+            >
+              {ticketKindGlyph[ticket.kind]}
+            </span>
+            <h2 className="m-0 text-base font-bold text-slate-900">{ticket.title}</h2>
+            <span className={cn(crm.badge, 'border-solid', ticketStatusMeta[ticket.status].badge)}>
+              {ticket.status_label}
+            </span>
+          </div>
+          <p className="m-0 text-[12px] text-slate-500">
+            {ticket.kind_label} · {ticket.area_label} · {ticket.reporter_name} · {formatDate(ticket.created_at)}
+          </p>
+          {handledName && handledAt ? (
+            <p className="m-0 text-[12px] text-slate-400">
+              Senast hanterat av {handledName} · {formatDate(handledAt)}
+            </p>
+          ) : null}
         </div>
-      ) : null}
-
-      {detail?.screenshot_url ? (
+      }
+      footer={
+        <>
+          {confirmDelete ? (
+            <>
+              <button
+                type="button"
+                onClick={() => setConfirmDelete(false)}
+                disabled={busy}
+                className={cn(crm.ghostButton, 'flex-1 sm:flex-none sm:px-5')}
+              >
+                Avbryt
+              </button>
+              <button
+                type="button"
+                onClick={remove}
+                disabled={busy}
+                className="inline-flex h-8 flex-1 items-center justify-center rounded-xl border border-rose-300 bg-rose-50 px-3 text-sm font-semibold text-rose-700 transition hover:bg-rose-100 disabled:opacity-50 sm:flex-none sm:px-5"
+              >
+                {deleting ? 'Tar bort…' : 'Ja, ta bort'}
+              </button>
+            </>
+          ) : (
+            <>
+              <button
+                type="button"
+                onClick={() => setConfirmDelete(true)}
+                disabled={busy}
+                className={cn(crm.ghostButton, 'shrink-0 hover:!border-rose-300 hover:!text-rose-600')}
+                title="Ta bort ärendet — för dubbletter och skräp"
+              >
+                Ta bort
+              </button>
+              <span className="flex-1" />
+              <button
+                type="button"
+                onClick={save}
+                disabled={busy}
+                className={cn(crm.formButton, 'shrink-0')}
+                style={{ backgroundColor: 'var(--crm-primary)' }}
+              >
+                {saving ? 'Sparar…' : 'Spara'}
+              </button>
+            </>
+          )}
+        </>
+      }
+    >
+      <div className="grid gap-4">
         <div className="grid gap-1">
-          <span className={crm.label}>Skärmbild</span>
-          <a href={detail.screenshot_url} target="_blank" rel="noreferrer" className="block w-fit max-w-full">
-            {/* eslint-disable-next-line @next/next/no-img-element -- signerad storage-URL, kan inte
-                gå genom bildoptimeringen */}
-            <img
-              src={detail.screenshot_url}
-              alt={`Skärmbild från ${ticket.reporter_name}`}
-              className="max-h-72 rounded-lg border border-solid border-[#dce4d8] bg-white object-contain"
+          <span className={crm.label}>{ticket.kind === 'bug' ? 'Vad händer' : 'Önskemål'}</span>
+          <p className="m-0 whitespace-pre-wrap text-sm text-slate-800">{description}</p>
+        </div>
+
+        {pagePath ? (
+          <div className="grid gap-1">
+            <span className={crm.label}>Rapporterat från</span>
+            <code className="w-fit max-w-full overflow-x-auto rounded border border-solid border-[#dce4d8] bg-[#f4f8f1] px-1.5 py-0.5 font-mono text-[11px] text-slate-600">
+              {pagePath}
+            </code>
+          </div>
+        ) : null}
+
+        {detail?.screenshot_url ? (
+          <div className="grid gap-1">
+            <span className={crm.label}>Skärmbild</span>
+            <a href={detail.screenshot_url} target="_blank" rel="noreferrer" className="block w-fit max-w-full">
+              {/* eslint-disable-next-line @next/next/no-img-element -- signerad storage-URL, kan inte
+                  gå genom bildoptimeringen */}
+              <img
+                src={detail.screenshot_url}
+                alt={`Skärmbild från ${ticket.reporter_name}`}
+                className="max-h-72 rounded-lg border border-solid border-[#dce4d8] bg-white object-contain"
+              />
+            </a>
+            <span className="text-[11px] text-slate-400">Klicka för full storlek.</span>
+          </div>
+        ) : ticket.has_screenshot ? (
+          <p className="m-0 text-[12px] text-slate-400">Skärmbilden kunde inte hämtas.</p>
+        ) : null}
+
+        <div className="grid gap-3 border-t border-solid border-slate-100 pt-4 sm:grid-cols-[10rem_1fr] sm:items-start">
+          <div className="grid gap-1.5">
+            <label htmlFor={`status-${ticket.id}`} className={crm.label}>Status</label>
+            <Select
+              id={`status-${ticket.id}`}
+              value={status}
+              onChange={(e) => setStatus(e.target.value as TicketStatus)}
+              disabled={busy}
+            >
+              {TICKET_STATUSES.map((s) => (
+                <option key={s} value={s}>{statusLabel[s]}</option>
+              ))}
+            </Select>
+          </div>
+
+          <div className="grid gap-1.5">
+            <label htmlFor={`resolution-${ticket.id}`} className={crm.label}>Svar till rapportören</label>
+            <Textarea
+              id={`resolution-${ticket.id}`}
+              value={resolution}
+              onChange={(e) => setResolution(e.target.value)}
+              placeholder="Vad gjordes, eller varför blir det inte av?"
+              className="min-h-[80px]"
+              disabled={busy}
             />
-          </a>
-        </div>
-      ) : ticket.has_screenshot ? (
-        <p className="m-0 text-[12px] text-slate-400">Skärmbilden kunde inte hämtas.</p>
-      ) : null}
-
-      <div className="grid gap-3 border-t border-solid border-[#e0e8dc] pt-3 sm:grid-cols-[10rem_1fr] sm:items-start">
-        <div className="grid gap-1.5">
-          <label htmlFor={`status-${ticket.id}`} className={crm.label}>Status</label>
-          <Select
-            id={`status-${ticket.id}`}
-            value={status}
-            onChange={(e) => setStatus(e.target.value as TicketStatus)}
-            disabled={saving}
-          >
-            {TICKET_STATUSES.map((s) => (
-              <option key={s} value={s}>{statusLabel[s]}</option>
-            ))}
-          </Select>
+          </div>
         </div>
 
-        <div className="grid gap-1.5">
-          <label htmlFor={`resolution-${ticket.id}`} className={crm.label}>Svar till rapportören</label>
+        <div className="grid gap-2 border-t border-solid border-slate-100 pt-4">
+          <label htmlFor={`changelog-${ticket.id}`} className={crm.label}>Changelog-text</label>
           <Textarea
-            id={`resolution-${ticket.id}`}
-            value={resolution}
-            onChange={(e) => setResolution(e.target.value)}
-            placeholder="Vad gjordes, eller varför blir det inte av?"
-            className="min-h-[80px]"
-            disabled={saving}
+            id={`changelog-${ticket.id}`}
+            value={changelogNote}
+            onChange={(e) => setChangelogNote(e.target.value)}
+            placeholder="En rad som beskriver ändringen för alla i appen."
+            className="min-h-[60px]"
+            maxLength={500}
+            disabled={busy}
           />
+          <label className="flex items-center gap-2 text-[13px] text-slate-700">
+            <input
+              type="checkbox"
+              checked={publish}
+              onChange={(e) => setPublish(e.target.checked)}
+              disabled={busy}
+              className="!w-4 shrink-0"
+            />
+            Visa i changeloggen
+          </label>
+          <p className="m-0 text-[12px] text-slate-500">
+            Kräver status <strong>Klar</strong> och en text. Changelog-vyn byggs härnäst — texten
+            sparas redan nu.
+          </p>
         </div>
-      </div>
 
-      <div className="grid gap-2 border-t border-solid border-[#e0e8dc] pt-3">
-        <label htmlFor={`changelog-${ticket.id}`} className={crm.label}>Changelog-text</label>
-        <Textarea
-          id={`changelog-${ticket.id}`}
-          value={changelogNote}
-          onChange={(e) => setChangelogNote(e.target.value)}
-          placeholder="En rad som beskriver ändringen för alla i appen."
-          className="min-h-[60px]"
-          maxLength={500}
-          disabled={saving}
-        />
-        <label className="flex items-center gap-2 text-[13px] text-slate-700">
-          <input
-            type="checkbox"
-            checked={publish}
-            onChange={(e) => setPublish(e.target.checked)}
-            disabled={saving}
-            className="!w-4 shrink-0"
-          />
-          Visa i changeloggen
-        </label>
-        <p className="m-0 text-[12px] text-slate-500">
-          Kräver status <strong>Klar</strong> och en text. Changelog-vyn byggs härnäst — texten
-          sparas redan nu.
-        </p>
-      </div>
+        {confirmDelete ? (
+          <div className="rounded-xl border border-solid border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-700">
+            Ärendet och dess skärmbild tas bort permanent. Ska rapportören få ett svar i stället —
+            välj status <strong>Blir inte av</strong> och skriv svaret.
+          </div>
+        ) : null}
 
-      {error ? (
-        <div className="rounded-xl border border-solid border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-700">{error}</div>
-      ) : null}
-      {notice ? (
-        <div className="rounded-xl border border-solid border-emerald-200 bg-emerald-50 px-3 py-2 text-sm text-emerald-800">{notice}</div>
-      ) : null}
-
-      <div>
-        <button
-          type="button"
-          onClick={save}
-          disabled={saving}
-          className={cn(crm.formButton)}
-          style={{ backgroundColor: 'var(--crm-primary)' }}
-        >
-          {saving ? 'Sparar…' : 'Spara ärendet'}
-        </button>
+        {error ? (
+          <div className="rounded-xl border border-solid border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-700">{error}</div>
+        ) : null}
+        {notice ? (
+          <div className="rounded-xl border border-solid border-emerald-200 bg-emerald-50 px-3 py-2 text-sm text-emerald-800">{notice}</div>
+        ) : null}
       </div>
-    </div>
+    </CrmModal>
   );
 }
 

--- a/app/admin/support/AdminSupportTickets.tsx
+++ b/app/admin/support/AdminSupportTickets.tsx
@@ -29,9 +29,12 @@ import {
 // jämföra ärenden med varandra. Modalen är dessutom mönstret på varje annan CRM-yta (offert, kund,
 // felanmälan), så den är redan inlärd.
 //
-// OBS preflight är av (tailwind.config.js): `border` på en <div>/<span> ritar ingen linje utan
-// `border-solid`. <button> får däremot `border: 1px solid transparent` från globals.css, så
-// listraderna (som ÄR knappar) ritar sina kanter utan tillägget.
+// OBS preflight är av (tailwind.config.js), så border-utilities beter sig INTE som i vanlig Tailwind
+// — därför bär rot-elementet klassen `support-surface`, som återställer reseten (globals.css). Utan
+// den ritar `border` på en <div> ingen linje alls, och `border-t border-solid` blir en LÅDA: stilen
+// sätts på alla fyra sidor men bredden bara på toppen, så de tre andra faller tillbaka på
+// webbläsarens `medium` (~3px). Med klassen på plats: skriv `border`/`border-t` som vanligt, och
+// lägg ALDRIG till `border-solid` här.
 
 type StateFilter = 'open' | 'closed' | 'any';
 
@@ -95,8 +98,9 @@ export default function AdminSupportTickets() {
 
   return (
     // p-5 matchar de andra adminflikarna (Behörigheter, Tidkoder) — AdminTabsClient lägger inget
-    // innerutrymme i sitt kort.
-    <div className="grid grid-cols-1 gap-4 p-5">
+    // innerutrymme i sitt kort. `support-surface` återställer border-reseten för hela trädet,
+    // modalen inkluderad (den renderas som barn här nere).
+    <div className="support-surface grid grid-cols-1 gap-4 p-5">
       <div className="grid gap-1">
         <h2 className="m-0 text-lg font-bold text-slate-900">Ärenden</h2>
         <p className="m-0 text-sm text-slate-600">
@@ -123,7 +127,7 @@ export default function AdminSupportTickets() {
       </div>
 
       {error ? (
-        <div className="rounded-xl border border-solid border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700">{error}</div>
+        <div className="rounded-xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700">{error}</div>
       ) : null}
 
       {loading ? (
@@ -196,11 +200,11 @@ function TicketRow({ ticket, onOpen }: { ticket: AppTicketView; onOpen: () => vo
             {ticketKindGlyph[ticket.kind]}
           </span>
           <span className="text-[13px] font-bold text-slate-900">{ticket.title}</span>
-          <span className={cn(crm.badge, 'border-solid', ticketStatusMeta[ticket.status].badge)}>
+          <span className={cn(crm.badge, ticketStatusMeta[ticket.status].badge)}>
             {ticket.status_label}
           </span>
           {ticket.changelog_published_at ? (
-            <span className={cn(crm.badge, 'border-solid border-emerald-200 bg-white text-emerald-700')}>
+            <span className={cn(crm.badge, 'border-emerald-200 bg-white text-emerald-700')}>
               I changeloggen
             </span>
           ) : null}
@@ -330,7 +334,7 @@ function TicketModal({
               {ticketKindGlyph[ticket.kind]}
             </span>
             <h2 className="m-0 text-base font-bold text-slate-900">{ticket.title}</h2>
-            <span className={cn(crm.badge, 'border-solid', ticketStatusMeta[ticket.status].badge)}>
+            <span className={cn(crm.badge, ticketStatusMeta[ticket.status].badge)}>
               {ticket.status_label}
             </span>
           </div>
@@ -400,7 +404,7 @@ function TicketModal({
         {pagePath ? (
           <div className="grid gap-1">
             <span className={crm.label}>Rapporterat från</span>
-            <code className="w-fit max-w-full overflow-x-auto rounded border border-solid border-[#dce4d8] bg-[#f4f8f1] px-1.5 py-0.5 font-mono text-[11px] text-slate-600">
+            <code className="w-fit max-w-full overflow-x-auto rounded border border-[#dce4d8] bg-[#f4f8f1] px-1.5 py-0.5 font-mono text-[11px] text-slate-600">
               {pagePath}
             </code>
           </div>
@@ -415,7 +419,7 @@ function TicketModal({
               <img
                 src={detail.screenshot_url}
                 alt={`Skärmbild från ${ticket.reporter_name}`}
-                className="max-h-72 rounded-lg border border-solid border-[#dce4d8] bg-white object-contain"
+                className="max-h-72 rounded-lg border border-[#dce4d8] bg-white object-contain"
               />
             </a>
             <span className="text-[11px] text-slate-400">Klicka för full storlek.</span>
@@ -424,7 +428,7 @@ function TicketModal({
           <p className="m-0 text-[12px] text-slate-400">Skärmbilden kunde inte hämtas.</p>
         ) : null}
 
-        <div className="grid gap-3 border-t border-solid border-slate-100 pt-4 sm:grid-cols-[10rem_1fr] sm:items-start">
+        <div className="grid gap-3 border-t border-slate-100 pt-4 sm:grid-cols-[10rem_1fr] sm:items-start">
           <div className="grid gap-1.5">
             <label htmlFor={`status-${ticket.id}`} className={crm.label}>Status</label>
             <Select
@@ -452,7 +456,7 @@ function TicketModal({
           </div>
         </div>
 
-        <div className="grid gap-2 border-t border-solid border-slate-100 pt-4">
+        <div className="grid gap-2 border-t border-slate-100 pt-4">
           <label htmlFor={`changelog-${ticket.id}`} className={crm.label}>Changelog-text</label>
           <Textarea
             id={`changelog-${ticket.id}`}
@@ -480,17 +484,17 @@ function TicketModal({
         </div>
 
         {confirmDelete ? (
-          <div className="rounded-xl border border-solid border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-700">
+          <div className="rounded-xl border border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-700">
             Ärendet och dess skärmbild tas bort permanent. Ska rapportören få ett svar i stället —
             välj status <strong>Blir inte av</strong> och skriv svaret.
           </div>
         ) : null}
 
         {error ? (
-          <div className="rounded-xl border border-solid border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-700">{error}</div>
+          <div className="rounded-xl border border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-700">{error}</div>
         ) : null}
         {notice ? (
-          <div className="rounded-xl border border-solid border-emerald-200 bg-emerald-50 px-3 py-2 text-sm text-emerald-800">{notice}</div>
+          <div className="rounded-xl border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm text-emerald-800">{notice}</div>
         ) : null}
       </div>
     </CrmModal>

--- a/app/admin/support/AdminSupportTickets.tsx
+++ b/app/admin/support/AdminSupportTickets.tsx
@@ -1,0 +1,409 @@
+"use client";
+
+import React from 'react';
+import { cn } from '../../../lib/shared/cn';
+import { crm } from '../../crm/lib/crmTokens';
+import Textarea from '../../../components/ui/Textarea';
+import Select from '../../../components/ui/Select';
+import { ticketKindGlyph, ticketKindGlyphClass, ticketStatusMeta } from '../../_lib/supportTokens';
+import {
+  TICKET_KINDS,
+  TICKET_STATUSES,
+  kindLabel,
+  statusLabel,
+  type AppTicketDetailView,
+  type AppTicketView,
+  type TicketKind,
+  type TicketStatus,
+} from '../../../lib/domains/support/types';
+
+// Admin → Ärenden. Backloggen för buggar och önskemål om appen.
+//
+// VAD VYN ÄR TILL FÖR: att svara på "vad är kvar" utan att någon behöver minnas. Därför öppnar den
+// på det som ÄR kvar (state=open) i stället för allt — en lista där klart och blir-inte-av ligger
+// blandat med nytt blir en logg, inte en backlog. Klara ärenden finns ett klick bort.
+//
+// OBS preflight är av (tailwind.config.js): `border` på en <div>/<span> ritar ingen linje utan
+// `border-solid`. <button> får däremot `border: 1px solid transparent` från globals.css, så
+// listraderna (som ÄR knappar) ritar sina kanter utan tillägget.
+
+type StateFilter = 'open' | 'closed' | 'any';
+
+const STATE_LABEL: Record<StateFilter, string> = {
+  open: 'Kvar att göra',
+  closed: 'Avslutade',
+  any: 'Alla',
+};
+
+export default function AdminSupportTickets() {
+  const [items, setItems] = React.useState<AppTicketView[]>([]);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState<string | null>(null);
+  const [stateFilter, setStateFilter] = React.useState<StateFilter>('open');
+  const [kindFilter, setKindFilter] = React.useState<TicketKind | 'all'>('all');
+  const [openId, setOpenId] = React.useState<string | null>(null);
+
+  // Samma kapplöpningsvakt som attestvyn: byter man filter snabbt kan ett tidigare svar landa
+  // sist och rita fel urval.
+  const loadSeq = React.useRef(0);
+
+  const load = React.useCallback(async () => {
+    const seq = ++loadSeq.current;
+    setLoading(true);
+    setError(null);
+    try {
+      const params = new URLSearchParams({ scope: 'all', state: stateFilter });
+      if (kindFilter !== 'all') params.set('kind', kindFilter);
+      const res = await fetch(`/api/support/tickets?${params.toString()}`, { cache: 'no-store', credentials: 'same-origin' });
+      const body = await res.json().catch(() => null);
+      if (seq !== loadSeq.current) return;
+      if (!res.ok || !body?.ok) throw new Error(body?.error || `Fel (${res.status})`);
+      setItems((body.data.items || []) as AppTicketView[]);
+    } catch (e) {
+      if (seq !== loadSeq.current) return;
+      setError((e as Error).message);
+      // Töm listan vid fel. Står gamla rader kvar under felrutan ser vyn ut att ha svarat.
+      setItems([]);
+    } finally {
+      if (seq === loadSeq.current) setLoading(false);
+    }
+  }, [stateFilter, kindFilter]);
+
+  React.useEffect(() => { load(); }, [load]);
+
+  // Djuplänk ur notisen: /admin?tab=arenden&arende=<id>. Öppnas en gång per id, inte vid varje
+  // omladdning — en sparning laddar om listan och hade annars slagit upp panelen igen.
+  const openedDeepLink = React.useRef<string | null>(null);
+  React.useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const id = new URLSearchParams(window.location.search).get('arende');
+    if (!id || openedDeepLink.current === id) return;
+    openedDeepLink.current = id;
+    setOpenId(id);
+    // Ett djuplänkat ärende kan vara avslutat — visa allt, annars öppnas en panel för en rad som
+    // inte finns i urvalet.
+    setStateFilter('any');
+  }, []);
+
+  const counts = React.useMemo(() => {
+    const byStatus = new Map<TicketStatus, number>();
+    for (const t of items) byStatus.set(t.status, (byStatus.get(t.status) || 0) + 1);
+    return byStatus;
+  }, [items]);
+
+  return (
+    // p-5 matchar de andra adminflikarna (Behörigheter, Tidkoder) — AdminTabsClient lägger inget
+    // innerutrymme i sitt kort.
+    <div className="grid gap-4 p-5">
+      <div className="grid gap-1">
+        <h2 className="m-0 text-lg font-bold text-slate-900">Ärenden</h2>
+        <p className="m-0 text-sm text-slate-600">
+          Buggar och önskemål som rapporterats i appen via Rapportera-knappen. Sätt status, svara
+          rapportören, och publicera det som är klart i changeloggen.
+        </p>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-2">
+        {(['open', 'closed', 'any'] as StateFilter[]).map((s) => (
+          <FilterChip key={s} active={stateFilter === s} onClick={() => setStateFilter(s)}>
+            {STATE_LABEL[s]}
+          </FilterChip>
+        ))}
+        <span className="mx-1 h-5 w-px shrink-0 bg-slate-200" aria-hidden />
+        <FilterChip active={kindFilter === 'all'} onClick={() => setKindFilter('all')}>
+          Allt
+        </FilterChip>
+        {TICKET_KINDS.map((k) => (
+          <FilterChip key={k} active={kindFilter === k} onClick={() => setKindFilter(k)}>
+            {kindLabel[k]}
+          </FilterChip>
+        ))}
+      </div>
+
+      {error ? (
+        <div className="rounded-xl border border-solid border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700">{error}</div>
+      ) : null}
+
+      {!loading && !error && items.length > 0 ? (
+        <div className="flex flex-wrap gap-1.5">
+          {TICKET_STATUSES.filter((s) => (counts.get(s) || 0) > 0).map((s) => (
+            <span key={s} className={cn(crm.badge, 'border-solid', ticketStatusMeta[s].badge)}>
+              {counts.get(s)} {statusLabel[s].toLowerCase()}
+            </span>
+          ))}
+        </div>
+      ) : null}
+
+      {loading ? (
+        <p className="m-0 text-sm text-slate-400">Laddar…</p>
+      ) : items.length === 0 && !error ? (
+        <div className="rounded-2xl border border-dashed border-[#d5e0cf] bg-[#f4f8f1] px-4 py-8 text-center">
+          <p className="m-0 text-sm text-slate-500">
+            {stateFilter === 'open' ? 'Inget kvar att göra just nu.' : 'Inga ärenden att visa.'}
+          </p>
+        </div>
+      ) : (
+        <ul role="list" className="m-0 grid list-none gap-1 p-0">
+          {items.map((ticket) => (
+            <li key={ticket.id}>
+              <TicketRow
+                ticket={ticket}
+                open={openId === ticket.id}
+                onToggle={() => setOpenId(openId === ticket.id ? null : ticket.id)}
+                onSaved={load}
+              />
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function FilterChip({ active, onClick, children }: { active: boolean; onClick: () => void; children: React.ReactNode }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        'rounded-full border px-2.5 py-1 text-[13px] font-semibold transition-colors',
+        active
+          ? 'border-emerald-200 bg-emerald-50 text-emerald-700'
+          : 'border-[#e0e8dc] bg-white text-slate-600 hover:border-emerald-200',
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
+function TicketRow({
+  ticket,
+  open,
+  onToggle,
+  onSaved,
+}: {
+  ticket: AppTicketView;
+  open: boolean;
+  onToggle: () => void;
+  onSaved: () => void;
+}) {
+  return (
+    <div className="overflow-hidden rounded-lg border border-solid border-[#e0e8dc] bg-white">
+      <button
+        type="button"
+        onClick={onToggle}
+        aria-expanded={open}
+        className="flex w-full items-stretch !border-0 bg-white text-left transition-colors hover:bg-[#f9fbf7]"
+      >
+        <span className={cn('w-1.5 shrink-0', ticketStatusMeta[ticket.status].accent)} aria-hidden />
+        <span className="grid flex-1 gap-0.5 px-3 py-2">
+          <span className="flex flex-wrap items-center gap-2">
+            <span
+              aria-hidden
+              className={cn(
+                'grid h-4 w-4 shrink-0 place-items-center rounded-full text-[11px] font-bold',
+                ticketKindGlyphClass[ticket.kind],
+              )}
+            >
+              {ticketKindGlyph[ticket.kind]}
+            </span>
+            <span className="text-[13px] font-bold text-slate-900">{ticket.title}</span>
+            <span className={cn(crm.badge, 'border-solid', ticketStatusMeta[ticket.status].badge)}>
+              {ticket.status_label}
+            </span>
+            {ticket.changelog_published_at ? (
+              <span className={cn(crm.badge, 'border-solid border-emerald-200 bg-white text-emerald-700')}>
+                I changeloggen
+              </span>
+            ) : null}
+          </span>
+          <span className="text-[11px] text-slate-400">
+            {ticket.reporter_name} · {ticket.area_label} · {formatDate(ticket.created_at)}
+            {ticket.has_screenshot ? ' · Skärmbild' : ''}
+          </span>
+        </span>
+      </button>
+
+      {open ? <TicketPanel ticket={ticket} onSaved={onSaved} /> : null}
+    </div>
+  );
+}
+
+function TicketPanel({ ticket, onSaved }: { ticket: AppTicketView; onSaved: () => void }) {
+  const [detail, setDetail] = React.useState<AppTicketDetailView | null>(null);
+  const [status, setStatus] = React.useState<TicketStatus>(ticket.status);
+  const [resolution, setResolution] = React.useState(ticket.resolution || '');
+  const [changelogNote, setChangelogNote] = React.useState(ticket.changelog_note || '');
+  const [publish, setPublish] = React.useState(!!ticket.changelog_published_at);
+  const [saving, setSaving] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+  const [notice, setNotice] = React.useState<string | null>(null);
+
+  // Detaljhämtningen ger beskrivningen, sökvägen och en signerad URL till skärmbilden.
+  React.useEffect(() => {
+    let alive = true;
+    (async () => {
+      try {
+        const res = await fetch(`/api/support/tickets/${ticket.id}`, { cache: 'no-store', credentials: 'same-origin' });
+        const body = await res.json().catch(() => null);
+        if (!alive || !res.ok || !body?.ok) return;
+        const item = body.data.item as AppTicketDetailView;
+        setDetail(item);
+        // Formulärets fält synkas mot det färska svaret — listraden kan vara någon minut gammal.
+        setStatus(item.status);
+        setResolution(item.resolution || '');
+        setChangelogNote(item.changelog_note || '');
+        setPublish(!!item.changelog_published_at);
+      } catch {
+        /* listradens data räcker för att visa panelen */
+      }
+    })();
+    return () => { alive = false; };
+  }, [ticket.id]);
+
+  const save = async () => {
+    setSaving(true);
+    setError(null);
+    setNotice(null);
+    try {
+      const res = await fetch(`/api/support/tickets/${ticket.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'same-origin',
+        body: JSON.stringify({
+          status,
+          resolution: resolution.trim() || null,
+          changelog_note: changelogNote.trim() || null,
+          publish_to_changelog: publish,
+        }),
+      });
+      const body = await res.json().catch(() => null);
+      if (!res.ok || !body?.ok) throw new Error(body?.error || `Fel (${res.status})`);
+      setNotice('Sparat.');
+      onSaved();
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const description = detail?.description ?? ticket.description;
+  const pagePath = detail?.page_path ?? ticket.page_path;
+
+  return (
+    <div className="grid gap-4 border-t border-solid border-slate-100 bg-[#f9fbf7] px-3 py-3">
+      <div className="grid gap-1">
+        <span className={crm.label}>{ticket.kind === 'bug' ? 'Vad händer' : 'Önskemål'}</span>
+        <p className="m-0 whitespace-pre-wrap text-sm text-slate-800">{description}</p>
+      </div>
+
+      {pagePath ? (
+        <div className="grid gap-1">
+          <span className={crm.label}>Rapporterat från</span>
+          <code className="w-fit max-w-full overflow-x-auto rounded border border-solid border-[#dce4d8] bg-white px-1.5 py-0.5 font-mono text-[11px] text-slate-600">
+            {pagePath}
+          </code>
+        </div>
+      ) : null}
+
+      {detail?.screenshot_url ? (
+        <div className="grid gap-1">
+          <span className={crm.label}>Skärmbild</span>
+          <a href={detail.screenshot_url} target="_blank" rel="noreferrer" className="block w-fit max-w-full">
+            {/* eslint-disable-next-line @next/next/no-img-element -- signerad storage-URL, kan inte
+                gå genom bildoptimeringen */}
+            <img
+              src={detail.screenshot_url}
+              alt={`Skärmbild från ${ticket.reporter_name}`}
+              className="max-h-72 rounded-lg border border-solid border-[#dce4d8] bg-white object-contain"
+            />
+          </a>
+        </div>
+      ) : ticket.has_screenshot ? (
+        <p className="m-0 text-[12px] text-slate-400">Skärmbilden kunde inte hämtas.</p>
+      ) : null}
+
+      <div className="grid gap-3 border-t border-solid border-[#e0e8dc] pt-3 sm:grid-cols-[10rem_1fr] sm:items-start">
+        <div className="grid gap-1.5">
+          <label htmlFor={`status-${ticket.id}`} className={crm.label}>Status</label>
+          <Select
+            id={`status-${ticket.id}`}
+            value={status}
+            onChange={(e) => setStatus(e.target.value as TicketStatus)}
+            disabled={saving}
+          >
+            {TICKET_STATUSES.map((s) => (
+              <option key={s} value={s}>{statusLabel[s]}</option>
+            ))}
+          </Select>
+        </div>
+
+        <div className="grid gap-1.5">
+          <label htmlFor={`resolution-${ticket.id}`} className={crm.label}>Svar till rapportören</label>
+          <Textarea
+            id={`resolution-${ticket.id}`}
+            value={resolution}
+            onChange={(e) => setResolution(e.target.value)}
+            placeholder="Vad gjordes, eller varför blir det inte av?"
+            className="min-h-[80px]"
+            disabled={saving}
+          />
+        </div>
+      </div>
+
+      <div className="grid gap-2 border-t border-solid border-[#e0e8dc] pt-3">
+        <label htmlFor={`changelog-${ticket.id}`} className={crm.label}>Changelog-text</label>
+        <Textarea
+          id={`changelog-${ticket.id}`}
+          value={changelogNote}
+          onChange={(e) => setChangelogNote(e.target.value)}
+          placeholder="En rad som beskriver ändringen för alla i appen."
+          className="min-h-[60px]"
+          maxLength={500}
+          disabled={saving}
+        />
+        <label className="flex items-center gap-2 text-[13px] text-slate-700">
+          <input
+            type="checkbox"
+            checked={publish}
+            onChange={(e) => setPublish(e.target.checked)}
+            disabled={saving}
+            className="!w-4 shrink-0"
+          />
+          Visa i changeloggen
+        </label>
+        <p className="m-0 text-[12px] text-slate-500">
+          Kräver status <strong>Klar</strong> och en text. Changelog-vyn byggs härnäst — texten
+          sparas redan nu.
+        </p>
+      </div>
+
+      {error ? (
+        <div className="rounded-xl border border-solid border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-700">{error}</div>
+      ) : null}
+      {notice ? (
+        <div className="rounded-xl border border-solid border-emerald-200 bg-emerald-50 px-3 py-2 text-sm text-emerald-800">{notice}</div>
+      ) : null}
+
+      <div>
+        <button
+          type="button"
+          onClick={save}
+          disabled={saving}
+          className={cn(crm.formButton)}
+          style={{ backgroundColor: 'var(--crm-primary)' }}
+        >
+          {saving ? 'Sparar…' : 'Spara ärendet'}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function formatDate(iso: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return '';
+  return new Intl.DateTimeFormat('sv-SE', { day: 'numeric', month: 'short', hour: '2-digit', minute: '2-digit' }).format(date);
+}

--- a/app/api/support/tickets/[id]/route.ts
+++ b/app/api/support/tickets/[id]/route.ts
@@ -5,9 +5,9 @@ import { getSupabaseAdmin } from '@/lib/supabase/server';
 import { ok, routeError, validationError, invalidUuidParam } from '@/lib/api/responses';
 import { updateTicketSchema } from '@/lib/domains/support/schemas';
 import { getTicket } from '@/lib/domains/support/queries';
-import { buildTicketUpdatePatch, checkChangelogPublishable, updateTicket } from '@/lib/domains/support/mutations';
+import { buildTicketUpdatePatch, checkChangelogPublishable, deleteTicket, updateTicket } from '@/lib/domains/support/mutations';
 import { mapTicketRow } from '@/lib/domains/support/mappers';
-import { getScreenshotUrl } from '@/lib/domains/support/storage';
+import { getScreenshotUrl, removeScreenshot } from '@/lib/domains/support/storage';
 import type { AppTicketRow } from '@/lib/domains/support/types';
 
 export const runtime = 'nodejs';
@@ -59,7 +59,12 @@ export async function PATCH(req: Request, { params }: { params: { id: string } }
     // Bara det klienten faktiskt skickade skrivs — annars hade en statusändring nollat ett svar
     // som redan stod i ärendet.
     const sentKeys = rawBody && typeof rawBody === 'object' && !Array.isArray(rawBody) ? Object.keys(rawBody) : [];
-    const patch = buildTicketUpdatePatch(parsed.data, sentKeys, { id: currentUser.id }, new Date().toISOString());
+    const patch = buildTicketUpdatePatch(
+      parsed.data,
+      sentKeys,
+      { id: currentUser.id, name: currentUser.name || 'Okänd användare' },
+      new Date().toISOString(),
+    );
     // updated_at ligger alltid i patchen; finns inget mer är det en tom sparning.
     if (Object.keys(patch).length <= 1) return routeError(400, 'nothing_to_update', 'Inget att spara.');
 
@@ -87,5 +92,35 @@ export async function PATCH(req: Request, { params }: { params: { id: string } }
     return ok({ item: data });
   } catch (e: any) {
     return routeError(500, 'app_tickets_unexpected', e?.message || 'Failed to update ticket');
+  }
+}
+
+// Radering är till för BRUS — dubbletter och skräp. Ett ärende som besvarats med "Blir inte av"
+// (declined) ska INTE raderas: det är ett svar till rapportören och information i sig.
+export async function DELETE(_req: Request, { params }: { params: { id: string } }) {
+  try {
+    const currentUser = await getCurrentUser();
+    if (!currentUser) return routeError(401, 'unauthorized', 'Unauthorized');
+    if (currentUser.role !== 'admin') return routeError(403, 'forbidden', 'Forbidden');
+
+    const badId = invalidUuidParam(params.id);
+    if (badId) return badId;
+
+    const supabase = createRouteHandlerClient({ cookies });
+    const { data, error } = await deleteTicket(supabase, params.id);
+    if (error) return routeError(500, 'app_ticket_delete_failed', error.message);
+    // Noll rader: raden fanns inte, eller RLS nekade. Grinden ovan har redan avgjort behörigheten,
+    // så det som återstår är att den inte finns.
+    if (!data) return routeError(404, 'not_found', 'Ärendet hittades inte.');
+
+    // Skärmbilden städas EFTER att raden är borta: blir storage-anropet fel är filen skräp, men
+    // ärendet är ändå raderat. Motsatt ordning kunde lämna en rad som pekar på en borttagen fil.
+    if (data.screenshot_bucket && data.screenshot_path) {
+      await removeScreenshot(getSupabaseAdmin(), data.screenshot_bucket, data.screenshot_path);
+    }
+
+    return ok({ deleted: true });
+  } catch (e: any) {
+    return routeError(500, 'app_tickets_unexpected', e?.message || 'Failed to delete ticket');
   }
 }

--- a/app/api/support/tickets/[id]/route.ts
+++ b/app/api/support/tickets/[id]/route.ts
@@ -1,0 +1,91 @@
+import { cookies } from 'next/headers';
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
+import { getCurrentUser } from '@/lib/auth/route';
+import { getSupabaseAdmin } from '@/lib/supabase/server';
+import { ok, routeError, validationError, invalidUuidParam } from '@/lib/api/responses';
+import { updateTicketSchema } from '@/lib/domains/support/schemas';
+import { getTicket } from '@/lib/domains/support/queries';
+import { buildTicketUpdatePatch, checkChangelogPublishable, updateTicket } from '@/lib/domains/support/mutations';
+import { mapTicketRow } from '@/lib/domains/support/mappers';
+import { getScreenshotUrl } from '@/lib/domains/support/storage';
+import type { AppTicketRow } from '@/lib/domains/support/types';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET(_req: Request, { params }: { params: { id: string } }) {
+  try {
+    const currentUser = await getCurrentUser();
+    if (!currentUser) return routeError(401, 'unauthorized', 'Unauthorized');
+
+    const badId = invalidUuidParam(params.id);
+    if (badId) return badId;
+
+    const supabase = createRouteHandlerClient({ cookies });
+    // RLS släpper igenom rapportören (egen rad) eller admin (alla). En rad man inte får se blir
+    // null — svara 404, inte 500.
+    const { data, error } = await getTicket(supabase, params.id);
+    if (error) return routeError(500, 'app_ticket_get_failed', error.message);
+    if (!data) return routeError(404, 'not_found', 'Ärendet hittades inte.');
+
+    const row = data as AppTicketRow;
+    // Skärmbilden signeras först här, efter att RLS redan avgjort att den här användaren får läsa
+    // raden. Listan signerar inget — se kommentaren på has_screenshot i types.ts.
+    const screenshot_url = row.screenshot_path
+      ? await getScreenshotUrl(getSupabaseAdmin(), row.screenshot_bucket, row.screenshot_path)
+      : null;
+
+    return ok({ item: { ...mapTicketRow(row), screenshot_url } });
+  } catch (e: any) {
+    return routeError(500, 'app_tickets_unexpected', e?.message || 'Failed to load ticket');
+  }
+}
+
+export async function PATCH(req: Request, { params }: { params: { id: string } }) {
+  try {
+    const currentUser = await getCurrentUser();
+    if (!currentUser) return routeError(401, 'unauthorized', 'Unauthorized');
+    // Bara admin ändrar ett ärende. Samma grind som RLS (app_tickets_update) — den här ger ett
+    // ärligt 403 i stället för RLS:ens tysta noll-raders-UPDATE, som annars hade blivit ett 404.
+    if (currentUser.role !== 'admin') return routeError(403, 'forbidden', 'Forbidden');
+
+    const badId = invalidUuidParam(params.id);
+    if (badId) return badId;
+
+    const rawBody = await req.json().catch(() => null);
+    const parsed = updateTicketSchema.safeParse(rawBody ?? {});
+    if (!parsed.success) return validationError(parsed.error);
+
+    // Bara det klienten faktiskt skickade skrivs — annars hade en statusändring nollat ett svar
+    // som redan stod i ärendet.
+    const sentKeys = rawBody && typeof rawBody === 'object' && !Array.isArray(rawBody) ? Object.keys(rawBody) : [];
+    const patch = buildTicketUpdatePatch(parsed.data, sentKeys, { id: currentUser.id }, new Date().toISOString());
+    // updated_at ligger alltid i patchen; finns inget mer är det en tom sparning.
+    if (Object.keys(patch).length <= 1) return routeError(400, 'nothing_to_update', 'Inget att spara.');
+
+    const supabase = createRouteHandlerClient({ cookies });
+    const { data: current, error: readError } = await getTicket(supabase, params.id);
+    if (readError) return routeError(500, 'app_ticket_get_failed', readError.message);
+    if (!current) return routeError(404, 'not_found', 'Ärendet hittades inte.');
+
+    // Changelog-publicering kräver både klarmarkering och en text. Kontrolleras mot nuläget +
+    // patchen, eftersom båda kan sättas i samma sparning.
+    const publishError = checkChangelogPublishable({
+      patch,
+      current: {
+        status: String((current as AppTicketRow).status),
+        changelog_note: (current as AppTicketRow).changelog_note,
+      },
+    });
+    if (publishError) return routeError(400, 'changelog_not_publishable', publishError);
+
+    const { data, error } = await updateTicket(supabase, params.id, patch);
+    if (error) return routeError(500, 'app_ticket_update_failed', error.message);
+    // Noll rader trots att läsningen ovan hittade raden = RLS nekade skrivningen.
+    if (!data) return routeError(403, 'forbidden', 'Du kan inte ändra det här ärendet.');
+
+    return ok({ item: data });
+  } catch (e: any) {
+    return routeError(500, 'app_tickets_unexpected', e?.message || 'Failed to update ticket');
+  }
+}

--- a/app/api/support/tickets/route.ts
+++ b/app/api/support/tickets/route.ts
@@ -1,0 +1,174 @@
+import { cookies } from 'next/headers';
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
+import { getCurrentUser } from '@/lib/auth/route';
+import { getSupabaseAdmin } from '@/lib/supabase/server';
+import { ok, routeError, validationError } from '@/lib/api/responses';
+import { createTicketSchema, listTicketsQuerySchema, validateScreenshot } from '@/lib/domains/support/schemas';
+import { createTicket } from '@/lib/domains/support/mutations';
+import { listAllTickets, listMyTickets } from '@/lib/domains/support/queries';
+import { mapTicketRows } from '@/lib/domains/support/mappers';
+import { removeScreenshot, uploadScreenshot } from '@/lib/domains/support/storage';
+import { excludeReporter, listTicketNotifyRecipients } from '@/lib/domains/support/recipients';
+import type { AppTicketRow, AppTicketView } from '@/lib/domains/support/types';
+import { buildAppTicketCreatedNotification } from '@/lib/domains/notifications/payload';
+import { expandNotificationToRecipients } from '@/lib/domains/notifications/mutations';
+import { deliverNotifications } from '@/lib/domains/notifications/delivery';
+
+// nodejs: skärmbilden läses som Buffer och laddas upp med service-role-nyckeln.
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET(req: Request) {
+  try {
+    const currentUser = await getCurrentUser();
+    if (!currentUser) return routeError(401, 'unauthorized', 'Unauthorized');
+
+    const url = new URL(req.url);
+    const parsed = listTicketsQuerySchema.safeParse({
+      scope: url.searchParams.get('scope') ?? undefined,
+      status: url.searchParams.get('status') ?? undefined,
+      kind: url.searchParams.get('kind') ?? undefined,
+      state: url.searchParams.get('state') ?? undefined,
+    });
+    if (!parsed.success) return validationError(parsed.error);
+
+    const { scope, ...filters } = parsed.data;
+    const supabase = createRouteHandlerClient({ cookies });
+
+    // Backloggen är adminytan. Grinden sitter både här och i RLS (app_tickets_select) — routen
+    // svarar 403 med ett begripligt fel i stället för att låta RLS returnera en tom lista, vilket
+    // hade sett ut som "inga ärenden" i stället för "du får inte se det här".
+    if (scope === 'all') {
+      if (currentUser.role !== 'admin') return routeError(403, 'forbidden', 'Forbidden');
+      const { data, error } = await listAllTickets(supabase, filters);
+      if (error) return routeError(500, 'app_tickets_list_failed', error.message);
+      return ok({ items: mapTicketRows(data as AppTicketRow[] | null) });
+    }
+
+    const { data, error } = await listMyTickets(supabase, currentUser.id, filters);
+    if (error) return routeError(500, 'app_tickets_list_failed', error.message);
+    return ok({ items: mapTicketRows(data as AppTicketRow[] | null) });
+  } catch (e: any) {
+    return routeError(500, 'app_tickets_unexpected', e?.message || 'Failed to list tickets');
+  }
+}
+
+type ParsedTicketBody = {
+  fields: Record<string, unknown>;
+  screenshot: { name: string; type: string; size: number; bytes: Buffer } | null;
+};
+
+// Klienten skickar multipart när en skärmbild följer med. JSON accepteras också, så routen går att
+// anropa utan filhantering (och så ett felaktigt content-type ger ett tydligt fel i stället för ett
+// kryptiskt formData()-undantag).
+async function parseTicketBody(req: Request): Promise<ParsedTicketBody | null> {
+  const contentType = (req.headers.get('content-type') || '').toLowerCase();
+
+  if (contentType.includes('application/json')) {
+    const body = await req.json().catch(() => null);
+    if (!body || typeof body !== 'object') return null;
+    return { fields: body as Record<string, unknown>, screenshot: null };
+  }
+
+  const form = await req.formData().catch(() => null);
+  if (!form) return null;
+
+  const fields: Record<string, unknown> = {
+    kind: form.get('kind'),
+    area: form.get('area'),
+    title: String(form.get('title') ?? ''),
+    description: String(form.get('description') ?? ''),
+    page_path: form.get('page_path'),
+  };
+
+  const candidate = form.get('screenshot');
+  // Duck-typing i stället för `instanceof File`: File finns i Node 20+ men en tom filinput skickar
+  // en sträng, och den ska behandlas som "ingen bild" — inte som ett fel.
+  const isFile = !!candidate && typeof candidate === 'object' && typeof (candidate as any).arrayBuffer === 'function';
+  if (!isFile) return { fields, screenshot: null };
+
+  const file = candidate as unknown as { name: string; type: string; size: number; arrayBuffer: () => Promise<ArrayBuffer> };
+  return {
+    fields,
+    screenshot: {
+      name: file.name || 'skarmbild',
+      type: file.type || '',
+      size: file.size,
+      bytes: Buffer.from(await file.arrayBuffer()),
+    },
+  };
+}
+
+export async function POST(req: Request) {
+  // Deklarerad utanför try:n så catch-grenen kan städa bort en redan uppladdad skärmbild. Kastar
+  // insert:en (i stället för att returnera ett fel) hade bilden annars blivit kvarglömt skräp i
+  // bucketen, utan någon rad som pekar på den.
+  let uploaded: { bucket: string; path: string } | null = null;
+
+  try {
+    const currentUser = await getCurrentUser();
+    if (!currentUser) return routeError(401, 'unauthorized', 'Unauthorized');
+
+    const body = await parseTicketBody(req);
+    if (!body) return routeError(400, 'invalid_body', 'Kunde inte läsa formuläret.');
+
+    const parsed = createTicketSchema.safeParse(body.fields);
+    if (!parsed.success) return validationError(parsed.error);
+
+    // Bilden valideras FÖRE uppladdningen: en för stor eller fel filtyp ska aldrig hinna kosta en
+    // storage-runda.
+    if (body.screenshot) {
+      const screenshotError = validateScreenshot(body.screenshot);
+      if (screenshotError) return routeError(400, 'invalid_screenshot', screenshotError);
+    }
+
+    // Uppladdning före insert, så ett ärende aldrig kan skapas med en trasig bildreferens. Blir
+    // insert:en fel städas objektet bort nedan.
+    if (body.screenshot) {
+      const admin = getSupabaseAdmin();
+      const result = await uploadScreenshot(admin, body.screenshot);
+      if (result.error) return routeError(500, 'screenshot_upload_failed', 'Kunde inte ladda upp skärmbilden.');
+      uploaded = { bucket: result.bucket, path: result.path };
+    }
+
+    const supabase = createRouteHandlerClient({ cookies });
+    const { data, error } = await createTicket(supabase, {
+      ...parsed.data,
+      reporter_id: currentUser.id,
+      reporter_name: currentUser.name || 'Okänd användare',
+      screenshot_bucket: uploaded?.bucket ?? null,
+      screenshot_path: uploaded?.path ?? null,
+    });
+
+    if (error || !data) {
+      if (uploaded) await removeScreenshot(getSupabaseAdmin(), uploaded.bucket, uploaded.path);
+      return routeError(500, 'app_ticket_create_failed', error?.message || 'Kunde inte spara ärendet.');
+    }
+
+    // Best-effort: en notisfel får aldrig fälla en inlämning användaren just gjort.
+    await notifyNewTicket(data).catch((e) => console.error('[support] notis-fan-out misslyckades', e));
+
+    return ok({ item: data }, 201);
+  } catch (e: any) {
+    if (uploaded) await removeScreenshot(getSupabaseAdmin(), uploaded.bucket, uploaded.path);
+    return routeError(500, 'app_tickets_unexpected', e?.message || 'Failed to create ticket');
+  }
+}
+
+async function notifyNewTicket(ticket: AppTicketView) {
+  const admin = getSupabaseAdmin();
+  const recipientIds = excludeReporter(await listTicketNotifyRecipients(admin), ticket.reporter_id);
+  if (recipientIds.length === 0) return;
+
+  const content = buildAppTicketCreatedNotification({
+    ticketId: ticket.id,
+    kindLabel: ticket.kind_label,
+    areaLabel: ticket.area_label,
+    title: ticket.title,
+    reporterName: ticket.reporter_name,
+  });
+
+  // deliverNotifications skriver klockraden OCH skickar push — pushen kommer gratis för varje
+  // notistyp som går genom den.
+  await deliverNotifications(admin, expandNotificationToRecipients(content, recipientIds));
+}

--- a/app/components/ReportIssueLauncher.tsx
+++ b/app/components/ReportIssueLauncher.tsx
@@ -49,7 +49,12 @@ export default function ReportIssueLauncher({ loggedIn }: { loggedIn: boolean })
   if (!loggedIn || isHiddenPath(pathname)) return null;
 
   return (
-    <>
+    // `crm-shell` bär CRM:ets CSS-variabler (globals.css) — och de är scopade till DEN klassen, inte
+    // till :root. Eftersom komponenten med flit renderas UTANFÖR AppShell (fältvyn saknar skal) var
+    // `var(--crm-primary)` odefinierad här, och Skicka-knappen blev vit text på ingen bakgrund:
+    // osynlig. Wrappern återger variablerna till hela trädet — knappen OCH modalen — så varje
+    // CRM-token fungerar som på övriga ytor. Div:en är layoutneutral: allt inuti är `fixed`.
+    <div className="crm-shell">
       <button
         type="button"
         onClick={() => {
@@ -85,7 +90,7 @@ export default function ReportIssueLauncher({ loggedIn }: { loggedIn: boolean })
           onClose={() => setOpen(false)}
         />
       )}
-    </>
+    </div>
   );
 }
 
@@ -377,7 +382,11 @@ function TicketForm({ pagePath, onCreated }: { pagePath: string; onCreated: () =
         type="submit"
         disabled={submitting}
         className={cn(crm.formButton, 'w-full')}
-        style={{ backgroundColor: 'var(--crm-primary)' }}
+        // Fallback-färgen är ingen dekoration: knappen har vit text, så en odefinierad
+        // `--crm-primary` gör den helt osynlig. Variabeln är scopad till `.crm-shell`, och den här
+        // komponenten lever utanför AppShell — händelseförloppet som gjorde knappen osynlig en
+        // gång. Wrappern ovan löser det, fallbacken gör att det inte kan hända igen.
+        style={{ backgroundColor: 'var(--crm-primary, #1a3f26)' }}
       >
         {submitting ? 'Skickar…' : 'Skicka rapport'}
       </button>

--- a/app/components/ReportIssueLauncher.tsx
+++ b/app/components/ReportIssueLauncher.tsx
@@ -1,0 +1,470 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { usePathname } from 'next/navigation';
+import { cn } from '@/lib/shared/cn';
+import { crm } from '@/app/crm/lib/crmTokens';
+import CrmModal from '@/app/crm/components/CrmModal';
+import Input from '@/components/ui/Input';
+import Select from '@/components/ui/Select';
+import Textarea from '@/components/ui/Textarea';
+import { useToast } from '@/lib/Toast';
+import { ticketKindGlyph, ticketKindGlyphClass, ticketStatusMeta } from '@/app/_lib/supportTokens';
+import { guessAreaFromPath } from '@/lib/domains/support/areas';
+import {
+  TICKET_AREAS,
+  TICKET_KINDS,
+  areaLabel,
+  kindLabel,
+  type AppTicketView,
+  type TicketArea,
+  type TicketKind,
+} from '@/lib/domains/support/types';
+
+// Rapportera-knappen: nås från varje sida i appen, förifylld med var användaren stod.
+//
+// VARFÖR EN MÄRKT PILL OCH INTE EN RUND IKONKNAPP. Den som ska rapportera en bugg mitt i ett jobb
+// har handskar på sig och har aldrig letat efter den här knappen förut. En cirkel med ett tecken i
+// kräver att man redan vet vad den gör; ordet gör det inte. På telefon krymper den till tecken +
+// kort ord så den inte lägger sig över innehållet.
+//
+// Ytor där den INTE ska finnas: inloggningen (ingen användare att rapportera som) och kundens
+// signeringssida (en extern kund ska inte se företagets interna supportformulär). Fältvyn
+// /arbetsorder saknar sidomeny men ÄR en inloggad yta — installatörerna är de som ser flest buggar,
+// så knappen ska finnas där. Därför renderas komponenten utanför AppShell (i root-layouten),
+// bredvid InstallPrompt.
+const HIDDEN_PREFIXES = ['/auth', '/kund/offert'];
+
+function isHiddenPath(pathname: string) {
+  return HIDDEN_PREFIXES.some((p) => pathname === p || pathname.startsWith(`${p}/`));
+}
+
+type Panel = 'form' | 'mine';
+
+export default function ReportIssueLauncher({ loggedIn }: { loggedIn: boolean }) {
+  const pathname = usePathname() || '/';
+  const [open, setOpen] = useState(false);
+  const [panel, setPanel] = useState<Panel>('form');
+
+  if (!loggedIn || isHiddenPath(pathname)) return null;
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => {
+          setPanel('form');
+          setOpen(true);
+        }}
+        aria-label="Rapportera ett problem eller önska en funktion"
+        className={cn(
+          // z-[25] med flit: knappen är app-krom och ska ALDRIG ligga över sidans egna kontroller.
+          // Offertformuläret har en fixerad spar-rad i mobil på z-30, sidomenyns overlay ligger på
+          // z-40 och varje dialog högre än så — alla täcker därmed knappen i stället för att täckas
+          // av den. Samma regel gäller automatiskt för framtida bottenrader: de vinner.
+          'fixed right-3 z-[25] inline-flex items-center gap-2 rounded-full border border-[#cfdcc9] bg-white/95',
+          'px-3 py-2 text-[13px] font-semibold text-slate-700 shadow-[0_6px_20px_rgba(20,44,27,0.18)] backdrop-blur',
+          'transition hover:border-emerald-300 hover:text-emerald-800 active:scale-[0.98]',
+          'bottom-[calc(0.75rem+env(safe-area-inset-bottom))]',
+        )}
+      >
+        <span
+          aria-hidden
+          className="grid h-5 w-5 place-items-center rounded-full bg-[#e4efe0] text-[12px] font-bold text-emerald-800"
+        >
+          ?
+        </span>
+        Rapportera
+      </button>
+
+      {open && (
+        <ReportModal
+          panel={panel}
+          setPanel={setPanel}
+          pagePath={pathname}
+          onClose={() => setOpen(false)}
+        />
+      )}
+    </>
+  );
+}
+
+function ReportModal({
+  panel,
+  setPanel,
+  pagePath,
+  onClose,
+}: {
+  panel: Panel;
+  setPanel: (p: Panel) => void;
+  pagePath: string;
+  onClose: () => void;
+}) {
+  const [reloadToken, setReloadToken] = useState(0);
+
+  return (
+    <CrmModal
+      onClose={onClose}
+      ariaLabel="Rapportera till appen"
+      maxWidth="sm:max-w-[560px]"
+      header={
+        <div className="grid gap-2">
+          <div className="grid gap-0.5">
+            <h2 className="m-0 text-base font-bold text-slate-900">Rapportera</h2>
+            <p className="m-0 text-[12px] text-slate-500">
+              Buggar och önskemål om appen. Det du skickar hamnar i utvecklarens lista.
+            </p>
+          </div>
+          <div role="tablist" aria-label="Rapportera" className="flex gap-2">
+            <PanelTab active={panel === 'form'} onClick={() => setPanel('form')}>
+              Ny rapport
+            </PanelTab>
+            <PanelTab active={panel === 'mine'} onClick={() => setPanel('mine')}>
+              Mina rapporter
+            </PanelTab>
+          </div>
+        </div>
+      }
+    >
+      {panel === 'form' ? (
+        <TicketForm
+          pagePath={pagePath}
+          onCreated={() => {
+            setPanel('mine');
+            setReloadToken((t) => t + 1);
+          }}
+        />
+      ) : (
+        <MyTickets reloadToken={reloadToken} />
+      )}
+    </CrmModal>
+  );
+}
+
+function PanelTab({ active, onClick, children }: { active: boolean; onClick: () => void; children: React.ReactNode }) {
+  return (
+    <button
+      type="button"
+      role="tab"
+      aria-selected={active}
+      onClick={onClick}
+      className={cn(
+        'rounded-full border px-3 py-1 text-[12px] font-semibold transition-colors',
+        active
+          ? 'border-emerald-200 bg-emerald-50 text-emerald-700'
+          : 'border-[#e0e8dc] bg-white text-slate-600 hover:border-emerald-200',
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
+function TicketForm({ pagePath, onCreated }: { pagePath: string; onCreated: () => void }) {
+  const toast = useToast();
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const [kind, setKind] = useState<TicketKind>('bug');
+  const [area, setArea] = useState<TicketArea>(() => guessAreaFromPath(pagePath));
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [screenshot, setScreenshot] = useState<File | null>(null);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Förhandsvisningen är en blob-URL — den måste återkallas, annars läcker bilden minne så länge
+  // fliken lever.
+  useEffect(() => {
+    if (!screenshot) {
+      setPreviewUrl(null);
+      return;
+    }
+    const url = URL.createObjectURL(screenshot);
+    setPreviewUrl(url);
+    return () => URL.revokeObjectURL(url);
+  }, [screenshot]);
+
+  const clearScreenshot = () => {
+    setScreenshot(null);
+    // Nollställ även inputen, annars kan samma fil inte väljas igen (ingen change-händelse).
+    if (fileInputRef.current) fileInputRef.current.value = '';
+  };
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    if (!title.trim()) {
+      setError('Skriv en kort rubrik.');
+      return;
+    }
+    if (!description.trim()) {
+      setError('Beskriv vad som händer.');
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      // FormData, inte JSON: skärmbilden går som binär del i stället för base64 (som hade svällt
+      // kroppen ~33 %).
+      const form = new FormData();
+      form.set('kind', kind);
+      form.set('area', area);
+      form.set('title', title.trim());
+      form.set('description', description.trim());
+      form.set('page_path', pagePath);
+      if (screenshot) form.set('screenshot', screenshot);
+
+      const res = await fetch('/api/support/tickets', { method: 'POST', body: form });
+      const j = await res.json().catch(() => null);
+      if (!res.ok) throw new Error(j?.error || 'Kunde inte skicka rapporten.');
+
+      toast.success('Rapporten är skickad.');
+      setTitle('');
+      setDescription('');
+      clearScreenshot();
+      // Före onCreated(): den byter panel och avmonterar det här formuläret, så en setState efteråt
+      // skulle träffa en komponent som inte finns kvar.
+      setSubmitting(false);
+      onCreated();
+    } catch (err: any) {
+      setError(err?.message || 'Kunde inte skicka rapporten.');
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <form onSubmit={submit} className="grid gap-4">
+      <div className="grid gap-1.5">
+        <span className={crm.label}>Vad gäller det?</span>
+        {/* Två alternativ → segmenterat val i stället för en <select>. Ett tryck i stället för
+            tre, och båda alternativen syns utan att öppna något. */}
+        <div className="grid grid-cols-2 gap-2">
+          {TICKET_KINDS.map((k) => (
+            <button
+              key={k}
+              type="button"
+              aria-pressed={kind === k}
+              onClick={() => setKind(k)}
+              disabled={submitting}
+              className={cn(
+                'inline-flex min-h-11 items-center justify-center gap-2 rounded-lg border text-[13px] font-semibold transition-colors',
+                kind === k
+                  ? 'border-emerald-300 bg-emerald-50 text-emerald-800'
+                  : 'border-[#dce4d8] bg-white text-slate-600 hover:border-[#c8d4c3]',
+              )}
+            >
+              <span
+                aria-hidden
+                className={cn('grid h-5 w-5 place-items-center rounded-full text-[12px] font-bold', ticketKindGlyphClass[k])}
+              >
+                {ticketKindGlyph[k]}
+              </span>
+              {kindLabel[k]}
+            </button>
+          ))}
+        </div>
+        <p className="m-0 text-[12px] text-slate-500">
+          {kind === 'bug' ? 'Något fungerar inte som det ska.' : 'Något du vill kunna göra i appen.'}
+        </p>
+      </div>
+
+      <div className="grid gap-1.5">
+        <label htmlFor="ticket-area" className={crm.label}>Var i appen?</label>
+        <Select
+          id="ticket-area"
+          value={area}
+          onChange={(e) => setArea(e.target.value as TicketArea)}
+          disabled={submitting}
+        >
+          {TICKET_AREAS.map((a) => (
+            <option key={a} value={a}>{areaLabel[a]}</option>
+          ))}
+        </Select>
+        {/* Sidan användaren står på. Visas för att den skickas med — och för att den ofta är mer
+            exakt än vald del av appen. Monospace: det är en adress, inte en mening. */}
+        <p className="m-0 flex flex-wrap items-center gap-1.5 text-[12px] text-slate-500">
+          Skickas med:
+          <code className="rounded border border-solid border-[#dce4d8] bg-[#f4f8f1] px-1.5 py-0.5 font-mono text-[11px] text-slate-600">
+            {pagePath}
+          </code>
+        </p>
+      </div>
+
+      <div className="grid gap-1.5">
+        <label htmlFor="ticket-title" className={crm.label}>Rubrik</label>
+        <Input
+          id="ticket-title"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder={kind === 'bug' ? 'T.ex. Offerten sparar inte' : 'T.ex. Sök på ordernummer'}
+          maxLength={120}
+          disabled={submitting}
+        />
+      </div>
+
+      <div className="grid gap-1.5">
+        <label htmlFor="ticket-description" className={crm.label}>
+          {kind === 'bug' ? 'Vad händer?' : 'Vad vill du kunna göra?'}
+        </label>
+        <Textarea
+          id="ticket-description"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          placeholder={
+            kind === 'bug'
+              ? 'Vad gjorde du, och vad hände i stället för det du väntade dig?'
+              : 'Beskriv vad du vill kunna göra, och varför.'
+          }
+          maxLength={4000}
+          disabled={submitting}
+        />
+      </div>
+
+      <div className="grid gap-1.5">
+        <span className={crm.label}>Skärmbild (frivilligt)</span>
+        {previewUrl ? (
+          <div className="grid gap-2">
+            {/* eslint-disable-next-line @next/next/no-img-element -- lokal blob-URL, inte en
+                optimerbar remote-bild */}
+            <img
+              src={previewUrl}
+              alt="Förhandsvisning av vald skärmbild"
+              className="max-h-56 w-full rounded-lg border border-solid border-[#dce4d8] bg-white object-contain"
+            />
+            <div className="flex items-center justify-between gap-2">
+              <span className="min-w-0 truncate text-[12px] text-slate-500">{screenshot?.name}</span>
+              <button
+                type="button"
+                onClick={clearScreenshot}
+                disabled={submitting}
+                className={cn(crm.ghostButton, 'shrink-0')}
+              >
+                Ta bort
+              </button>
+            </div>
+          </div>
+        ) : (
+          <label
+            htmlFor="ticket-screenshot"
+            className="inline-flex min-h-11 cursor-pointer items-center justify-center rounded-lg border border-dashed border-[#cfdcc9] bg-[#f4f8f1] px-3 text-[13px] font-semibold text-slate-600 transition-colors hover:border-emerald-300 hover:text-emerald-800"
+          >
+            Välj en bild
+          </label>
+        )}
+        <input
+          ref={fileInputRef}
+          id="ticket-screenshot"
+          type="file"
+          accept="image/*"
+          className="sr-only"
+          disabled={submitting}
+          onChange={(e) => {
+            const file = e.target.files?.[0] || null;
+            setError(null);
+            if (file && file.size > 10 * 1024 * 1024) {
+              setError('Skärmbilden är för stor (max 10 MB).');
+              clearScreenshot();
+              return;
+            }
+            setScreenshot(file);
+          }}
+        />
+      </div>
+
+      {error && <p className="m-0 text-sm text-red-700">{error}</p>}
+
+      <button
+        type="submit"
+        disabled={submitting}
+        className={cn(crm.formButton, 'w-full')}
+        style={{ backgroundColor: 'var(--crm-primary)' }}
+      >
+        {submitting ? 'Skickar…' : 'Skicka rapport'}
+      </button>
+    </form>
+  );
+}
+
+function MyTickets({ reloadToken }: { reloadToken: number }) {
+  const [items, setItems] = useState<AppTicketView[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/support/tickets?scope=mine', { cache: 'no-store' });
+      const j = await res.json().catch(() => null);
+      if (!res.ok) throw new Error(j?.error || 'Kunde inte hämta dina rapporter.');
+      setItems((j?.data?.items || []) as AppTicketView[]);
+    } catch (err: any) {
+      setError(err?.message || 'Kunde inte hämta dina rapporter.');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { load(); }, [load, reloadToken]);
+
+  if (loading) return <p className="m-0 text-sm text-slate-500">Laddar…</p>;
+  if (error) return <p className="m-0 text-sm text-red-700">{error}</p>;
+  if (items.length === 0) {
+    return (
+      <div className="rounded-2xl border border-dashed border-[#d5e0cf] bg-[#f4f8f1] px-4 py-8 text-center">
+        <p className="m-0 text-sm text-slate-500">
+          Du har inte rapporterat något än. Hittar du en bugg eller saknar något — skriv det här.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <ul role="list" className="m-0 grid list-none gap-1 p-0">
+      {items.map((t) => {
+        const expanded = expandedId === t.id;
+        return (
+          <li key={t.id}>
+            <button
+              type="button"
+              onClick={() => setExpandedId(expanded ? null : t.id)}
+              aria-expanded={expanded}
+              className="flex w-full items-stretch overflow-hidden rounded-lg border border-[#e0e8dc] bg-white text-left transition-colors hover:border-[#cfdcc9]"
+            >
+              <span className={cn('w-1.5 shrink-0', ticketStatusMeta[t.status].accent)} aria-hidden />
+              <span className="grid flex-1 gap-0.5 px-3 py-2">
+                <span className="flex flex-wrap items-center gap-2">
+                  <span className="text-[13px] font-bold text-slate-900">{t.title}</span>
+                  <span className={cn(crm.badge, ticketStatusMeta[t.status].badge)}>{t.status_label}</span>
+                </span>
+                <span className="text-[11px] text-slate-400">
+                  {t.kind_label} · {t.area_label} · {formatDate(t.created_at)}
+                </span>
+                {expanded && (
+                  <span className="mt-1 grid gap-2 border-t border-solid border-slate-100 pt-2">
+                    <span className="whitespace-pre-wrap text-[12px] text-slate-700">{t.description}</span>
+                    {t.resolution && (
+                      <span className="grid gap-0.5 rounded-lg border border-solid border-[#e0e8dc] bg-[#f9fbf7] px-2.5 py-2">
+                        <span className="text-[10px] font-bold uppercase tracking-[0.12em] text-slate-400">Svar</span>
+                        <span className="whitespace-pre-wrap text-[12px] text-slate-700">{t.resolution}</span>
+                      </span>
+                    )}
+                  </span>
+                )}
+              </span>
+            </button>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+function formatDate(iso: string): string {
+  try {
+    return new Date(iso).toLocaleString('sv-SE', { day: 'numeric', month: 'short', hour: '2-digit', minute: '2-digit' });
+  } catch {
+    return '';
+  }
+}

--- a/app/components/ReportIssueLauncher.tsx
+++ b/app/components/ReportIssueLauncher.tsx
@@ -49,12 +49,19 @@ export default function ReportIssueLauncher({ loggedIn }: { loggedIn: boolean })
   if (!loggedIn || isHiddenPath(pathname)) return null;
 
   return (
-    // `crm-shell` bär CRM:ets CSS-variabler (globals.css) — och de är scopade till DEN klassen, inte
-    // till :root. Eftersom komponenten med flit renderas UTANFÖR AppShell (fältvyn saknar skal) var
-    // `var(--crm-primary)` odefinierad här, och Skicka-knappen blev vit text på ingen bakgrund:
-    // osynlig. Wrappern återger variablerna till hela trädet — knappen OCH modalen — så varje
-    // CRM-token fungerar som på övriga ytor. Div:en är layoutneutral: allt inuti är `fixed`.
-    <div className="crm-shell">
+    // Två klasser, båda för att komponenten med flit renderas UTANFÖR AppShell (fältvyn saknar skal):
+    //
+    // `crm-shell` bär CRM:ets CSS-variabler, och de är scopade till DEN klassen — inte till :root.
+    // Utan den var `var(--crm-primary)` odefinierad och Skicka-knappen blev vit text på ingen
+    // bakgrund: osynlig.
+    //
+    // `support-surface` återställer Tailwinds border-reset (preflight är av). Utan den ritar
+    // `border` på en <div> ingen linje, och `border-t border-solid` blir en LÅDA — bredden sätts
+    // bara på toppen medan de tre andra sidorna faller tillbaka på webbläsarens `medium` (~3px).
+    // Med den: skriv `border`/`border-t` som vanligt och lägg ALDRIG till `border-solid` här.
+    //
+    // Div:en är layoutneutral: allt inuti är `fixed`.
+    <div className="crm-shell support-surface">
       <button
         type="button"
         onClick={() => {
@@ -289,7 +296,7 @@ function TicketForm({ pagePath, onCreated }: { pagePath: string; onCreated: () =
             exakt än vald del av appen. Monospace: det är en adress, inte en mening. */}
         <p className="m-0 flex flex-wrap items-center gap-1.5 text-[12px] text-slate-500">
           Skickas med:
-          <code className="rounded border border-solid border-[#dce4d8] bg-[#f4f8f1] px-1.5 py-0.5 font-mono text-[11px] text-slate-600">
+          <code className="rounded border border-[#dce4d8] bg-[#f4f8f1] px-1.5 py-0.5 font-mono text-[11px] text-slate-600">
             {pagePath}
           </code>
         </p>
@@ -334,7 +341,7 @@ function TicketForm({ pagePath, onCreated }: { pagePath: string; onCreated: () =
             <img
               src={previewUrl}
               alt="Förhandsvisning av vald skärmbild"
-              className="max-h-56 w-full rounded-lg border border-solid border-[#dce4d8] bg-white object-contain"
+              className="max-h-56 w-full rounded-lg border border-[#dce4d8] bg-white object-contain"
             />
             <div className="flex items-center justify-between gap-2">
               <span className="min-w-0 truncate text-[12px] text-slate-500">{screenshot?.name}</span>
@@ -451,10 +458,10 @@ function MyTickets({ reloadToken }: { reloadToken: number }) {
                   {t.kind_label} · {t.area_label} · {formatDate(t.created_at)}
                 </span>
                 {expanded && (
-                  <span className="mt-1 grid gap-2 border-t border-solid border-slate-100 pt-2">
+                  <span className="mt-1 grid gap-2 border-t border-slate-100 pt-2">
                     <span className="whitespace-pre-wrap text-[12px] text-slate-700">{t.description}</span>
                     {t.resolution && (
-                      <span className="grid gap-0.5 rounded-lg border border-solid border-[#e0e8dc] bg-[#f9fbf7] px-2.5 py-2">
+                      <span className="grid gap-0.5 rounded-lg border border-[#e0e8dc] bg-[#f9fbf7] px-2.5 py-2">
                         <span className="text-[10px] font-bold uppercase tracking-[0.12em] text-slate-400">Svar</span>
                         <span className="whitespace-pre-wrap text-[12px] text-slate-700">{t.resolution}</span>
                       </span>

--- a/app/globals.css
+++ b/app/globals.css
@@ -28,6 +28,19 @@
     border-width: 0;
     border-style: solid;
   }
+
+  /* Appärendena (Rapportera-knappen + backloggen i admin). Samma reset, samma skäl — men värt att
+     stava ut vilket fel den tar bort, för det var inte uppenbart: `border-t border-solid` sätter
+     stilen på ALLA fyra sidor och bredden bara på toppen, så de tre andra föll tillbaka på
+     webbläsarens `medium` (~3px) och en tänkt avdelarlinje blev en låda runt hela sektionen.
+     Med reseten beter sig varje border-utility som i vanlig Tailwind, och `border-solid` behöver
+     inte strös ut i komponenterna. */
+  .support-surface *,
+  .support-surface *::before,
+  .support-surface *::after {
+    border-width: 0;
+    border-style: solid;
+  }
 }
 
 /* Planning density: the board was designed a touch large, so scale the whole planning surface down

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,6 +6,7 @@ import { ToastProvider } from '../lib/Toast';
 import { TruckAssignmentsProvider } from '../lib/TruckAssignmentsContext';
 import AppShell from './components/AppShell';
 import InstallPrompt from '../components/pwa/InstallPrompt';
+import ReportIssueLauncher from './components/ReportIssueLauncher';
 
 export const viewport = {
   width: 'device-width',
@@ -45,6 +46,10 @@ export default async function RootLayout({ children }: { children: React.ReactNo
               {children}
             </AppShell>
             <InstallPrompt loggedIn={!!profile} />
+            {/* Utanför AppShell med flit: fältvyn /arbetsorder renderas utan skal, och det är
+                installatörerna som ser flest buggar. Komponenten gömmer sig själv på inloggnings-
+                och kundsidorna. */}
+            <ReportIssueLauncher loggedIn={!!profile} />
           </TruckAssignmentsProvider>
         </ToastProvider>
       </UserProfileProvider>

--- a/lib/domains/notifications/payload.ts
+++ b/lib/domains/notifications/payload.ts
@@ -61,3 +61,24 @@ export function buildFaultReportUpdatedNotification(input: FaultReportNotificati
     entity_id: input.reportId,
   };
 }
+
+// Sent to the admins when someone files an app ticket (bug report / feature request).
+//
+// The href deep-links straight into the backlog tab with the ärende pre-opened — the point of the
+// notification is to get from "phone buzzed" to "reading the report" in one tap.
+export function buildAppTicketCreatedNotification(input: {
+  ticketId: string;
+  kindLabel: string; // "Bugg" / "Förslag"
+  areaLabel: string; // e.g. "CRM, offerter & ordrar"
+  title: string;
+  reporterName: string;
+}): NotificationContent {
+  return {
+    type: 'app_ticket.created',
+    title: `${input.kindLabel}: ${input.title}`,
+    body: `${input.reporterName} · ${input.areaLabel}`,
+    href: `/admin?tab=arenden&arende=${input.ticketId}`,
+    entity_type: 'app_ticket',
+    entity_id: input.ticketId,
+  };
+}

--- a/lib/domains/support/areas.ts
+++ b/lib/domains/support/areas.ts
@@ -1,0 +1,33 @@
+import type { TicketArea } from './types';
+
+// Gissar vilken del av appen ett ärende gäller utifrån sidan användaren står på.
+//
+// Ren funktion i ett eget modul (inte i "use client"-komponenten) så den kan enhetstestas utan att
+// dra in next/navigation och hela modalen. Gissningen är det som gör formuläret snabbt att fylla i
+// — en felgissning ger en osorterad backlog, så ordningen nedan spelar roll: mer specifika prefix
+// måste testas före de bredare.
+export function guessAreaFromPath(pathname: string): TicketArea {
+  const path = pathname || '/';
+
+  // /crm/* har egna underytor som hör hemma i andra areor — de måste fångas före den breda
+  // /crm-grenen längre ner.
+  if (path.startsWith('/crm/planering') || path.startsWith('/plannering')) return 'planning';
+  if (path.startsWith('/crm/korjournal')) return 'korjournal';
+  if (path.startsWith('/crm/dokument') || path.startsWith('/mina-dokument') || path.startsWith('/dokument')) {
+    return 'documents';
+  }
+  if (path.startsWith('/crm')) return 'crm';
+
+  // Offertkalkylatorn är säljarnas verktyg och hör till samma värld som offerterna.
+  if (path.startsWith('/offert')) return 'crm';
+
+  if (path.startsWith('/mina-jobb') || path.startsWith('/arbetsorder')) return 'field';
+  if (path.startsWith('/egenkontroll') || path.startsWith('/archive')) return 'self_check';
+
+  // Både den nya /tid och den Blikk-kopplade /tidrapport är "Tidrapport" för den som använder dem.
+  if (path.startsWith('/tid')) return 'time';
+
+  if (path.startsWith('/auth')) return 'account';
+
+  return 'other';
+}

--- a/lib/domains/support/mappers.ts
+++ b/lib/domains/support/mappers.ts
@@ -1,0 +1,47 @@
+import {
+  areaLabel,
+  isClosedTicketStatus,
+  kindLabel,
+  statusLabel,
+  toTicketArea,
+  toTicketKind,
+  toTicketStatus,
+  type AppTicketRow,
+  type AppTicketView,
+} from './types';
+
+export function mapTicketRow(row: AppTicketRow): AppTicketView {
+  // Okänd kind ska aldrig kunna finnas (CHECK i DB) — men en rad från framtiden med en ny nyckel
+  // ska visas som något, inte krascha listan. 'bug' är den försiktiga tolkningen: hellre en
+  // felmärkt bugg i backloggen än ett bortglömt ärende.
+  const kind = toTicketKind(row.kind) ?? 'bug';
+  const area = toTicketArea(row.area);
+  const status = toTicketStatus(row.status);
+
+  return {
+    id: row.id,
+    reporter_id: row.reporter_id,
+    reporter_name: row.reporter_name,
+    kind,
+    kind_label: kindLabel[kind],
+    area,
+    area_label: areaLabel[area],
+    title: row.title,
+    description: row.description,
+    page_path: row.page_path,
+    status,
+    status_label: statusLabel[status],
+    is_closed: isClosedTicketStatus(status),
+    resolution: row.resolution,
+    has_screenshot: !!(row.screenshot_bucket && row.screenshot_path),
+    changelog_note: row.changelog_note,
+    changelog_published_at: row.changelog_published_at,
+    handled_at: row.handled_at,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+  };
+}
+
+export function mapTicketRows(rows: AppTicketRow[] | null | undefined): AppTicketView[] {
+  return (rows || []).map(mapTicketRow);
+}

--- a/lib/domains/support/mappers.ts
+++ b/lib/domains/support/mappers.ts
@@ -36,6 +36,7 @@ export function mapTicketRow(row: AppTicketRow): AppTicketView {
     has_screenshot: !!(row.screenshot_bucket && row.screenshot_path),
     changelog_note: row.changelog_note,
     changelog_published_at: row.changelog_published_at,
+    handled_by_name: row.handled_by_name,
     handled_at: row.handled_at,
     created_at: row.created_at,
     updated_at: row.updated_at,

--- a/lib/domains/support/mutations.ts
+++ b/lib/domains/support/mutations.ts
@@ -1,0 +1,110 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { mapTicketRow } from './mappers';
+import { ticketSelect } from './queries';
+import type { CreateTicketInput, UpdateTicketInput } from './schemas';
+import type { AppTicketRow, AppTicketView } from './types';
+
+type MutationResult = { data: AppTicketView | null; error: { message: string; code?: string } | null };
+
+// Skapar ärendet som den inloggade användaren (sessionsklient — RLS kräver reporter_id = auth.uid()).
+// Skärmbilden är redan uppladdad när vi kommer hit; bucket/path följer med som en färdig referens.
+export async function createTicket(
+  supabase: SupabaseClient,
+  input: CreateTicketInput & {
+    reporter_id: string;
+    reporter_name: string;
+    screenshot_bucket?: string | null;
+    screenshot_path?: string | null;
+  },
+): Promise<MutationResult> {
+  const result = await supabase
+    .from('app_tickets')
+    .insert({
+      reporter_id: input.reporter_id,
+      reporter_name: input.reporter_name,
+      kind: input.kind,
+      area: input.area,
+      title: input.title,
+      description: input.description,
+      page_path: input.page_path,
+      screenshot_bucket: input.screenshot_bucket ?? null,
+      screenshot_path: input.screenshot_path ?? null,
+    })
+    .select(ticketSelect)
+    .single();
+
+  return { data: result.data ? mapTicketRow(result.data as AppTicketRow) : null, error: result.error };
+}
+
+// Bygger den faktiska kolumnuppdateringen ur admins indata. Ren funktion (inget I/O) så reglerna
+// nedan är enhetstestade i stället för att bara existera i en route.
+//
+// `sentKeys` är nycklarna klienten faktiskt skickade. Zod fyller i defaults för utelämnade fält, och
+// att skriva dem hade nollat kolumner ingen rört — samma fälla som pickProvidedFields löser på
+// CRM-sidan (se app/api/crm/_shared.ts).
+export function buildTicketUpdatePatch(
+  input: UpdateTicketInput,
+  sentKeys: string[],
+  actor: { id: string },
+  now: string,
+): Record<string, unknown> {
+  const patch: Record<string, unknown> = { updated_at: now };
+  const sent = new Set(sentKeys);
+
+  if (sent.has('status') && input.status) {
+    patch.status = input.status;
+    // Vem som senast tog i ärendet, och när. Stämplas vid varje statusändring — inte bara den
+    // första — så "handled_at" svarar på "när rörde vi det här sist", vilket är frågan man
+    // faktiskt ställer om en backlog.
+    patch.handled_by = actor.id;
+    patch.handled_at = now;
+  }
+
+  if (sent.has('resolution')) patch.resolution = input.resolution ?? null;
+  if (sent.has('changelog_note')) patch.changelog_note = input.changelog_note ?? null;
+
+  if (sent.has('publish_to_changelog')) {
+    patch.changelog_published_at = input.publish_to_changelog ? now : null;
+  }
+
+  return patch;
+}
+
+// Avgör om patchen får publicera i changeloggen. Två villkor, båda för att skydda läsaren av
+// changeloggen: ärendet måste vara KLART (en publik rad om något ofixat är ett löfte, inte en
+// changelog), och det måste finnas en text att visa (annars blir raden tom).
+//
+// Tar emot både patchen och nuläget, eftersom admin kan publicera i samma sparning som hen sätter
+// status till 'done' och skriver texten — då finns inget av det i DB ännu.
+export function checkChangelogPublishable(args: {
+  patch: Record<string, unknown>;
+  current: { status: string; changelog_note: string | null };
+}): string | null {
+  const { patch, current } = args;
+  if (patch.changelog_published_at == null) return null; // publiceras inte i den här sparningen
+
+  const resultingStatus = (patch.status as string | undefined) ?? current.status;
+  if (resultingStatus !== 'done') {
+    return 'Bara ett klarmarkerat ärende kan publiceras i changeloggen.';
+  }
+
+  const resultingNote =
+    'changelog_note' in patch ? (patch.changelog_note as string | null) : current.changelog_note;
+  if (!resultingNote) {
+    return 'Skriv en changelog-text innan du publicerar ärendet.';
+  }
+
+  return null;
+}
+
+// Admin-uppdatering. RLS (app_tickets_update) släpper bara igenom admin; för alla andra matchar
+// UPDATE:n noll rader och `data` blir null — routen svarar 404/403 deliberat i stället för 500.
+export async function updateTicket(
+  supabase: SupabaseClient,
+  id: string,
+  patch: Record<string, unknown>,
+): Promise<MutationResult> {
+  const result = await supabase.from('app_tickets').update(patch).eq('id', id).select(ticketSelect).maybeSingle();
+
+  return { data: result.data ? mapTicketRow(result.data as AppTicketRow) : null, error: result.error };
+}

--- a/lib/domains/support/mutations.ts
+++ b/lib/domains/support/mutations.ts
@@ -45,7 +45,7 @@ export async function createTicket(
 export function buildTicketUpdatePatch(
   input: UpdateTicketInput,
   sentKeys: string[],
-  actor: { id: string },
+  actor: { id: string; name: string },
   now: string,
 ): Record<string, unknown> {
   const patch: Record<string, unknown> = { updated_at: now };
@@ -55,8 +55,10 @@ export function buildTicketUpdatePatch(
     patch.status = input.status;
     // Vem som senast tog i ärendet, och när. Stämplas vid varje statusändring — inte bara den
     // första — så "handled_at" svarar på "när rörde vi det här sist", vilket är frågan man
-    // faktiskt ställer om en backlog.
+    // faktiskt ställer om en backlog. Namnet lagras som kopia eftersom `profiles` är
+    // self-read-only och alltså inte går att läsa upp i efterhand.
     patch.handled_by = actor.id;
+    patch.handled_by_name = actor.name;
     patch.handled_at = now;
   }
 
@@ -107,4 +109,17 @@ export async function updateTicket(
   const result = await supabase.from('app_tickets').update(patch).eq('id', id).select(ticketSelect).maybeSingle();
 
   return { data: result.data ? mapTicketRow(result.data as AppTicketRow) : null, error: result.error };
+}
+
+// Raderar ärendet (admin, RLS app_tickets_delete). Returnerar den RÅA raden — inte vyn — eftersom
+// anroparen behöver bucket och path för att städa bort skärmbilden ur storage. Utan `.select()` vet
+// vi inte vilken fil som just blev föräldralös. Noll rader tillbaka = RLS nekade, eller raden fanns
+// inte.
+export async function deleteTicket(
+  supabase: SupabaseClient,
+  id: string,
+): Promise<{ data: AppTicketRow | null; error: { message: string; code?: string } | null }> {
+  const result = await supabase.from('app_tickets').delete().eq('id', id).select(ticketSelect).maybeSingle();
+
+  return { data: (result.data as AppTicketRow | null) ?? null, error: result.error };
 }

--- a/lib/domains/support/queries.ts
+++ b/lib/domains/support/queries.ts
@@ -6,7 +6,7 @@ import type { ListTicketsQuery } from './schemas';
 // select-strängens LITERALTYP, och `'a' + 'b'` degraderar den till `string` — då blir `data` en
 // union med GenericStringError och varje mappning kräver en dubbelcast.
 export const ticketSelect =
-  'id, reporter_id, reporter_name, kind, area, title, description, page_path, status, resolution, screenshot_bucket, screenshot_path, changelog_note, changelog_published_at, handled_by, handled_at, created_at, updated_at';
+  'id, reporter_id, reporter_name, kind, area, title, description, page_path, status, resolution, screenshot_bucket, screenshot_path, changelog_note, changelog_published_at, handled_by, handled_by_name, handled_at, created_at, updated_at';
 
 // Öppna statusar uttryckt som en positiv lista. Att i stället negera de stängda (`not.in`) hade
 // gett samma svar men kräver PostgREST-citering i strängform — en positiv `.in()` går inte att

--- a/lib/domains/support/queries.ts
+++ b/lib/domains/support/queries.ts
@@ -1,0 +1,63 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { CLOSED_TICKET_STATUSES, TICKET_STATUSES, type TicketKind, type TicketStatus } from './types';
+import type { ListTicketsQuery } from './schemas';
+
+// EN sammanhållen literal, inte ihopslagna delsträngar: supabase-js typar svaret utifrån
+// select-strängens LITERALTYP, och `'a' + 'b'` degraderar den till `string` — då blir `data` en
+// union med GenericStringError och varje mappning kräver en dubbelcast.
+export const ticketSelect =
+  'id, reporter_id, reporter_name, kind, area, title, description, page_path, status, resolution, screenshot_bucket, screenshot_path, changelog_note, changelog_published_at, handled_by, handled_at, created_at, updated_at';
+
+// Öppna statusar uttryckt som en positiv lista. Att i stället negera de stängda (`not.in`) hade
+// gett samma svar men kräver PostgREST-citering i strängform — en positiv `.in()` går inte att
+// stava fel, och listan härleds ur samma källa så en ny status inte kan glömmas bort här.
+const OPEN_TICKET_STATUSES: TicketStatus[] = TICKET_STATUSES.filter((s) => !CLOSED_TICKET_STATUSES.includes(s));
+
+type TicketFilters = Pick<ListTicketsQuery, 'status' | 'kind' | 'state'>;
+
+// Gemensam filtrering för båda scoparna, så "mina" och backloggen aldrig tolkar samma
+// frågeparametrar olika.
+function applyFilters<T extends { eq: any; in: any }>(query: T, filters: TicketFilters): T {
+  let q: any = query;
+  // En explicit status vinner över state — den är mer specifik, och att lägga båda hade kunnat ge
+  // en tom lista utan att användaren förstår varför (t.ex. state=open + status=done).
+  if (filters.status) {
+    q = q.eq('status', filters.status);
+  } else if (filters.state === 'open') {
+    q = q.in('status', OPEN_TICKET_STATUSES);
+  } else if (filters.state === 'closed') {
+    q = q.in('status', CLOSED_TICKET_STATUSES as TicketStatus[]);
+  }
+  if (filters.kind) q = q.eq('kind', filters.kind as TicketKind);
+  return q as T;
+}
+
+// Rapportörens egna ärenden. En användares egna ärenden är få — inget behov av paginering.
+export async function listMyTickets(supabase: SupabaseClient, reporterId: string, filters: TicketFilters) {
+  const query = supabase
+    .from('app_tickets')
+    .select(ticketSelect)
+    .eq('reporter_id', reporterId)
+    .order('created_at', { ascending: false })
+    .limit(100);
+
+  return applyFilters(query as any, filters);
+}
+
+// Backloggen (admin). Taket ligger under PostgREST:s radgräns; växer den förbi 500 öppna ärenden
+// är det ett annat problem än paginering.
+export async function listAllTickets(supabase: SupabaseClient, filters: TicketFilters) {
+  const query = supabase
+    .from('app_tickets')
+    .select(ticketSelect)
+    .order('created_at', { ascending: false })
+    .limit(500);
+
+  return applyFilters(query as any, filters);
+}
+
+// RLS avgör synligheten: rapportören ser sin egen rad, admin ser alla. maybeSingle → null när
+// raden inte finns ELLER är osynlig, så routen kan svara 404 i stället för att läcka ett 500.
+export async function getTicket(supabase: SupabaseClient, id: string) {
+  return supabase.from('app_tickets').select(ticketSelect).eq('id', id).maybeSingle();
+}

--- a/lib/domains/support/recipients.ts
+++ b/lib/domains/support/recipients.ts
@@ -1,0 +1,23 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+// Vem som notifieras om ett nytt appärende.
+//
+// VARFÖR ADMINROLLEN OCH INGEN EGEN MOTTAGARLISTA: felanmälan har en tabell
+// (fault_report_recipients) eftersom "arbetsledare" inte är en roll i appen. Här sammanfaller
+// mottagaren med den som kan agera — backloggen är admin-gatad, så att notifiera exakt den
+// mängden håller notis och behörighet i takt automatiskt. Ingen tabell, ingen adminyta att
+// underhålla, ingen risk att listan säger en sak och RLS en annan.
+//
+// Service-role-klient krävs: `profiles` är self-read-only under RLS, så en sessionsklient hade
+// aldrig fått se någon annans rad.
+export async function listTicketNotifyRecipients(admin: SupabaseClient): Promise<string[]> {
+  const { data, error } = await admin.from('profiles').select('id').eq('role', 'admin');
+  if (error || !data) return [];
+  return (data as Array<{ id: string }>).map((row) => row.id).filter(Boolean);
+}
+
+// Rapportören ska inte få en notis om sitt eget ärende — hen står framför formuläret och har redan
+// sett bekräftelsen. Gäller på riktigt: den som rapporterar är ofta själv admin.
+export function excludeReporter(recipientIds: string[], reporterId: string | null): string[] {
+  return recipientIds.filter((id) => id !== reporterId);
+}

--- a/lib/domains/support/schemas.ts
+++ b/lib/domains/support/schemas.ts
@@ -1,0 +1,93 @@
+import { z } from 'zod';
+import { TICKET_AREAS, TICKET_KINDS, TICKET_STATUSES } from './types';
+
+// Fritextlängder. Titeln är en etikett i en lista, inte en beskrivning — taket hindrar att någon
+// klistrar in hela buggen där och gör backloggen oläslig. Beskrivningens tak är generöst men
+// ändligt, så en klistrad stacktrace inte blir en obegränsad kolumn.
+const TITLE_MAX = 120;
+const DESCRIPTION_MAX = 4000;
+const RESOLUTION_MAX = 4000;
+const CHANGELOG_NOTE_MAX = 500;
+const PAGE_PATH_MAX = 500;
+
+// Tomt → null, annars trimmat. Används på varje valfritt textfält så "   " aldrig lagras som text.
+const optionalText = (max: number) =>
+  z.preprocess(
+    (v) => {
+      if (v == null) return null;
+      const t = String(v).trim();
+      return t.length > 0 ? t.slice(0, max) : null;
+    },
+    z.string().max(max).nullable(),
+  );
+
+export const createTicketSchema = z.object({
+  kind: z.enum(TICKET_KINDS, { errorMap: () => ({ message: 'Välj om det är en bugg eller ett förslag' }) }),
+  area: z.enum(TICKET_AREAS, { errorMap: () => ({ message: 'Välj vilken del av appen det gäller' }) }),
+  title: z.string().trim().min(1, 'Skriv en kort rubrik').max(TITLE_MAX, `Rubriken får vara högst ${TITLE_MAX} tecken`),
+  description: z
+    .string()
+    .trim()
+    .min(1, 'Beskriv vad som händer')
+    .max(DESCRIPTION_MAX, `Beskrivningen får vara högst ${DESCRIPTION_MAX} tecken`),
+  // Fylls av klienten (window.location.pathname), inte av användaren. Valideras ändå: en absolut
+  // URL eller ett protokoll-relativt värde här hade blivit en öppen redirect om vyn någon gång
+  // gör den klickbar. Bara app-interna sökvägar accepteras.
+  page_path: z.preprocess(
+    (v) => {
+      if (v == null) return null;
+      const t = String(v).trim();
+      if (!t.startsWith('/') || t.startsWith('//')) return null;
+      return t.slice(0, PAGE_PATH_MAX);
+    },
+    z.string().max(PAGE_PATH_MAX).nullable(),
+  ),
+});
+
+export type CreateTicketInput = z.infer<typeof createTicketSchema>;
+
+// Admin-uppdatering. Alla fält är valfria — routen skriver bara det klienten faktiskt skickade
+// (pickProvidedFields), så en statusändring inte nollar ett resolution-svar.
+export const updateTicketSchema = z.object({
+  status: z.enum(TICKET_STATUSES, { errorMap: () => ({ message: 'Ogiltig status' }) }).optional(),
+  resolution: optionalText(RESOLUTION_MAX).optional(),
+  changelog_note: optionalText(CHANGELOG_NOTE_MAX).optional(),
+  // true = publicera i changeloggen, false = ta tillbaka. Tidsstämpeln sätts serverside.
+  publish_to_changelog: z.boolean().optional(),
+});
+
+export type UpdateTicketInput = z.infer<typeof updateTicketSchema>;
+
+export const listTicketsQuerySchema = z.object({
+  scope: z.enum(['mine', 'all']).optional().default('mine'),
+  status: z.enum(TICKET_STATUSES).optional(),
+  kind: z.enum(TICKET_KINDS).optional(),
+  // 'open' (default i backloggen) döljer klara/avvisade; 'closed' visar bara dem; 'any' allt.
+  // Skilt från `status` så vyn kan visa "det som återstår" utan att välja en enda status.
+  state: z.enum(['open', 'closed', 'any']).optional().default('any'),
+});
+
+export type ListTicketsQuery = z.infer<typeof listTicketsQuerySchema>;
+
+// Skärmbilden. Bara bilder, och ett tak som rymmer en telefonskärmdump utan att bli en
+// uppladdningskanal. Filen kommer som en del av en multipart-POST (FormData), aldrig som base64
+// i JSON — det senare hade svällt kroppen ~33 %.
+export const SCREENSHOT_MAX_BYTES = 10 * 1024 * 1024;
+export const SCREENSHOT_CONTENT_TYPES = ['image/png', 'image/jpeg', 'image/webp', 'image/gif', 'image/heic', 'image/heif'] as const;
+
+export function validateScreenshot(file: { size: number; type: string; name: string }): string | null {
+  if (file.size === 0) return 'Skärmbilden är tom.';
+  if (file.size > SCREENSHOT_MAX_BYTES) return 'Skärmbilden är för stor (max 10 MB).';
+  // Vissa mobilbrowsers skickar tom type för HEIC — fall tillbaka på filändelsen.
+  const type = (file.type || '').toLowerCase();
+  if (type) {
+    if (!SCREENSHOT_CONTENT_TYPES.includes(type as (typeof SCREENSHOT_CONTENT_TYPES)[number])) {
+      return 'Bara bildfiler kan bifogas (png, jpg, webp, gif, heic).';
+    }
+    return null;
+  }
+  if (!/\.(png|jpe?g|webp|gif|heic|heif)$/i.test(file.name)) {
+    return 'Bara bildfiler kan bifogas (png, jpg, webp, gif, heic).';
+  }
+  return null;
+}

--- a/lib/domains/support/storage.ts
+++ b/lib/domains/support/storage.ts
@@ -1,0 +1,78 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+// Skärmbildslagring för appärenden.
+//
+// VARFÖR INGEN EGEN BUCKET: den befintliga bucketen används redan med prefix per område
+// (Documents/, Egenkontroller/) och all läsning sker via signerade URL:er som servern skapar med
+// service-role-nyckeln. En ny bucket hade krävt egna storage-policyer utan att ge något — åtkomsten
+// gatas ändå av app_tickets-RLS innan URL:en signeras. Namnet sparas per rad i DB
+// (screenshot_bucket), så en framtida flytt inte gör gamla rader olästbara.
+
+const SCREENSHOT_PREFIX = 'Support';
+
+// Signerad URL:s livstid. Kort med flit — den passerar genom ett JSON-svar och hamnar i
+// webbläsarhistorik/loggar; en halvtimme räcker gott för att titta på en bild i ett ärende.
+const SIGNED_URL_TTL_SECONDS = 60 * 30;
+
+export function getSupportBucket(): string {
+  return process.env.SUPABASE_SUPPORT_BUCKET || process.env.SUPABASE_BUCKET || 'pdfs';
+}
+
+// Samma teckenregler som dokumentbiblioteket (app/api/documents/_util.ts) — duplicerad med flit:
+// domänlagret ska inte importera ur app/api. Tar bort sökvägstecken och allt utanför [A-Za-z0-9_.-]
+// (åäö blir `_`, precis som i dokumentbiblioteket) så storage-nyckeln blir ren ASCII. Filnamnet är
+// bara kosmetik — ärendet bär all visningsinformation — så förlusten kostar ingenting.
+export function sanitizeScreenshotName(name: string): string {
+  const cleaned = String(name || '')
+    .trim()
+    .replace(/[\\/]+/g, '-')
+    .replace(/\s+/g, '-')
+    .replace(/\.+\./g, '.')
+    .replace(/[^\w.-]+/g, '_')
+    .trim();
+  return cleaned.slice(0, 120) || 'skarmbild';
+}
+
+export function buildScreenshotPath(fileName: string, uid: string): string {
+  return `${SCREENSHOT_PREFIX}/${uid}-${sanitizeScreenshotName(fileName)}`;
+}
+
+// Laddar upp skärmbilden och returnerar var den hamnade. Anropas FÖRE raden skapas, så en
+// misslyckad uppladdning aldrig lämnar ett ärende med en trasig bildreferens. Blir insert:en fel
+// efteråt städar anroparen bort objektet (removeScreenshot).
+export async function uploadScreenshot(
+  admin: SupabaseClient,
+  file: { name: string; type: string; bytes: Buffer | Uint8Array },
+): Promise<{ bucket: string; path: string; error: { message: string } | null }> {
+  const bucket = getSupportBucket();
+  const path = buildScreenshotPath(file.name, crypto.randomUUID());
+
+  const { error } = await admin.storage.from(bucket).upload(path, file.bytes, {
+    contentType: file.type || 'application/octet-stream',
+    upsert: false,
+  });
+
+  return { bucket, path, error: error ? { message: error.message } : null };
+}
+
+// Best-effort städning. Ett kvarglömt objekt är skräp, inte ett fel användaren ska se.
+export async function removeScreenshot(admin: SupabaseClient, bucket: string, path: string): Promise<void> {
+  try {
+    await admin.storage.from(bucket).remove([path]);
+  } catch {
+    /* ignoreras med flit */
+  }
+}
+
+// Kortlivad läs-URL. Anroparen MÅSTE ha gatat åtkomsten först (RLS-läsningen av raden) — den här
+// funktionen använder service-role och frågar inte vem som tittar.
+export async function getScreenshotUrl(
+  admin: SupabaseClient,
+  bucket: string | null,
+  path: string | null,
+): Promise<string | null> {
+  if (!bucket || !path) return null;
+  const { data, error } = await admin.storage.from(bucket).createSignedUrl(path, SIGNED_URL_TTL_SECONDS);
+  if (error || !data?.signedUrl) return null;
+  return data.signedUrl;
+}

--- a/lib/domains/support/types.ts
+++ b/lib/domains/support/types.ts
@@ -87,6 +87,7 @@ export type AppTicketRow = {
   changelog_note: string | null;
   changelog_published_at: string | null;
   handled_by: string | null;
+  handled_by_name: string | null;
   handled_at: string | null;
   created_at: string;
   updated_at: string;
@@ -113,6 +114,9 @@ export type AppTicketView = {
   has_screenshot: boolean;
   changelog_note: string | null;
   changelog_published_at: string | null;
+  // Vem som senast tog i ärendet, och när. Namnet är en beständig kopia — `profiles` är
+  // self-read-only, så det går inte att läsa upp i efterhand.
+  handled_by_name: string | null;
   handled_at: string | null;
   created_at: string;
   updated_at: string;

--- a/lib/domains/support/types.ts
+++ b/lib/domains/support/types.ts
@@ -1,0 +1,122 @@
+// Appärenden — domäntyper. DB lagrar stabila engelska nycklar (text + CHECK); de svenska
+// etiketterna bor här så listan, formuläret och notiserna renderar samma ord.
+//
+// Skilt från lib/domains/fault-reports/* med flit: felanmälan gäller företagets utrustning och
+// fan-outar till flera arbetsledare, det här gäller appen och går till utvecklaren. Se
+// supabase/sql/20260812_app_tickets.sql för resonemanget.
+
+export const TICKET_KINDS = ['bug', 'idea'] as const;
+export type TicketKind = (typeof TICKET_KINDS)[number];
+
+export const TICKET_AREAS = [
+  'crm',
+  'planning',
+  'field',
+  'self_check',
+  'time',
+  'documents',
+  'korjournal',
+  'account',
+  'other',
+] as const;
+export type TicketArea = (typeof TICKET_AREAS)[number];
+
+// Backlog-flödet. 'declined' är den ärliga utgången för ett ärende som inte blir av — utan den
+// hamnar sådana i 'new' för alltid och backloggen slutar gå att lita på.
+export const TICKET_STATUSES = ['new', 'planned', 'in_progress', 'done', 'declined'] as const;
+export type TicketStatus = (typeof TICKET_STATUSES)[number];
+
+// Statusar som räknas som avslutade — de göms bakom ett filter i backloggen så listan visar det
+// som återstår. Delas av admin-vyn och räknarna.
+export const CLOSED_TICKET_STATUSES: readonly TicketStatus[] = ['done', 'declined'];
+
+export function isClosedTicketStatus(status: TicketStatus): boolean {
+  return CLOSED_TICKET_STATUSES.includes(status);
+}
+
+export const kindLabel: Record<TicketKind, string> = {
+  bug: 'Bugg',
+  idea: 'Förslag',
+};
+
+export const areaLabel: Record<TicketArea, string> = {
+  crm: 'CRM, offerter & ordrar',
+  planning: 'Planering',
+  field: 'Mina jobb & arbetsorder',
+  self_check: 'Egenkontroll',
+  time: 'Tidrapport',
+  documents: 'Dokument',
+  korjournal: 'Körjournal',
+  account: 'Inloggning & konto',
+  other: 'Annat / vet inte',
+};
+
+export const statusLabel: Record<TicketStatus, string> = {
+  new: 'Ny',
+  planned: 'Planerad',
+  in_progress: 'Pågår',
+  done: 'Klar',
+  declined: 'Blir inte av',
+};
+
+export function toTicketKind(value: unknown): TicketKind | null {
+  return TICKET_KINDS.includes(value as TicketKind) ? (value as TicketKind) : null;
+}
+
+export function toTicketArea(value: unknown): TicketArea {
+  return TICKET_AREAS.includes(value as TicketArea) ? (value as TicketArea) : 'other';
+}
+
+export function toTicketStatus(value: unknown): TicketStatus {
+  return TICKET_STATUSES.includes(value as TicketStatus) ? (value as TicketStatus) : 'new';
+}
+
+export type AppTicketRow = {
+  id: string;
+  reporter_id: string | null;
+  reporter_name: string;
+  kind: string;
+  area: string;
+  title: string;
+  description: string;
+  page_path: string | null;
+  status: string;
+  resolution: string | null;
+  screenshot_bucket: string | null;
+  screenshot_path: string | null;
+  changelog_note: string | null;
+  changelog_published_at: string | null;
+  handled_by: string | null;
+  handled_at: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+export type AppTicketView = {
+  id: string;
+  reporter_id: string | null;
+  reporter_name: string;
+  kind: TicketKind;
+  kind_label: string;
+  area: TicketArea;
+  area_label: string;
+  title: string;
+  description: string;
+  page_path: string | null;
+  status: TicketStatus;
+  status_label: string;
+  is_closed: boolean;
+  resolution: string | null;
+  // Sant när raden bär en skärmbild. Själva URL:en är signerad och kortlivad, så den skickas bara
+  // med i detaljsvaret (screenshot_url) — aldrig i listan, som annars hade signerat N filer per
+  // laddning för bilder ingen tittar på.
+  has_screenshot: boolean;
+  changelog_note: string | null;
+  changelog_published_at: string | null;
+  handled_at: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+// Detaljsvaret: vyn + en färsk signerad URL till skärmbilden, när det finns en.
+export type AppTicketDetailView = AppTicketView & { screenshot_url: string | null };

--- a/supabase/sql/20260812_app_tickets.sql
+++ b/supabase/sql/20260812_app_tickets.sql
@@ -1,0 +1,142 @@
+-- Appärenden (ticket-/supportsystem för APPEN: buggar + funktionsönskemål).
+--
+-- VARFÖR EN EGEN DOMÄN OCH INTE FELANMÄLAN. `fault_reports` handlar om företagets fysiska grejer
+-- (truck, lastbil, isoleringsmaskin) och fan-outar till en admin-hanterad lista arbetsledare. Det
+-- här handlar om appen, och mottagaren är EN person: utvecklaren. Merparten av
+-- felanmälningsdomänen — recipients-tabellen, e-postutskicken, fan-out-maskineriet — hade alltså
+-- varit dödvikt här. Värdet ligger i att ärendena blir en BESTÄNDIG BACKLOG som går att följa upp,
+-- inte i utskick. Modellen nedan är byggd för det: status, vad som är kvar, vad som är gjort.
+--
+-- DEPLOY-ORDNING: helt ADDITIV (ny tabell, ny funktion, inga ändringar på befintliga objekt), så
+-- ordningen mellan SQL och kod spelar ingen roll. Körs SQL:en efter koden svarar routen 500 tills
+-- tabellen finns — inget läses fel, ingenting skrivs sönder. Kör i Supabase SQL editor. Idempotent.
+--
+-- ADMIN-GRINDEN: rollbaserad (`profiles.role = 'admin'`), inte en ny permission-nyckel. Skälet är
+-- att backloggen bor under `/admin`, och den ytan är rollgatad i hela appen (se app/admin/page.tsx
+-- och fault_report_recipients-policyerna). PERMISSIONS.md håller RBAC till CRM/Fortnox/tid/planering
+-- och säger uttryckligen att adminytorna migreras senare — då flyttar den här med, på ett ställe.
+
+-- ---------------------------------------------------------------------------
+-- Admin-predikat
+-- ---------------------------------------------------------------------------
+-- SECURITY DEFINER så policyerna kan läsa `profiles` utan att gå via dess egen RLS (och utan
+-- rekursion), STABLE så den beräknas ~en gång per query i stället för en gång per rad. Samma
+-- mönster som is_fault_report_recipient() och has_permission().
+create or replace function public.is_app_ticket_admin() returns boolean
+language sql stable security definer set search_path = public as $$
+  select exists (
+    select 1 from public.profiles p
+    where p.id = auth.uid() and p.role = 'admin'
+  );
+$$;
+grant execute on function public.is_app_ticket_admin() to authenticated;
+
+-- ---------------------------------------------------------------------------
+-- Ärenden
+-- ---------------------------------------------------------------------------
+
+create table if not exists public.app_tickets (
+  id             uuid primary key default gen_random_uuid(),
+
+  -- Nullable för att matcha ON DELETE SET NULL (en NOT NULL-kolumn + SET NULL avbryter
+  -- profilraderingen). reporter_name är den beständiga visningskopian: `profiles` är self-read-only,
+  -- så admin kan inte läsa om rapportörens namn i efterhand. Samma resonemang som fault_reports.
+  reporter_id    uuid references public.profiles(id) on delete set null,
+  reporter_name  text not null,
+
+  -- 'bug' = något är trasigt, 'idea' = önskemål. Grundskillnaden i backloggen.
+  kind           text not null,
+  -- Vilken del av appen det gäller. Rapportören väljer; page_path fylls automatiskt.
+  area           text not null,
+  -- Kort etikett så backloggen går att skanna, + hela beskrivningen.
+  title          text not null,
+  description    text not null,
+  -- Sidan användaren stod på när hen tryckte Rapportera (t.ex. "/crm/arbetsorder/<uuid>"). Fylls av
+  -- klienten, inte av användaren — det är oftast mer exakt än vald area.
+  page_path      text,
+
+  status         text not null default 'new',
+  -- Vad som gjordes / varför det inte blir av. Syns för rapportören, så hen slutar fråga.
+  resolution     text,
+
+  -- Skärmbild. Bucket sparas per rad (som documents_files) så en framtida bucketflytt inte gör
+  -- gamla rader olästbara. Filen ligger under prefixet Support/ i den befintliga bucketen —
+  -- ingen ny bucket, inga nya storage-policyer: läsning sker alltid via en signerad URL som
+  -- servern skapar med service-role-nyckeln, efter att den gatat på RLS-villkoren nedan.
+  screenshot_bucket text,
+  screenshot_path   text,
+
+  -- FÖRBEREDER CHANGELOGGEN (nästa bygg). Ett stängt ärende kan publiceras som en changelog-rad:
+  -- changelog_note är den publika texten, changelog_published_at att den är ute. Changelog-vyn
+  -- läser härifrån och kan sedan unionas med handskrivna poster i sin egen tabell — därför ligger
+  -- bara de två kolumnerna här, inga antaganden om changeloggens schema.
+  changelog_note         text,
+  changelog_published_at timestamptz,
+
+  handled_by     uuid references public.profiles(id) on delete set null,
+  handled_at     timestamptz,
+  created_at     timestamptz not null default now(),
+  updated_at     timestamptz not null default now(),
+
+  constraint app_tickets_kind_chk   check (kind in ('bug', 'idea')),
+  constraint app_tickets_status_chk check (status in ('new', 'planned', 'in_progress', 'done', 'declined')),
+  constraint app_tickets_area_chk   check (area in (
+    'crm', 'planning', 'field', 'self_check', 'time', 'documents', 'korjournal', 'account', 'other'
+  )),
+  -- Bucket och path hör ihop: antingen finns båda eller ingen. Utan detta kan en halv referens
+  -- uppstå och läsningen får gissa vilken bucket som gällde.
+  constraint app_tickets_screenshot_chk check (
+    (screenshot_bucket is null and screenshot_path is null)
+    or (screenshot_bucket is not null and screenshot_path is not null)
+  )
+);
+
+create index if not exists app_tickets_reporter_idx on public.app_tickets (reporter_id, created_at desc);
+create index if not exists app_tickets_status_idx   on public.app_tickets (status, created_at desc);
+-- Partiellt: changeloggen läser bara publicerade rader, och de är en liten delmängd.
+create index if not exists app_tickets_changelog_idx
+  on public.app_tickets (changelog_published_at desc)
+  where changelog_published_at is not null;
+
+alter table public.app_tickets enable row level security;
+grant select, insert, update on public.app_tickets to authenticated;
+
+-- Alla inloggade rapporterar, men bara som sig själva.
+drop policy if exists app_tickets_insert on public.app_tickets;
+create policy app_tickets_insert on public.app_tickets
+  for insert to authenticated
+  with check (reporter_id = auth.uid());
+
+-- Rapportören ser sina egna, admin ser alla.
+drop policy if exists app_tickets_select on public.app_tickets;
+create policy app_tickets_select on public.app_tickets
+  for select to authenticated
+  using (reporter_id = auth.uid() or public.is_app_ticket_admin());
+
+-- Bara admin ändrar status/svar/changelog. Rapportören kan INTE redigera sitt ärende i efterhand —
+-- backloggen ska inte kunna ändras under fötterna på den som håller i den. Matchande SELECT-policy
+-- finns ovan (UPDATE ⇒ SELECT-regeln).
+drop policy if exists app_tickets_update on public.app_tickets;
+create policy app_tickets_update on public.app_tickets
+  for update to authenticated
+  using (public.is_app_ticket_admin())
+  with check (public.is_app_ticket_admin());
+
+-- ── Verifiering (kör efter applicering) ──────────────────────────────────────
+--
+-- 1. Policyerna ska vara tre, och funktionen ska svara.
+--
+--      select policyname, cmd from pg_policies
+--      where schemaname = 'public' and tablename = 'app_tickets' order by policyname;
+--
+--      select public.is_app_ticket_admin();   -- true för dig, false för en installatör
+--
+-- 2. Constraint-listan ska innehålla alla fyra checkarna.
+--
+--      select conname from pg_constraint
+--      where conrelid = 'public.app_tickets'::regclass and contype = 'c' order by conname;
+--
+-- 3. Halv skärmbildsreferens ska nekas (förväntat: fel om app_tickets_screenshot_chk).
+--
+--      insert into public.app_tickets (reporter_id, reporter_name, kind, area, title, description, screenshot_bucket)
+--      values (auth.uid(), 'Test', 'bug', 'crm', 'x', 'y', 'pdfs');

--- a/supabase/sql/20260812_app_tickets_admin_actions.sql
+++ b/supabase/sql/20260812_app_tickets_admin_actions.sql
@@ -1,0 +1,55 @@
+-- Appärenden, komplettering: admin får radera, och den som tog i ärendet syns.
+--
+-- ⚠️ DEPLOY-ORDNING: **KÖR DEN HÄR FÖRE KODEN.** Additiv i sig (ny kolumn, ny policy, nytt grant —
+-- inget befintligt ändras), MEN koden som hör till selectar `handled_by_name`. Deployas koden först
+-- svarar PostgREST "column does not exist" på VARJE läsning av app_tickets — hela ärendelistan och
+-- Mina rapporter går ner, inte bara den nya funktionen. Kör SQL:en först och ordningen kan inte
+-- bita. Se lärdomen i 20260812_invoice_rounds_index_compat.sql.
+--
+-- Kör i Supabase SQL editor. Idempotent.
+--
+-- VARFÖR RADERING ÖVER HUVUD TAGET. `declined` ("Blir inte av") är ett svar till rapportören och ska
+-- ligga kvar — det är information. En dubblett eller ett skräpärende är inte information, det är
+-- brus i den lista som ska svara på "vad är kvar". Utan radering växer bruset monotont och
+-- backloggen slutar gå att lita på. Därför BÅDA: declined för beslut, delete för brus.
+
+-- ---------------------------------------------------------------------------
+-- Vem som senast tog i ärendet
+-- ---------------------------------------------------------------------------
+-- Namnet lagras som en beständig kopia, precis som reporter_name: `profiles` är self-read-only under
+-- RLS, så en admin kan inte läsa upp en ANNAN admins namn i efterhand. handled_by (FK) blir kvar för
+-- spårbarheten, handled_by_name är det som går att visa.
+alter table public.app_tickets
+  add column if not exists handled_by_name text;
+
+-- ---------------------------------------------------------------------------
+-- Radering (admin)
+-- ---------------------------------------------------------------------------
+-- Grantet saknades helt i 20260812_app_tickets.sql (select, insert, update) — utan det nekas DELETE
+-- på tabellnivå innan RLS ens hinner titta.
+grant delete on public.app_tickets to authenticated;
+
+-- Bara admin raderar. Rapportören kan inte ta bort sitt eget ärende: det som är rapporterat är
+-- rapporterat, och en backlog som kan tömmas av den som fyllde den är ingen backlog.
+drop policy if exists app_tickets_delete on public.app_tickets;
+create policy app_tickets_delete on public.app_tickets
+  for delete to authenticated
+  using (public.is_app_ticket_admin());
+
+-- ── Verifiering (kör efter applicering) ──────────────────────────────────────
+--
+-- 1. Kolumnen ska finnas.
+--
+--      select column_name from information_schema.columns
+--      where table_schema = 'public' and table_name = 'app_tickets' and column_name = 'handled_by_name';
+--
+-- 2. Policyerna ska nu vara FYRA, en per kommando.
+--
+--      select policyname, cmd from pg_policies
+--      where schemaname = 'public' and tablename = 'app_tickets' order by cmd;
+--
+-- 3. Grantet ska omfatta delete.
+--
+--      select privilege_type from information_schema.role_table_grants
+--      where table_schema = 'public' and table_name = 'app_tickets' and grantee = 'authenticated'
+--      order by privilege_type;

--- a/tests/support/tickets.test.ts
+++ b/tests/support/tickets.test.ts
@@ -41,6 +41,7 @@ const baseRow: AppTicketRow = {
   changelog_note: null,
   changelog_published_at: null,
   handled_by: null,
+  handled_by_name: null,
   handled_at: null,
   created_at: '2026-08-12T08:00:00.000Z',
   updated_at: '2026-08-12T08:00:00.000Z',
@@ -176,7 +177,7 @@ describe('mapTicketRow', () => {
 
 describe('buildTicketUpdatePatch', () => {
   const now = '2026-08-12T10:00:00.000Z';
-  const actor = { id: '33333333-3333-4333-8333-333333333333' };
+  const actor = { id: '33333333-3333-4333-8333-333333333333', name: 'William' };
 
   it('skriver BARA de fält klienten skickade', () => {
     const patch = buildTicketUpdatePatch(
@@ -185,7 +186,13 @@ describe('buildTicketUpdatePatch', () => {
       actor,
       now,
     );
-    expect(patch).toEqual({ updated_at: now, status: 'planned', handled_by: actor.id, handled_at: now });
+    expect(patch).toEqual({
+      updated_at: now,
+      status: 'planned',
+      handled_by: actor.id,
+      handled_by_name: actor.name,
+      handled_at: now,
+    });
     expect(patch).not.toHaveProperty('resolution');
     expect(patch).not.toHaveProperty('changelog_note');
   });
@@ -195,10 +202,21 @@ describe('buildTicketUpdatePatch', () => {
     expect(patch.resolution).toBeNull();
   });
 
-  it('stämplar handled_by/handled_at vid varje statusändring', () => {
+  // Namnet lagras som kopia: `profiles` är self-read-only, så det går inte att läsa upp i efterhand.
+  it('stämplar handled_by, handled_by_name och handled_at vid varje statusändring', () => {
     const patch = buildTicketUpdatePatch({ status: 'done' }, ['status'], actor, now);
     expect(patch.handled_by).toBe(actor.id);
+    expect(patch.handled_by_name).toBe(actor.name);
     expect(patch.handled_at).toBe(now);
+  });
+
+  // Bara en statusändring stämplar hanteraren. Att rätta en stavning i svaret är inte att "ta i"
+  // ärendet, och skulle annars skriva om när det senast hände något.
+  it('stämplar INTE hanteraren när bara svaret ändras', () => {
+    const patch = buildTicketUpdatePatch({ resolution: 'rättad text' }, ['resolution'], actor, now);
+    expect(patch).not.toHaveProperty('handled_by');
+    expect(patch).not.toHaveProperty('handled_by_name');
+    expect(patch).not.toHaveProperty('handled_at');
   });
 
   it('sätter och tar bort changelog-publiceringen', () => {

--- a/tests/support/tickets.test.ts
+++ b/tests/support/tickets.test.ts
@@ -1,0 +1,360 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  createTicketSchema,
+  updateTicketSchema,
+  listTicketsQuerySchema,
+  validateScreenshot,
+  SCREENSHOT_MAX_BYTES,
+} from '@/lib/domains/support/schemas';
+import { mapTicketRow, mapTicketRows } from '@/lib/domains/support/mappers';
+import { buildTicketUpdatePatch, checkChangelogPublishable } from '@/lib/domains/support/mutations';
+import { guessAreaFromPath } from '@/lib/domains/support/areas';
+import { buildScreenshotPath, sanitizeScreenshotName } from '@/lib/domains/support/storage';
+import { excludeReporter } from '@/lib/domains/support/recipients';
+import {
+  TICKET_AREAS,
+  TICKET_KINDS,
+  TICKET_STATUSES,
+  areaLabel,
+  isClosedTicketStatus,
+  kindLabel,
+  statusLabel,
+  type AppTicketRow,
+} from '@/lib/domains/support/types';
+import { buildAppTicketCreatedNotification } from '@/lib/domains/notifications/payload';
+
+const baseRow: AppTicketRow = {
+  id: '11111111-1111-4111-8111-111111111111',
+  reporter_id: '22222222-2222-4222-8222-222222222222',
+  reporter_name: 'Anna Installatör',
+  kind: 'bug',
+  area: 'crm',
+  title: 'Offerten sparar inte',
+  description: 'Jag trycker Spara och inget händer.',
+  page_path: '/crm/offerter',
+  status: 'new',
+  resolution: null,
+  screenshot_bucket: null,
+  screenshot_path: null,
+  changelog_note: null,
+  changelog_published_at: null,
+  handled_by: null,
+  handled_at: null,
+  created_at: '2026-08-12T08:00:00.000Z',
+  updated_at: '2026-08-12T08:00:00.000Z',
+};
+
+describe('createTicketSchema', () => {
+  const valid = { kind: 'bug', area: 'crm', title: 'Rubrik', description: 'Beskrivning', page_path: '/crm' };
+
+  it('accepterar varje kind och area', () => {
+    for (const kind of TICKET_KINDS) {
+      expect(createTicketSchema.parse({ ...valid, kind }).kind).toBe(kind);
+    }
+    for (const area of TICKET_AREAS) {
+      expect(createTicketSchema.parse({ ...valid, area }).area).toBe(area);
+    }
+  });
+
+  it('avvisar okänd kind och area', () => {
+    expect(() => createTicketSchema.parse({ ...valid, kind: 'question' })).toThrow();
+    expect(() => createTicketSchema.parse({ ...valid, area: 'fortnox' })).toThrow();
+  });
+
+  it('kräver rubrik och beskrivning, och trimmar dem', () => {
+    expect(() => createTicketSchema.parse({ ...valid, title: '   ' })).toThrow();
+    expect(() => createTicketSchema.parse({ ...valid, description: '' })).toThrow();
+    const parsed = createTicketSchema.parse({ ...valid, title: '  Rubrik  ', description: '  Text  ' });
+    expect(parsed.title).toBe('Rubrik');
+    expect(parsed.description).toBe('Text');
+  });
+
+  it('avvisar en rubrik över 120 tecken', () => {
+    expect(() => createTicketSchema.parse({ ...valid, title: 'a'.repeat(121) })).toThrow();
+    expect(createTicketSchema.parse({ ...valid, title: 'a'.repeat(120) }).title).toHaveLength(120);
+  });
+
+  // page_path fylls av klienten men får aldrig bli en väg ut ur appen: skulle en vy göra den
+  // klickbar vore en absolut URL en öppen redirect.
+  it('släpper bara igenom app-interna sökvägar i page_path', () => {
+    expect(createTicketSchema.parse({ ...valid, page_path: '/crm/arbetsorder/abc' }).page_path).toBe('/crm/arbetsorder/abc');
+    expect(createTicketSchema.parse({ ...valid, page_path: 'https://evil.example/x' }).page_path).toBeNull();
+    expect(createTicketSchema.parse({ ...valid, page_path: '//evil.example/x' }).page_path).toBeNull();
+    expect(createTicketSchema.parse({ ...valid, page_path: 'crm/offerter' }).page_path).toBeNull();
+    expect(createTicketSchema.parse({ ...valid, page_path: null }).page_path).toBeNull();
+  });
+});
+
+describe('updateTicketSchema', () => {
+  it('tillåter en tom uppdatering (routen avgör att inget skickades)', () => {
+    expect(updateTicketSchema.parse({})).toEqual({});
+  });
+
+  it('normaliserar blanka texter till null och trimmar riktiga', () => {
+    expect(updateTicketSchema.parse({ resolution: '   ' }).resolution).toBeNull();
+    expect(updateTicketSchema.parse({ resolution: ' fixat ' }).resolution).toBe('fixat');
+    expect(updateTicketSchema.parse({ changelog_note: '  ny sökruta  ' }).changelog_note).toBe('ny sökruta');
+  });
+
+  it('avvisar en okänd status', () => {
+    expect(() => updateTicketSchema.parse({ status: 'closed' })).toThrow();
+    for (const status of TICKET_STATUSES) {
+      expect(updateTicketSchema.parse({ status }).status).toBe(status);
+    }
+  });
+});
+
+describe('listTicketsQuerySchema', () => {
+  it('defaultar scope till mine och state till any', () => {
+    const parsed = listTicketsQuerySchema.parse({});
+    expect(parsed.scope).toBe('mine');
+    expect(parsed.state).toBe('any');
+  });
+
+  it('avvisar okänd scope och state', () => {
+    expect(() => listTicketsQuerySchema.parse({ scope: 'everyone' })).toThrow();
+    expect(() => listTicketsQuerySchema.parse({ state: 'archived' })).toThrow();
+  });
+});
+
+describe('validateScreenshot', () => {
+  it('accepterar en vanlig bild', () => {
+    expect(validateScreenshot({ size: 1024, type: 'image/png', name: 'skarm.png' })).toBeNull();
+  });
+
+  it('avvisar tom fil och för stor fil', () => {
+    expect(validateScreenshot({ size: 0, type: 'image/png', name: 'x.png' })).toMatch(/tom/i);
+    expect(validateScreenshot({ size: SCREENSHOT_MAX_BYTES + 1, type: 'image/png', name: 'x.png' })).toMatch(/stor/i);
+  });
+
+  it('avvisar icke-bilder', () => {
+    expect(validateScreenshot({ size: 10, type: 'application/pdf', name: 'x.pdf' })).toMatch(/bildfiler/i);
+  });
+
+  // Vissa mobilbrowsers skickar tom content-type för HEIC.
+  it('faller tillbaka på filändelsen när content-type saknas', () => {
+    expect(validateScreenshot({ size: 10, type: '', name: 'IMG_0001.HEIC' })).toBeNull();
+    expect(validateScreenshot({ size: 10, type: '', name: 'anteckning.txt' })).toMatch(/bildfiler/i);
+  });
+});
+
+describe('mapTicketRow', () => {
+  it('sätter svenska etiketter för kind, area och status', () => {
+    const view = mapTicketRow(baseRow);
+    expect(view.kind_label).toBe(kindLabel.bug);
+    expect(view.area_label).toBe(areaLabel.crm);
+    expect(view.status_label).toBe(statusLabel.new);
+    expect(view.is_closed).toBe(false);
+  });
+
+  it('markerar klara och avvisade som stängda', () => {
+    expect(mapTicketRow({ ...baseRow, status: 'done' }).is_closed).toBe(true);
+    expect(mapTicketRow({ ...baseRow, status: 'declined' }).is_closed).toBe(true);
+    expect(isClosedTicketStatus('in_progress')).toBe(false);
+  });
+
+  it('kräver BÅDE bucket och path för has_screenshot', () => {
+    expect(mapTicketRow(baseRow).has_screenshot).toBe(false);
+    expect(mapTicketRow({ ...baseRow, screenshot_bucket: 'pdfs' }).has_screenshot).toBe(false);
+    expect(mapTicketRow({ ...baseRow, screenshot_bucket: 'pdfs', screenshot_path: 'Support/a.png' }).has_screenshot).toBe(true);
+  });
+
+  it('faller tillbaka på begripliga värden för okända nycklar i stället för att krascha', () => {
+    const view = mapTicketRow({ ...baseRow, kind: 'nonsens', area: 'nonsens', status: 'nonsens' });
+    expect(view.kind).toBe('bug');
+    expect(view.area).toBe('other');
+    expect(view.status).toBe('new');
+  });
+
+  it('mapTicketRows hanterar null', () => {
+    expect(mapTicketRows(null)).toEqual([]);
+    expect(mapTicketRows([baseRow])).toHaveLength(1);
+  });
+});
+
+describe('buildTicketUpdatePatch', () => {
+  const now = '2026-08-12T10:00:00.000Z';
+  const actor = { id: '33333333-3333-4333-8333-333333333333' };
+
+  it('skriver BARA de fält klienten skickade', () => {
+    const patch = buildTicketUpdatePatch(
+      { status: 'planned', resolution: 'svar', changelog_note: 'text' },
+      ['status'],
+      actor,
+      now,
+    );
+    expect(patch).toEqual({ updated_at: now, status: 'planned', handled_by: actor.id, handled_at: now });
+    expect(patch).not.toHaveProperty('resolution');
+    expect(patch).not.toHaveProperty('changelog_note');
+  });
+
+  it('nollar ett fält som skickats som null', () => {
+    const patch = buildTicketUpdatePatch({ resolution: null }, ['resolution'], actor, now);
+    expect(patch.resolution).toBeNull();
+  });
+
+  it('stämplar handled_by/handled_at vid varje statusändring', () => {
+    const patch = buildTicketUpdatePatch({ status: 'done' }, ['status'], actor, now);
+    expect(patch.handled_by).toBe(actor.id);
+    expect(patch.handled_at).toBe(now);
+  });
+
+  it('sätter och tar bort changelog-publiceringen', () => {
+    expect(buildTicketUpdatePatch({ publish_to_changelog: true }, ['publish_to_changelog'], actor, now).changelog_published_at).toBe(now);
+    expect(buildTicketUpdatePatch({ publish_to_changelog: false }, ['publish_to_changelog'], actor, now).changelog_published_at).toBeNull();
+  });
+
+  it('ger bara updated_at när inget skickades — routen tolkar det som tom sparning', () => {
+    expect(buildTicketUpdatePatch({}, [], actor, now)).toEqual({ updated_at: now });
+  });
+});
+
+describe('checkChangelogPublishable', () => {
+  const current = { status: 'new', changelog_note: null as string | null };
+
+  it('bryr sig inte om sparningar som inte publicerar', () => {
+    expect(checkChangelogPublishable({ patch: { updated_at: 'x' }, current })).toBeNull();
+    expect(checkChangelogPublishable({ patch: { changelog_published_at: null }, current })).toBeNull();
+  });
+
+  it('kräver att ärendet är klart', () => {
+    const error = checkChangelogPublishable({
+      patch: { changelog_published_at: 'nu', changelog_note: 'text' },
+      current,
+    });
+    expect(error).toMatch(/klarmarkerat/i);
+  });
+
+  it('kräver en text att visa', () => {
+    const error = checkChangelogPublishable({
+      patch: { changelog_published_at: 'nu', status: 'done' },
+      current,
+    });
+    expect(error).toMatch(/changelog-text/i);
+  });
+
+  // Status, text och publicering sätts ofta i EN sparning — då finns inget av det i DB ännu.
+  it('godkänner när status och text sätts i samma sparning', () => {
+    expect(
+      checkChangelogPublishable({
+        patch: { changelog_published_at: 'nu', status: 'done', changelog_note: 'Sökruta tillagd' },
+        current,
+      }),
+    ).toBeNull();
+  });
+
+  it('godkänner när status och text redan står i ärendet', () => {
+    expect(
+      checkChangelogPublishable({
+        patch: { changelog_published_at: 'nu' },
+        current: { status: 'done', changelog_note: 'Sökruta tillagd' },
+      }),
+    ).toBeNull();
+  });
+
+  // Att tömma texten i samma sparning som man publicerar ska nekas — annars blir changelog-raden tom.
+  it('nekar när texten nollas i samma sparning', () => {
+    const error = checkChangelogPublishable({
+      patch: { changelog_published_at: 'nu', changelog_note: null },
+      current: { status: 'done', changelog_note: 'fanns förut' },
+    });
+    expect(error).toMatch(/changelog-text/i);
+  });
+});
+
+describe('guessAreaFromPath', () => {
+  it('väljer den mest specifika grenen först', () => {
+    expect(guessAreaFromPath('/crm/planering')).toBe('planning');
+    expect(guessAreaFromPath('/crm/korjournal')).toBe('korjournal');
+    expect(guessAreaFromPath('/crm/dokument')).toBe('documents');
+    expect(guessAreaFromPath('/crm/offerter/abc')).toBe('crm');
+  });
+
+  it('mappar fält-, egenkontroll- och tidytorna', () => {
+    expect(guessAreaFromPath('/mina-jobb')).toBe('field');
+    expect(guessAreaFromPath('/arbetsorder/abc')).toBe('field');
+    expect(guessAreaFromPath('/egenkontroll')).toBe('self_check');
+    expect(guessAreaFromPath('/archive')).toBe('self_check');
+    expect(guessAreaFromPath('/tid')).toBe('time');
+    expect(guessAreaFromPath('/tidrapport')).toBe('time');
+    expect(guessAreaFromPath('/plannering')).toBe('planning');
+  });
+
+  it('faller tillbaka på other för okända sidor', () => {
+    expect(guessAreaFromPath('/')).toBe('other');
+    expect(guessAreaFromPath('/nyheter')).toBe('other');
+    expect(guessAreaFromPath('')).toBe('other');
+  });
+});
+
+describe('skärmbildens lagringsväg', () => {
+  // Nyckeln blir ren ASCII: mellanslag → bindestreck, åäö och parenteser → _, ändelsen kvar.
+  it('rensar filnamnet men behåller ändelsen', () => {
+    expect(sanitizeScreenshotName('Skärm bild (1).png')).toBe('Sk_rm-bild-_1_.png');
+    expect(sanitizeScreenshotName('../../etc/passwd')).toBe('.-.-etc-passwd');
+    expect(sanitizeScreenshotName('')).toBe('skarmbild');
+  });
+
+  it('lägger allt under Support-prefixet med ett unikt id', () => {
+    expect(buildScreenshotPath('bild.png', 'uid-1')).toBe('Support/uid-1-bild.png');
+  });
+});
+
+describe('notismottagare', () => {
+  it('utesluter rapportören ur sina egna notiser', () => {
+    expect(excludeReporter(['a', 'b'], 'a')).toEqual(['b']);
+    expect(excludeReporter(['a', 'b'], null)).toEqual(['a', 'b']);
+  });
+});
+
+// Nycklarna finns på två ställen: TS-listorna och CHECK-villkoren i migrationen. Glider de isär
+// blir felet TYST i utvecklingen och ett 500 i drift — formuläret erbjuder ett värde som databasen
+// vägrar ta emot. Den här kontrollen är hela skyddet mot det.
+describe('TS-nycklarna matchar CHECK-villkoren i migrationen', () => {
+  const sql = readFileSync(join(process.cwd(), 'supabase/sql/20260812_app_tickets.sql'), 'utf8');
+
+  function allowedValues(constraint: string): string[] {
+    const start = sql.indexOf(constraint);
+    expect(start, `hittade inte ${constraint} i migrationen`).toBeGreaterThan(-1);
+    const match = sql.slice(start).match(/in \(([^)]*)\)/);
+    expect(match, `kunde inte läsa in-listan för ${constraint}`).not.toBeNull();
+    return [...(match as RegExpMatchArray)[1].matchAll(/'([^']+)'/g)].map((m) => m[1]);
+  }
+
+  it('kind', () => {
+    expect(allowedValues('app_tickets_kind_chk').sort()).toEqual([...TICKET_KINDS].sort());
+  });
+
+  it('status', () => {
+    expect(allowedValues('app_tickets_status_chk').sort()).toEqual([...TICKET_STATUSES].sort());
+  });
+
+  it('area', () => {
+    expect(allowedValues('app_tickets_area_chk').sort()).toEqual([...TICKET_AREAS].sort());
+  });
+
+  it('varje nyckel har en svensk etikett', () => {
+    for (const kind of TICKET_KINDS) expect(kindLabel[kind]).toBeTruthy();
+    for (const area of TICKET_AREAS) expect(areaLabel[area]).toBeTruthy();
+    for (const status of TICKET_STATUSES) expect(statusLabel[status]).toBeTruthy();
+  });
+});
+
+describe('buildAppTicketCreatedNotification', () => {
+  it('djuplänkar till backlog-fliken med ärendet förvalt', () => {
+    const content = buildAppTicketCreatedNotification({
+      ticketId: baseRow.id,
+      kindLabel: 'Bugg',
+      areaLabel: 'CRM, offerter & ordrar',
+      title: 'Offerten sparar inte',
+      reporterName: 'Anna Installatör',
+    });
+    expect(content.type).toBe('app_ticket.created');
+    expect(content.title).toBe('Bugg: Offerten sparar inte');
+    expect(content.href).toBe(`/admin?tab=arenden&arende=${baseRow.id}`);
+    expect(content.entity_type).toBe('app_ticket');
+    expect(content.entity_id).toBe(baseRow.id);
+  });
+});


### PR DESCRIPTION
Användarnas buggar och önskemål kom muntligt, i meddelanden och i förbifarten — inget spårades. Den här grenen ger dem en väg in, och en backlog som går att följa upp.

## Vad som byggs

**Rapportera-knappen** ligger i app-skalet och nås från varje inloggad sida, förifylld med sidan användaren stod på. Två flikar: *Ny rapport* och *Mina rapporter*, så den som rapporterat ser status och svar utan att fråga.

**Backloggen** är en ny flik `Ärenden` i `/admin`. Den öppnar på det som är **kvar** (`state=open`) i stället för allt — en lista där klart och blir-inte-av ligger blandat med nytt är en logg, inte en backlog. Listrad öppnar en modal, samma mönster som varje annan CRM-yta.

**Notis + push** till admin vid nytt ärende, via befintliga `deliverNotifications`. Ingen ny fan-out-maskin.

**Radering** (admin, två steg) för dubbletter och skräp. `declined` ("Blir inte av") ligger kvar — det är ett *svar* till rapportören och information i sig, medan brus inte är det.

## Beslut värda att granska

- **Skilt från felanmälan** (`lib/domains/fault-reports`) med flit: den gäller företagets utrustning och fan-outar till flera arbetsledare. Här är mottagaren admin, så mottagartabell + e-postutskick hade varit dödvikt.
- **Notiser går till alla admins**, inte en mottagarlista — mottagarna sammanfaller då automatiskt med dem som kan agera, så notis och behörighet aldrig glider isär.
- **Admin-grinden är rollbaserad**, ingen ny permission-nyckel: backloggen bor under `/admin` som är rollgatad i hela appen, och `PERMISSIONS.md` håller RBAC till CRM/Fortnox/tid/planering.
- **Skärmbilder i befintlig bucket** under prefix `Support/` — ingen ny bucket, inga nya storage-policyer. Läsning via kortlivad signerad URL som skapas **efter** att RLS läst raden.
- **Changeloggen förberedd:** `changelog_note` + `changelog_published_at` ligger på tabellen. Publicering kräver status `done` + en text — en publik rad om något ofixat är ett löfte, inte en changelog.

## Två fällor som fångades under bygget

1. **Osynlig Skicka-knapp.** `var(--crm-primary)` är scopad till `.crm-shell`, och komponenten renderas med flit *utanför* AppShell (fältvyn `/arbetsorder` saknar skal). Variabeln var odefinierad → vit text på ingen bakgrund. Löst med wrapper + fallback-färg.
2. **Fantomkanter.** `border-t border-solid` sätter stilen på alla fyra sidor men bredden bara på toppen; med preflight av föll de tre andra tillbaka på `medium` (~3px) och avdelaren blev en låda. Löst med den scopade reseten `.support-surface` — samma grepp som `.planning-density`/`.planning-modal` — så `border-solid` kunde tas bort helt ur komponenterna.

## Migreringar — båda är körda och verifierade

| Fil | Ordning |
|---|---|
| `20260812_app_tickets.sql` | Additiv, ordningsoberoende |
| `20260812_app_tickets_admin_actions.sql` | **SQL före kod** — koden selectar `handled_by_name` |

Verifierat mot skarp databas före merge: tabellen finns, kolumnen finns, och kodens exakta select-sträng svarar.

## Testning

- 968 tester gröna (`tests/support/tickets.test.ts` täcker scheman, mappning, patch-reglerna, changelog-grinden och area-gissningen)
- Ett regressionsskydd jämför TS-nycklarna mot CHECK-villkoren i migrationen — glider de isär blir felet annars tyst i utveckling och ett 500 i drift
- `npm run type-check` + `npm run build` rena
- Manuellt verifierat i appen: rapportera, notis, backlog, modal, radering

🤖 Generated with [Claude Code](https://claude.com/claude-code)