### PR TITLE
fix(crm): kräv personnummer med fullt årtal — tolv siffror, inte tio

### DIFF
--- a/app/api/crm/customers/_lib.ts
+++ b/app/api/crm/customers/_lib.ts
@@ -1,5 +1,17 @@
 import { z } from 'zod';
+import { isValidPersonalNumber, PERSONAL_NUMBER_ERROR } from '@/lib/domains/crm/personalNumber';
 export { ok, routeError, validationError, invalidUuidParam, requireCrmUser, requireCrmWriter, requirePermission, requireCrmAdmin, pickProvidedFields } from '../_shared';
+
+// Personnumret får vara tomt (säljaren får det ofta först när jobbet bokas), men står det något
+// ska det vara ETT FULLT nummer med århundrade. Tio siffror sparas utan protest av både oss och
+// Fortnox — men ROT- och husarbetesuppgifterna slutar då fungera på dokumentet, och avdraget måste
+// läggas in för hand i efterhand. Låset sitter här och inte bara i formuläret, eftersom det är
+// routen som avgör vad som faktiskt hamnar i databasen.
+const personalNumberSchema = z
+  .string()
+  .trim()
+  .nullable()
+  .refine((val) => !val || isValidPersonalNumber(val), { message: PERSONAL_NUMBER_ERROR });
 
 // Zod's built-in .email() rejects Unicode domain names (e.g. byggmästaren.se).
 // This helper validates the structural shape of an email while accepting IDN domains.
@@ -74,7 +86,7 @@ export const createCrmCustomerSchema = z
     organization_number: z.string().trim().nullable().optional().default(null),
     first_name: z.string().trim().nullable().optional().default(null),
     last_name: z.string().trim().nullable().optional().default(null),
-    personal_number: z.string().trim().nullable().optional().default(null),
+    personal_number: personalNumberSchema.optional().default(null),
     email: intlEmail('Ogiltig e-post').default(null),
     phone: z.string().trim().nullable().optional().default(null),
     mobile: z.string().trim().nullable().optional().default(null),
@@ -127,7 +139,7 @@ export const updateCrmCustomerSchema = z
     organization_number: z.string().trim().nullable().optional(),
     first_name: z.string().trim().nullable().optional(),
     last_name: z.string().trim().nullable().optional(),
-    personal_number: z.string().trim().nullable().optional(),
+    personal_number: personalNumberSchema.optional(),
     email: intlEmail('Ogiltig e-post'),
     phone: z.string().trim().nullable().optional(),
     mobile: z.string().trim().nullable().optional(),

--- a/app/api/crm/quotes/[id]/work-order/route.ts
+++ b/app/api/crm/quotes/[id]/work-order/route.ts
@@ -26,7 +26,9 @@ export async function POST(_req: Request, context: RouteContext) {
 
       // Emit the same code the standalone route uses so the client's personnummer prompt
       // (which keys off crm_work_order_missing_personal_number) fires on both order paths.
-      if (result.reason === 'missing_personal_number') {
+      // `invalid_personal_number` (tio siffror i stället för tolv) delar kod: åtgärden är densamma
+      // — fyll i ett fullständigt nummer — och meddelandet förklarar skillnaden.
+      if (result.reason === 'missing_personal_number' || result.reason === 'invalid_personal_number') {
         return routeError(409, 'crm_work_order_missing_personal_number', result.error?.message || 'Personnummer krävs för privatkund innan order kan skapas');
       }
 

--- a/app/api/crm/work-orders/route.ts
+++ b/app/api/crm/work-orders/route.ts
@@ -80,10 +80,16 @@ export async function POST(req: Request) {
     });
 
     if (result.error) {
-      const status = result.reason === 'customer_not_found'
-        ? 404
-        : result.reason === 'missing_personal_number' ? 409 : 500;
-      return routeError(status, `crm_work_order_${result.reason}`, result.error.message || 'Kunde inte skapa order');
+      if (result.reason === 'customer_not_found') {
+        return routeError(404, 'crm_work_order_customer_not_found', result.error.message || 'Kunde inte skapa order');
+      }
+      // Saknat OCH ogiltigt personnummer får samma kod med flit: åtgärden är identisk — fyll i ett
+      // fullständigt nummer — och klienten fäller redan ut fältet på den koden. Ett eget felnamn
+      // hade krävt en andra gren i UI:t för samma handling. Meddelandet skiljer dem åt.
+      if (result.reason === 'missing_personal_number' || result.reason === 'invalid_personal_number') {
+        return routeError(409, 'crm_work_order_missing_personal_number', result.error.message || 'Personnummer krävs för privatkund innan order kan skapas');
+      }
+      return routeError(500, `crm_work_order_${result.reason}`, result.error.message || 'Kunde inte skapa order');
     }
 
     return ok({ item: result.data }, 201);

--- a/app/crm/arbetsorder/WorkOrdersClient.tsx
+++ b/app/crm/arbetsorder/WorkOrdersClient.tsx
@@ -10,7 +10,7 @@ import AssigneeFilter, { MINE, type AssigneeFilterValue, type AssigneeOption } f
 import DocumentNumberBadge from '@/app/crm/components/DocumentNumberBadge';
 import CrmModal from '@/app/crm/components/CrmModal';
 import EntityCombobox, { type EntityResult } from '@/app/crm/components/EntityCombobox';
-import { formatSwedishIdNumber } from '@/app/crm/kunder/customerNumbers';
+import { formatPersonalNumber, isValidPersonalNumber, PERSONAL_NUMBER_ERROR } from '@/lib/domains/crm/personalNumber';
 import { useToast } from '@/lib/Toast';
 
 type WorkOrderStatus = 'draft' | 'scheduled' | 'ready' | 'in_progress' | 'completed' | 'partially_invoiced' | 'invoiced' | 'cancelled';
@@ -148,6 +148,9 @@ export default function WorkOrdersClient({ currentUserId }: { currentUserId: str
     if (!newOrderCustomerId) { toast.error('Välj en kund'); return; }
     if (!newOrderName.trim()) { toast.error('Ange ett ordernamn'); return; }
     if (needsPersonalNumber && !newOrderPersonalNumber.trim()) { toast.error('Fyll i personnummer för privatkunden'); return; }
+    // Tolv siffror krävs — tio ger trasiga ROT-uppgifter i Fortnox. Fångas här så användaren
+    // slipper en runda till servern för att få veta det.
+    if (needsPersonalNumber && !isValidPersonalNumber(newOrderPersonalNumber)) { toast.error(PERSONAL_NUMBER_ERROR); return; }
     setCreatingOrder(true);
     try {
       // If a prior attempt flagged a missing personnummer, save it on the customer first so the
@@ -489,12 +492,13 @@ export default function WorkOrdersClient({ currentUserId }: { currentUserId: str
                 <p className={cn('mb-1.5', crm.sectionTitle)}>Personnummer (privatkund)</p>
                 <Input
                   value={newOrderPersonalNumber}
-                  onChange={(e) => setNewOrderPersonalNumber(formatSwedishIdNumber(e.target.value))}
-                  placeholder="ÅÅMMDD-XXXX"
+                  onChange={(e) => setNewOrderPersonalNumber(formatPersonalNumber(e.target.value))}
+                  placeholder="ÅÅÅÅMMDD-XXXX"
+                  inputMode="numeric"
                   autoFocus
                 />
                 <p className="mt-1.5 text-[11px] leading-snug text-amber-700">
-                  Privatkunden saknar personnummer. Fortnox behöver det för att fakturera ordern – det sparas på kundkortet.
+                  Privatkunden saknar ett fullständigt personnummer. Fortnox behöver det med fullt årtal för att fakturera ordern och för att ROT ska fungera – det sparas på kundkortet.
                 </p>
               </div>
             ) : null}

--- a/app/crm/kunder/CustomerDetailClient.tsx
+++ b/app/crm/kunder/CustomerDetailClient.tsx
@@ -9,6 +9,12 @@ import { useToast } from '@/lib/Toast';
 import { cn } from '@/lib/shared/cn';
 import { crm, customerStageLabel, customerStageClass, syncStatusLabel, syncStatusClass, workOrderStatusLabel } from '@/app/crm/lib/crmTokens';
 import { formatSwedishIdNumber, isValidSwedishOrgNumber, vatFromOrgNumber } from './customerNumbers';
+import {
+  formatPersonalNumber,
+  isValidPersonalNumber,
+  PERSONAL_NUMBER_ERROR,
+  PERSONAL_NUMBER_HINT,
+} from '@/lib/domains/crm/personalNumber';
 import { riskTypeLabel } from '@/lib/domains/tic/mappers';
 import type { TicCreditReport } from '@/lib/domains/tic/types';
 import { PhoneLink, EmailLink, AddressLink } from '@/app/crm/components/ContactLinks';
@@ -396,6 +402,11 @@ export default function CustomerDetailClient({ customerId, fortnoxConnected }: {
     if (!customer || !editDraft) return;
     if (customer.customer_type === 'private' && !editDraft.personal_number.trim()) {
       toast.error('Personnummer krävs för privatkund'); return;
+    }
+    // Tio siffror räcker för att spara men gör att ROT- och husarbetesuppgifterna faller tyst i
+    // Fortnox — och felet upptäcks först i bokföringen. Neka här i stället.
+    if (customer.customer_type === 'private' && !isValidPersonalNumber(editDraft.personal_number)) {
+      toast.error(PERSONAL_NUMBER_ERROR); return;
     }
     setSaving(true);
     try {
@@ -788,7 +799,23 @@ export default function CustomerDetailClient({ customerId, fortnoxConnected }: {
                       </div>
                       <div>
                         <FieldLabel>Personnummer *</FieldLabel>
-                        <Input value={editDraft.personal_number} onChange={(e) => setField('personal_number', formatSwedishIdNumber(e.target.value))} placeholder="ÅÅMMDD-XXXX" />
+                        <Input
+                          value={editDraft.personal_number}
+                          onChange={(e) => setField('personal_number', formatPersonalNumber(e.target.value))}
+                          placeholder="ÅÅÅÅMMDD-XXXX"
+                          inputMode="numeric"
+                          aria-invalid={!!editDraft.personal_number.trim() && !isValidPersonalNumber(editDraft.personal_number)}
+                        />
+                        <p
+                          className={cn(
+                            'mt-1 text-[11px] leading-snug',
+                            editDraft.personal_number.trim() && !isValidPersonalNumber(editDraft.personal_number)
+                              ? 'text-rose-600'
+                              : 'text-slate-400',
+                          )}
+                        >
+                          {PERSONAL_NUMBER_HINT}
+                        </p>
                       </div>
                     </>
                   )}

--- a/app/crm/kunder/CustomerFormClient.tsx
+++ b/app/crm/kunder/CustomerFormClient.tsx
@@ -10,6 +10,12 @@ import { useToast } from '@/lib/Toast';
 import { crm } from '@/app/crm/lib/crmTokens';
 import { cn } from '@/lib/shared/cn';
 import { formatSwedishIdNumber, isValidSwedishOrgNumber, vatFromOrgNumber } from './customerNumbers';
+import {
+  formatPersonalNumber,
+  isValidPersonalNumber,
+  PERSONAL_NUMBER_ERROR,
+  PERSONAL_NUMBER_HINT,
+} from '@/lib/domains/crm/personalNumber';
 import { riskTypeLabel } from '@/lib/domains/tic/mappers';
 import { CreditReportSummary } from '@/app/crm/components/CreditReport';
 import type { TicLookupResult, TicRiskIndicator, TicCreditReport } from '@/lib/domains/tic/types';
@@ -325,7 +331,9 @@ export default function CustomerFormClient({ fortnoxConnected }: Props) {
       } else {
         if (r.first_name && !c.first_name.trim()) next.first_name = r.first_name;
         if (r.last_name && !c.last_name.trim()) next.last_name = r.last_name;
-        if (r.personal_number && !c.personal_number.trim()) next.personal_number = formatSwedishIdNumber(r.personal_number);
+        // Personnummer har EGEN maskning: formatSwedishIdNumber kapar vid tio siffror (rätt för
+        // org.nr) och hade klippt bort århundradet.
+        if (r.personal_number && !c.personal_number.trim()) next.personal_number = formatPersonalNumber(r.personal_number);
       }
       if (r.email && !c.email.trim()) next.email = r.email;
       if (r.phone && !c.phone.trim()) next.phone = r.phone;
@@ -396,7 +404,15 @@ export default function CustomerFormClient({ fortnoxConnected }: Props) {
       } else {
         body.first_name = draft.first_name.trim();
         body.last_name = draft.last_name.trim();
-        body.personal_number = draft.personal_number.trim() || null;
+        // Tomt är fortfarande tillåtet här (fylls ofta i senare) — men står det något ska det
+        // hålla, annars når ett trasigt nummer Fortnox och ROT-uppgifterna faller tyst.
+        const personalNumber = draft.personal_number.trim();
+        if (personalNumber && !isValidPersonalNumber(personalNumber)) {
+          // `finally` nedan nollställer saving — därför ingen egen setSaving här.
+          toast.error(PERSONAL_NUMBER_ERROR);
+          return;
+        }
+        body.personal_number = personalNumber || null;
       }
 
       const res = await fetch('/api/crm/customers', {
@@ -554,8 +570,20 @@ export default function CustomerFormClient({ fortnoxConnected }: Props) {
                     </div>
                     <div>
                       <FieldLabel>Personnummer</FieldLabel>
-                      <Input value={draft.personal_number} onChange={(e) => set('personal_number', formatSwedishIdNumber(e.target.value))} placeholder="ÅÅMMDD-XXXX" />
-                      <p className="mt-1 text-[11px] leading-snug text-slate-400">Kan fyllas i senare, men krävs innan en order kan skapas för kunden.</p>
+                      <Input
+                        value={draft.personal_number}
+                        onChange={(e) => set('personal_number', formatPersonalNumber(e.target.value))}
+                        placeholder="ÅÅÅÅMMDD-XXXX"
+                        inputMode="numeric"
+                        aria-invalid={!!draft.personal_number.trim() && !isValidPersonalNumber(draft.personal_number)}
+                      />
+                      {draft.personal_number.trim() && !isValidPersonalNumber(draft.personal_number) ? (
+                        <p className="mt-1 text-[11px] leading-snug text-rose-600">{PERSONAL_NUMBER_ERROR}</p>
+                      ) : (
+                        <p className="mt-1 text-[11px] leading-snug text-slate-400">
+                          Kan fyllas i senare, men krävs innan en order kan skapas. {PERSONAL_NUMBER_HINT}
+                        </p>
+                      )}
                     </div>
                   </>
                 )}

--- a/app/crm/offerter/QuoteFormClient.tsx
+++ b/app/crm/offerter/QuoteFormClient.tsx
@@ -12,7 +12,7 @@ import { lineItemQuantity } from '@/lib/domains/crm/lineItems';
 import { crm } from '@/app/crm/lib/crmTokens';
 import AddressAutocompleteInput from '@/app/crm/components/AddressAutocompleteInput';
 import CrmModal from '@/app/crm/components/CrmModal';
-import { formatSwedishIdNumber } from '@/app/crm/kunder/customerNumbers';
+import { formatPersonalNumber, isValidPersonalNumber, PERSONAL_NUMBER_ERROR } from '@/lib/domains/crm/personalNumber';
 import { DndContext, closestCenter, PointerSensor, TouchSensor, useSensor, useSensors, type DragEndEvent } from '@dnd-kit/core';
 import { SortableContext, verticalListSortingStrategy, arrayMove, useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
@@ -2664,7 +2664,7 @@ export default function QuoteFormClient({ quoteId }: { quoteId?: string }) {
           }
         >
           <Field label="Personnummer">
-            <Input value={pnValue} onChange={(e) => setPnValue(formatSwedishIdNumber(e.target.value))} placeholder="ÅÅMMDD-XXXX" autoFocus />
+            <Input value={pnValue} onChange={(e) => setPnValue(formatPersonalNumber(e.target.value))} placeholder="ÅÅÅÅMMDD-XXXX" inputMode="numeric" autoFocus />
           </Field>
         </CrmModal>
       ) : null}

--- a/lib/domains/crm/personalNumber.ts
+++ b/lib/domains/crm/personalNumber.ts
@@ -1,0 +1,113 @@
+// Svenskt personnummer — format och validering.
+//
+// VARFÖR TOLV SIFFROR, INTE TIO. Fortnox tar emot personnumret i samma fält som ett företags
+// org.nr (OrganisationNumber), och accepterar tio siffror utan att klaga. Men ROT- och
+// husarbetesuppgifterna slutar då fungera på dokumentet, och avdraget måste läggas in för hand i
+// Fortnox efteråt. Felet syns alltså inte där det begås — det dyker upp långt senare, i
+// bokföringen. Därför låser vi formatet i stället för att varna.
+//
+// EGEN MODUL I lib/, inte i app/crm/kunder/customerNumbers.ts: reglerna måste gälla i BÅDA
+// riktningarna. Klienten maskar medan man skriver, routen validerar det som faktiskt sparas, och
+// orderflödet vägrar skapa en order på ett ofullständigt nummer. Tre ställen, en sanning.
+//
+// Org.nr rör vi inte — det ÄR tio siffror. formatSwedishIdNumber lever kvar för det.
+
+/** Alla icke-siffror bort. Personnummer skrivs med bindestreck, plus, mellanslag — allt duger. */
+export function personalNumberDigits(value: string): string {
+  return (value || '').replace(/\D/g, '');
+}
+
+// Luhn (mod 10) över de tio sista siffrorna (ÅÅMMDDXXXX). Kontrollsiffran räknas ALLTID på
+// tiosiffersformen — århundradet ingår inte i beräkningen, vilket är just därför ett felaktigt
+// århundrade passerar Luhn och måste fångas av datumkontrollen nedan.
+function luhn10Valid(digits: string): boolean {
+  if (!/^\d{10}$/.test(digits)) return false;
+  let sum = 0;
+  for (let i = 0; i < 10; i++) {
+    let d = digits.charCodeAt(i) - 48;
+    if (i % 2 === 0) {
+      d *= 2;
+      if (d > 9) d -= 9;
+    }
+    sum += d;
+  }
+  return sum % 10 === 0;
+}
+
+/**
+ * Maskar medan man skriver: ÅÅÅÅMMDD-XXXX. Tolv siffror, bindestreck efter det åttonde.
+ *
+ * Skilt från formatSwedishIdNumber (org.nr), som kapar vid tio och sätter bindestrecket efter det
+ * sjätte. Att återanvända den för personnummer var precis felet — den klippte bort århundradet.
+ */
+export function formatPersonalNumber(value: string): string {
+  const digits = personalNumberDigits(value).slice(0, 12);
+  if (digits.length <= 8) return digits;
+  return `${digits.slice(0, 8)}-${digits.slice(8)}`;
+}
+
+/**
+ * Födelsedatumet ur ett tolvsiffrigt nummer, eller null om det inte är ett verkligt datum.
+ *
+ * Samordningsnummer (för den som saknar personnummer men ska folkbokföras för t.ex. arbete eller
+ * fastighetsägande) har dag + 60. De är giltiga kundnummer och får inte nekas.
+ */
+export function parsePersonalNumberBirthDate(digits: string): Date | null {
+  if (!/^\d{12}$/.test(digits)) return null;
+
+  const year = Number(digits.slice(0, 4));
+  const month = Number(digits.slice(4, 6));
+  const rawDay = Number(digits.slice(6, 8));
+  const day = rawDay > 60 ? rawDay - 60 : rawDay;
+
+  if (month < 1 || month > 12) return null;
+  if (day < 1 || day > 31) return null;
+
+  const date = new Date(year, month - 1, day);
+  // Fångar 31 februari och liknande: Date rullar över till nästa månad.
+  if (date.getFullYear() !== year || date.getMonth() !== month - 1 || date.getDate() !== day) return null;
+
+  return date;
+}
+
+/**
+ * Är numret ett komplett, rimligt personnummer med fullt årtal?
+ *
+ * Tre villkor, och det tredje är det som gör verklig nytta: eftersom Luhn bara räknar på de tio
+ * sista siffrorna passerar ett FELAKTIGT århundrade kontrollsiffran utan problem. Skriver någon
+ * `20850101-...` för en person född 1985 blir födelsedatumet 2085 — i framtiden. Utan
+ * datumkontrollen hade det sett giltigt ut hela vägen fram till Fortnox.
+ */
+export function isValidPersonalNumber(value: string, now: Date = new Date()): boolean {
+  const digits = personalNumberDigits(value);
+  if (digits.length !== 12) return false;
+  if (!luhn10Valid(digits.slice(2))) return false;
+
+  const birth = parsePersonalNumberBirthDate(digits);
+  if (!birth) return false;
+  if (birth.getTime() > now.getTime()) return false;
+
+  // Ingen levande kund är över 120 år. Fångar ett århundrade som slunkit ner i stället för upp.
+  const oldest = new Date(now.getFullYear() - 120, now.getMonth(), now.getDate());
+  if (birth.getTime() < oldest.getTime()) return false;
+
+  return true;
+}
+
+/**
+ * Kanonisk lagringsform: ÅÅÅÅMMDD-XXXX. Returnerar null när numret inte håller — anroparen ska
+ * då neka, inte gissa. Att härleda århundradet ur ett tiosiffrigt nummer vore en gissning, och en
+ * gissning på fel sida av sekelskiftet ger exakt samma trasiga ROT-uppgifter som idag.
+ */
+export function normalizePersonalNumber(value: string, now: Date = new Date()): string | null {
+  if (!isValidPersonalNumber(value, now)) return null;
+  const digits = personalNumberDigits(value);
+  return `${digits.slice(0, 8)}-${digits.slice(8)}`;
+}
+
+/** Felmeddelandet, på ett ställe — samma ord i formuläret, i routen och i orderflödet. */
+export const PERSONAL_NUMBER_ERROR =
+  'Ange personnumret med fullt årtal: ÅÅÅÅMMDD-XXXX (12 siffror). Tio siffror gör att ROT- och husarbetesuppgifterna slutar fungera i Fortnox.';
+
+/** Kortare variant för trånga ytor (inline-hjälp under fältet). */
+export const PERSONAL_NUMBER_HINT = 'Fullt årtal krävs — ÅÅÅÅMMDD-XXXX. Annars fungerar inte ROT i Fortnox.';

--- a/lib/domains/crm/work-orders.ts
+++ b/lib/domains/crm/work-orders.ts
@@ -3,6 +3,7 @@ import { crmQuoteSelect } from './quotes';
 import { resolveCrmContact, type CrmContactSource } from './contacts';
 import { computePricing, type PricingLineItem } from './pricing';
 import { activeLineItems, computeInvoiceState, validateLineItemEdit, type InvoiceRound } from '@/lib/domains/fortnox/partialInvoices';
+import { isValidPersonalNumber, PERSONAL_NUMBER_ERROR } from './personalNumber';
 
 export const crmWorkOrderSelect = `
   id,
@@ -156,6 +157,14 @@ export async function createStandaloneCrmWorkOrder(supabase: SupabaseClient, inp
     return { data: null, error: { message: 'Personnummer krävs för privatkund innan order kan skapas' }, reason: 'missing_personal_number' as const };
   }
 
+  // Och det ska vara ETT FULLT nummer. Kundkortet låser formatet numera, men rader som skapades
+  // innan dess bär tio siffror — och de tar sig hela vägen till Fortnox, där ROT- och
+  // husarbetesuppgifterna faller tyst och måste läggas in för hand. Här är sista stället felet går
+  // att fånga innan det blir ett bokföringsärende.
+  if (customer.customer_type === 'private' && !isValidPersonalNumber(customer.personal_number as string)) {
+    return { data: null, error: { message: PERSONAL_NUMBER_ERROR }, reason: 'invalid_personal_number' as const };
+  }
+
   const isBusiness = customer.customer_type === 'business';
   const clientName = isBusiness
     ? (customer.company_name || 'Okänd kund')
@@ -302,6 +311,13 @@ export async function createCrmWorkOrderFromQuote(supabase: SupabaseClient, quot
       return { data: null, error: { message: 'Personnummer krävs för privatkund innan order kan skapas' }, reason: 'missing_personal_number' as const };
     }
     orderSnapshot = { ...orderSnapshot, personal_number: personalNumber };
+  }
+
+  // Samma krav som på standalone-ordern, och det gäller BÅDE numret som redan låg i offertens
+  // snapshot och det som just hämtades från kundkortet: tio siffror ger trasiga ROT-uppgifter i
+  // Fortnox.
+  if (quote.quote_type === 'private' && !isValidPersonalNumber(String(orderSnapshot.personal_number ?? ''))) {
+    return { data: null, error: { message: PERSONAL_NUMBER_ERROR }, reason: 'invalid_personal_number' as const };
   }
 
   // ROT can only be filed with the property identified: fastighetsbeteckning for a småhus, or the

--- a/tests/crm/customers.route.test.ts
+++ b/tests/crm/customers.route.test.ts
@@ -427,7 +427,7 @@ describe('PATCH /api/crm/customers/[id]', () => {
   it('blockerar tömning av personnummer på en Fortnox-synkad privatkund (409, ingen skrivning)', async () => {
     mockGetCurrentUser.mockResolvedValue(salesUser);
     mockGet.mockResolvedValue({
-      data: { id: CUSTOMER_ID, customer_type: 'private', personal_number: '900101-1234', fortnox_customer_id: '123' },
+      data: { id: CUSTOMER_ID, customer_type: 'private', personal_number: '19850101-1236', fortnox_customer_id: '123' },
       error: null,
     } as any);
 
@@ -449,7 +449,7 @@ describe('PATCH /api/crm/customers/[id]', () => {
     mockUpdate.mockResolvedValue({ data: { id: CUSTOMER_ID }, error: null } as any);
 
     const res = await PATCH(
-      makeRequest('/api/crm/customers/c1', { method: 'PATCH', body: JSON.stringify({ personal_number: '900101-1234' }) }),
+      makeRequest('/api/crm/customers/c1', { method: 'PATCH', body: JSON.stringify({ personal_number: '19850101-1236' }) }),
       ctx
     );
 

--- a/tests/crm/customers.schema.test.ts
+++ b/tests/crm/customers.schema.test.ts
@@ -63,7 +63,7 @@ describe('createCrmCustomerSchema', () => {
         customer_type: 'private',
         first_name: 'Anna',
         last_name: 'Svensson',
-        personal_number: '900101-1234',
+        personal_number: '19850101-1236',
       });
       expect(result.success).toBe(true);
     });

--- a/tests/crm/personalNumber.test.ts
+++ b/tests/crm/personalNumber.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest';
+import {
+  formatPersonalNumber,
+  isValidPersonalNumber,
+  normalizePersonalNumber,
+  parsePersonalNumberBirthDate,
+  personalNumberDigits,
+} from '@/lib/domains/crm/personalNumber';
+
+// Referensnummer med giltig Luhn-kontrollsiffra över de tio sista siffrorna.
+// 850101-1236 → checksumman går jämnt ut.
+const VALID_10 = '8501011236';
+const VALID_12 = `19${VALID_10}`;
+const NOW = new Date('2026-08-12T12:00:00.000Z');
+
+describe('formatPersonalNumber', () => {
+  it('maskar till ÅÅÅÅMMDD-XXXX', () => {
+    expect(formatPersonalNumber('198501011236')).toBe('19850101-1236');
+  });
+
+  it('lägger bindestrecket efter ÅTTA siffror, inte sex', () => {
+    // Det var precis felet: org.nr-maskningen satte det efter sex och kapade vid tio, vilket
+    // klippte bort århundradet ur ett personnummer.
+    expect(formatPersonalNumber('19850101')).toBe('19850101');
+    expect(formatPersonalNumber('198501011')).toBe('19850101-1');
+  });
+
+  it('kapar vid tolv siffror och struntar i skiljetecken', () => {
+    expect(formatPersonalNumber('19850101-1236999')).toBe('19850101-1236');
+    expect(formatPersonalNumber('19850101 1236')).toBe('19850101-1236');
+    expect(formatPersonalNumber('19850101+1236')).toBe('19850101-1236');
+  });
+
+  it('hanterar tomt och skräp utan att krascha', () => {
+    expect(formatPersonalNumber('')).toBe('');
+    expect(formatPersonalNumber('abc')).toBe('');
+    expect(personalNumberDigits('19850101-1236')).toBe('198501011236');
+  });
+});
+
+describe('isValidPersonalNumber', () => {
+  it('godkänner ett fullständigt nummer', () => {
+    expect(isValidPersonalNumber(VALID_12, NOW)).toBe(true);
+    expect(isValidPersonalNumber('19850101-1236', NOW)).toBe(true);
+  });
+
+  // Kärnan i hela ändringen: tio siffror sparades förut utan protest och gav trasiga
+  // ROT-uppgifter i Fortnox.
+  it('NEKAR tio siffror, även med giltig kontrollsiffra', () => {
+    expect(isValidPersonalNumber(VALID_10, NOW)).toBe(false);
+    expect(isValidPersonalNumber('850101-1236', NOW)).toBe(false);
+  });
+
+  it('nekar fel kontrollsiffra', () => {
+    expect(isValidPersonalNumber('19850101-1237', NOW)).toBe(false);
+  });
+
+  // Luhn räknas bara på de tio sista siffrorna, så ett felaktigt århundrade passerar
+  // kontrollsiffran. Datumkontrollen är det enda som fångar det.
+  it('nekar ett århundrade som ger ett födelsedatum i framtiden', () => {
+    expect(isValidPersonalNumber(`20${VALID_10}`, NOW)).toBe(false);
+  });
+
+  it('nekar en orimligt gammal person', () => {
+    expect(isValidPersonalNumber(`18${VALID_10}`, NOW)).toBe(false);
+  });
+
+  it('nekar omöjliga datum', () => {
+    expect(isValidPersonalNumber('19851301-1236', NOW)).toBe(false); // månad 13
+    expect(isValidPersonalNumber('19850230-1236', NOW)).toBe(false); // 30 februari
+  });
+
+  it('nekar tomt och skräp', () => {
+    expect(isValidPersonalNumber('', NOW)).toBe(false);
+    expect(isValidPersonalNumber('inte ett nummer', NOW)).toBe(false);
+  });
+});
+
+// Samordningsnummer (dag + 60) tilldelas den som saknar personnummer men ska folkbokföras —
+// de kan äga fastighet och vara kund. De får inte nekas.
+describe('samordningsnummer', () => {
+  it('tolkar dag + 60 som ett verkligt datum', () => {
+    const birth = parsePersonalNumberBirthDate('198501611236');
+    expect(birth).not.toBeNull();
+    expect(birth!.getDate()).toBe(1);
+    expect(birth!.getMonth()).toBe(0);
+  });
+
+  it('nekar en dag som är omöjlig även efter avdraget', () => {
+    expect(parsePersonalNumberBirthDate('198501991236')).toBeNull(); // 99 − 60 = 39
+  });
+});
+
+describe('normalizePersonalNumber', () => {
+  it('ger den kanoniska formen', () => {
+    expect(normalizePersonalNumber('198501011236', NOW)).toBe('19850101-1236');
+    expect(normalizePersonalNumber(' 19850101 1236 ', NOW)).toBe('19850101-1236');
+  });
+
+  // Att härleda århundradet ur tio siffror vore en gissning — och en gissning på fel sida av
+  // sekelskiftet ger exakt samma trasiga ROT-uppgifter som felet vi rättar.
+  it('GISSAR INTE århundradet, utan returnerar null', () => {
+    expect(normalizePersonalNumber(VALID_10, NOW)).toBeNull();
+  });
+});

--- a/tests/crm/work-orders.test.ts
+++ b/tests/crm/work-orders.test.ts
@@ -94,11 +94,11 @@ describe('createCrmWorkOrderFromQuote — fält-mappning', () => {
 
   it('tillåter privatorder när snapshot har personnummer, och bevarar det på ordern', async () => {
     const { supabase, captured } = makeSupabase(
-      wonQuote({ quote_type: 'private', customer_id: null, customer_snapshot: { customer_name: 'Anna', personal_number: '900101-1234' } }),
+      wonQuote({ quote_type: 'private', customer_id: null, customer_snapshot: { customer_name: 'Anna', personal_number: '19850101-1236' } }),
     );
     const result = await createCrmWorkOrderFromQuote(supabase as any, 'q1', 'user-1');
     expect(result.error).toBeNull();
-    expect(captured.insert!.customer_snapshot.personal_number).toBe('900101-1234');
+    expect(captured.insert!.customer_snapshot.personal_number).toBe('19850101-1236');
   });
 
   // V3: ROT-avdraget kan inte begäras utan att fastigheten är identifierad, och Fortnox har inget
@@ -110,8 +110,8 @@ describe('createCrmWorkOrderFromQuote — fält-mappning', () => {
     wonQuote({
       quote_type: 'private',
       customer_id: null,
-      customer_snapshot: { customer_name: 'Anna', personal_number: '900101-1234' },
-      rot_details: { enabled: true, personal_number: '900101-1234', ...rot },
+      customer_snapshot: { customer_name: 'Anna', personal_number: '19850101-1236' },
+      rot_details: { enabled: true, personal_number: '19850101-1236', ...rot },
     });
 
   it('blockerar ROT-order utan fastighetsbeteckning och BRF org.nr', async () => {


### PR DESCRIPTION
Tio siffror sparades utan protest och accepterades även av Fortnox — men ROT- och husarbetesuppgifterna slutade då fungera på dokumentet, och avdraget fick läggas in för hand i efterhand. Felet syntes inte där det begicks; det dök upp i bokföringen.

## Grundorsaken

Samma formatterare användes för org.nr och personnummer. `formatSwedishIdNumber` kapar hårt vid tio siffror och sätter bindestrecket efter det sjätte — helt rätt för ett org.nr, men **det klipper bort århundradet ur ett personnummer**. Skrev man `19850101-1236` blev det `198501-0112`.

Personnumret har nu egen maskning: `ÅÅÅÅMMDD-XXXX`. Org.nr är orört.

## Tre lager, en sanning

Reglerna ligger i [`lib/domains/crm/personalNumber.ts`](lib/domains/crm/personalNumber.ts) så att alla lager validerar likadant:

| Lager | Vad det gör |
|---|---|
| Kundformulär + detaljvy | maskar medan man skriver, varnar direkt under fältet |
| `POST`/`PATCH /api/crm/customers` | avgör vad som faktiskt sparas |
| Orderflödet (båda vägarna) | vägrar skapa order på ett ofullständigt nummer |

Det sista lagret är det som fångar rader skapade **före** den här ändringen — och det är där skadan uppstår, eftersom ordern är det som når Fortnox.

## Datumkontrollen är inte pynt

Luhn räknas bara på de tio sista siffrorna. Ett **felaktigt århundrade passerar alltså kontrollsiffran obemärkt**: skriver någon `20850101-…` för en person född 1985 blir födelsedatumet 2085. Utan kontrollen "födelsedatumet får inte ligga i framtiden" hade det sett giltigt ut hela vägen fram till Fortnox — samma tysta fel, ny orsak.

Samordningsnummer (dag + 60) godkänns: de tilldelas den som saknar personnummer men ska folkbokföras, och de kan äga fastighet och vara kund.

## Felkod

Ogiltigt personnummer delar kod med saknat (`crm_work_order_missing_personal_number`). Åtgärden är identisk — fyll i ett fullständigt nummer — och klienten fäller redan ut fältet på den koden. Ett eget felnamn hade krävt en andra gren i UI:t för samma handling; meddelandet skiljer dem åt.

## Mätt mot skarp data före merge

794 privatkunder:

| Siffror | Antal | Innebörd |
|---|---|---|
| 12 | **447** | fungerar redan |
| tomt / null | 322 | blockeras redan idag — **ingen förändring** |
| 5–11 | **25** | nyblockerade |

Bara 25 kunder påverkas, och de flesta bär platshållare (`111111`, `1111111`, `0000000`) som någon skrivit för att komma förbi det obligatoriska fältet. Bland de äkta finns en handfull tiosiffriga och två avhuggna tolvsiffriga (`19720727-`, `19730917`). Det är precis de kunderna där ROT tyst gick sönder.

**Ingen migrering.** Befintliga rader rörs inte — de rättas i kundkortet när de dyker upp, och orderspärren säger till exakt när det behövs.

## Testning

- 1021 tester gröna, 15 nya för formatering, Luhn, århundrade, samordningsnummer och normalisering
- Sju befintliga tester failade på fixtures med `900101-1234` (tio siffror, inte ens Luhn-giltigt) — uppdaterade, och de bekräftade att låset fungerar
- `npm run type-check` + `npm run build` rena
