### PR TITLE
feat(changelog): visa vad som fixats och tillkommit i appen

### DIFF
--- a/app/_lib/changelogTokens.ts
+++ b/app/_lib/changelogTokens.ts
@@ -1,0 +1,44 @@
+import type { ChangelogCategory } from '@/lib/domains/changelog/types';
+
+// Visuella tokens för changeloggen. Delade mellan kortet på CRM-översikten och adminvyn.
+//
+// Tecknet gör mer jobb än färgen här: raderna är korta och ligger tätt, och en läsare som skannar
+// "vad har hänt" vill se SORTEN direkt — inte tolka en nyans. Färgen förstärker bara.
+export const changelogCategoryMeta: Record<ChangelogCategory, { glyph: string; badge: string; glyphClass: string }> = {
+  fixed: {
+    glyph: '✓',
+    badge: 'border-emerald-200 bg-emerald-50 text-emerald-800',
+    glyphClass: 'bg-emerald-100 text-emerald-700',
+  },
+  new: {
+    glyph: '+',
+    badge: 'border-sky-200 bg-sky-50 text-sky-800',
+    glyphClass: 'bg-sky-100 text-sky-700',
+  },
+  improved: {
+    glyph: '↑',
+    badge: 'border-violet-200 bg-violet-50 text-violet-700',
+    glyphClass: 'bg-violet-100 text-violet-700',
+  },
+};
+
+// Dagsrubrik i listan: "12 augusti" — året bara när det inte är innevarande, så den vanliga raden
+// blir så kort som möjligt. Tar emot ISO-datum (ÅÅÅÅ-MM-DD) ur groupChangelogByDay.
+export function formatChangelogDay(isoDay: string, today = new Date()): string {
+  const date = new Date(`${isoDay}T00:00:00`);
+  if (Number.isNaN(date.getTime())) return isoDay;
+
+  const sameYear = date.getFullYear() === today.getFullYear();
+  return new Intl.DateTimeFormat('sv-SE', {
+    day: 'numeric',
+    month: 'long',
+    ...(sameYear ? {} : { year: 'numeric' }),
+  }).format(date);
+}
+
+// Kompakt datum för kortets rader, där dagsrubriker inte får plats.
+export function formatChangelogStamp(iso: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return '';
+  return new Intl.DateTimeFormat('sv-SE', { day: 'numeric', month: 'short' }).format(date);
+}

--- a/app/admin/AdminTabsClient.tsx
+++ b/app/admin/AdminTabsClient.tsx
@@ -16,8 +16,9 @@ const AdminPermissions = dynamic(() => import('./permissions/AdminPermissions'),
 const AdminTimeReference = dynamic(() => import('./tid/AdminTimeReference'), { ssr: false });
 const AdminTimeApprovals = dynamic(() => import('./tid/AdminTimeApprovals'), { ssr: false });
 const AdminSupportTickets = dynamic(() => import('./support/AdminSupportTickets'), { ssr: false });
+const AdminChangelog = dynamic(() => import('./changelog/AdminChangelog'), { ssr: false });
 
-type AdminTab = 'users'|'permissions'|'contacts'|'depots'|'blikk'|'tid'|'attest'|'news'|'arenden';
+type AdminTab = 'users'|'permissions'|'contacts'|'depots'|'blikk'|'tid'|'attest'|'news'|'arenden'|'changelog';
 
 const tabs: Array<{ id: AdminTab; label: string; summary: string }> = [
   { id: 'users', label: 'Användare', summary: 'Konton, roller och taggar' },
@@ -29,6 +30,7 @@ const tabs: Array<{ id: AdminTab; label: string; summary: string }> = [
   { id: 'attest', label: 'Attest', summary: 'Lås tidrapporteringen per person och kalendermånad' },
   { id: 'news', label: 'Nyheter', summary: 'Skapa och publicera dashboardnyheter' },
   { id: 'arenden', label: 'Ärenden', summary: 'Buggar och önskemål som rapporterats i appen' },
+  { id: 'changelog', label: 'Changelog', summary: 'Vad som fixats och tillkommit — visas i CRM' },
 ];
 
 function resolveAdminTab(fromQuery: string | null, fromStorage: string | null): AdminTab | null {
@@ -99,6 +101,7 @@ export default function AdminTabsClient() {
         {tab==='attest' && <AdminTimeApprovals />}
         {tab==='news' && <AdminNews />}
         {tab==='arenden' && <AdminSupportTickets />}
+        {tab==='changelog' && <AdminChangelog />}
       </section>
     </PageShell>
   );

--- a/app/admin/changelog/AdminChangelog.tsx
+++ b/app/admin/changelog/AdminChangelog.tsx
@@ -1,0 +1,301 @@
+"use client";
+
+import React from 'react';
+import { cn } from '../../../lib/shared/cn';
+import { crm } from '../../crm/lib/crmTokens';
+import Input from '../../../components/ui/Input';
+import Select from '../../../components/ui/Select';
+import Textarea from '../../../components/ui/Textarea';
+import { changelogCategoryMeta, formatChangelogStamp } from '../../_lib/changelogTokens';
+import {
+  CHANGELOG_CATEGORIES,
+  categoryLabel,
+  type ChangelogCategory,
+  type ChangelogDraftView,
+} from '../../../lib/domains/changelog/types';
+
+// Admin → Changelog. Skriver de FRIA posterna.
+//
+// Ärendehärledda rader syns INTE här, med flit: de ägs av sitt ärende och publiceras i fliken
+// Ärenden. Två vägar in i samma text hade blivit två sanningar. Vyn säger det rakt ut i stället för
+// att lämna en gåta om varför en publicerad rad saknas.
+//
+// Utkast (published_at = null) finns för att en post oftast skrivs innan ändringen är ute. RLS
+// döljer dem för alla utom admin.
+//
+// OBS preflight är av (tailwind.config.js) — rot-elementet bär `support-surface`, som återställer
+// border-reseten. Skriv `border` som vanligt, lägg ALDRIG till `border-solid`.
+
+export default function AdminChangelog() {
+  const [entries, setEntries] = React.useState<ChangelogDraftView[]>([]);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState<string | null>(null);
+
+  const load = React.useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/changelog?scope=drafts', { cache: 'no-store', credentials: 'same-origin' });
+      const body = await res.json().catch(() => null);
+      if (!res.ok || !body?.ok) throw new Error(body?.error || `Fel (${res.status})`);
+      setEntries((body.data.entries || []) as ChangelogDraftView[]);
+    } catch (e) {
+      setError((e as Error).message);
+      setEntries([]);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  React.useEffect(() => { load(); }, [load]);
+
+  return (
+    <div className="support-surface grid grid-cols-1 gap-4 p-5">
+      <div className="grid gap-1">
+        <h2 className="m-0 text-lg font-bold text-slate-900">Changelog</h2>
+        <p className="m-0 text-sm text-slate-600">
+          Det som visas under <strong>Nytt i appen</strong> på CRM-översikten. Poster som kommer från
+          ett rapporterat ärende skrivs i fliken <strong>Ärenden</strong> och listas inte här.
+        </p>
+      </div>
+
+      <NewEntryForm onSaved={load} />
+
+      {error ? (
+        <div className="rounded-xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700">{error}</div>
+      ) : null}
+
+      {loading ? (
+        <p className="m-0 text-sm text-slate-400">Laddar…</p>
+      ) : entries.length === 0 && !error ? (
+        <div className="rounded-2xl border border-dashed border-[#d5e0cf] bg-[#f4f8f1] px-4 py-8 text-center">
+          <p className="m-0 text-sm text-slate-500">Inga egna poster ännu.</p>
+        </div>
+      ) : (
+        <ul role="list" className="m-0 grid list-none gap-1 p-0">
+          {entries.map((entry) => (
+            <li key={entry.id}>
+              <EntryRow entry={entry} onChanged={load} />
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function NewEntryForm({ onSaved }: { onSaved: () => void }) {
+  const [category, setCategory] = React.useState<ChangelogCategory>('fixed');
+  const [title, setTitle] = React.useState('');
+  const [body, setBody] = React.useState('');
+  const [saving, setSaving] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+
+  const submit = async (publish: boolean) => {
+    if (!title.trim()) {
+      setError('Skriv vad som ändrats.');
+      return;
+    }
+    setSaving(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/changelog', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'same-origin',
+        body: JSON.stringify({ category, title: title.trim(), body: body.trim() || null, publish }),
+      });
+      const payload = await res.json().catch(() => null);
+      if (!res.ok || !payload?.ok) throw new Error(payload?.error || `Fel (${res.status})`);
+      setTitle('');
+      setBody('');
+      onSaved();
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className={cn(crm.cardInner, 'grid gap-3')}>
+      <span className={crm.label}>Ny post</span>
+
+      <div className="grid gap-3 sm:grid-cols-[10rem_1fr] sm:items-start">
+        <div className="grid gap-1.5">
+          <label htmlFor="changelog-category" className={crm.label}>Sort</label>
+          <Select
+            id="changelog-category"
+            value={category}
+            onChange={(e) => setCategory(e.target.value as ChangelogCategory)}
+            disabled={saving}
+          >
+            {CHANGELOG_CATEGORIES.map((c) => (
+              <option key={c} value={c}>{categoryLabel[c]}</option>
+            ))}
+          </Select>
+        </div>
+
+        <div className="grid gap-1.5">
+          <label htmlFor="changelog-title" className={crm.label}>Vad ändrades?</label>
+          <Input
+            id="changelog-title"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder="T.ex. Ordern synkar nu kontakt och adress till Fortnox"
+            maxLength={160}
+            disabled={saving}
+          />
+        </div>
+      </div>
+
+      <div className="grid gap-1.5">
+        <label htmlFor="changelog-body" className={crm.label}>Mer (frivilligt)</label>
+        <Textarea
+          id="changelog-body"
+          value={body}
+          onChange={(e) => setBody(e.target.value)}
+          placeholder="Bara när rubriken inte räcker."
+          className="min-h-[60px]"
+          maxLength={2000}
+          disabled={saving}
+        />
+      </div>
+
+      {error ? <p className="m-0 text-sm text-red-700">{error}</p> : null}
+
+      <div className="flex flex-wrap gap-2">
+        <button
+          type="button"
+          onClick={() => submit(true)}
+          disabled={saving}
+          className={cn(crm.formButton)}
+          style={{ backgroundColor: 'var(--crm-primary, #1a3f26)' }}
+        >
+          {saving ? 'Sparar…' : 'Publicera'}
+        </button>
+        <button type="button" onClick={() => submit(false)} disabled={saving} className={cn(crm.ghostButton, 'h-9')}>
+          Spara som utkast
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function EntryRow({ entry, onChanged }: { entry: ChangelogDraftView; onChanged: () => void }) {
+  const [busy, setBusy] = React.useState(false);
+  const [confirmDelete, setConfirmDelete] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+  const published = !!entry.published_at;
+  const meta = changelogCategoryMeta[entry.category];
+
+  const patch = async (payload: Record<string, unknown>) => {
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/changelog/${entry.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'same-origin',
+        body: JSON.stringify(payload),
+      });
+      const body = await res.json().catch(() => null);
+      if (!res.ok || !body?.ok) throw new Error(body?.error || `Fel (${res.status})`);
+      onChanged();
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const remove = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/changelog/${entry.id}`, { method: 'DELETE', credentials: 'same-origin' });
+      const body = await res.json().catch(() => null);
+      if (!res.ok || !body?.ok) throw new Error(body?.error || `Fel (${res.status})`);
+      onChanged();
+    } catch (e) {
+      setError((e as Error).message);
+      setBusy(false);
+      setConfirmDelete(false);
+    }
+  };
+
+  return (
+    <div className="grid gap-2 rounded-lg border border-[#e0e8dc] bg-white px-3 py-2">
+      <div className="flex flex-wrap items-start gap-2">
+        <span
+          aria-hidden
+          className={cn('mt-0.5 grid h-4 w-4 shrink-0 place-items-center rounded-full text-[11px] font-bold', meta.glyphClass)}
+        >
+          {meta.glyph}
+        </span>
+        <div className="min-w-0 flex-1 grid gap-0.5">
+          <span className="text-[13px] font-semibold text-slate-900">{entry.title}</span>
+          {entry.body ? <span className="whitespace-pre-wrap text-[12px] text-slate-600">{entry.body}</span> : null}
+          <span className="text-[11px] text-slate-400">
+            {entry.category_label} · {entry.created_by_name}
+            {published ? ` · publicerad ${formatChangelogStamp(entry.published_at as string)}` : ''}
+          </span>
+        </div>
+        <span className={cn(crm.badge, published ? meta.badge : 'border-slate-200 bg-slate-50 text-slate-500')}>
+          {published ? 'Publicerad' : 'Utkast'}
+        </span>
+      </div>
+
+      {error ? <p className="m-0 text-[12px] text-red-700">{error}</p> : null}
+
+      <div className="flex flex-wrap gap-2">
+        {published ? (
+          <button
+            type="button"
+            onClick={() => patch({ publish: false })}
+            disabled={busy}
+            className={cn(crm.ghostButton, 'h-8')}
+            title="Tas ur listan men behålls här"
+          >
+            Avpublicera
+          </button>
+        ) : (
+          <button
+            type="button"
+            onClick={() => patch({ publish: true })}
+            disabled={busy}
+            className={cn(crm.formButton, 'h-8')}
+            style={{ backgroundColor: 'var(--crm-primary, #1a3f26)' }}
+          >
+            Publicera
+          </button>
+        )}
+
+        {confirmDelete ? (
+          <>
+            <button type="button" onClick={() => setConfirmDelete(false)} disabled={busy} className={cn(crm.ghostButton, 'h-8')}>
+              Avbryt
+            </button>
+            <button
+              type="button"
+              onClick={remove}
+              disabled={busy}
+              className="inline-flex h-8 items-center justify-center rounded-xl border border-rose-300 bg-rose-50 px-3 text-sm font-semibold text-rose-700 transition hover:bg-rose-100 disabled:opacity-50"
+            >
+              {busy ? 'Tar bort…' : 'Ja, ta bort'}
+            </button>
+          </>
+        ) : (
+          <button
+            type="button"
+            onClick={() => setConfirmDelete(true)}
+            disabled={busy}
+            className={cn(crm.ghostButton, 'h-8 hover:!border-rose-300 hover:!text-rose-600')}
+          >
+            Ta bort
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/api/changelog/[id]/route.ts
+++ b/app/api/changelog/[id]/route.ts
@@ -1,0 +1,75 @@
+import { cookies } from 'next/headers';
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
+import { getCurrentUser } from '@/lib/auth/route';
+import { ok, routeError, validationError, invalidUuidParam } from '@/lib/api/responses';
+import { updateChangelogEntrySchema } from '@/lib/domains/changelog/schemas';
+import { getEntry } from '@/lib/domains/changelog/queries';
+import {
+  buildEntryUpdatePatch,
+  deleteChangelogEntry,
+  updateChangelogEntry,
+} from '@/lib/domains/changelog/mutations';
+import type { ChangelogEntryRow } from '@/lib/domains/changelog/types';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+// Både PATCH och DELETE gäller BARA fritt skrivna poster. En ärendehärledd rad tas ur changeloggen
+// genom att avpubliceras på sitt ärende — den texten ägs där.
+export async function PATCH(req: Request, { params }: { params: { id: string } }) {
+  try {
+    const currentUser = await getCurrentUser();
+    if (!currentUser) return routeError(401, 'unauthorized', 'Unauthorized');
+    if (currentUser.role !== 'admin') return routeError(403, 'forbidden', 'Forbidden');
+
+    const badId = invalidUuidParam(params.id);
+    if (badId) return badId;
+
+    const rawBody = await req.json().catch(() => null);
+    const parsed = updateChangelogEntrySchema.safeParse(rawBody ?? {});
+    if (!parsed.success) return validationError(parsed.error);
+
+    const sentKeys = rawBody && typeof rawBody === 'object' && !Array.isArray(rawBody) ? Object.keys(rawBody) : [];
+
+    const supabase = createRouteHandlerClient({ cookies });
+    // Nuläget behövs för att avgöra publiceringstidpunkten: en redan publicerad post ska BEHÅLLA
+    // sin, annars flyttas gamla poster till toppen så fort man rättar ett stavfel.
+    const { data: current, error: readError } = await getEntry(supabase, params.id);
+    if (readError) return routeError(500, 'changelog_get_failed', readError.message);
+    if (!current) return routeError(404, 'not_found', 'Posten hittades inte.');
+
+    const patch = buildEntryUpdatePatch(parsed.data, sentKeys, new Date().toISOString(), {
+      published_at: (current as ChangelogEntryRow).published_at,
+    });
+    // updated_at ligger alltid i patchen; finns inget mer är det en tom sparning.
+    if (Object.keys(patch).length <= 1) return routeError(400, 'nothing_to_update', 'Inget att spara.');
+
+    const { data, error } = await updateChangelogEntry(supabase, params.id, patch);
+    if (error) return routeError(500, 'changelog_update_failed', error.message);
+    if (!data) return routeError(403, 'forbidden', 'Du kan inte ändra den här posten.');
+
+    return ok({ entry: data });
+  } catch (e: any) {
+    return routeError(500, 'changelog_unexpected', e?.message || 'Failed to update changelog entry');
+  }
+}
+
+export async function DELETE(_req: Request, { params }: { params: { id: string } }) {
+  try {
+    const currentUser = await getCurrentUser();
+    if (!currentUser) return routeError(401, 'unauthorized', 'Unauthorized');
+    if (currentUser.role !== 'admin') return routeError(403, 'forbidden', 'Forbidden');
+
+    const badId = invalidUuidParam(params.id);
+    if (badId) return badId;
+
+    const supabase = createRouteHandlerClient({ cookies });
+    const { data, error } = await deleteChangelogEntry(supabase, params.id);
+    if (error) return routeError(500, 'changelog_delete_failed', error.message);
+    if (!data) return routeError(404, 'not_found', 'Posten hittades inte.');
+
+    return ok({ deleted: true });
+  } catch (e: any) {
+    return routeError(500, 'changelog_unexpected', e?.message || 'Failed to delete changelog entry');
+  }
+}

--- a/app/api/changelog/route.ts
+++ b/app/api/changelog/route.ts
@@ -1,0 +1,83 @@
+import { cookies } from 'next/headers';
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
+import { getCurrentUser } from '@/lib/auth/route';
+import { ok, routeError, validationError } from '@/lib/api/responses';
+import { createChangelogEntrySchema, listChangelogQuerySchema } from '@/lib/domains/changelog/schemas';
+import { listAllEntries, listPublishedEntries, listPublishedTickets } from '@/lib/domains/changelog/queries';
+import { createChangelogEntry, mapEntriesToDrafts } from '@/lib/domains/changelog/mutations';
+import { mergeChangelog } from '@/lib/domains/changelog/merge';
+import type { ChangelogEntryRow, ChangelogTicketRow } from '@/lib/domains/changelog/types';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET(req: Request) {
+  try {
+    const currentUser = await getCurrentUser();
+    if (!currentUser) return routeError(401, 'unauthorized', 'Unauthorized');
+
+    const url = new URL(req.url);
+    const parsed = listChangelogQuerySchema.safeParse({
+      scope: url.searchParams.get('scope') ?? undefined,
+      limit: url.searchParams.get('limit') ?? undefined,
+    });
+    if (!parsed.success) return validationError(parsed.error);
+
+    const supabase = createRouteHandlerClient({ cookies });
+
+    // Adminvyn: fria poster inklusive utkast, INTE sammanslagna med ärendena. Ärendehärledda rader
+    // redigeras på sitt ärende — att visa dem som redigerbara här hade inbjudit till två vägar in
+    // i samma text.
+    if (parsed.data.scope === 'drafts') {
+      if (currentUser.role !== 'admin') return routeError(403, 'forbidden', 'Forbidden');
+      const { data, error } = await listAllEntries(supabase, parsed.data.limit);
+      if (error) return routeError(500, 'changelog_list_failed', error.message);
+      return ok({ entries: mapEntriesToDrafts(data as ChangelogEntryRow[] | null) });
+    }
+
+    // Den publika listan: båda källorna, sammanslagna och sorterade i TS. Två frågor i stället för
+    // en vy i databasen — texterna bor i olika tabeller med olika ägare, och en SQL-vy hade låst
+    // ihop dem.
+    const [entries, tickets] = await Promise.all([
+      listPublishedEntries(supabase, parsed.data.limit),
+      listPublishedTickets(supabase, parsed.data.limit),
+    ]);
+
+    if (entries.error) return routeError(500, 'changelog_list_failed', entries.error.message);
+    if (tickets.error) return routeError(500, 'changelog_list_failed', tickets.error.message);
+
+    const items = mergeChangelog(
+      entries.data as ChangelogEntryRow[] | null,
+      tickets.data as ChangelogTicketRow[] | null,
+    );
+
+    return ok({ items: items.slice(0, parsed.data.limit) });
+  } catch (e: any) {
+    return routeError(500, 'changelog_unexpected', e?.message || 'Failed to list changelog');
+  }
+}
+
+export async function POST(req: Request) {
+  try {
+    const currentUser = await getCurrentUser();
+    if (!currentUser) return routeError(401, 'unauthorized', 'Unauthorized');
+    if (currentUser.role !== 'admin') return routeError(403, 'forbidden', 'Forbidden');
+
+    const parsed = createChangelogEntrySchema.safeParse(await req.json().catch(() => null));
+    if (!parsed.success) return validationError(parsed.error);
+
+    const supabase = createRouteHandlerClient({ cookies });
+    const { data, error } = await createChangelogEntry(supabase, {
+      ...parsed.data,
+      created_by: currentUser.id,
+      created_by_name: currentUser.name || 'Okänd användare',
+      now: new Date().toISOString(),
+    });
+
+    if (error || !data) return routeError(500, 'changelog_create_failed', error?.message || 'Kunde inte spara posten.');
+
+    return ok({ entry: data }, 201);
+  } catch (e: any) {
+    return routeError(500, 'changelog_unexpected', e?.message || 'Failed to create changelog entry');
+  }
+}

--- a/app/crm/components/ChangelogCard.tsx
+++ b/app/crm/components/ChangelogCard.tsx
@@ -1,0 +1,230 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { cn } from '@/lib/shared/cn';
+import { crm } from '@/app/crm/lib/crmTokens';
+import CrmModal from '@/app/crm/components/CrmModal';
+import { changelogCategoryMeta, formatChangelogDay, formatChangelogStamp } from '@/app/_lib/changelogTokens';
+import { groupChangelogByDay, latestPublishedAt, newSince } from '@/lib/domains/changelog/merge';
+import type { ChangelogItemView } from '@/lib/domains/changelog/types';
+
+// "Nytt i appen" på CRM-översikten.
+//
+// PROBLEMET: ändringar går ut utan att någon vet om dem. En sida man måste hitta till löser det
+// inte — därför ligger de senaste raderna på ytan man ändå landar på, och modalen slår upp EN gång
+// när något tillkommit sedan sist.
+//
+// "Sedan sist" spåras i localStorage, inte i databasen. Det är per webbläsare i stället för per
+// användare, men det räcker för ett "har du sett det här?" och slipper en tabell + en skrivning vid
+// varje sidladdning. Samma val som nyhetsmodalen på dashboarden gjorde.
+//
+// OBS preflight är av (tailwind.config.js) — rot-elementet bär `support-surface`, som återställer
+// border-reseten för hela trädet (globals.css). Skriv `border`/`border-t` som vanligt här, och lägg
+// ALDRIG till `border-solid`.
+
+const SEEN_KEY = 'crm.changelog.seenAt';
+const CARD_ITEM_COUNT = 3;
+
+export default function ChangelogCard() {
+  const [items, setItems] = useState<ChangelogItemView[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [failed, setFailed] = useState(false);
+  const [modal, setModal] = useState<null | 'all' | 'new'>(null);
+  const [unseen, setUnseen] = useState<ChangelogItemView[]>([]);
+
+  // Stämplingen får bara ske en gång per laddning, annars kan en omrendering hinna nolla "nytt"
+  // innan modalen ens visats.
+  const stamped = useRef(false);
+
+  const markSeen = useCallback((list: ChangelogItemView[]) => {
+    // Nyaste postens tidsstämpel, inte `now`: webbläsarklockan kan gå fel, och `now` skulle då
+    // kunna hoppa över en post som publiceras strax efter.
+    const latest = latestPublishedAt(list);
+    if (!latest || typeof window === 'undefined') return;
+    try {
+      window.localStorage.setItem(SEEN_KEY, latest);
+    } catch {
+      /* privat läge / full kvot — inte värt ett felmeddelande */
+    }
+  }, []);
+
+  useEffect(() => {
+    let alive = true;
+    (async () => {
+      try {
+        const res = await fetch('/api/changelog?limit=100', { cache: 'no-store', credentials: 'same-origin' });
+        const body = await res.json().catch(() => null);
+        if (!alive) return;
+        if (!res.ok || !body?.ok) throw new Error(body?.error || `Fel (${res.status})`);
+
+        const list = (body.data.items || []) as ChangelogItemView[];
+        setItems(list);
+
+        if (stamped.current) return;
+        stamped.current = true;
+
+        let lastSeen: string | null = null;
+        try {
+          lastSeen = window.localStorage.getItem(SEEN_KEY);
+        } catch {
+          lastSeen = null;
+        }
+
+        const fresh = newSince(list, lastSeen);
+        if (fresh.length > 0) {
+          setUnseen(fresh);
+          setModal('new');
+        } else if (lastSeen === null) {
+          // Första besöket: stämpla direkt utan att visa något. Att slå upp hela historiken som
+          // "nytt" hade varit en modal med trettio rader som ingen läser.
+          markSeen(list);
+        }
+      } catch {
+        // Changeloggen är en trevlighet på en sida full av annat — den ska aldrig kunna ge ett
+        // felmeddelande som ser ut att gälla översikten. Kortet döljer sig i stället.
+        if (alive) setFailed(true);
+      } finally {
+        if (alive) setLoading(false);
+      }
+    })();
+    return () => { alive = false; };
+  }, [markSeen]);
+
+  const closeModal = () => {
+    markSeen(items);
+    setUnseen([]);
+    setModal(null);
+  };
+
+  if (loading || failed || items.length === 0) return null;
+
+  const preview = items.slice(0, CARD_ITEM_COUNT);
+
+  return (
+    <section className={cn('support-surface', crm.cardInner, 'grid grid-cols-1 gap-2.5')} aria-labelledby="changelog-heading">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <h2 id="changelog-heading" className={crm.sectionTitle}>Nytt i appen</h2>
+          {unseen.length > 0 && (
+            <span className={cn(crm.badge, 'border-emerald-200 bg-emerald-50 text-emerald-700')}>
+              {unseen.length} {unseen.length === 1 ? 'ny' : 'nya'}
+            </span>
+          )}
+        </div>
+        <button
+          type="button"
+          onClick={() => setModal('all')}
+          className="!border-0 !bg-transparent !p-0 text-[12px] font-semibold text-emerald-800 underline-offset-2 hover:underline"
+        >
+          Visa alla
+        </button>
+      </div>
+
+      <ul role="list" className="m-0 grid list-none gap-1.5 p-0">
+        {preview.map((item) => (
+          <li key={`${item.source}-${item.id}`} className="flex items-start gap-2">
+            <CategoryGlyph item={item} />
+            <span className="min-w-0 flex-1 text-[13px] leading-snug text-slate-800">{item.title}</span>
+            <span className="shrink-0 text-[11px] text-slate-400">{formatChangelogStamp(item.published_at)}</span>
+          </li>
+        ))}
+      </ul>
+
+      {modal && (
+        <CrmModal
+          onClose={closeModal}
+          ariaLabel="Nytt i appen"
+          maxWidth="sm:max-w-[560px]"
+          header={
+            <div className="grid gap-0.5">
+              <h2 className="m-0 text-base font-bold text-slate-900">
+                {modal === 'new' ? 'Nytt sedan du var här' : 'Nytt i appen'}
+              </h2>
+              <p className="m-0 text-[12px] text-slate-500">
+                {modal === 'new'
+                  ? 'Det här har ändrats sedan du senast öppnade CRM.'
+                  : 'Allt som fixats, tillkommit och förbättrats.'}
+              </p>
+            </div>
+          }
+          footer={
+            modal === 'new' ? (
+              <>
+                <button
+                  type="button"
+                  onClick={() => setModal('all')}
+                  className={cn(crm.ghostButton, 'flex-1 sm:flex-none sm:px-5')}
+                >
+                  Visa allt
+                </button>
+                <button
+                  type="button"
+                  onClick={closeModal}
+                  className={cn(crm.formButton, 'flex-1 sm:flex-none sm:px-5')}
+                  style={{ backgroundColor: 'var(--crm-primary, #1a3f26)' }}
+                >
+                  Okej
+                </button>
+              </>
+            ) : (
+              <button type="button" onClick={closeModal} className={cn(crm.ghostButton, 'flex-1 sm:flex-none sm:px-5')}>
+                Stäng
+              </button>
+            )
+          }
+        >
+          <ChangelogList items={modal === 'new' ? unseen : items} />
+        </CrmModal>
+      )}
+    </section>
+  );
+}
+
+function CategoryGlyph({ item }: { item: ChangelogItemView }) {
+  const meta = changelogCategoryMeta[item.category];
+  return (
+    <span
+      // Etiketten läses upp för skärmläsare; tecknet ensamt säger inget.
+      title={item.category_label}
+      className={cn('mt-0.5 grid h-4 w-4 shrink-0 place-items-center rounded-full text-[11px] font-bold', meta.glyphClass)}
+    >
+      <span aria-hidden>{meta.glyph}</span>
+      <span className="sr-only">{item.category_label}</span>
+    </span>
+  );
+}
+
+function ChangelogList({ items }: { items: ChangelogItemView[] }) {
+  if (items.length === 0) {
+    return <p className="m-0 text-sm text-slate-500">Inget att visa ännu.</p>;
+  }
+
+  const groups = groupChangelogByDay(items);
+
+  return (
+    <div className="grid gap-4">
+      {groups.map((group) => (
+        <section key={group.day} className="grid gap-1.5">
+          <h3 className={crm.sectionTitle}>{formatChangelogDay(group.day)}</h3>
+          <ul role="list" className="m-0 grid list-none gap-2 p-0">
+            {group.items.map((item) => (
+              <li key={`${item.source}-${item.id}`} className="flex items-start gap-2">
+                <CategoryGlyph item={item} />
+                <div className="min-w-0 flex-1 grid gap-0.5">
+                  <span className="text-[13px] font-semibold leading-snug text-slate-900">{item.title}</span>
+                  {item.body && (
+                    <span className="whitespace-pre-wrap text-[12px] leading-snug text-slate-600">{item.body}</span>
+                  )}
+                  {/* Loopen tillbaka till den som rapporterade: hen ser att just deras grej kom med. */}
+                  {item.reported_by && (
+                    <span className="text-[11px] text-slate-400">Rapporterat av {item.reported_by}</span>
+                  )}
+                </div>
+              </li>
+            ))}
+          </ul>
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/app/crm/components/CrmOverview.tsx
+++ b/app/crm/components/CrmOverview.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { useEffect, useMemo, useState } from 'react';
 import EmptyState from '../../../components/ui/EmptyState';
 import MetricCard from './MetricCard';
+import ChangelogCard from './ChangelogCard';
 import type { UserRole } from '@/lib/roles';
 import { getVisibleCrmNavItems } from '../_lib/nav';
 import { cn } from '@/lib/shared/cn';
@@ -714,6 +715,11 @@ export default function CrmOverview({ role }: { role: UserRole | null }) {
           <LeaderboardPanel loading={loading} teamLeaderboard={teamLeaderboard} />
         </div>
       </div>
+
+      {/* Nytt i appen. Ligger efter innehållet men före snabbnavigeringen: ändringarna ska synas
+          utan att man letar, men de är inte det man kom hit för. Kortet döljer sig självt när det
+          inte finns något att visa. */}
+      <ChangelogCard />
 
       {/* Quick nav */}
       {items.length > 0 ? (

--- a/app/globals.css
+++ b/app/globals.css
@@ -29,12 +29,16 @@
     border-style: solid;
   }
 
-  /* Appärendena (Rapportera-knappen + backloggen i admin). Samma reset, samma skäl — men värt att
-     stava ut vilket fel den tar bort, för det var inte uppenbart: `border-t border-solid` sätter
-     stilen på ALLA fyra sidor och bredden bara på toppen, så de tre andra föll tillbaka på
-     webbläsarens `medium` (~3px) och en tänkt avdelarlinje blev en låda runt hela sektionen.
-     Med reseten beter sig varje border-utility som i vanlig Tailwind, och `border-solid` behöver
-     inte strös ut i komponenterna. */
+  /* Appärendena (Rapportera-knappen + backloggen i admin) OCH changeloggen — samma familj: det
+     användarna säger in, och det som går ut till dem. Samma reset, samma skäl — men värt att stava
+     ut vilket fel den tar bort, för det var inte uppenbart: `border-t border-solid` sätter stilen
+     på ALLA fyra sidor och bredden bara på toppen, så de tre andra föll tillbaka på webbläsarens
+     `medium` (~3px) och en tänkt avdelarlinje blev en låda runt hela sektionen. Med reseten beter
+     sig varje border-utility som i vanlig Tailwind, och `border-solid` behöver inte strös ut i
+     komponenterna.
+
+     ⚠️ TEMPORÄR. Preflight ska slås på app-vitt när de gamla ytorna stängts ner — då ska den här
+     regeln och sina syskon ovan raderas, inte utökas med fler selektorer. */
   .support-surface *,
   .support-surface *::before,
   .support-surface *::after {

--- a/lib/domains/changelog/merge.ts
+++ b/lib/domains/changelog/merge.ts
@@ -1,0 +1,108 @@
+import {
+  categoryFromTicketKind,
+  categoryLabel,
+  toChangelogCategory,
+  type ChangelogEntryRow,
+  type ChangelogItemView,
+  type ChangelogTicketRow,
+} from './types';
+
+// Sammanslagningen av changeloggens två källor. Rent räknande, inget I/O — hela poängen är att
+// reglerna nedan går att enhetstesta i stället för att bara existera inuti en route.
+
+// En fritt skriven post blir en rad först när den är publicerad. Utkast filtreras bort här och inte
+// i SQL, så adminvyn kan läsa samma funktion utan en andra fråga.
+export function mapEntryToItem(row: ChangelogEntryRow): ChangelogItemView | null {
+  if (!row.published_at) return null;
+  const category = toChangelogCategory(row.category);
+  return {
+    id: row.id,
+    source: 'entry',
+    category,
+    category_label: categoryLabel[category],
+    title: row.title,
+    body: row.body,
+    published_at: row.published_at,
+    reported_by: null,
+  };
+}
+
+// Ett ärende blir en rad när BÅDE texten och publiceringstidpunkten finns. Kravet på texten är
+// medvetet dubbelt: routen vägrar redan publicera utan den, men en rad utan titel skulle bli en tom
+// punkt i listan — och en tom rad i en changelog är värre än ingen rad.
+export function mapTicketToItem(row: ChangelogTicketRow): ChangelogItemView | null {
+  if (!row.changelog_published_at) return null;
+  const title = (row.changelog_note || '').trim();
+  if (!title) return null;
+
+  const category = categoryFromTicketKind(row.kind);
+  return {
+    id: row.id,
+    source: 'ticket',
+    category,
+    category_label: categoryLabel[category],
+    title,
+    body: null,
+    published_at: row.changelog_published_at,
+    reported_by: row.reporter_name || null,
+  };
+}
+
+// Nyast först. Tidsstämplarna kan kollidera (två poster publicerade i samma sparning), så id:t är
+// andrasortering — utan den kan ordningen kastas om mellan två laddningar och listan "hoppa" utan
+// att något ändrats.
+export function mergeChangelog(
+  entries: ChangelogEntryRow[] | null | undefined,
+  tickets: ChangelogTicketRow[] | null | undefined,
+): ChangelogItemView[] {
+  const items = [
+    ...(entries || []).map(mapEntryToItem),
+    ...(tickets || []).map(mapTicketToItem),
+  ].filter((item): item is ChangelogItemView => item !== null);
+
+  return items.sort((a, b) => {
+    if (a.published_at !== b.published_at) return a.published_at < b.published_at ? 1 : -1;
+    return a.id < b.id ? 1 : -1;
+  });
+}
+
+// Grupperar på publiceringsdag. Nyckeln är ÅÅÅÅ-MM-DD; formateringen till svenska lämnas åt vyn.
+export type ChangelogDayGroup = { day: string; items: ChangelogItemView[] };
+
+// LOKALT datum, inte `published_at.slice(0, 10)`. Tidsstämpeln är UTC, så en post publicerad kvart
+// över midnatt svensk tid ligger på föregående UTC-dygn — och hade visats under "gårdagen" för den
+// som publicerade den några minuter tidigare. Samma resonemang som periodberäkningen i attestvyn:
+// lokala getters, aldrig toISOString.
+function localDayKey(iso: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return iso.slice(0, 10);
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${date.getFullYear()}-${month}-${day}`;
+}
+
+export function groupChangelogByDay(items: ChangelogItemView[]): ChangelogDayGroup[] {
+  const groups: ChangelogDayGroup[] = [];
+  for (const item of items) {
+    const day = localDayKey(item.published_at);
+    const last = groups[groups.length - 1];
+    // Listan är redan sorterad, så en dag kan bara vara den senast påbörjade gruppen.
+    if (last && last.day === day) last.items.push(item);
+    else groups.push({ day, items: [item] });
+  }
+  return groups;
+}
+
+// Vad som tillkommit sedan användaren sist tittade. `lastSeen` är en ISO-tid ur localStorage; saknas
+// den har användaren aldrig öppnat listan — och då är INGET nytt. Att visa hela historiken som
+// "nytt" första gången vore en modal med trettio rader som ingen läser.
+export function newSince(items: ChangelogItemView[], lastSeen: string | null): ChangelogItemView[] {
+  if (!lastSeen) return [];
+  return items.filter((item) => item.published_at > lastSeen);
+}
+
+// Tidsstämpeln att spara när listan visats: den nyaste posten, inte "nu". Klockan i webbläsaren kan
+// gå fel, och `now` skulle då kunna hoppa över en post som publiceras strax efter.
+export function latestPublishedAt(items: ChangelogItemView[]): string | null {
+  return items.length > 0 ? items[0].published_at : null;
+}

--- a/lib/domains/changelog/mutations.ts
+++ b/lib/domains/changelog/mutations.ts
@@ -1,0 +1,98 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { changelogEntrySelect } from './queries';
+import type { CreateChangelogEntryInput, UpdateChangelogEntryInput } from './schemas';
+import { categoryLabel, toChangelogCategory, type ChangelogDraftView, type ChangelogEntryRow } from './types';
+
+export function mapEntryToDraft(row: ChangelogEntryRow): ChangelogDraftView {
+  const category = toChangelogCategory(row.category);
+  return {
+    id: row.id,
+    category,
+    category_label: categoryLabel[category],
+    title: row.title,
+    body: row.body,
+    published_at: row.published_at,
+    created_by_name: row.created_by_name,
+    created_at: row.created_at,
+  };
+}
+
+export function mapEntriesToDrafts(rows: ChangelogEntryRow[] | null | undefined): ChangelogDraftView[] {
+  return (rows || []).map(mapEntryToDraft);
+}
+
+type MutationResult = { data: ChangelogDraftView | null; error: { message: string; code?: string } | null };
+
+export async function createChangelogEntry(
+  supabase: SupabaseClient,
+  input: CreateChangelogEntryInput & { created_by: string; created_by_name: string; now: string },
+): Promise<MutationResult> {
+  const result = await supabase
+    .from('app_changelog_entries')
+    .insert({
+      category: input.category,
+      title: input.title,
+      body: input.body ?? null,
+      // Publiceringstidpunkten är sorteringsnyckeln, inte created_at — så en post kan skrivas i
+      // förväg och dateras när den faktiskt går ut.
+      published_at: input.publish ? input.now : null,
+      created_by: input.created_by,
+      created_by_name: input.created_by_name,
+    })
+    .select(changelogEntrySelect)
+    .single();
+
+  return { data: result.data ? mapEntryToDraft(result.data as ChangelogEntryRow) : null, error: result.error };
+}
+
+// Bygger kolumnuppdateringen ur admins indata. Ren funktion — reglerna nedan är enhetstestade.
+//
+// `sentKeys` är nycklarna klienten faktiskt skickade: Zod fyller i defaults för utelämnade fält, och
+// att skriva dem hade nollat kolumner ingen rört.
+export function buildEntryUpdatePatch(
+  input: UpdateChangelogEntryInput,
+  sentKeys: string[],
+  now: string,
+  current: { published_at: string | null },
+): Record<string, unknown> {
+  const patch: Record<string, unknown> = { updated_at: now };
+  const sent = new Set(sentKeys);
+
+  if (sent.has('category') && input.category) patch.category = input.category;
+  if (sent.has('title') && input.title) patch.title = input.title;
+  if (sent.has('body')) patch.body = input.body ?? null;
+
+  if (sent.has('publish')) {
+    if (input.publish) {
+      // En redan publicerad post BEHÅLLER sin tidsstämpel. Att sätta om den vid varje sparning
+      // hade flyttat gamla poster till toppen så fort man rättade ett stavfel — och läsaren hade
+      // sett en två veckor gammal ändring presenteras som ny.
+      patch.published_at = current.published_at ?? now;
+    } else {
+      patch.published_at = null;
+    }
+  }
+
+  return patch;
+}
+
+export async function updateChangelogEntry(
+  supabase: SupabaseClient,
+  id: string,
+  patch: Record<string, unknown>,
+): Promise<MutationResult> {
+  const result = await supabase
+    .from('app_changelog_entries')
+    .update(patch)
+    .eq('id', id)
+    .select(changelogEntrySelect)
+    .maybeSingle();
+
+  return { data: result.data ? mapEntryToDraft(result.data as ChangelogEntryRow) : null, error: result.error };
+}
+
+// Raderar en fritt skriven post. Ärendehärledda rader raderas INTE här — de tas ur changeloggen
+// genom att avpubliceras på ärendet, som äger sin text.
+export async function deleteChangelogEntry(supabase: SupabaseClient, id: string) {
+  return supabase.from('app_changelog_entries').delete().eq('id', id).select('id').maybeSingle();
+}

--- a/lib/domains/changelog/queries.ts
+++ b/lib/domains/changelog/queries.ts
@@ -1,0 +1,47 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+// EN literal, inte ihopslagna delsträngar — supabase-js typar svaret utifrån select-strängens
+// literaltyp, och `'a' + 'b'` degraderar den till `string`.
+export const changelogEntrySelect =
+  'id, category, title, body, published_at, created_by, created_by_name, created_at, updated_at';
+
+// Bara de fält changeloggen behöver ur ärendet. Beskrivning, skärmbild och det interna svaret till
+// rapportören ska ALDRIG nå den här vyn — den läses av alla, ärendet av rapportören och admin.
+export const changelogTicketSelect = 'id, kind, changelog_note, changelog_published_at, reporter_name';
+
+// Publicerade fria poster. RLS släpper igenom utkast till admin, så filtret här är det som gör
+// listan till "det alla ser" oavsett vem som frågar.
+export function listPublishedEntries(supabase: SupabaseClient, limit: number) {
+  return supabase
+    .from('app_changelog_entries')
+    .select(changelogEntrySelect)
+    .not('published_at', 'is', null)
+    .order('published_at', { ascending: false })
+    .limit(limit);
+}
+
+// Adminvyn: publicerat OCH utkast, nyast först. `published_at` är null för utkast och sorteras sist
+// med nullsFirst:false, så det som är ute ligger överst och det oskrivna längst ned.
+export function listAllEntries(supabase: SupabaseClient, limit: number) {
+  return supabase
+    .from('app_changelog_entries')
+    .select(changelogEntrySelect)
+    .order('published_at', { ascending: false, nullsFirst: false })
+    .order('created_at', { ascending: false })
+    .limit(limit);
+}
+
+// Publicerade appärenden — changeloggens andra källa. Texten bor kvar på ärendet med flit: ett
+// stängt ärende ÄR posten, och en kopia hit hade blivit en andra sanning.
+export function listPublishedTickets(supabase: SupabaseClient, limit: number) {
+  return supabase
+    .from('app_tickets')
+    .select(changelogTicketSelect)
+    .not('changelog_published_at', 'is', null)
+    .order('changelog_published_at', { ascending: false })
+    .limit(limit);
+}
+
+export function getEntry(supabase: SupabaseClient, id: string) {
+  return supabase.from('app_changelog_entries').select(changelogEntrySelect).eq('id', id).maybeSingle();
+}

--- a/lib/domains/changelog/schemas.ts
+++ b/lib/domains/changelog/schemas.ts
@@ -1,0 +1,45 @@
+import { z } from 'zod';
+import { CHANGELOG_CATEGORIES } from './types';
+
+// En changelog-rad ska gå att läsa på en rad. Taket är där för att hålla det löftet — inte för att
+// spara plats.
+const TITLE_MAX = 160;
+const BODY_MAX = 2000;
+
+const optionalBody = z.preprocess(
+  (v) => {
+    if (v == null) return null;
+    const t = String(v).trim();
+    return t.length > 0 ? t.slice(0, BODY_MAX) : null;
+  },
+  z.string().max(BODY_MAX).nullable(),
+);
+
+export const createChangelogEntrySchema = z.object({
+  category: z.enum(CHANGELOG_CATEGORIES, { errorMap: () => ({ message: 'Välj Fixat, Nytt eller Förbättrat' }) }),
+  title: z.string().trim().min(1, 'Skriv vad som ändrats').max(TITLE_MAX, `Rubriken får vara högst ${TITLE_MAX} tecken`),
+  body: optionalBody.optional().default(null),
+  // true = publicera direkt, false/utelämnat = spara som utkast. Tidsstämpeln sätts serverside.
+  publish: z.boolean().optional().default(false),
+});
+
+export type CreateChangelogEntryInput = z.infer<typeof createChangelogEntrySchema>;
+
+// Alla fält valfria — routen skriver bara det klienten faktiskt skickade, så en publicering inte
+// nollar en text ingen rört.
+export const updateChangelogEntrySchema = z.object({
+  category: z.enum(CHANGELOG_CATEGORIES, { errorMap: () => ({ message: 'Ogiltig kategori' }) }).optional(),
+  title: z.string().trim().min(1, 'Skriv vad som ändrats').max(TITLE_MAX).optional(),
+  body: optionalBody.optional(),
+  publish: z.boolean().optional(),
+});
+
+export type UpdateChangelogEntryInput = z.infer<typeof updateChangelogEntrySchema>;
+
+export const listChangelogQuerySchema = z.object({
+  // 'published' (default) = det alla ser. 'drafts' = adminvyn, som också vill se det oskrivna.
+  scope: z.enum(['published', 'drafts']).optional().default('published'),
+  limit: z.coerce.number().int().min(1).max(200).optional().default(100),
+});
+
+export type ListChangelogQuery = z.infer<typeof listChangelogQuerySchema>;

--- a/lib/domains/changelog/types.ts
+++ b/lib/domains/changelog/types.ts
@@ -1,0 +1,75 @@
+// Changelog — domäntyper.
+//
+// Listan har TVÅ källor: fritt skrivna poster (app_changelog_entries) och publicerade appärenden
+// (app_tickets med changelog_published_at satt). Vyn nedan är den gemensamma formen båda mappas
+// till, så resten av appen aldrig behöver veta varifrån en rad kom. Sammanslagningen sker i
+// merge.ts.
+
+export const CHANGELOG_CATEGORIES = ['fixed', 'new', 'improved'] as const;
+export type ChangelogCategory = (typeof CHANGELOG_CATEGORIES)[number];
+
+export const categoryLabel: Record<ChangelogCategory, string> = {
+  fixed: 'Fixat',
+  new: 'Nytt',
+  improved: 'Förbättrat',
+};
+
+export function toChangelogCategory(value: unknown): ChangelogCategory {
+  return CHANGELOG_CATEGORIES.includes(value as ChangelogCategory) ? (value as ChangelogCategory) : 'improved';
+}
+
+// Ett publicerat ärendes `kind` avgör kategorin. En bugg som stängts ÄR något som fixats, ett
+// önskemål som byggts ÄR något nytt — så läsaren slipper veta att raden kom från ett ärende.
+export function categoryFromTicketKind(kind: string): ChangelogCategory {
+  return kind === 'bug' ? 'fixed' : 'new';
+}
+
+export type ChangelogEntryRow = {
+  id: string;
+  category: string;
+  title: string;
+  body: string | null;
+  published_at: string | null;
+  created_by: string | null;
+  created_by_name: string;
+  created_at: string;
+  updated_at: string;
+};
+
+// Delmängden av app_tickets som changeloggen läser. Skilt från AppTicketRow: den här vyn ska inte
+// råka få tillgång till beskrivning, skärmbild eller interna svar.
+export type ChangelogTicketRow = {
+  id: string;
+  kind: string;
+  changelog_note: string | null;
+  changelog_published_at: string | null;
+  reporter_name: string;
+};
+
+export type ChangelogSource = 'entry' | 'ticket';
+
+export type ChangelogItemView = {
+  id: string;
+  source: ChangelogSource;
+  category: ChangelogCategory;
+  category_label: string;
+  title: string;
+  body: string | null;
+  published_at: string;
+  // Bara satt för ärendevägen: vem som rapporterade det som nu är fixat. Det är den detaljen som
+  // sluter loopen mot ticketsystemet — den som skrev in något ser att det kom med.
+  reported_by: string | null;
+};
+
+// Ett utkast (published_at = null) syns bara i adminvyn. Skilt från ChangelogItemView eftersom den
+// senare garanterar en publiceringstidpunkt — och listan sorteras på den.
+export type ChangelogDraftView = {
+  id: string;
+  category: ChangelogCategory;
+  category_label: string;
+  title: string;
+  body: string | null;
+  published_at: string | null;
+  created_by_name: string;
+  created_at: string;
+};

--- a/supabase/sql/20260812_app_changelog.sql
+++ b/supabase/sql/20260812_app_changelog.sql
@@ -1,0 +1,92 @@
+-- Changelog: vad som fixats, tillkommit och förbättrats i appen.
+--
+-- PROBLEMET DEN LÖSER: ändringar går ut utan att någon vet om dem. Fyra PR:er 2026-08-12 ändrade hur
+-- ordern beter sig och inget av det syntes för användarna.
+--
+-- TVÅ KÄLLOR, EN LISTA. Den här tabellen håller FRITT SKRIVNA poster. Publicerade appärenden
+-- (`app_tickets.changelog_note` + `changelog_published_at`) är den andra källan och bor kvar där —
+-- ett stängt ärende ÄR redan posten, och att kopiera texten hit hade skapat två sanningar som kan
+-- glida isär. Sammanslagningen sker i läsningen (lib/domains/changelog/merge.ts), inte i databasen.
+--
+-- Varför fria poster alls: de flesta ändringar kommer inte från ett rapporterat ärende. Utan dem
+-- blir loggen missvisande gles och ser ut som att nästan inget händer.
+--
+-- DEPLOY-ORDNING: helt ADDITIV (ny tabell, inget befintligt ändras), så ordningen SQL/kod spelar
+-- ingen roll. Körs SQL:en efter koden svarar changelog-routen 500 tills tabellen finns; ingenting
+-- annat påverkas och inget läses fel. Kör i Supabase SQL editor. Idempotent.
+
+create table if not exists public.app_changelog_entries (
+  id           uuid primary key default gen_random_uuid(),
+
+  -- 'fixed' = något som var trasigt fungerar nu, 'new' = något som inte fanns, 'improved' = något
+  -- som fanns men blev bättre. Samma tre som ärendena mappas till (bug→fixed, idea→new), så en
+  -- läsare inte behöver veta vilken källa raden kom ifrån.
+  category     text not null,
+  title        text not null,
+  -- Valfri utveckling under rubriken. En changelog-post ska gå att läsa på en rad; body är för de
+  -- gånger raden inte räcker.
+  body         text,
+
+  -- NULL = utkast, syns inte för någon. Sätts när posten publiceras, och är sorteringsnyckeln —
+  -- inte created_at, så en post kan skrivas i förväg och dateras när den faktiskt gick ut.
+  published_at timestamptz,
+
+  -- Beständig visningskopia: `profiles` är self-read-only, så namnet går inte att läsa upp senare.
+  created_by      uuid references public.profiles(id) on delete set null,
+  created_by_name text not null,
+  created_at      timestamptz not null default now(),
+  updated_at      timestamptz not null default now(),
+
+  constraint app_changelog_category_chk check (category in ('fixed', 'new', 'improved')),
+  constraint app_changelog_title_chk    check (length(btrim(title)) > 0)
+);
+
+-- Listan läses alltid publicerat-först. Partiellt index: utkasten är få och läses bara av admin.
+create index if not exists app_changelog_published_idx
+  on public.app_changelog_entries (published_at desc)
+  where published_at is not null;
+
+alter table public.app_changelog_entries enable row level security;
+grant select, insert, update, delete on public.app_changelog_entries to authenticated;
+
+-- Alla inloggade läser PUBLICERADE poster. Utkast ser bara admin — annars läcker en halvfärdig
+-- formulering ut till hela företaget.
+drop policy if exists app_changelog_select on public.app_changelog_entries;
+create policy app_changelog_select on public.app_changelog_entries
+  for select to authenticated
+  using (published_at is not null or public.is_app_ticket_admin());
+
+-- Bara admin skriver. Återanvänder predikatet från appärendena med flit: det är samma person som
+-- håller i backloggen och skriver changeloggen, och två predikat hade kunnat glida isär.
+drop policy if exists app_changelog_write on public.app_changelog_entries;
+create policy app_changelog_write on public.app_changelog_entries
+  for all to authenticated
+  using (public.is_app_ticket_admin())
+  with check (public.is_app_ticket_admin());
+
+-- ── Verifiering (kör efter applicering) ──────────────────────────────────────
+--
+-- 1. Två policyer, och skrivpolicyn ska gälla alla kommandon.
+--
+--      select policyname, cmd from pg_policies
+--      where schemaname = 'public' and tablename = 'app_changelog_entries' order by policyname;
+--
+-- 2. Tom titel ska nekas (förväntat: fel om app_changelog_title_chk).
+--
+--      insert into public.app_changelog_entries (category, title, created_by_name)
+--      values ('fixed', '   ', 'Test');
+--
+-- 3. Okänd kategori ska nekas (förväntat: fel om app_changelog_category_chk).
+--
+--      insert into public.app_changelog_entries (category, title, created_by_name)
+--      values ('breaking', 'x', 'Test');
+--
+-- 4. Så här ser den sammanslagna listan ut i SQL — samma två källor som koden slår ihop.
+--    Bra att köra en gång efter första publiceringen, så du ser att båda vägarna landar rätt.
+--
+--      select 'entry' as kalla, category, title, published_at
+--      from public.app_changelog_entries where published_at is not null
+--      union all
+--      select 'ticket', case when kind = 'bug' then 'fixed' else 'new' end, changelog_note, changelog_published_at
+--      from public.app_tickets where changelog_published_at is not null
+--      order by published_at desc;

--- a/tests/changelog/changelog.test.ts
+++ b/tests/changelog/changelog.test.ts
@@ -1,0 +1,272 @@
+import { describe, it, expect } from 'vitest';
+import {
+  mapEntryToItem,
+  mapTicketToItem,
+  mergeChangelog,
+  groupChangelogByDay,
+  newSince,
+  latestPublishedAt,
+} from '@/lib/domains/changelog/merge';
+import { buildEntryUpdatePatch, mapEntryToDraft } from '@/lib/domains/changelog/mutations';
+import {
+  createChangelogEntrySchema,
+  updateChangelogEntrySchema,
+  listChangelogQuerySchema,
+} from '@/lib/domains/changelog/schemas';
+import {
+  CHANGELOG_CATEGORIES,
+  categoryFromTicketKind,
+  categoryLabel,
+  type ChangelogEntryRow,
+  type ChangelogTicketRow,
+} from '@/lib/domains/changelog/types';
+import { formatChangelogDay } from '@/app/_lib/changelogTokens';
+
+const entry = (over: Partial<ChangelogEntryRow> = {}): ChangelogEntryRow => ({
+  id: 'aaaaaaaa-0000-4000-8000-000000000001',
+  category: 'improved',
+  title: 'Snabbare kundsök',
+  body: null,
+  published_at: '2026-08-12T10:00:00.000Z',
+  created_by: null,
+  created_by_name: 'William',
+  created_at: '2026-08-12T09:00:00.000Z',
+  updated_at: '2026-08-12T09:00:00.000Z',
+  ...over,
+});
+
+const ticket = (over: Partial<ChangelogTicketRow> = {}): ChangelogTicketRow => ({
+  id: 'bbbbbbbb-0000-4000-8000-000000000001',
+  kind: 'bug',
+  changelog_note: 'Offerten sparar nu korrekt',
+  changelog_published_at: '2026-08-12T12:00:00.000Z',
+  reporter_name: 'Anna Installatör',
+  ...over,
+});
+
+describe('mapEntryToItem', () => {
+  it('mappar en publicerad post', () => {
+    const item = mapEntryToItem(entry())!;
+    expect(item.source).toBe('entry');
+    expect(item.category).toBe('improved');
+    expect(item.category_label).toBe(categoryLabel.improved);
+    expect(item.reported_by).toBeNull();
+  });
+
+  // Utkast filtreras bort i mappningen, inte i SQL — så adminvyn kan läsa samma funktion.
+  it('släpper igenom INGET utkast', () => {
+    expect(mapEntryToItem(entry({ published_at: null }))).toBeNull();
+  });
+
+  it('faller tillbaka på en känd kategori för okänt värde', () => {
+    expect(mapEntryToItem(entry({ category: 'breaking' }))!.category).toBe('improved');
+  });
+});
+
+describe('mapTicketToItem', () => {
+  // Kategorin härleds ur ärendets kind, så läsaren inte behöver veta att raden kom från ett ärende.
+  it('en stängd bugg blir "Fixat", ett byggt önskemål blir "Nytt"', () => {
+    expect(mapTicketToItem(ticket({ kind: 'bug' }))!.category).toBe('fixed');
+    expect(mapTicketToItem(ticket({ kind: 'idea' }))!.category).toBe('new');
+    expect(categoryFromTicketKind('bug')).toBe('fixed');
+  });
+
+  it('bär med rapportören — det är den som sluter loopen', () => {
+    expect(mapTicketToItem(ticket())!.reported_by).toBe('Anna Installatör');
+  });
+
+  it('utesluter opublicerade ärenden', () => {
+    expect(mapTicketToItem(ticket({ changelog_published_at: null }))).toBeNull();
+  });
+
+  // En rad utan titel blir en tom punkt i listan — värre än ingen rad alls.
+  it('utesluter publicerade ärenden UTAN text', () => {
+    expect(mapTicketToItem(ticket({ changelog_note: null }))).toBeNull();
+    expect(mapTicketToItem(ticket({ changelog_note: '   ' }))).toBeNull();
+  });
+
+  it('trimmar texten', () => {
+    expect(mapTicketToItem(ticket({ changelog_note: '  Fixat  ' }))!.title).toBe('Fixat');
+  });
+});
+
+describe('mergeChangelog', () => {
+  it('slår ihop båda källorna, nyast först', () => {
+    const items = mergeChangelog(
+      [entry({ published_at: '2026-08-10T10:00:00.000Z' }), entry({ id: 'aaaaaaaa-0000-4000-8000-000000000002', published_at: '2026-08-13T10:00:00.000Z' })],
+      [ticket()],
+    );
+    expect(items.map((i) => i.published_at)).toEqual([
+      '2026-08-13T10:00:00.000Z',
+      '2026-08-12T12:00:00.000Z',
+      '2026-08-10T10:00:00.000Z',
+    ]);
+    expect(items.map((i) => i.source)).toEqual(['entry', 'ticket', 'entry']);
+  });
+
+  it('hanterar null från båda källorna', () => {
+    expect(mergeChangelog(null, null)).toEqual([]);
+    expect(mergeChangelog(undefined, [ticket()])).toHaveLength(1);
+  });
+
+  it('filtrerar bort opublicerat ur båda källorna', () => {
+    const items = mergeChangelog([entry({ published_at: null })], [ticket({ changelog_published_at: null })]);
+    expect(items).toEqual([]);
+  });
+
+  // Utan andrasortering kan två poster med samma tidsstämpel byta plats mellan laddningar, och
+  // listan "hoppar" utan att något ändrats.
+  it('är deterministisk när tidsstämplarna kolliderar', () => {
+    const a = entry({ id: 'aaaaaaaa-0000-4000-8000-000000000001', published_at: '2026-08-12T10:00:00.000Z' });
+    const b = entry({ id: 'aaaaaaaa-0000-4000-8000-000000000002', published_at: '2026-08-12T10:00:00.000Z' });
+    expect(mergeChangelog([a, b], []).map((i) => i.id)).toEqual(mergeChangelog([b, a], []).map((i) => i.id));
+  });
+});
+
+describe('groupChangelogByDay', () => {
+  // Tidsstämplarna ligger mitt på dagen med flit: då hamnar de på samma lokala datum oavsett vilken
+  // tidszon testet körs i, och testet mäter grupperingen — inte maskinens inställningar.
+  it('grupperar på publiceringsdag i ordning', () => {
+    const items = mergeChangelog(
+      [
+        entry({ id: 'aaaaaaaa-0000-4000-8000-000000000001', published_at: '2026-08-12T14:00:00.000Z' }),
+        entry({ id: 'aaaaaaaa-0000-4000-8000-000000000002', published_at: '2026-08-12T10:00:00.000Z' }),
+        entry({ id: 'aaaaaaaa-0000-4000-8000-000000000003', published_at: '2026-08-09T10:00:00.000Z' }),
+      ],
+      [],
+    );
+    const groups = groupChangelogByDay(items);
+    expect(groups.map((g) => g.day)).toEqual(['2026-08-12', '2026-08-09']);
+    expect(groups[0].items).toHaveLength(2);
+  });
+
+  // Dygnsgränsen räknas LOKALT: en post publicerad kvart över midnatt svensk tid ligger på
+  // föregående UTC-dygn, och skulle med en ren strängklippning hamna under "gårdagen".
+  it('grupperar på lokal dag, inte på UTC-dygnet', () => {
+    const midnightish = new Date(2026, 7, 12, 0, 15, 0); // 12 aug 00:15 lokal tid
+    const items = mergeChangelog([entry({ published_at: midnightish.toISOString() })], []);
+    expect(groupChangelogByDay(items)[0].day).toBe('2026-08-12');
+  });
+
+  it('ger en tom lista för inga poster', () => {
+    expect(groupChangelogByDay([])).toEqual([]);
+  });
+});
+
+describe('newSince', () => {
+  const items = mergeChangelog(
+    [
+      entry({ id: 'aaaaaaaa-0000-4000-8000-000000000001', published_at: '2026-08-13T10:00:00.000Z' }),
+      entry({ id: 'aaaaaaaa-0000-4000-8000-000000000002', published_at: '2026-08-11T10:00:00.000Z' }),
+    ],
+    [],
+  );
+
+  it('ger bara det som publicerats efter tidsstämpeln', () => {
+    expect(newSince(items, '2026-08-12T00:00:00.000Z').map((i) => i.published_at)).toEqual(['2026-08-13T10:00:00.000Z']);
+  });
+
+  // Första besöket ska inte slå upp hela historiken som "nytt".
+  it('ger INGET när användaren aldrig sett listan', () => {
+    expect(newSince(items, null)).toEqual([]);
+  });
+
+  it('ger inget när allt redan setts', () => {
+    expect(newSince(items, '2026-08-13T10:00:00.000Z')).toEqual([]);
+  });
+
+  it('latestPublishedAt tar nyaste posten, inte "nu"', () => {
+    expect(latestPublishedAt(items)).toBe('2026-08-13T10:00:00.000Z');
+    expect(latestPublishedAt([])).toBeNull();
+  });
+});
+
+describe('createChangelogEntrySchema', () => {
+  it('kräver rubrik och giltig kategori', () => {
+    expect(() => createChangelogEntrySchema.parse({ category: 'fixed', title: '  ' })).toThrow();
+    expect(() => createChangelogEntrySchema.parse({ category: 'breaking', title: 'x' })).toThrow();
+    for (const c of CHANGELOG_CATEGORIES) {
+      expect(createChangelogEntrySchema.parse({ category: c, title: 'x' }).category).toBe(c);
+    }
+  });
+
+  it('defaultar till utkast — publicering ska vara ett aktivt val', () => {
+    expect(createChangelogEntrySchema.parse({ category: 'new', title: 'x' }).publish).toBe(false);
+  });
+
+  it('normaliserar blank body till null', () => {
+    expect(createChangelogEntrySchema.parse({ category: 'new', title: 'x', body: '   ' }).body).toBeNull();
+  });
+});
+
+describe('updateChangelogEntrySchema + listChangelogQuerySchema', () => {
+  it('tillåter en tom uppdatering (routen avgör att inget skickades)', () => {
+    expect(updateChangelogEntrySchema.parse({})).toEqual({});
+  });
+
+  it('defaultar listan till publicerat', () => {
+    const parsed = listChangelogQuerySchema.parse({});
+    expect(parsed.scope).toBe('published');
+    expect(parsed.limit).toBe(100);
+  });
+
+  it('avvisar orimliga limits', () => {
+    expect(() => listChangelogQuerySchema.parse({ limit: 0 })).toThrow();
+    expect(() => listChangelogQuerySchema.parse({ limit: 5000 })).toThrow();
+  });
+});
+
+describe('buildEntryUpdatePatch', () => {
+  const now = '2026-08-13T10:00:00.000Z';
+
+  it('skriver bara de fält klienten skickade', () => {
+    const patch = buildEntryUpdatePatch({ title: 'Ny rubrik', body: 'text' }, ['title'], now, { published_at: null });
+    expect(patch).toEqual({ updated_at: now, title: 'Ny rubrik' });
+  });
+
+  it('publicerar ett utkast med nuvarande tid', () => {
+    const patch = buildEntryUpdatePatch({ publish: true }, ['publish'], now, { published_at: null });
+    expect(patch.published_at).toBe(now);
+  });
+
+  // Annars flyttas en gammal post till toppen så fort man rättar ett stavfel, och läsaren ser en
+  // två veckor gammal ändring presenterad som ny.
+  it('BEHÅLLER tidsstämpeln på en redan publicerad post', () => {
+    const patch = buildEntryUpdatePatch({ publish: true }, ['publish'], now, {
+      published_at: '2026-08-01T08:00:00.000Z',
+    });
+    expect(patch.published_at).toBe('2026-08-01T08:00:00.000Z');
+  });
+
+  it('avpublicerar genom att nolla tidsstämpeln', () => {
+    const patch = buildEntryUpdatePatch({ publish: false }, ['publish'], now, {
+      published_at: '2026-08-01T08:00:00.000Z',
+    });
+    expect(patch.published_at).toBeNull();
+  });
+
+  it('ger bara updated_at när inget skickades', () => {
+    expect(buildEntryUpdatePatch({}, [], now, { published_at: null })).toEqual({ updated_at: now });
+  });
+});
+
+describe('mapEntryToDraft', () => {
+  it('behåller publiceringsstatus så adminvyn kan skilja utkast från publicerat', () => {
+    expect(mapEntryToDraft(entry()).published_at).toBe('2026-08-12T10:00:00.000Z');
+    expect(mapEntryToDraft(entry({ published_at: null })).published_at).toBeNull();
+  });
+});
+
+describe('formatChangelogDay', () => {
+  it('utelämnar året för innevarande år', () => {
+    expect(formatChangelogDay('2026-08-12', new Date('2026-11-01T00:00:00.000Z'))).toBe('12 augusti');
+  });
+
+  it('tar med året för ett annat år', () => {
+    expect(formatChangelogDay('2025-08-12', new Date('2026-11-01T00:00:00.000Z'))).toContain('2025');
+  });
+
+  it('faller tillbaka på indata vid ogiltigt datum', () => {
+    expect(formatChangelogDay('inte-ett-datum')).toBe('inte-ett-datum');
+  });
+});


### PR DESCRIPTION
Ändringar gick ut utan att någon visste om dem — fyra PR:er den 12 augusti ändrade hur ordern beter sig, och inget av det syntes för användarna. Det här är sista delen av bågen som började med ticketsystemet (#62).

## Var den syns

**"Nytt i appen"** som ett kort på CRM-översikten — ytan man ändå landar på. En sida man måste hitta till hade inte löst problemet. Kortet visar de tre senaste raderna och `Visa alla` öppnar hela loggen, grupperad per dag.

**Modalen slår upp en gång** när något tillkommit sedan sist. "Sedan sist" spåras i `localStorage`, samma val som nyhetsmodalen på dashboarden gör — det räcker för ett "har du sett det här?" och slipper en skrivning vid varje sidladdning. Första besöket stämplas tyst: att visa hela historiken som "nytt" hade varit en modal ingen läser.

**Admin → Changelog** för fritt skrivna poster, med utkast. Ärendehärledda rader listas inte där — de ägs av sitt ärende och publiceras i fliken Ärenden. Vyn säger det rakt ut i stället för att lämna en gåta om varför en publicerad rad saknas.

## Två källor, en lista

Fritt skrivna poster i `app_changelog_entries`, plus publicerade appärenden — vars text bor kvar på ärendet, eftersom ett stängt ärende **är** posten och en kopia hade blivit en andra sanning som kan glida isär. Sammanslagningen sker i läsningen ([`merge.ts`](lib/domains/changelog/merge.ts)), inte i en SQL-vy som hade låst ihop två tabeller med olika ägare.

Ärendets `kind` avgör kategorin (bug→Fixat, idea→Nytt), så läsaren aldrig behöver veta varifrån raden kom. Men rapportörens namn följer med — det är det som sluter loopen mot ticketsystemet: den som skrev in något ser att just deras grej kom med.

Fria poster behövs för att de flesta ändringar inte kommer från ett rapporterat ärende. Utan dem blir loggen missvisande gles och ser ut som att nästan inget händer.

## Detaljer värda en blick i granskningen

- **En publicerad post behåller sin tidsstämpel** vid redigering. Annars flyttas en gammal ändring till toppen så fort man rättar ett stavfel, och läsaren ser något två veckor gammalt presenterat som nytt.
- **Dygnsgränsen räknas lokalt**, inte på UTC — annars hamnar en post publicerad strax efter midnatt under gårdagen.
- **Sorteringen har andrasortering på id.** Två poster publicerade i samma sparning delar tidsstämpel, och utan den kan listan kasta om sig mellan två laddningar utan att något ändrats.
- **Kortet döljer sig självt om hämtningen failar.** Changeloggen är en trevlighet på en sida full av annat och ska aldrig ge ett felmeddelande som ser ut att gälla översikten.
- **En rad utan text filtreras bort** ur båda källorna. En tom punkt i en changelog är värre än ingen rad.

## Migrering

`20260812_app_changelog.sql` — helt additiv (bara en ny tabell), så ordningen SQL/deploy spelar ingen roll. Utan tabellen döljer sig kortet i stället för att störa. Filen innehåller verifieringsfrågor, inklusive en som visar den sammanslagna listan i SQL så båda vägarna går att kontrollera.

RLS: alla inloggade läser publicerat, utkast ser bara admin. Skrivpolicyn återanvänder `is_app_ticket_admin()` med flit — det är samma person som håller i backloggen och skriver changeloggen, och två predikat hade kunnat glida isär.

## Testning

- 1002 tester gröna, varav 34 nya i `tests/changelog/` — sammanslagningen, dygnsgrupperingen, "nytt sedan sist", publiceringsreglerna och scheman
- `npm run type-check` + `npm run build` rena
