### PR TITLE
fix(changelog): visa modalen vid första besöket i stället för att stämpla tyst

### DIFF
--- a/app/crm/components/ChangelogCard.tsx
+++ b/app/crm/components/ChangelogCard.tsx
@@ -5,7 +5,13 @@ import { cn } from '@/lib/shared/cn';
 import { crm } from '@/app/crm/lib/crmTokens';
 import CrmModal from '@/app/crm/components/CrmModal';
 import { changelogCategoryMeta, formatChangelogDay, formatChangelogStamp } from '@/app/_lib/changelogTokens';
-import { groupChangelogByDay, latestPublishedAt, newSince } from '@/lib/domains/changelog/merge';
+import {
+  FIRST_VISIT_WINDOW_DAYS,
+  groupChangelogByDay,
+  latestPublishedAt,
+  newSince,
+  publishedWithin,
+} from '@/lib/domains/changelog/merge';
 import type { ChangelogItemView } from '@/lib/domains/changelog/types';
 
 // "Nytt i appen" på CRM-översikten.
@@ -18,6 +24,12 @@ import type { ChangelogItemView } from '@/lib/domains/changelog/types';
 // användare, men det räcker för ett "har du sett det här?" och slipper en tabell + en skrivning vid
 // varje sidladdning. Samma val som nyhetsmodalen på dashboarden gjorde.
 //
+// FÖRSTA BESÖKET har inget "sedan sist" att jämföra mot — ingen har besökt listan innan den fanns.
+// Där avgör FÄRSKHET i stället (publishedWithin): vid lansering är allt nytt och alla ser det, medan
+// en nyanställd om ett år bara möts av det som faktiskt hänt nyligen. Regeln var först "stämpla tyst
+// vid första besöket", vilket hade gjort själva lanseringen osynlig för alla utom den som råkade
+// titta efter nästa publicering.
+//
 // OBS preflight är av (tailwind.config.js) — rot-elementet bär `support-surface`, som återställer
 // border-reseten för hela trädet (globals.css). Skriv `border`/`border-t` som vanligt här, och lägg
 // ALDRIG till `border-solid`.
@@ -29,7 +41,9 @@ export default function ChangelogCard() {
   const [items, setItems] = useState<ChangelogItemView[]>([]);
   const [loading, setLoading] = useState(true);
   const [failed, setFailed] = useState(false);
-  const [modal, setModal] = useState<null | 'all' | 'new'>(null);
+  // 'first' och 'new' visar samma urval men olika rubrik: "sedan du var här" är fel ord för någon
+  // som aldrig varit här.
+  const [modal, setModal] = useState<null | 'all' | 'new' | 'first'>(null);
   const [unseen, setUnseen] = useState<ChangelogItemView[]>([]);
 
   // Stämplingen får bara ske en gång per laddning, annars kan en omrendering hinna nolla "nytt"
@@ -70,13 +84,18 @@ export default function ChangelogCard() {
           lastSeen = null;
         }
 
-        const fresh = newSince(list, lastSeen);
+        // Första besöket har inget "sedan sist" att jämföra mot — ingen har besökt listan innan den
+        // fanns. Då avgör färskhet i stället: vid lansering är allt nytt och visas, senare möts en
+        // ny användare bara av det som faktiskt hänt nyligen.
+        const fresh =
+          lastSeen === null ? publishedWithin(list, FIRST_VISIT_WINDOW_DAYS) : newSince(list, lastSeen);
+
         if (fresh.length > 0) {
           setUnseen(fresh);
-          setModal('new');
-        } else if (lastSeen === null) {
-          // Första besöket: stämpla direkt utan att visa något. Att slå upp hela historiken som
-          // "nytt" hade varit en modal med trettio rader som ingen läser.
+          setModal(lastSeen === null ? 'first' : 'new');
+        } else {
+          // Inget att visa — stämpla ändå, så nästa post räknas som ny i stället för att jämföras
+          // mot ingenting.
           markSeen(list);
         }
       } catch {
@@ -143,12 +162,14 @@ export default function ChangelogCard() {
               <p className="m-0 text-[12px] text-slate-500">
                 {modal === 'new'
                   ? 'Det här har ändrats sedan du senast öppnade CRM.'
-                  : 'Allt som fixats, tillkommit och förbättrats.'}
+                  : modal === 'first'
+                    ? 'Härifrån kan du följa vad som fixats och tillkommit. Det här är det senaste.'
+                    : 'Allt som fixats, tillkommit och förbättrats.'}
               </p>
             </div>
           }
           footer={
-            modal === 'new' ? (
+            modal === 'new' || modal === 'first' ? (
               <>
                 <button
                   type="button"
@@ -173,7 +194,7 @@ export default function ChangelogCard() {
             )
           }
         >
-          <ChangelogList items={modal === 'new' ? unseen : items} />
+          <ChangelogList items={modal === 'all' ? items : unseen} />
         </CrmModal>
       )}
     </section>

--- a/lib/domains/changelog/merge.ts
+++ b/lib/domains/changelog/merge.ts
@@ -106,3 +106,21 @@ export function newSince(items: ChangelogItemView[], lastSeen: string | null): C
 export function latestPublishedAt(items: ChangelogItemView[]): string | null {
   return items.length > 0 ? items[0].published_at : null;
 }
+
+// Vad som är FÄRSKT just nu, oavsett om användaren sett listan förut.
+//
+// Används vid första besöket, där det inte finns något "sedan sist" att jämföra mot. Att stämpla
+// tyst hade gjort lanseringen osynlig — ingen har ju besökt listan innan den fanns. Att i stället
+// visa allt hade gjort att en nyanställd om ett år möts av hela historiken. Färskhetsfönstret löser
+// båda: vid lansering är allt nytt och visas, senare möts en ny användare bara av det som faktiskt
+// hänt nyligen — och oftast av ingenting alls.
+export const FIRST_VISIT_WINDOW_DAYS = 14;
+
+export function publishedWithin(
+  items: ChangelogItemView[],
+  days: number,
+  now: Date = new Date(),
+): ChangelogItemView[] {
+  const cutoff = new Date(now.getTime() - days * 24 * 60 * 60 * 1000).toISOString();
+  return items.filter((item) => item.published_at > cutoff);
+}

--- a/tests/changelog/changelog.test.ts
+++ b/tests/changelog/changelog.test.ts
@@ -6,6 +6,8 @@ import {
   groupChangelogByDay,
   newSince,
   latestPublishedAt,
+  publishedWithin,
+  FIRST_VISIT_WINDOW_DAYS,
 } from '@/lib/domains/changelog/merge';
 import { buildEntryUpdatePatch, mapEntryToDraft } from '@/lib/domains/changelog/mutations';
 import {
@@ -178,6 +180,45 @@ describe('newSince', () => {
   it('latestPublishedAt tar nyaste posten, inte "nu"', () => {
     expect(latestPublishedAt(items)).toBe('2026-08-13T10:00:00.000Z');
     expect(latestPublishedAt([])).toBeNull();
+  });
+});
+
+// Första besöket har inget "sedan sist" att jämföra mot — ingen har besökt listan innan den fanns.
+// Regeln var först "stämpla tyst", vilket gjorde själva lanseringen osynlig: alla stämplades som
+// om de sett listan, och ingen fick modalen förrän NÄSTA post publicerades.
+describe('publishedWithin (första besöket)', () => {
+  const now = new Date('2026-08-13T12:00:00.000Z');
+  const items = mergeChangelog(
+    [
+      entry({ id: 'aaaaaaaa-0000-4000-8000-000000000001', published_at: '2026-08-12T10:00:00.000Z' }),
+      entry({ id: 'aaaaaaaa-0000-4000-8000-000000000002', published_at: '2026-06-01T10:00:00.000Z' }),
+    ],
+    [],
+  );
+
+  it('tar med det som publicerats inom fönstret', () => {
+    expect(publishedWithin(items, 14, now).map((i) => i.published_at)).toEqual(['2026-08-12T10:00:00.000Z']);
+  });
+
+  it('utesluter det som hunnit bli gammalt', () => {
+    // En nyanställd om ett år ska inte mötas av hela historiken.
+    expect(publishedWithin(items, 14, new Date('2027-08-13T12:00:00.000Z'))).toEqual([]);
+  });
+
+  // Lanseringsläget: allt skrevs samma dag, och alla ska se allt.
+  it('tar med allt när posterna publicerats nyss', () => {
+    const justPublished = mergeChangelog(
+      [
+        entry({ id: 'aaaaaaaa-0000-4000-8000-000000000003', published_at: '2026-08-13T09:00:00.000Z' }),
+        entry({ id: 'aaaaaaaa-0000-4000-8000-000000000004', published_at: '2026-08-13T09:05:00.000Z' }),
+      ],
+      [],
+    );
+    expect(publishedWithin(justPublished, 14, now)).toHaveLength(2);
+  });
+
+  it('fönstret är 14 dagar', () => {
+    expect(FIRST_VISIT_WINDOW_DAYS).toBe(14);
   });
 });
 


### PR DESCRIPTION
Regeln var **"första besöket stämplas tyst"**, motiverad av att en nyanställd om ett år inte ska mötas av en modal med hela historiken.

Den missade att **lanseringen är ett första besök för alla**. Varje användare hade stämplats som om de redan sett listan, och ingen hade fått modalen förrän nästa post publicerades. Det som skulle synas först var alltså det enda som garanterat inte gjorde det.

## Vad som ändras

Rätt villkor är **färskhet**, inte besöksordning. Vid ett första besök visas det som publicerats de senaste 14 dagarna:

| Läge | Före | Efter |
|---|---|---|
| Lansering — allt är nytt | tyst stämpling, ingen ser något | alla ser modalen |
| Återkommande användare | modal vid nytt sedan sist | oförändrat |
| Ny användare om ett år | tyst stämpling | tyst stämpling (inget inom 14 dagar) |

Modalen får en egen rubriktext för första besöket — *"sedan du var här"* är fel ord för någon som aldrig varit här.

## Omfattning

Ren klientlogik: när modalen ska slå upp. **Ingen migrering, ingen datamigrering, inget som rör det som redan är publicerat.** Logiken ligger i `publishedWithin` (ren funktion, tar `now` som argument) så regeln är testad i stället för att bara finnas i en komponent.

Tre filer, +90/−10.

## Testning

- 1006 tester gröna, fyra nya för färskhetsfönstret (lansering, gammal historik, gränsen)
- `npm run type-check` + `npm run build` rena

## Deploy-ordning

Migreringen är körd men tabellen är tom, och **en tom lista skriver ingen stämpel** — `markSeen` avbryter när det inte finns någon post att stämpla mot. Ingen är alltså tyst stämplad ännu.

Ordningen som ger alla modalen: **deploya den här först, lägg in de första posterna efteråt.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)