### PR TITLE
Offertformuläret: giltighetstid, artikelbeskrivning och täckningsgrad

### DIFF
--- a/app/api/crm/quotes/_lib.ts
+++ b/app/api/crm/quotes/_lib.ts
@@ -93,6 +93,11 @@ export const quoteLineItemSchema = z.object({
   article_number: z.preprocess((value) => normalizeOptionalText(value), z.string().nullable()).optional().default(null),
   article_price: z.preprocess((value) => (value == null || value === '' ? null : parseAmount(value)), z.number().finite('Ogiltigt artikelpris').nullable()).optional().default(null),
   article_unit_name: z.preprocess((value) => normalizeOptionalText(value), z.string().nullable()).optional().default(null),
+  // Artikelns beskrivning ur artikelregistret, kopierad till raden när artikeln väljs. MÅSTE ligga
+  // i schemat — annars strippar Zod fältet vid varje sparning och hjälptexten försvinner tyst så
+  // fort offerten öppnas igen. Samma fälla som is_rot_work och written_off gick i.
+  // INTERN: läses aldrig av Fortnox-pushen, se tests/fortnox/offers.test.ts.
+  article_note: z.preprocess((value) => normalizeOptionalText(value), z.string().nullable()).optional().default(null),
   discount_percent: z.preprocess((value) => normalizeOptionalText(value) ?? '', z.string()).optional().default(''),
   line_note: z.preprocess((value) => normalizeOptionalText(value) ?? '', z.string()).optional().default(''),
   is_rot_work: z.boolean().optional().default(false),

--- a/app/api/fortnox/articles/route.ts
+++ b/app/api/fortnox/articles/route.ts
@@ -36,8 +36,10 @@ export async function GET(req: Request) {
 
     const articles = await listCachedFortnoxArticles({
       search: parsed.data.q,
-      // En uppslagning på nummer ska hitta artikeln även om den avaktiverats sedan offerten skrevs.
-      activeOnly: numbers ? false : parsed.data.active_only !== 'false',
+      // En uppslagning på nummer ska SOM DEFAULT hitta artikeln även om den avaktiverats sedan
+      // offerten skrevs — men en anropare som uttryckligen ber om active_only=true ska få det.
+      // Att tyst kasta bort parametern hade gett tillbaka avaktiverade artiklar utan någon signal.
+      activeOnly: numbers ? parsed.data.active_only === 'true' : parsed.data.active_only !== 'false',
       limit: parsed.data.limit,
       numbers,
     });

--- a/app/api/fortnox/articles/route.ts
+++ b/app/api/fortnox/articles/route.ts
@@ -10,6 +10,10 @@ const querySchema = z.object({
   q: z.string().trim().optional(),
   active_only: z.enum(['true', 'false']).optional(),
   limit: z.coerce.number().int().min(1).max(1000).optional(),
+  // Kommaseparerade artikelnummer. Offertformuläret slår upp inköpspris för de artiklar en
+  // redigerad offert redan använder, i stället för att hämta hela registret. Taket speglar
+  // registrets storlek och hindrar en orimligt lång IN-lista.
+  numbers: z.string().trim().min(1).optional(),
 });
 
 export async function GET(req: Request) {
@@ -22,13 +26,20 @@ export async function GET(req: Request) {
       q: url.searchParams.get('q') || undefined,
       active_only: url.searchParams.get('active_only') || undefined,
       limit: url.searchParams.get('limit') || undefined,
+      numbers: url.searchParams.get('numbers') || undefined,
     });
     if (!parsed.success) return validationError(parsed.error);
 
+    const numbers = parsed.data.numbers
+      ? [...new Set(parsed.data.numbers.split(',').map((n) => n.trim()).filter(Boolean))].slice(0, 500)
+      : undefined;
+
     const articles = await listCachedFortnoxArticles({
       search: parsed.data.q,
-      activeOnly: parsed.data.active_only !== 'false',
+      // En uppslagning på nummer ska hitta artikeln även om den avaktiverats sedan offerten skrevs.
+      activeOnly: numbers ? false : parsed.data.active_only !== 'false',
       limit: parsed.data.limit,
+      numbers,
     });
 
     return ok({ items: articles, count: articles.length });

--- a/app/api/fortnox/articles/sync/route.ts
+++ b/app/api/fortnox/articles/sync/route.ts
@@ -7,7 +7,9 @@ export async function POST() {
     if (admin.response) return admin.response;
 
     const result = await syncFortnoxArticles();
-    return ok({ synced: result.synced, pages: result.pages });
+    // notesFetched: hur många artikelbeskrivningar som hämtades. Första körningen efter att
+    // funktionen infördes hämtar hela registret (~100 s); därefter är den nära noll.
+    return ok({ synced: result.synced, pages: result.pages, notesFetched: result.notesFetched });
   } catch (e: any) {
     return routeError(500, 'fortnox_articles_sync_failed', e?.message || 'Artikelsynk misslyckades');
   }

--- a/app/api/fortnox/articles/sync/route.ts
+++ b/app/api/fortnox/articles/sync/route.ts
@@ -1,6 +1,12 @@
 import { requireCrmAdmin, ok, routeError } from '../../_shared';
 import { syncFortnoxArticles } from '@/lib/domains/fortnox/articles';
 
+// Den FÖRSTA synken efter att beskrivningarna infördes hämtar dem en artikel i taget, throttlat
+// (~289 anrop à 300 ms ≈ 100 s), och kan därtill rida ut en 429-backoff. Deklarera taket i stället
+// för att förlita sig på plattformens default — en tystnad här ser ut som "synk misslyckades" fast
+// rader faktiskt skrevs. Efterföljande synkar hämtar bara nya artiklar och tar sekunder.
+export const maxDuration = 300;
+
 export async function POST() {
   try {
     const admin = await requireCrmAdmin();

--- a/app/crm/installningar/artiklar/ArticlesClient.tsx
+++ b/app/crm/installningar/artiklar/ArticlesClient.tsx
@@ -69,12 +69,22 @@ export default function ArticlesClient({ initialArticles, fortnoxConnected }: Ar
   async function handleSync() {
     setSyncing(true);
     try {
-      await apiRequest('/api/fortnox/articles/sync', { method: 'POST' });
+      // Synken hämtar även artiklarnas beskrivningar, och de finns bara på Fortnox enskild-GET —
+      // alltså ett anrop per artikel, throttlat. Första körningen tar därför ett par minuter.
+      // Därefter hämtas bara nya artiklar och synken är snabb igen. Utan den här förvarningen ser
+      // en tyst knapp ut som att ingenting händer, och någon trycker om eller lämnar sidan.
+      const result = await apiRequest<{ synced: number; notesFetched?: number }>(
+        '/api/fortnox/articles/sync', { method: 'POST' },
+      );
       const data = await apiRequest<{ items: CachedFortnoxArticle[] }>(
         '/api/fortnox/articles?active_only=false&limit=1000',
       );
       setArticles(data.items);
-      toast.success('Artikelregistret synkades från Fortnox');
+      toast.success(
+        result.notesFetched
+          ? `Artikelregistret synkades — ${result.notesFetched} beskrivningar hämtades`
+          : 'Artikelregistret synkades från Fortnox',
+      );
     } catch (e: any) {
       toast.error(e?.message || 'Synk misslyckades');
     } finally {
@@ -94,7 +104,7 @@ export default function ArticlesClient({ initialArticles, fortnoxConnected }: Ar
         </div>
         <div className="flex flex-wrap items-center gap-2">
           <Button variant="secondary" onClick={handleSync} disabled={!fortnoxConnected || syncing}>
-            {syncing ? 'Synkar…' : 'Synka från Fortnox'}
+            {syncing ? 'Synkar… (kan ta ett par minuter)' : 'Synka från Fortnox'}
           </Button>
           <Link href={`${LIST_BASE}/ny`} className={buttonVariants({ variant: 'primary' }) + ' no-underline'}>
             Ny artikel

--- a/app/crm/offerter/QuoteFormClient.tsx
+++ b/app/crm/offerter/QuoteFormClient.tsx
@@ -10,7 +10,8 @@ import { cn } from '@/lib/shared/cn';
 import { parseDecimal } from '@/lib/shared/number';
 import { lineItemQuantity } from '@/lib/domains/crm/lineItems';
 import {
-  lineItemMarginPercent, marginTier, quoteMargin, MARGIN_THRESHOLDS, type MarginTier,
+  rowMarginPercent, marginTier, quoteMargin, MARGIN_THRESHOLDS,
+  type MarginRow, type MarginTier,
 } from '@/lib/domains/crm/pricing';
 import { crm } from '@/app/crm/lib/crmTokens';
 import AddressAutocompleteInput from '@/app/crm/components/AddressAutocompleteInput';
@@ -854,12 +855,14 @@ function MarginBadge({ marginPercent, className }: { marginPercent: number | nul
     <span
       title={titles[tier]}
       className={cn(
+        // En decimal, inte toFixed(0): 34,6 % är rött men avrundades till "TG 35 %" — märket
+        // påstod exakt den tröskel det låg under. Siffran måste hamna på samma sida som färgen.
         'inline-flex items-center gap-1 rounded-md border border-solid px-1.5 py-0.5 text-[11px] font-semibold tabular-nums',
         styles[tier],
         className,
       )}
     >
-      TG {marginPercent.toFixed(0)} %
+      TG {marginPercent.toFixed(1)} %
     </span>
   );
 }
@@ -1024,8 +1027,12 @@ function LineItemRow({
             </Select>
           </label>
         ) : null}
-        <MarginBadge marginPercent={marginPercent} className="ml-auto" />
-        <span className="text-sm font-semibold tabular-nums text-slate-900">{formatCurrency(metrics?.rowTotal ?? 0, 'SEK')}</span>
+        {/* ml-auto MÅSTE sitta på summan, inte på märket: MarginBadge renderar null när
+            inköpspriset saknas (61 av 289 artiklar, plus varje rad utan vald artikel), och då
+            tappade beloppet sin högerställning och hoppade i sidled mellan raderna. */}
+        <span className="ml-auto flex items-center gap-2 text-sm font-semibold tabular-nums text-slate-900">
+          <MarginBadge marginPercent={marginPercent} />{formatCurrency(metrics?.rowTotal ?? 0, 'SEK')}
+        </span>
       </div>
 
       <Field label="Radtext"><Input value={row.line_note} onChange={(e) => onChange({ line_note: e.target.value })} placeholder="Fritext för raden" /></Field>
@@ -1806,6 +1813,58 @@ export default function QuoteFormClient({ quoteId }: { quoteId?: string }) {
     await createWorkOrderFromQuote();
   }
 
+  // ── Täckningsgrad (TG) ──
+  //
+  // ⚠️ HOOKARNA MÅSTE LIGGA HÄR, ÖVER `if (loading) return`. Ligger de under körs de inte på
+  // första rendern av en redigerad offert (loading startar true) men väl på den andra, och React
+  // kastar "Rendered more hooks than during the previous render" → vit sida vid varje redigering.
+  // Repot saknar ESLint, så react-hooks/rules-of-hooks fångar det inte; type-check och tester
+  // gjorde det inte heller.
+  //
+  // ⚠️ Inköpspriserna hålls i komponent-state — aldrig i `draft`. Utkastet sparas som `line_items`,
+  // och de följer med offert → arbetsorder → fältvyn (redactWorkOrderForField plockar bara bort
+  // amount/pricing_summary). Ett inköpspris på raden hade alltså hamnat i installatörernas payload.
+  const [purchasePrices, setPurchasePrices] = useState<Record<string, number | null>>({});
+
+  // Vid redigering bär raderna artikelnummer men inget inköpspris (det är ju aldrig sparat). Slå
+  // upp priserna för just de artiklar offerten använder — inte hela registret.
+  const articleNumbersOnRows = draft.items.map((i) => i.article_number).filter(Boolean).join(',');
+  useEffect(() => {
+    const numbers = [...new Set(articleNumbersOnRows.split(',').filter(Boolean))]
+      .filter((nr) => !(nr in purchasePrices));
+    if (numbers.length === 0) return;
+    let cancelled = false;
+    fetch(`/api/fortnox/articles?numbers=${encodeURIComponent(numbers.join(','))}`, { cache: 'no-store' })
+      .then((r) => r.json().catch(() => ({})))
+      .then((json) => {
+        if (cancelled) return;
+        const items: Array<{ article_number: string; purchase_price?: number | null }> =
+          Array.isArray(json?.data?.items) ? json.data.items : [];
+        // Varje efterfrågat nummer får ett svar, ÄVEN när priset saknas (null). Utan den negativa
+        // noteringen skulle de 61 artiklarna utan inköpspris slås upp på nytt vid varje
+        // radändring, eftersom `!(nr in purchasePrices)` aldrig blev falskt för dem.
+        const next: Record<string, number | null> = Object.fromEntries(numbers.map((nr) => [nr, null]));
+        for (const a of items) {
+          if (typeof a.purchase_price === 'number' && a.purchase_price > 0) next[a.article_number] = a.purchase_price;
+        }
+        setPurchasePrices((prev) => ({ ...prev, ...next }));
+      })
+      .catch(() => { /* tyst — TG är hjälpinformation, inte något offerten hänger på */ });
+    return () => { cancelled = true; };
+  }, [articleNumbersOnRows]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // TG räknas på SAMMA belopp som visas på skärmen (effectiveRows.rowTotal), inte ur raden på nytt.
+  // Formuläret prissätter auto-prissatta rader med sin egen stub medan pricing.ts ger dem 0 — räknade
+  // vi om här skulle en auto-rad bidra med 0 kr till TG:n men synas i Delsumman, och inte ens
+  // flaggas som obedömd. Se MarginRow i pricing.ts.
+  const marginRows: MarginRow[] = effectiveRows.map((r) => ({
+    revenue: r.rowTotal,
+    quantity: r.amount,
+    purchasePrice: r.article_number ? purchasePrices[r.article_number] ?? null : null,
+  }));
+  const quoteMarginResult = quoteMargin(marginRows);
+  const quoteMarginTier = marginTier(quoteMarginResult.marginPercent);
+
   if (loading) {
     return (
       <div className="flex min-h-screen items-center justify-center">
@@ -1848,48 +1907,6 @@ export default function QuoteFormClient({ quoteId }: { quoteId?: string }) {
   // lagrat — se matchedValidityPreset i quoteSerializers.
   const validityPreset = matchedValidityPreset(draft.quote_date, draft.valid_until);
 
-  // Radernas täckningsgrad: intäkt mot inköpspris.
-  //
-  // ⚠️ Inköpspriserna hålls HÄR, i komponent-state — aldrig i `draft`. Utkastet sparas som
-  // `line_items`, och de följer med offert → arbetsorder → fältvyn (redactWorkOrderForField
-  // plockar bara bort amount/pricing_summary). Ett inköpspris på raden hade alltså hamnat i
-  // installatörernas payload. Genom att aldrig lägga det där finns ingen läckyta att täta.
-  const [purchasePrices, setPurchasePrices] = useState<Record<string, number>>({});
-
-  // Vid redigering bär raderna artikelnummer men inget inköpspris (det är ju aldrig sparat). Slå
-  // upp priserna för just de artiklar offerten använder — inte hela registret.
-  const articleNumbersOnRows = draft.items.map((i) => i.article_number).filter(Boolean).join(',');
-  useEffect(() => {
-    const numbers = [...new Set(articleNumbersOnRows.split(',').filter(Boolean))]
-      .filter((nr) => !(nr in purchasePrices));
-    if (numbers.length === 0) return;
-    let cancelled = false;
-    fetch(`/api/fortnox/articles?numbers=${encodeURIComponent(numbers.join(','))}&limit=500`, { cache: 'no-store' })
-      .then((r) => r.json().catch(() => ({})))
-      .then((json) => {
-        if (cancelled) return;
-        const items: Array<{ article_number: string; purchase_price?: number | null }> =
-          Array.isArray(json?.data?.items) ? json.data.items : [];
-        const next: Record<string, number> = {};
-        for (const a of items) {
-          if (typeof a.purchase_price === 'number' && a.purchase_price > 0) next[a.article_number] = a.purchase_price;
-        }
-        // Icke-fatalt om uppslaget failar: TG visas bara inte, offerten fungerar som förut.
-        if (Object.keys(next).length) setPurchasePrices((prev) => ({ ...prev, ...next }));
-      })
-      .catch(() => { /* tyst — TG är hjälpinformation, inte något offerten hänger på */ });
-    return () => { cancelled = true; };
-  }, [articleNumbersOnRows]); // eslint-disable-line react-hooks/exhaustive-deps
-
-  const purchasePriceForRow = (item: QuoteLineItem): number | null =>
-    (item.article_number ? purchasePrices[item.article_number] : undefined) ?? null;
-
-  // Offertens samlade TG. Viktad på belopp, inte ett snitt av radernas procent — se quoteMargin.
-  const quoteMarginResult = quoteMargin(
-    draft.items,
-    (index) => purchasePriceForRow(draft.items[index]),
-  );
-  const quoteMarginTier = marginTier(quoteMarginResult.marginPercent);
 
   const sections: { id: string; label: string; done?: boolean }[] = [
     { id: 'section-kund', label: 'Kund', done: Boolean(draft.quote_type === 'business' ? (draft.company_name || draft.customer_name) : draft.customer_name) },
@@ -2369,7 +2386,7 @@ export default function QuoteFormClient({ quoteId }: { quoteId?: string }) {
                 dragHandle={dragHandle}
                 metrics={effectiveRows.find((r) => r.id === row.id)}
                 rotEnabled={draft.rot_enabled}
-                marginPercent={lineItemMarginPercent(row, purchasePriceForRow(row))}
+                marginPercent={rowMarginPercent(marginRows[index])}
                 expanded={expandedRowId === row.id}
                 onToggle={(next) => setExpandedRowId(next ? row.id : null)}
                 onChange={(patch) => setDraft((d) => ({ ...d, items: d.items.map((item) => item.id === row.id ? { ...item, ...patch } : item) }))}

--- a/app/crm/offerter/QuoteFormClient.tsx
+++ b/app/crm/offerter/QuoteFormClient.tsx
@@ -9,6 +9,9 @@ import { useToast } from '@/lib/Toast';
 import { cn } from '@/lib/shared/cn';
 import { parseDecimal } from '@/lib/shared/number';
 import { lineItemQuantity } from '@/lib/domains/crm/lineItems';
+import {
+  lineItemMarginPercent, marginTier, quoteMargin, MARGIN_THRESHOLDS, type MarginTier,
+} from '@/lib/domains/crm/pricing';
 import { crm } from '@/app/crm/lib/crmTokens';
 import AddressAutocompleteInput from '@/app/crm/components/AddressAutocompleteInput';
 import CrmModal from '@/app/crm/components/CrmModal';
@@ -212,6 +215,9 @@ type ArticleLite = {
   isFavorite?: boolean;
   // Artikelns beskrivning ur registret. INTERN hjälptext för säljaren — se article_note på raden.
   note?: string | null;
+  // Inköpspris ur artikelcachen, för täckningsgraden. Lagras ALDRIG på offertraden (se pricing.ts):
+  // line_items följer med till fältvyn, och där har installatörerna inget med inköpspriser att göra.
+  purchasePrice?: number | null;
 };
 
 type CrmCustomerLite = {
@@ -474,7 +480,7 @@ function ArticlePicker({ value, articleNumber, price, unit, note, onSelect, onCl
         .then((r) => r.json().catch(() => ({})))
         .then((json) => {
           if (!cancelled) {
-            const raw: Array<{ article_number: string; description: string | null; note?: string | null; sales_price: number | null; unit: string | null; is_favorite?: boolean }> =
+            const raw: Array<{ article_number: string; description: string | null; note?: string | null; sales_price: number | null; purchase_price?: number | null; unit: string | null; is_favorite?: boolean }> =
               Array.isArray(json?.data?.items) ? json.data.items : [];
             setItems(raw.map((a) => ({
               id: a.article_number,
@@ -484,6 +490,7 @@ function ArticlePicker({ value, articleNumber, price, unit, note, onSelect, onCl
               unit: a.unit ?? undefined,
               isFavorite: a.is_favorite ?? false,
               note: a.note ?? null,
+              purchasePrice: a.purchase_price ?? null,
             })));
           }
         })
@@ -818,11 +825,51 @@ function SortableLineItem({ id, children }: { id: string; children: (dragHandle:
   );
 }
 
+// ─── MarginBadge ──────────────────────────────────────────────────────────────
+//
+// Täckningsgrad per rad, färgad efter MARGIN_THRESHOLDS. Ett stöd för säljaren att se när en
+// rabatt äter marginalen — inte en spärr: rött hindrar ingen från att spara eller skicka, det
+// säger att offerten behöver godkännas.
+//
+// Saknas inköpspris visas INGET märke alls (61 av 289 artiklar har inget). Ett grått "?" på var
+// femte rad hade blivit brus, och en avsaknad av pris är inte en dålig affär.
+function MarginBadge({ marginPercent, className }: { marginPercent: number | null; className?: string }) {
+  const tier = marginTier(marginPercent);
+  if (tier === 'unknown' || marginPercent == null) return null;
+
+  // Egna klasser i stället för Badge-primitiven: den här ska vara liten och sifferorienterad
+  // (tabular-nums så procenten inte hoppar i sidled när säljaren skriver i prisfältet).
+  const styles: Record<Exclude<MarginTier, 'unknown'>, string> = {
+    good: 'border-emerald-200 bg-emerald-50 text-emerald-700',
+    watch: 'border-amber-200 bg-amber-50 text-amber-700',
+    bad: 'border-rose-200 bg-rose-50 text-rose-700',
+  };
+  const titles: Record<Exclude<MarginTier, 'unknown'>, string> = {
+    good: `Täckningsgrad ${marginPercent.toFixed(1)} % – över ${MARGIN_THRESHOLDS.good} %`,
+    watch: `Täckningsgrad ${marginPercent.toFixed(1)} % – under ${MARGIN_THRESHOLDS.good} %, se över priset`,
+    bad: `Täckningsgrad ${marginPercent.toFixed(1)} % – under ${MARGIN_THRESHOLDS.watch} %, offerten kräver godkännande`,
+  };
+
+  return (
+    <span
+      title={titles[tier]}
+      className={cn(
+        'inline-flex items-center gap-1 rounded-md border border-solid px-1.5 py-0.5 text-[11px] font-semibold tabular-nums',
+        styles[tier],
+        className,
+      )}
+    >
+      TG {marginPercent.toFixed(0)} %
+    </span>
+  );
+}
+
 function LineItemRow({
   row,
   index,
   metrics,
   rotEnabled,
+  marginPercent,
   expanded,
   onToggle,
   onChange,
@@ -835,6 +882,8 @@ function LineItemRow({
   index: number;
   metrics: EffectiveRow | undefined;
   rotEnabled: boolean;
+  /** Radens täckningsgrad i procent, eller null när artikeln saknar inköpspris. */
+  marginPercent: number | null;
   // Accordion: which row is open is owned by the parent so opening one collapses the rest.
   expanded: boolean;
   onToggle: (next: boolean) => void;
@@ -975,7 +1024,8 @@ function LineItemRow({
             </Select>
           </label>
         ) : null}
-        <span className="ml-auto text-sm font-semibold tabular-nums text-slate-900">{formatCurrency(metrics?.rowTotal ?? 0, 'SEK')}</span>
+        <MarginBadge marginPercent={marginPercent} className="ml-auto" />
+        <span className="text-sm font-semibold tabular-nums text-slate-900">{formatCurrency(metrics?.rowTotal ?? 0, 'SEK')}</span>
       </div>
 
       <Field label="Radtext"><Input value={row.line_note} onChange={(e) => onChange({ line_note: e.target.value })} placeholder="Fritext för raden" /></Field>
@@ -1798,6 +1848,49 @@ export default function QuoteFormClient({ quoteId }: { quoteId?: string }) {
   // lagrat — se matchedValidityPreset i quoteSerializers.
   const validityPreset = matchedValidityPreset(draft.quote_date, draft.valid_until);
 
+  // Radernas täckningsgrad: intäkt mot inköpspris.
+  //
+  // ⚠️ Inköpspriserna hålls HÄR, i komponent-state — aldrig i `draft`. Utkastet sparas som
+  // `line_items`, och de följer med offert → arbetsorder → fältvyn (redactWorkOrderForField
+  // plockar bara bort amount/pricing_summary). Ett inköpspris på raden hade alltså hamnat i
+  // installatörernas payload. Genom att aldrig lägga det där finns ingen läckyta att täta.
+  const [purchasePrices, setPurchasePrices] = useState<Record<string, number>>({});
+
+  // Vid redigering bär raderna artikelnummer men inget inköpspris (det är ju aldrig sparat). Slå
+  // upp priserna för just de artiklar offerten använder — inte hela registret.
+  const articleNumbersOnRows = draft.items.map((i) => i.article_number).filter(Boolean).join(',');
+  useEffect(() => {
+    const numbers = [...new Set(articleNumbersOnRows.split(',').filter(Boolean))]
+      .filter((nr) => !(nr in purchasePrices));
+    if (numbers.length === 0) return;
+    let cancelled = false;
+    fetch(`/api/fortnox/articles?numbers=${encodeURIComponent(numbers.join(','))}&limit=500`, { cache: 'no-store' })
+      .then((r) => r.json().catch(() => ({})))
+      .then((json) => {
+        if (cancelled) return;
+        const items: Array<{ article_number: string; purchase_price?: number | null }> =
+          Array.isArray(json?.data?.items) ? json.data.items : [];
+        const next: Record<string, number> = {};
+        for (const a of items) {
+          if (typeof a.purchase_price === 'number' && a.purchase_price > 0) next[a.article_number] = a.purchase_price;
+        }
+        // Icke-fatalt om uppslaget failar: TG visas bara inte, offerten fungerar som förut.
+        if (Object.keys(next).length) setPurchasePrices((prev) => ({ ...prev, ...next }));
+      })
+      .catch(() => { /* tyst — TG är hjälpinformation, inte något offerten hänger på */ });
+    return () => { cancelled = true; };
+  }, [articleNumbersOnRows]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const purchasePriceForRow = (item: QuoteLineItem): number | null =>
+    (item.article_number ? purchasePrices[item.article_number] : undefined) ?? null;
+
+  // Offertens samlade TG. Viktad på belopp, inte ett snitt av radernas procent — se quoteMargin.
+  const quoteMarginResult = quoteMargin(
+    draft.items,
+    (index) => purchasePriceForRow(draft.items[index]),
+  );
+  const quoteMarginTier = marginTier(quoteMarginResult.marginPercent);
+
   const sections: { id: string; label: string; done?: boolean }[] = [
     { id: 'section-kund', label: 'Kund', done: Boolean(draft.quote_type === 'business' ? (draft.company_name || draft.customer_name) : draft.customer_name) },
     { id: 'section-offert', label: 'Offert', done: Boolean(draft.project_name.trim()) },
@@ -2276,6 +2369,7 @@ export default function QuoteFormClient({ quoteId }: { quoteId?: string }) {
                 dragHandle={dragHandle}
                 metrics={effectiveRows.find((r) => r.id === row.id)}
                 rotEnabled={draft.rot_enabled}
+                marginPercent={lineItemMarginPercent(row, purchasePriceForRow(row))}
                 expanded={expandedRowId === row.id}
                 onToggle={(next) => setExpandedRowId(next ? row.id : null)}
                 onChange={(patch) => setDraft((d) => ({ ...d, items: d.items.map((item) => item.id === row.id ? { ...item, ...patch } : item) }))}
@@ -2284,6 +2378,10 @@ export default function QuoteFormClient({ quoteId }: { quoteId?: string }) {
                   const unitName = getArticleUnitName(article.unit);
                   const normalizedUnit = unitName.trim().toLowerCase();
                   const pricingMode: 'm3' | 'item' = normalizedUnit === 'm3' || normalizedUnit === 'm³' || /m\s*³/i.test(normalizedUnit) ? 'm3' : 'item';
+                  if (article.articleNumber && typeof article.purchasePrice === 'number' && article.purchasePrice > 0) {
+                    // Inköpspriset stannar i komponent-state, aldrig i draft — se purchasePrices.
+                    setPurchasePrices((prev) => ({ ...prev, [article.articleNumber!]: article.purchasePrice! }));
+                  }
                   setDraft((current) => ({
                     ...current,
                     items: current.items.map((item) => item.id === row.id ? {
@@ -2536,6 +2634,41 @@ export default function QuoteFormClient({ quoteId }: { quoteId?: string }) {
                           <span className="tabular-nums">{formatCurrency(totals.toPay, 'SEK')}</span>
                         </div>
                       </>
+                    ) : null}
+
+                    {/* Offertens samlade täckningsgrad. Viktad på belopp — se quoteMargin; ett
+                        ovägt snitt av radernas procent hade låtit en småpostrad väga lika tungt
+                        som huvudposten. Visas bara när minst en rad går att bedöma.
+
+                        INGEN ram och särskilt inte `border-t border-solid`: med preflight av
+                        sätter border-solid stilen på ALLA fyra sidor medan border-t bara sätter
+                        bredden upptill, så övriga sidor ärver webbläsarens `medium` (3px) och det
+                        blir en fantomram runt hela blocket. Se FRONTEND_SYSTEM.md. Raderna ovanför
+                        separeras med luft, så den här gör likadant. */}
+                    {quoteMarginResult.marginPercent != null ? (
+                      <div className="mt-2.5 grid gap-1">
+                        <div className="flex items-center justify-between text-xs">
+                          <span className="text-slate-500">Täckningsgrad</span>
+                          <MarginBadge marginPercent={quoteMarginResult.marginPercent} />
+                        </div>
+                        {quoteMarginResult.unpricedRows > 0 ? (
+                          // Utan den här upplysningen ser TG:n ut att gälla hela offerten, och en
+                          // grön siffra kan dölja att halva beloppet aldrig bedömdes.
+                          <p className="m-0 text-[11px] leading-snug text-slate-400">
+                            {quoteMarginResult.unpricedRows} {quoteMarginResult.unpricedRows === 1 ? 'rad' : 'rader'} saknar
+                            inköpspris ({formatCurrency(quoteMarginResult.unpricedRevenue, 'SEK')}) och ingår inte i siffran.
+                          </p>
+                        ) : null}
+                        {quoteMarginTier === 'bad' ? (
+                          <p className="m-0 rounded-md border border-solid border-rose-200 bg-rose-50 px-2 py-1.5 text-[11px] font-medium leading-snug text-rose-700">
+                            Täckningsgraden är under {MARGIN_THRESHOLDS.watch} %. Offerten behöver godkännas av säljchef innan den skickas.
+                          </p>
+                        ) : quoteMarginTier === 'watch' ? (
+                          <p className="m-0 text-[11px] leading-snug text-amber-700">
+                            Under {MARGIN_THRESHOLDS.good} % — se över priset innan du skickar.
+                          </p>
+                        ) : null}
+                      </div>
                     ) : null}
                   </div>
                 ) : (

--- a/app/crm/offerter/QuoteFormClient.tsx
+++ b/app/crm/offerter/QuoteFormClient.tsx
@@ -427,13 +427,16 @@ const initialDraft: QuoteDraft = {
 
 // ─── ArticlePicker ────────────────────────────────────────────────────────────
 
-function ArticlePicker({ value, articleNumber, price, unit, note, onSelect, onClear }: {
+function ArticlePicker({ value, articleNumber, price, unit, note, purchasePrice, onSelect, onClear }: {
   value: string;
   articleNumber?: string | null;
   price?: number | null;
   unit?: string | null;
   /** Artikelns beskrivning ur registret — INTERN hjälptext, når aldrig Fortnox. */
   note?: string | null;
+  /** Inköpspris per enhet ur artikelregistret. Visas som underlag till täckningsgraden — utan
+   *  kronorna är procenten svår att förhandla mot. Lagras aldrig på raden (se pricing.ts). */
+  purchasePrice?: number | null;
   onSelect: (article: ArticleLite) => void;
   onClear: () => void;
 }) {
@@ -508,6 +511,9 @@ function ArticlePicker({ value, articleNumber, price, unit, note, onSelect, onCl
       articleNumber || 'Utan artikelnummer',
       typeof price === 'number' ? `${price.toFixed(2)} kr` : null,
       getArticleUnitName(unit) || null,
+      // Inköpspriset som underlag till TG-märket på raden: procenten säger att marginalen är tunn,
+      // kronorna säger hur mycket utrymme som faktiskt finns kvar att förhandla med.
+      typeof purchasePrice === 'number' ? `Inköp ${purchasePrice.toFixed(2)} kr` : null,
     ].filter(Boolean).join(' · ');
     return (
       <div className="flex items-center justify-between gap-3 rounded-xl border border-emerald-200 bg-emerald-50 px-3.5 py-2.5">
@@ -873,6 +879,7 @@ function LineItemRow({
   metrics,
   rotEnabled,
   marginPercent,
+  purchasePrice,
   expanded,
   onToggle,
   onChange,
@@ -887,6 +894,8 @@ function LineItemRow({
   rotEnabled: boolean;
   /** Radens täckningsgrad i procent, eller null när artikeln saknar inköpspris. */
   marginPercent: number | null;
+  /** Artikelns inköpspris per enhet, visat som underlag till täckningsgraden. */
+  purchasePrice: number | null;
   // Accordion: which row is open is owned by the parent so opening one collapses the rest.
   expanded: boolean;
   onToggle: (next: boolean) => void;
@@ -956,6 +965,7 @@ function LineItemRow({
         price={row.article_price}
         unit={row.article_unit_name}
         note={row.article_note}
+        purchasePrice={purchasePrice}
         onSelect={onSelectArticle}
         onClear={onClearArticle}
       />
@@ -2387,6 +2397,7 @@ export default function QuoteFormClient({ quoteId }: { quoteId?: string }) {
                 metrics={effectiveRows.find((r) => r.id === row.id)}
                 rotEnabled={draft.rot_enabled}
                 marginPercent={rowMarginPercent(marginRows[index])}
+                purchasePrice={marginRows[index].purchasePrice ?? null}
                 expanded={expandedRowId === row.id}
                 onToggle={(next) => setExpandedRowId(next ? row.id : null)}
                 onChange={(patch) => setDraft((d) => ({ ...d, items: d.items.map((item) => item.id === row.id ? { ...item, ...patch } : item) }))}

--- a/app/crm/offerter/QuoteFormClient.tsx
+++ b/app/crm/offerter/QuoteFormClient.tsx
@@ -66,6 +66,10 @@ type QuoteLineItem = {
   article_id: string | null;
   article_name: string | null;
   article_number: string | null;
+  // Artikelns beskrivning från registret, kopierad till raden när artikeln väljs — samma
+  // denormalisering som article_price/article_unit_name. INTERN: visas som grå hjälptext under
+  // vald artikel och läses aldrig av Fortnox-pushen (buildOfferRows rör den inte).
+  article_note: string | null;
   article_price: number | null;
   article_unit_name: string | null;
   discount_percent: string;
@@ -206,6 +210,8 @@ type ArticleLite = {
   price?: number | null;
   unit?: string | { name?: string | null; objectiveName?: string | null } | null;
   isFavorite?: boolean;
+  // Artikelns beskrivning ur registret. INTERN hjälptext för säljaren — se article_note på raden.
+  note?: string | null;
 };
 
 type CrmCustomerLite = {
@@ -253,6 +259,7 @@ function createEmptyLineItem(): QuoteLineItem {
     article_id: null,
     article_name: null,
     article_number: null,
+    article_note: null,
     article_price: null,
     article_unit_name: null,
     discount_percent: '',
@@ -413,11 +420,13 @@ const initialDraft: QuoteDraft = {
 
 // ─── ArticlePicker ────────────────────────────────────────────────────────────
 
-function ArticlePicker({ value, articleNumber, price, unit, onSelect, onClear }: {
+function ArticlePicker({ value, articleNumber, price, unit, note, onSelect, onClear }: {
   value: string;
   articleNumber?: string | null;
   price?: number | null;
   unit?: string | null;
+  /** Artikelns beskrivning ur registret — INTERN hjälptext, når aldrig Fortnox. */
+  note?: string | null;
   onSelect: (article: ArticleLite) => void;
   onClear: () => void;
 }) {
@@ -465,7 +474,7 @@ function ArticlePicker({ value, articleNumber, price, unit, onSelect, onClear }:
         .then((r) => r.json().catch(() => ({})))
         .then((json) => {
           if (!cancelled) {
-            const raw: Array<{ article_number: string; description: string | null; sales_price: number | null; unit: string | null; is_favorite?: boolean }> =
+            const raw: Array<{ article_number: string; description: string | null; note?: string | null; sales_price: number | null; unit: string | null; is_favorite?: boolean }> =
               Array.isArray(json?.data?.items) ? json.data.items : [];
             setItems(raw.map((a) => ({
               id: a.article_number,
@@ -474,6 +483,7 @@ function ArticlePicker({ value, articleNumber, price, unit, onSelect, onClear }:
               price: a.sales_price,
               unit: a.unit ?? undefined,
               isFavorite: a.is_favorite ?? false,
+              note: a.note ?? null,
             })));
           }
         })
@@ -497,6 +507,18 @@ function ArticlePicker({ value, articleNumber, price, unit, onSelect, onClear }:
           <span className="text-[10px] font-semibold uppercase tracking-[0.14em] text-emerald-600">Vald artikel</span>
           <span className="truncate text-sm font-semibold text-slate-900">{value}</span>
           {meta ? <span className="truncate text-xs text-slate-500">{meta}</span> : null}
+          {/* Artikelns beskrivning ur registret — INTERN. Ett stöd för säljaren att se vad artikeln
+              faktiskt innehåller; den skickas aldrig med till Fortnox och syns inte på offerten.
+              Inte truncate: hela poängen är att kunna läsa texten. Tre rader räcker för de
+              beskrivningar som finns och hindrar en lång text från att svälla ut raden. */}
+          {/* text-xs/slate-500 är repots hjälptext-token, inte 11px/slate-400 som stod här först:
+              slate-400 på vitt ligger kring 3:1 i kontrast, under gränsen för läsbar brödtext.
+              Beskrivningen är dessutom den längsta texten i kortet och den enda man faktiskt läser
+              — meta-raden ovanför är siffror man skummar. Att göra den minst och ljusast var
+              bakvänt. */}
+          {note?.trim() ? (
+            <span className="line-clamp-3 text-xs leading-relaxed text-slate-500">{note.trim()}</span>
+          ) : null}
         </div>
         <div className="flex shrink-0 items-center gap-2">
           <button
@@ -881,6 +903,7 @@ function LineItemRow({
         articleNumber={row.article_number}
         price={row.article_price}
         unit={row.article_unit_name}
+        note={row.article_note}
         onSelect={onSelectArticle}
         onClear={onClearArticle}
       />
@@ -1169,7 +1192,7 @@ export default function QuoteFormClient({ quoteId }: { quoteId?: string }) {
           end_contact_email: item.customer_snapshot?.end_contact_email || '',
           label: item.customer_snapshot?.label || '',
           items: item.line_items?.length
-            ? item.line_items.map((line) => ({ ...line, line_note: line.line_note || '', is_rot_work: line.is_rot_work ?? false, house_work_type: line.house_work_type || 'CONSTRUCTION', labor_cost: line.labor_cost || '', density: line.density || '' }))
+            ? item.line_items.map((line) => ({ ...line, line_note: line.line_note || '', is_rot_work: line.is_rot_work ?? false, house_work_type: line.house_work_type || 'CONSTRUCTION', labor_cost: line.labor_cost || '', density: line.density || '', article_note: line.article_note ?? null }))
             : [createEmptyLineItem()],
           project_name: item.project_name,
           description: item.description || '',
@@ -2270,6 +2293,7 @@ export default function QuoteFormClient({ quoteId }: { quoteId?: string }) {
                       article_number: article.articleNumber || null,
                       article_price: typeof article.price === 'number' ? article.price : null,
                       article_unit_name: unitName || null,
+                      article_note: article.note ?? null,
                       construction: construction || item.construction,
                       pricing_mode: pricingMode,
                       auto_price: false,
@@ -2281,7 +2305,7 @@ export default function QuoteFormClient({ quoteId }: { quoteId?: string }) {
                 onClearArticle={() => setDraft((current) => ({
                   ...current,
                   items: current.items.map((item) => item.id === row.id ? {
-                    ...item, article_id: null, article_name: null, article_number: null, article_price: null, article_unit_name: null,
+                    ...item, article_id: null, article_name: null, article_number: null, article_price: null, article_unit_name: null, article_note: null,
                   } : item),
                 }))}
                 onRemove={() => setDraft((d) => ({ ...d, items: d.items.length > 1 ? d.items.filter((item) => item.id !== row.id) : [createEmptyLineItem()] }))}

--- a/app/crm/offerter/QuoteFormClient.tsx
+++ b/app/crm/offerter/QuoteFormClient.tsx
@@ -22,6 +22,10 @@ import {
   buildRotDetails,
   buildInternalHandoff,
   buildMeasurementLines,
+  addDaysIso,
+  matchedValidityPreset,
+  OFFER_VALIDITY_DAYS,
+  OFFER_VALIDITY_PRESETS,
 } from './quoteSerializers';
 import { resolveCrmContact } from '@/lib/domains/crm/contacts';
 import { ROT_HOUSE_WORK_TYPES } from '@/lib/domains/fortnox/types';
@@ -291,15 +295,8 @@ function formatDate(value: string | null | undefined) {
   return new Intl.DateTimeFormat('sv-SE', { dateStyle: 'medium' }).format(date);
 }
 
-// An offer is valid for one month by default — "Giltig till" is derived as the offer date + 30 days
-// (and re-derived when the offer date changes). Noon avoids DST edge cases on the date-only string.
-const OFFER_VALIDITY_DAYS = 30;
-function addDaysIso(iso: string, days: number): string {
-  const date = new Date(`${iso}T12:00:00`);
-  if (Number.isNaN(date.getTime())) return iso;
-  date.setDate(date.getDate() + days);
-  return date.toISOString().slice(0, 10);
-}
+// Giltighetstiden (standard 30 dagar, rullgardinens val och datumräkningen) bor i
+// quoteSerializers — ren logik i en icke-klientmodul, så den är enhetstestad.
 
 function getDefaultDraftCustomerSource(prospectId?: string | null): QuoteDraft['customer_source'] {
   return {
@@ -1774,6 +1771,10 @@ export default function QuoteFormClient({ quoteId }: { quoteId?: string }) {
   // Single source of truth for the visible sections (in order). Drives both the
   // section header numbers and the sidebar nav so they can never drift apart.
   // `done: undefined` marks an internal section with no completion requirement.
+  // Vilket val i giltighetstids-rullgardinen datumen motsvarar (null = eget datum). Härlett, inte
+  // lagrat — se matchedValidityPreset i quoteSerializers.
+  const validityPreset = matchedValidityPreset(draft.quote_date, draft.valid_until);
+
   const sections: { id: string; label: string; done?: boolean }[] = [
     { id: 'section-kund', label: 'Kund', done: Boolean(draft.quote_type === 'business' ? (draft.company_name || draft.customer_name) : draft.customer_name) },
     { id: 'section-offert', label: 'Offert', done: Boolean(draft.project_name.trim()) },
@@ -2107,33 +2108,69 @@ export default function QuoteFormClient({ quoteId }: { quoteId?: string }) {
             <Field label="Beskrivning" className="md:col-span-2">
               <Textarea value={draft.description} onChange={(e) => setDraft((d) => ({ ...d, description: e.target.value }))} rows={3} placeholder="Kort om omfattning eller vad som offereras" />
             </Field>
-            {/* Moms + the two dates on one even 3-column row. */}
-            <div className="grid gap-4 sm:grid-cols-3 md:col-span-2">
-              <Field label="Moms %">
+            {/* Moms + de två datumen på EN rad. Sex kolumner i stället för tre jämna: momsfältet
+                rymmer "25" och behöver inte en tredjedel av bredden, medan "Giltig till" bär två
+                kontroller (giltighetstid + datum) och behöver halva. */}
+            <div className="grid gap-4 sm:grid-cols-6 md:col-span-2">
+              <Field label="Moms %" className="sm:col-span-1">
                 <Input value={draft.vat_percent} onChange={(e) => setDraft((d) => ({ ...d, vat_percent: e.target.value }))} inputMode="decimal" placeholder="25" />
-                {selectedCustomer?.reverse_vat ? (
-                  <p className="mt-1 text-[11px] leading-snug text-amber-700">
-                    Kunden har <strong>omvänd skattskyldighet</strong> – moms sätts till 0 %. Köparen redovisar momsen själv.
-                  </p>
-                ) : null}
               </Field>
-              <Field label="Offertdatum" plain>
-                {/* Changing the offer date re-derives "Giltig till" to offer date + 30 days — but only
-                    while the validity is still the default. A validity the user set by hand (e.g. a
-                    negotiated 60-day offer) is preserved when the offer date changes. */}
+              <Field label="Offertdatum" plain className="sm:col-span-2">
+                {/* Ändras offertdatumet flyttas "Giltig till" med och BEHÅLLER giltighetstiden —
+                    väljer man 15 dagar ska det förbli 15 dagar, inte ett datum som blir fel så fort
+                    offertdatumet justeras. Ett datum som inte motsvarar något val i rullgardinen
+                    ("Eget datum") lämnas däremot orört: då är det just det datumet som gäller. */}
                 <DatePicker
                   value={draft.quote_date}
                   clearable={false}
                   aria-label="Offertdatum"
                   onChange={(next) => setDraft((d) => {
-                    const wasDefault = !d.valid_until || d.valid_until === addDaysIso(d.quote_date, OFFER_VALIDITY_DAYS);
-                    return { ...d, quote_date: next, valid_until: next && wasDefault ? addDaysIso(next, OFFER_VALIDITY_DAYS) : d.valid_until };
+                    const preset = matchedValidityPreset(d.quote_date, d.valid_until);
+                    const keepDays = d.valid_until ? preset : OFFER_VALIDITY_DAYS;
+                    return {
+                      ...d,
+                      quote_date: next,
+                      valid_until: next && keepDays !== null ? addDaysIso(next, keepDays) : d.valid_until,
+                    };
                   })}
                 />
               </Field>
-              <Field label="Giltig till" plain>
-                <DatePicker value={draft.valid_until} onChange={(v) => setDraft((d) => ({ ...d, valid_until: v }))} aria-label="Giltig till" />
+              <Field label="Giltig till" plain className="sm:col-span-3">
+                {/* Rullgardinen är den snabba vägen: giltighetstiden är nästan alltid ett jämnt
+                    antal dagar, och då ska ingen behöva räkna fram ett datum i kalendern. Valet
+                    HÄRLEDS ur datumen (matchedValidityPreset) i stället för att lagras — ett eget
+                    fält hade blivit en andra sanning vid sidan av valid_until, som är det som går
+                    till Fortnox. Kalendern står bredvid för de gånger ett specifikt datum gäller.
+
+                    minmax(0,1fr) på datumkolumnen med flit: ett <input> har min-width auto och
+                    spränger annars ut rutnätet i stället för att krympa (se FRONTEND_SYSTEM.md om
+                    grid blowout). */}
+                <div className="grid grid-cols-[7.5rem_minmax(0,1fr)] gap-2">
+                  <Select
+                    aria-label="Giltighetstid"
+                    value={validityPreset ?? 'custom'}
+                    onChange={(e) => setDraft((d) => ({ ...d, valid_until: addDaysIso(d.quote_date, Number(e.target.value)) }))}
+                  >
+                    {OFFER_VALIDITY_PRESETS.map((days) => (
+                      <option key={days} value={days}>{days} dagar</option>
+                    ))}
+                    {/* "Eget datum" är ett TILLSTÅND, inte ett val: man hamnar där genom att plocka
+                        ett datum i kalendern, och det finns inget vettigt för ett klick här att
+                        göra. Alternativet visas därför bara när det faktiskt gäller, och är
+                        avstängt — annars står det i listan och ser trasigt ut när ingenting händer. */}
+                    {validityPreset === null ? <option value="custom" disabled>Eget datum</option> : null}
+                  </Select>
+                  <DatePicker value={draft.valid_until} onChange={(v) => setDraft((d) => ({ ...d, valid_until: v }))} aria-label="Giltig till" />
+                </div>
               </Field>
+              {/* Byggmoms-notisen står på egen rad under fälten, inte inuti momsfältet. Momskolumnen
+                  är en sjättedel bred nu, och där hade texten radbrutits till en smal remsa som
+                  drog upp höjden på hela raden. */}
+              {selectedCustomer?.reverse_vat ? (
+                <p className="text-[11px] leading-snug text-amber-700 sm:col-span-6">
+                  Kunden har <strong>omvänd skattskyldighet</strong> – moms sätts till 0 %. Köparen redovisar momsen själv.
+                </p>
+              ) : null}
             </div>
           </div>
 

--- a/app/crm/offerter/quoteSerializers.ts
+++ b/app/crm/offerter/quoteSerializers.ts
@@ -30,6 +30,9 @@ export const OFFER_VALIDITY_PRESETS = [10, 15, 20, 30, 45, 60] as const;
 export function addDaysIso(iso: string, days: number): string {
   const date = new Date(`${iso}T12:00:00`);
   if (Number.isNaN(date.getTime())) return iso;
+  // Vakta ÄVEN dagantalet: setDate(NaN) gör datumet ogiltigt och toISOString KASTAR då
+  // (RangeError), vilket hade tagit ner hela formulärets rendering i stället för att degradera.
+  if (!Number.isFinite(days)) return iso;
   date.setDate(date.getDate() + days);
   return date.toISOString().slice(0, 10);
 }

--- a/app/crm/offerter/quoteSerializers.ts
+++ b/app/crm/offerter/quoteSerializers.ts
@@ -8,6 +8,56 @@
 import { parseDecimal } from '@/lib/shared/number';
 import { inferMaterialFromArticle, lineItemSacks } from '@/lib/domains/crm/materials';
 
+// ── Giltighetstid ────────────────────────────────────────────────────────────
+//
+// "Giltig till" härleds ur offertdatumet plus ett antal dagar. Säljaren väljer antalet i en
+// rullgardin i stället för att behöva plocka ett datum i kalendern — det vanliga fallet är ett
+// jämnt antal dagar, inte ett specifikt datum. Kalendern finns kvar för de gånger det ÄR ett
+// specifikt datum som gäller.
+
+/** Standard: en månad. Det är den giltighetstid offerterna har haft sedan formuläret byggdes. */
+export const OFFER_VALIDITY_DAYS = 30;
+
+/** Valen i rullgardinen. 30 ligger med som standardvalet. */
+export const OFFER_VALIDITY_PRESETS = [10, 15, 20, 30, 45, 60] as const;
+
+/**
+ * Datumet `days` dagar efter `iso` (YYYY-MM-DD).
+ *
+ * Klockan tolvs på dagen med flit: en date-only-sträng tolkad som midnatt kan tippa över till fel
+ * dygn när sommartid slår om, och då blir giltighetstiden en dag kort eller lång.
+ */
+export function addDaysIso(iso: string, days: number): string {
+  const date = new Date(`${iso}T12:00:00`);
+  if (Number.isNaN(date.getTime())) return iso;
+  date.setDate(date.getDate() + days);
+  return date.toISOString().slice(0, 10);
+}
+
+/** Antal dagar mellan två datum (YYYY-MM-DD), eller null om något av dem inte är ett datum. */
+export function daysBetweenIso(from: string, to: string): number | null {
+  if (!from || !to) return null;
+  const start = new Date(`${from}T12:00:00`);
+  const end = new Date(`${to}T12:00:00`);
+  if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) return null;
+  return Math.round((end.getTime() - start.getTime()) / 86_400_000);
+}
+
+/**
+ * Vilket rullgardinsval giltighetstiden motsvarar, eller null för ett datum som inte är någon av
+ * dem ("Eget datum").
+ *
+ * Härleds ur datumen i stället för att lagras separat. Ett eget fält för "valt antal dagar" hade
+ * blivit en andra sanning som kan glida isär från `valid_until` — och det är `valid_until` som går
+ * till Fortnox. Följden blir också att en offert som redigeras visar rätt val i rullgardinen utan
+ * att något behöver ha sparats.
+ */
+export function matchedValidityPreset(quoteDate: string, validUntil: string): number | null {
+  const days = daysBetweenIso(quoteDate, validUntil);
+  if (days === null) return null;
+  return (OFFER_VALIDITY_PRESETS as readonly number[]).includes(days) ? days : null;
+}
+
 export type QuoteCustomerFields = {
   quote_type: 'private' | 'business';
   customer_name: string;

--- a/lib/domains/crm/pricing.ts
+++ b/lib/domains/crm/pricing.ts
@@ -95,6 +95,109 @@ export function computePricing(
   return { subtotal, vat, total, vatPercent, rotDeduction, toPay: total - rotDeduction };
 }
 
+// ─── Täckningsgrad (TG) ────────────────────────────────────────────────────────
+//
+// TG = (pris − inköpspris) ÷ PRIS. Det är måttet säljchefen bett om, och det som brukar menas med
+// "procentuell vinst". Blanda ALDRIG ihop det med påslag ((pris − inköp) ÷ inköp): köp för 100 och
+// sälj för 200 är 50 % TG men 100 % påslag, och tröskelvärdena nedan är satta för TG.
+//
+// ⚠️ INKÖPSPRISET LAGRAS INTE PÅ OFFERTRADEN. Det slås upp ur artikelcachen bara för att räkna i
+// offertformuläret. Skälet: `line_items` följer med offert → arbetsorder → fältvyn, och
+// `redactWorkOrderForField` plockar bara bort `amount`/`pricing_summary` — ett inköpspris på raden
+// hade alltså hamnat i installatörernas payload. Genom att aldrig lägga det där finns ingen läckyta
+// att komma ihåg att täta.
+
+/** Hur en rads TG bedöms. `unknown` = artikeln saknar inköpspris, då går det inte att uttala sig. */
+export type MarginTier = 'good' | 'watch' | 'bad' | 'unknown';
+
+/**
+ * ⚠️ PRELIMINÄRA TRÖSKLAR — SÄLJCHEFEN SKA SÄTTA DE SKARPA.
+ *
+ * Satta kring registrets faktiska median (53,7 % mätt 2026-08-13, tionde percentilen 40,3 %), så
+ * ungefär hälften av artiklarna hamnar grönt på listpris och rött triggar vid rejäl rabatt.
+ * De styr en färg som säljare kommer att lita på — ändra dem HÄR och ingen annanstans.
+ */
+export const MARGIN_THRESHOLDS = {
+  /** TG ≥ detta = grönt. */
+  good: 50,
+  /** TG ≥ detta men under `good` = gult. Under detta = rött. */
+  watch: 35,
+} as const;
+
+/**
+ * Radens täckningsgrad i procent, eller null när den inte går att räkna.
+ *
+ * Räknas på radens FAKTISKA intäkt (antal × rabatterat à-pris) mot inköp × samma antal, så en
+ * rabatt slår igenom direkt — det är hela poängen: säljaren ska se när rabatten äter marginalen.
+ *
+ * Returnerar null när inköpspriset saknas (61 av 289 artiklar) eller när raden inte har någon
+ * intäkt. Noll intäkt ger ingen meningsfull procent, och att visa "0 %" eller "−100 %" på en tom
+ * rad hade fått nya rader att lysa rött innan säljaren ens skrivit något.
+ */
+export function lineItemMarginPercent(
+  item: PricingLineItem,
+  purchasePrice: number | null | undefined,
+): number | null {
+  if (purchasePrice == null || !Number.isFinite(purchasePrice) || purchasePrice <= 0) return null;
+  const quantity = lineItemQuantity(item);
+  const revenue = lineItemRowTotal(item);
+  if (!(revenue > 0) || !(quantity > 0)) return null;
+  const cost = purchasePrice * quantity;
+  return ((revenue - cost) / revenue) * 100;
+}
+
+/** Färgnivån för en TG. `null` (okänt inköpspris) ger `unknown` — inte rött. */
+export function marginTier(
+  marginPercent: number | null | undefined,
+  thresholds: { good: number; watch: number } = MARGIN_THRESHOLDS,
+): MarginTier {
+  if (marginPercent == null || !Number.isFinite(marginPercent)) return 'unknown';
+  if (marginPercent >= thresholds.good) return 'good';
+  if (marginPercent >= thresholds.watch) return 'watch';
+  return 'bad';
+}
+
+/**
+ * Offertens samlade TG över de rader som går att räkna på.
+ *
+ * Summerar intäkt och kostnad var för sig i stället för att medelvärdesbilda radernas procent — ett
+ * ovägt snitt låter en 5-kronorsrad väga lika tungt som en 50 000-kronorsrad och ger fel svar på
+ * frågan "tjänar vi pengar på den här offerten".
+ *
+ * Rader utan inköpspris hålls UTANFÖR båda summorna. Att räkna dem som kostnadsfria hade blåst upp
+ * TG:n och gjort siffran farligt optimistisk; `unpricedRows` säger i stället hur mycket av offerten
+ * som inte kunde bedömas.
+ */
+export function quoteMargin(
+  items: PricingLineItem[],
+  purchasePriceFor: (index: number) => number | null | undefined,
+): { marginPercent: number | null; revenue: number; cost: number; unpricedRows: number; unpricedRevenue: number } {
+  let revenue = 0;
+  let cost = 0;
+  let unpricedRows = 0;
+  let unpricedRevenue = 0;
+
+  for (const [index, item] of items.entries()) {
+    const rowRevenue = lineItemRowTotal(item);
+    const purchase = purchasePriceFor(index);
+    const quantity = lineItemQuantity(item);
+    if (purchase == null || !Number.isFinite(purchase) || purchase <= 0 || !(quantity > 0)) {
+      if (rowRevenue > 0) { unpricedRows++; unpricedRevenue += rowRevenue; }
+      continue;
+    }
+    revenue += rowRevenue;
+    cost += purchase * quantity;
+  }
+
+  return {
+    marginPercent: revenue > 0 ? ((revenue - cost) / revenue) * 100 : null,
+    revenue,
+    cost,
+    unpricedRows,
+    unpricedRevenue,
+  };
+}
+
 // ─── VAT display convention (agreed with finance) ──────────────────────────────
 // How a quote's amount is presented to the seller / customer differs by customer type:
 //   • private customer  → lead with the price to pay INCL moms (what they actually pay)

--- a/lib/domains/crm/pricing.ts
+++ b/lib/domains/crm/pricing.ts
@@ -125,25 +125,41 @@ export const MARGIN_THRESHOLDS = {
 } as const;
 
 /**
- * Radens täckningsgrad i procent, eller null när den inte går att räkna.
+ * En rad att räkna täckningsgrad på.
  *
- * Räknas på radens FAKTISKA intäkt (antal × rabatterat à-pris) mot inköp × samma antal, så en
- * rabatt slår igenom direkt — det är hela poängen: säljaren ska se när rabatten äter marginalen.
+ * ⚠️ `revenue` SKICKAS IN, den härleds inte här. Skälet är en bugg som annars uppstår tyst:
+ * offertformuläret prissätter auto-prissatta rader med sin egen stub (`computeUnitPrice`), medan
+ * `lineItemUnitPrice` ger dem 0. Räknade vi själva ur raden skulle en auto-prissatt rad bidra med
+ * 0 kr till TG:n men synas i Delsumman — och eftersom den då har noll intäkt skulle den inte ens
+ * flaggas som obedömd. Säljaren hade sett en grön TG som ignorerade nästan hela offerten.
+ *
+ * Genom att anroparen skickar SAMMA belopp som visas på skärmen kan siffrorna inte glida isär.
+ */
+export type MarginRow = {
+  /** Radens intäkt i kronor, rabatt inräknad — exakt det belopp som visas för raden. */
+  revenue: number;
+  /** Antalet raden fakturerar (m³-volym eller styck), för att multiplicera inköpspriset. */
+  quantity: number;
+  /** Inköpspris per enhet ur artikelregistret, eller null när det saknas. */
+  purchasePrice: number | null | undefined;
+};
+
+function hasPurchasePrice(purchasePrice: number | null | undefined): purchasePrice is number {
+  return purchasePrice != null && Number.isFinite(purchasePrice) && purchasePrice > 0;
+}
+
+/**
+ * Radens täckningsgrad i procent, eller null när den inte går att räkna.
  *
  * Returnerar null när inköpspriset saknas (61 av 289 artiklar) eller när raden inte har någon
  * intäkt. Noll intäkt ger ingen meningsfull procent, och att visa "0 %" eller "−100 %" på en tom
  * rad hade fått nya rader att lysa rött innan säljaren ens skrivit något.
  */
-export function lineItemMarginPercent(
-  item: PricingLineItem,
-  purchasePrice: number | null | undefined,
-): number | null {
-  if (purchasePrice == null || !Number.isFinite(purchasePrice) || purchasePrice <= 0) return null;
-  const quantity = lineItemQuantity(item);
-  const revenue = lineItemRowTotal(item);
-  if (!(revenue > 0) || !(quantity > 0)) return null;
-  const cost = purchasePrice * quantity;
-  return ((revenue - cost) / revenue) * 100;
+export function rowMarginPercent(row: MarginRow): number | null {
+  if (!hasPurchasePrice(row.purchasePrice)) return null;
+  if (!(row.revenue > 0) || !(row.quantity > 0)) return null;
+  const cost = row.purchasePrice * row.quantity;
+  return ((row.revenue - cost) / row.revenue) * 100;
 }
 
 /** Färgnivån för en TG. `null` (okänt inköpspris) ger `unknown` — inte rött. */
@@ -165,28 +181,29 @@ export function marginTier(
  * frågan "tjänar vi pengar på den här offerten".
  *
  * Rader utan inköpspris hålls UTANFÖR båda summorna. Att räkna dem som kostnadsfria hade blåst upp
- * TG:n och gjort siffran farligt optimistisk; `unpricedRows` säger i stället hur mycket av offerten
- * som inte kunde bedömas.
+ * TG:n och gjort siffran farligt optimistisk; `unpricedRevenue` säger i stället hur stor del av
+ * offerten som inte kunde bedömas. Det gäller ÄVEN auto-prissatta rader utan vald artikel — de har
+ * en intäkt på skärmen men inget inköpspris, och utan den här raden hade de försvunnit spårlöst.
  */
-export function quoteMargin(
-  items: PricingLineItem[],
-  purchasePriceFor: (index: number) => number | null | undefined,
-): { marginPercent: number | null; revenue: number; cost: number; unpricedRows: number; unpricedRevenue: number } {
+export function quoteMargin(rows: MarginRow[]): {
+  marginPercent: number | null;
+  revenue: number;
+  cost: number;
+  unpricedRows: number;
+  unpricedRevenue: number;
+} {
   let revenue = 0;
   let cost = 0;
   let unpricedRows = 0;
   let unpricedRevenue = 0;
 
-  for (const [index, item] of items.entries()) {
-    const rowRevenue = lineItemRowTotal(item);
-    const purchase = purchasePriceFor(index);
-    const quantity = lineItemQuantity(item);
-    if (purchase == null || !Number.isFinite(purchase) || purchase <= 0 || !(quantity > 0)) {
-      if (rowRevenue > 0) { unpricedRows++; unpricedRevenue += rowRevenue; }
+  for (const row of rows) {
+    if (!hasPurchasePrice(row.purchasePrice) || !(row.quantity > 0)) {
+      if (row.revenue > 0) { unpricedRows++; unpricedRevenue += row.revenue; }
       continue;
     }
-    revenue += rowRevenue;
-    cost += purchase * quantity;
+    revenue += row.revenue;
+    cost += row.purchasePrice * row.quantity;
   }
 
   return {

--- a/lib/domains/fortnox/articles.ts
+++ b/lib/domains/fortnox/articles.ts
@@ -208,6 +208,13 @@ export async function listCachedFortnoxArticles(opts?: {
   activeOnly?: boolean;
   search?: string;
   limit?: number;
+  /**
+   * Slå upp specifika artikelnummer. Används av offertformuläret vid redigering: raderna bär
+   * artikelnummer men inte inköpspris (det lagras med flit aldrig på raden — se pricing.ts), så
+   * täckningsgraden behöver slås upp för just de artiklar offerten faktiskt använder i stället för
+   * att dra hem hela registret.
+   */
+  numbers?: string[];
 }): Promise<CachedFortnoxArticle[]> {
   const supabase = getSupabaseAdmin();
   const favorites = await listFavoriteArticleNumbers();
@@ -217,6 +224,7 @@ export async function listCachedFortnoxArticles(opts?: {
   const buildQuery = () => {
     let q = supabase.from('fortnox_articles_cache').select(ARTICLE_CACHE_SELECT).order('article_number', { ascending: true });
     if (opts?.activeOnly !== false) q = q.eq('active', true);
+    if (opts?.numbers?.length) q = q.in('article_number', opts.numbers);
     // Each token adds an AND group: (number~token OR description~token) — multi-word order-independent.
     for (const token of tokens) q = q.or(`article_number.ilike.%${token}%,description.ilike.%${token}%`);
     return q;

--- a/lib/domains/fortnox/articles.ts
+++ b/lib/domains/fortnox/articles.ts
@@ -1,5 +1,5 @@
 import { getSupabaseAdmin } from '@/lib/supabase/server';
-import { fortnoxGet, fortnoxPost, fortnoxPut, fortnoxDelete, FortnoxApiError } from './client';
+import { fortnoxGet, fortnoxPost, fortnoxPut, fortnoxDelete, fortnoxSleep, FortnoxApiError } from './client';
 import { articleSearchTokens, sortArticlesFavoritesFirst } from './articleSearch';
 import { listFortnoxPriceLists } from './customers';
 import type {
@@ -25,7 +25,7 @@ type FortnoxPriceResponse = { Price: { Price: number | null } };
 export type ArticleSyncResult = {
   synced: number;
   pages: number;
-  /** Antal artiklar vars beskrivning (Note) hämtades i den här körningen. */
+  /** Antal artiklar som FICK en beskrivning i den här körningen (tomma Note räknas inte). */
   notesFetched: number;
 };
 
@@ -45,10 +45,6 @@ const NOTE_FETCH_DELAY_MS = 300;
  * växer kraftigt — resten hämtas vid nästa synk, eftersom `note_synced_at` gör passet resumebart.
  */
 const NOTE_FETCH_MAX_PER_RUN = 400;
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
 
 /**
  * Städar en artikelbeskrivning från upprepade segment.
@@ -103,11 +99,15 @@ export async function syncArticleNotes(): Promise<number> {
         `/articles/${encodeURIComponent(articleNumber)}`,
       );
       note = dedupeArticleNote(Article?.Note);
-      fetched++;
+      if (note) fetched++;
     } catch (e) {
-      // Icke-fatalt: en artikel som inte går att läsa ska inte välta hela synken. Stämpeln sätts
-      // ändå, annars fastnar passet på samma rad vid varje körning.
+      // ⚠️ STÄMPLA INTE vid fel. Ett enda 429 eller timeout hade annars satt note_synced_at på en
+      // artikel vars beskrivning aldrig lästes — och eftersom passet bara plockar rader där
+      // stämpeln är null, och den fulla synken medvetet inte rör kolumnerna, hade den
+      // beskrivningen varit borta för alltid utan annan väg tillbaka än manuell SQL. Raden lämnas
+      // orörd och plockas upp vid nästa synk. Samma val som verifyCustomerTypesBatch gör.
       console.warn(`[Fortnox] kunde inte hämta beskrivning för artikel ${articleNumber}:`, (e as Error).message);
+      continue;
     }
 
     const { error: updateError } = await supabase
@@ -118,7 +118,7 @@ export async function syncArticleNotes(): Promise<number> {
       console.warn(`[Fortnox] kunde inte spara beskrivning för artikel ${articleNumber}:`, updateError.message);
     }
 
-    if (i < pending.length - 1) await sleep(NOTE_FETCH_DELAY_MS);
+    if (i < pending.length - 1) await fortnoxSleep(NOTE_FETCH_DELAY_MS);
   }
 
   return fetched;

--- a/lib/domains/fortnox/articles.ts
+++ b/lib/domains/fortnox/articles.ts
@@ -51,6 +51,29 @@ function sleep(ms: number): Promise<void> {
 }
 
 /**
+ * Städar en artikelbeskrivning från upprepade segment.
+ *
+ * ⚠️ Beskrivningarna i Fortnox är till stor del DUBBLETTER: samma text ligger två till fyra gånger
+ * i samma fält, separerad med semikolon. Vid mätning 2026-08-13 gällde det 177 av 227 ifyllda
+ * beskrivningar (78 %), och en artikel gick från 435 till 108 tecken vid dedupe. Mönstret ser ut
+ * som upprepade importer där texten lagts på i stället för att ersättas.
+ *
+ * Vi städar vid skrivning till vår cache i stället för att röra Fortnox: fältet är hjälptext för
+ * säljaren, och att skriva om 177 artiklar i det skarpa registret är en helt annan sorts åtgärd som
+ * kräver ett eget beslut. Funktionen är idempotent, så en omsynk ger samma resultat.
+ *
+ * Segment jämförs exakt efter trim — inget försök att slå ihop "nästan lika" texter, eftersom två
+ * snarlika segment mycket väl kan vara två verkliga upplysningar.
+ */
+export function dedupeArticleNote(note: string | null | undefined): string | null {
+  const trimmed = (note ?? '').trim();
+  if (!trimmed) return null;
+  const segments = trimmed.split(';').map((s) => s.trim()).filter(Boolean);
+  if (segments.length === 0) return null;
+  return [...new Set(segments)].join('; ');
+}
+
+/**
  * Hämtar `Note` för artiklar som ännu inte frågats efter och skriver in den i cachen.
  *
  * Sekventiellt med paus — INTE `Promise.all`. Parallell fan-out mot Fortnox är precis vad som
@@ -79,7 +102,7 @@ export async function syncArticleNotes(): Promise<number> {
       const { Article } = await fortnoxGet<FortnoxArticleWriteResponse>(
         `/articles/${encodeURIComponent(articleNumber)}`,
       );
-      note = Article?.Note?.trim() || null;
+      note = dedupeArticleNote(Article?.Note);
       fetched++;
     } catch (e) {
       // Icke-fatalt: en artikel som inte går att läsa ska inte välta hela synken. Stämpeln sätts
@@ -361,7 +384,7 @@ async function upsertArticleCacheRow(article: FortnoxArticle): Promise<void> {
       // Det här är svaret från en ENSKILD artikel, alltså den enda vägen `Note` kommer med. Skriv in
       // den direkt så en beskrivning som ändras i CRM:s artikelformulär slår igenom i offertens
       // artikelväljare med en gång, utan att invänta nästa fulla synk.
-      note: article.Note?.trim() || null,
+      note: dedupeArticleNote(article.Note),
       note_synced_at: now,
     }, { onConflict: 'article_number' });
   if (error) throw new Error(`Kunde inte uppdatera artikelcache: ${error.message}`);

--- a/lib/domains/fortnox/articles.ts
+++ b/lib/domains/fortnox/articles.ts
@@ -25,10 +25,90 @@ type FortnoxPriceResponse = { Price: { Price: number | null } };
 export type ArticleSyncResult = {
   synced: number;
   pages: number;
+  /** Antal artiklar vars beskrivning (Note) hämtades i den här körningen. */
+  notesFetched: number;
 };
+
+// ── Artikelbeskrivningar (Fortnox `Note`) ────────────────────────────────────
+//
+// `GET /articles` (listan) returnerar INTE `Note` — bara enskild-GET gör det (samma lucka som
+// kundernas `Type` och artiklarnas `HouseworkType`). Beskrivningen måste därför hämtas per artikel.
+//
+// Kostnaden bärs EN gång: `note_synced_at` markerar att vi frågat, så en artikel utan beskrivning
+// inte frågas om igen. Första körningen tar ~100 s för ~289 artiklar; därefter hämtas bara nya.
+
+/** Fortnox tål ~4 req/s. En paus mellan varje anrop håller oss under, med marginal. */
+const NOTE_FETCH_DELAY_MS = 300;
+
+/**
+ * Tak per körning. Skyddar mot att synken springer in i en funktionstimeout om artikelregistret
+ * växer kraftigt — resten hämtas vid nästa synk, eftersom `note_synced_at` gör passet resumebart.
+ */
+const NOTE_FETCH_MAX_PER_RUN = 400;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Hämtar `Note` för artiklar som ännu inte frågats efter och skriver in den i cachen.
+ *
+ * Sekventiellt med paus — INTE `Promise.all`. Parallell fan-out mot Fortnox är precis vad som
+ * sprängde kundimporten (TD-3): 429-storm, tappade svar och tyst felaktig data. Ett misslyckat
+ * anrop stämplar ändå `note_synced_at` så en trasig artikel inte blockerar passet för alltid; den
+ * plockas upp igen vid nästa fulla omsynk.
+ */
+export async function syncArticleNotes(): Promise<number> {
+  const supabase = getSupabaseAdmin();
+
+  const { data: pending, error } = await supabase
+    .from('fortnox_articles_cache')
+    .select('article_number')
+    .is('note_synced_at', null)
+    .order('article_number', { ascending: true })
+    .limit(NOTE_FETCH_MAX_PER_RUN);
+
+  if (error) throw new Error(`Kunde inte läsa artiklar utan beskrivning: ${error.message}`);
+  if (!pending?.length) return 0;
+
+  let fetched = 0;
+  for (const [i, row] of pending.entries()) {
+    const articleNumber = (row as { article_number: string }).article_number;
+    let note: string | null = null;
+    try {
+      const { Article } = await fortnoxGet<FortnoxArticleWriteResponse>(
+        `/articles/${encodeURIComponent(articleNumber)}`,
+      );
+      note = Article?.Note?.trim() || null;
+      fetched++;
+    } catch (e) {
+      // Icke-fatalt: en artikel som inte går att läsa ska inte välta hela synken. Stämpeln sätts
+      // ändå, annars fastnar passet på samma rad vid varje körning.
+      console.warn(`[Fortnox] kunde inte hämta beskrivning för artikel ${articleNumber}:`, (e as Error).message);
+    }
+
+    const { error: updateError } = await supabase
+      .from('fortnox_articles_cache')
+      .update({ note, note_synced_at: new Date().toISOString() })
+      .eq('article_number', articleNumber);
+    if (updateError) {
+      console.warn(`[Fortnox] kunde inte spara beskrivning för artikel ${articleNumber}:`, updateError.message);
+    }
+
+    if (i < pending.length - 1) await sleep(NOTE_FETCH_DELAY_MS);
+  }
+
+  return fetched;
+}
 
 // Map a Fortnox article into a fortnox_articles_cache row. Shared by the bulk
 // sync and the single-article write paths so the cached shape stays identical.
+//
+// ⚠️ `note`/`note_synced_at` ligger MED FLIT utanför. Listendpointen returnerar ingen `Note`, så
+// hade fältet stått här hade varje full artikelsynk nollat alla beskrivningar vi mödosamt hämtat
+// en och en. En PostgREST-upsert rör bara de kolumner som finns i payloaden — utelämnade kolumner
+// står kvar orörda, vilket är precis vad vi vill här. Enskild-GET-vägen sätter dem explicit
+// (se upsertArticleCacheRow).
 function mapFortnoxArticleToCacheRow(a: FortnoxArticle, now: string) {
   return {
     article_number: a.ArticleNumber,
@@ -75,12 +155,23 @@ export async function syncFortnoxArticles(): Promise<ArticleSyncResult> {
     page++;
   } while (page <= totalPages);
 
-  return { synced: totalSynced, pages: totalPages };
+  // Beskrivningarna (Note) finns inte i listsvaret och hämtas per artikel — men bara för dem vi
+  // inte redan frågat om. Första körningen är därför långsam (~100 s), därefter snabb igen.
+  // Icke-fatalt: artiklarna är synkade även om beskrivningshämtningen fallerar, och passet är
+  // resumebart via note_synced_at.
+  let notesFetched = 0;
+  try {
+    notesFetched = await syncArticleNotes();
+  } catch (e) {
+    console.warn('[Fortnox] hämtning av artikelbeskrivningar misslyckades:', (e as Error).message);
+  }
+
+  return { synced: totalSynced, pages: totalPages, notesFetched };
 }
 
 // Read articles from local cache. Fast, no external API call.
 const ARTICLE_CACHE_SELECT =
-  'article_number, description, sales_price, purchase_price, unit, article_type, active, last_fetched_at';
+  'article_number, description, note, sales_price, purchase_price, unit, article_type, active, last_fetched_at';
 
 // The global favorite article numbers (shared, not per-user). Small curated set.
 export async function listFavoriteArticleNumbers(): Promise<Set<string>> {
@@ -262,11 +353,17 @@ export async function listFortnoxArticlePriceLists(): Promise<FortnoxArticlePric
 // for integration writes, consistent with syncFortnoxArticles.
 async function upsertArticleCacheRow(article: FortnoxArticle): Promise<void> {
   const supabase = getSupabaseAdmin();
+  const now = new Date().toISOString();
   const { error } = await supabase
     .from('fortnox_articles_cache')
-    .upsert(mapFortnoxArticleToCacheRow(article, new Date().toISOString()), {
-      onConflict: 'article_number',
-    });
+    .upsert({
+      ...mapFortnoxArticleToCacheRow(article, now),
+      // Det här är svaret från en ENSKILD artikel, alltså den enda vägen `Note` kommer med. Skriv in
+      // den direkt så en beskrivning som ändras i CRM:s artikelformulär slår igenom i offertens
+      // artikelväljare med en gång, utan att invänta nästa fulla synk.
+      note: article.Note?.trim() || null,
+      note_synced_at: now,
+    }, { onConflict: 'article_number' });
   if (error) throw new Error(`Kunde inte uppdatera artikelcache: ${error.message}`);
 }
 

--- a/lib/domains/fortnox/client.ts
+++ b/lib/domains/fortnox/client.ts
@@ -63,9 +63,13 @@ function buildFortnoxError(status: number, method: string, path: string, text: s
   return new FortnoxApiError(status, `Fortnox ${method} ${path} misslyckades (${status}): ${text}`, code, message);
 }
 
-function sleep(ms: number): Promise<void> {
+// Exporterad: klienten äger rate-limit-policyn mot Fortnox, så de pass som throttlar sina egna
+// anrop (artikelbeskrivningar, kundtyp-verifiering) ska använda samma paus i stället för att var
+// och en bära en egen kopia.
+export function fortnoxSleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
+const sleep = fortnoxSleep;
 
 // Fortnox rate-limits the API (~4 req/s). On 429 it returns Retry-After. Retry
 // transparently with backoff so callers (sync passes, document pushes) ride out

--- a/lib/domains/fortnox/types.ts
+++ b/lib/domains/fortnox/types.ts
@@ -95,6 +95,9 @@ export type FortnoxArticleListResponse = {
 export type CachedFortnoxArticle = {
   article_number: string;
   description: string | null;
+  // Artikelns beskrivning (Fortnox `Note`). Hämtas per artikel — listendpointen returnerar den
+  // inte. INTERN: visas som hjälptext för säljaren, skickas aldrig till Fortnox.
+  note?: string | null;
   sales_price: number | null;
   purchase_price: number | null;
   unit: string | null;

--- a/supabase/sql/20260813_fortnox_article_notes.sql
+++ b/supabase/sql/20260813_fortnox_article_notes.sql
@@ -1,0 +1,51 @@
+-- Artikelns beskrivning (Fortnox `Note`) i artikelcachen.
+--
+-- PROBLEMET DEN LÖSER: säljaren ser inte vad en artikel egentligen innehåller när den väljs i
+-- offerten. Beskrivningen finns i Fortnox och visas redan på CRM:s artikelsida — men den sidan
+-- hämtar EN artikel live (`GET /articles/{nr}`). Offertens artikelväljare läser cachen, och cachen
+-- fylls av `GET /articles` (listan) som INTE returnerar `Note`. Vid mätning 2026-08-13 hade 0 av
+-- 289 cachade artiklar fältet. Samma lucka som kundernas `Type` (brist 1) och artiklarnas
+-- `HouseworkType` (brist 4): fältet finns bara på enskild-GET.
+--
+-- VARFÖR TVÅ KOLUMNER. `note_synced_at` skiljer "artikeln har ingen beskrivning" från "vi har
+-- aldrig frågat". Utan den går det inte att veta vilka artiklar som återstår, och synken skulle
+-- fråga om alla 289 varje gång — ~100 sekunder per körning i stället för bara första gången.
+--
+-- BESKRIVNINGEN ÄR INTERN. Den visas för säljaren i offertformuläret och skrivs aldrig in på
+-- offertraden, så den kan inte nå Fortnox. Radens `Description` kommer från `article_name` och
+-- radtexten från `line_note` — två fält som inget av detta rör.
+--
+-- DEPLOY-ORDNING: helt ADDITIV (två nullbara kolumner, inget befintligt ändras), så ordningen
+-- SQL/kod spelar ingen roll. Körs koden först är `note` bara null och ingen hjälprad visas.
+-- Kör i Supabase SQL editor. Idempotent.
+
+alter table public.fortnox_articles_cache
+  add column if not exists note           text,
+  add column if not exists note_synced_at timestamptz;
+
+-- Synken frågar efter artiklar som ännu inte har hämtats (`note_synced_at is null`). Partiellt
+-- index: efter första fulla körningen är mängden tom eller mycket liten, och då ska frågan inte
+-- behöva läsa hela tabellen.
+create index if not exists fortnox_articles_cache_note_pending_idx
+  on public.fortnox_articles_cache (article_number)
+  where note_synced_at is null;
+
+-- ── Verifiering (kör efter applicering) ──────────────────────────────────────
+--
+-- 1. Kolumnerna finns och är nullbara.
+--
+--      select column_name, data_type, is_nullable
+--      from information_schema.columns
+--      where table_schema = 'public' and table_name = 'fortnox_articles_cache'
+--        and column_name in ('note', 'note_synced_at');
+--
+-- 2. Före första synken: alla artiklar väntar på hämtning.
+--
+--      select count(*) filter (where note_synced_at is null) as vantar,
+--             count(*) filter (where note_synced_at is not null) as hamtade,
+--             count(*) filter (where coalesce(btrim(note), '') <> '') as med_beskrivning
+--      from public.fortnox_articles_cache;
+--
+-- 3. Efter en synk ska `vantar` vara 0. Är `med_beskrivning` då oväntat lågt ligger texten i ett
+--    annat Fortnox-fält än `Note` — kontrollera mot en artikel i CRM:s artikelflik innan något
+--    byggs om.

--- a/supabase/sql/20260813_fortnox_article_notes.sql
+++ b/supabase/sql/20260813_fortnox_article_notes.sql
@@ -15,9 +15,15 @@
 -- offertraden, så den kan inte nå Fortnox. Radens `Description` kommer från `article_name` och
 -- radtexten från `line_note` — två fält som inget av detta rör.
 --
--- DEPLOY-ORDNING: helt ADDITIV (två nullbara kolumner, inget befintligt ändras), så ordningen
--- SQL/kod spelar ingen roll. Körs koden först är `note` bara null och ingen hjälprad visas.
--- Kör i Supabase SQL editor. Idempotent.
+-- ⚠️ DEPLOY-ORDNING: KÖR SQL:EN FÖRE KODEN.
+--
+-- Migreringen är additiv i den meningen att inget befintligt ändras, men koden är det INTE:
+-- `ARTICLE_CACHE_SELECT` i lib/domains/fortnox/articles.ts begär `note`, och PostgREST svarar 400
+-- ("column ... does not exist") på ett select mot en kolumn som saknas — den returnerar inte null.
+-- Deployas koden först slutar därför ALLA artikelläsningar att fungera: offertens artikelväljare
+-- får inga träffar och artikelsidan (server-renderad) kraschar helt.
+--
+-- Additiv i schemat ≠ ofarlig ordning. Kör i Supabase SQL editor. Idempotent.
 
 alter table public.fortnox_articles_cache
   add column if not exists note           text,

--- a/supabase/sql/20260813_fortnox_article_notes_dedupe.sql
+++ b/supabase/sql/20260813_fortnox_article_notes_dedupe.sql
@@ -1,0 +1,66 @@
+-- Städar upprepade segment ur artikelbeskrivningarna som redan hämtats.
+--
+-- KÖRS EFTER 20260813_fortnox_article_notes.sql och efter att artikelsynken hämtat beskrivningarna.
+--
+-- PROBLEMET: beskrivningarna i Fortnox innehåller till stor del samma text flera gånger, separerad
+-- med semikolon — troligen upprepade importer som lagt på texten i stället för att ersätta den.
+-- Vid mätning 2026-08-13, direkt efter första synken: 177 av 227 ifyllda beskrivningar (78 %) hade
+-- upprepade segment, och 19 843 tecken var ren dubblering. Artikel 10124 hade samma mening fyra
+-- gånger, 435 tecken där 108 räckte.
+--
+-- VARFÖR HÄR OCH INTE VIA SYNKEN: koden dedupar numera vid skrivning (dedupeArticleNote), men de
+-- rader som redan hämtats bär den odedupade texten och `note_synced_at` är satt — synken frågar
+-- alltså inte om dem igen. Att nolla stämpeln och hämta om hade kostat ~289 API-anrop och några
+-- minuter för något SQL gör på en sekund, på text vi redan har.
+--
+-- VI RÖR INTE FORTNOX. Beskrivningen är hjälptext för säljaren i offertformuläret. Att skriva om
+-- 177 artiklar i det skarpa artikelregistret är en helt annan sorts åtgärd med andra konsekvenser
+-- (allt annat som läser fältet påverkas) och kräver ett eget beslut.
+--
+-- IDEMPOTENT: andra körningen matchar noll rader, eftersom villkoret kräver att den städade texten
+-- faktiskt skiljer sig från den lagrade.
+
+update public.fortnox_articles_cache AS c
+set note = sub.cleaned
+from (
+  select
+    article_number,
+    (
+      -- Unika segment i den ordning de först dök upp. `with ordinality` bär positionen så
+      -- ordningen bevaras — utan den blir resultatet godtyckligt sorterat.
+      select string_agg(d.part, '; ' order by d.first_pos)
+      from (
+        select btrim(part) as part, min(ord) as first_pos
+        from unnest(string_to_array(a.note, ';')) with ordinality as t(part, ord)
+        where btrim(part) <> ''
+        group by btrim(part)
+      ) d
+    ) as cleaned
+  from public.fortnox_articles_cache a
+  where a.note is not null and btrim(a.note) <> ''
+) sub
+where c.article_number = sub.article_number
+  and sub.cleaned is not null
+  and sub.cleaned <> c.note;
+
+-- ── Verifiering (kör efter applicering) ──────────────────────────────────────
+--
+-- 1. Inga beskrivningar ska ha upprepade segment kvar. Förväntat: 0 rader.
+--
+--      select article_number, note
+--      from public.fortnox_articles_cache
+--      where note is not null
+--        and (select count(*) from unnest(string_to_array(note, ';')) p where btrim(p) <> '')
+--          <> (select count(distinct btrim(p)) from unnest(string_to_array(note, ';')) p where btrim(p) <> '');
+--
+-- 2. Längderna ska ha kortats rejält. Förväntat efter städning: median kring 49 tecken.
+--
+--      select count(*) as med_beskrivning,
+--             round(avg(length(note))) as snitt,
+--             max(length(note)) as langsta
+--      from public.fortnox_articles_cache
+--      where note is not null and btrim(note) <> '';
+--
+-- 3. Stickprov mot en artikel som var illa däran.
+--
+--      select article_number, note from public.fortnox_articles_cache where article_number = '10124';

--- a/supabase/sql/20260813_fortnox_article_notes_dedupe.sql
+++ b/supabase/sql/20260813_fortnox_article_notes_dedupe.sql
@@ -40,8 +40,12 @@ from (
   where a.note is not null and btrim(a.note) <> ''
 ) sub
 where c.article_number = sub.article_number
-  and sub.cleaned is not null
-  and sub.cleaned <> c.note;
+  -- `is distinct from` i stället för `<>`: en beskrivning som bara består av avskiljare (';;;')
+  -- ger NULL ur string_agg, och med `<>` hade raden hoppats över så skräpsträngen blivit kvar och
+  -- renderats som hjälptext under artikeln. dedupeArticleNote i koden ger null för samma indata —
+  -- städningen måste matcha funktionen den efterliknar, annars beror resultatet på vilken väg
+  -- värdet råkade komma in.
+  and sub.cleaned is distinct from c.note;
 
 -- ── Verifiering (kör efter applicering) ──────────────────────────────────────
 --

--- a/tests/crm/pricing.test.ts
+++ b/tests/crm/pricing.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   lineItemRowTotal, computePricing, resolveQuoteVatBreakdown, quoteAmountDisplay,
-  lineItemMarginPercent, marginTier, quoteMargin, MARGIN_THRESHOLDS,
+  rowMarginPercent, marginTier, quoteMargin, MARGIN_THRESHOLDS,
 } from '@/lib/domains/crm/pricing';
 
 describe('lineItemRowTotal', () => {
@@ -167,38 +167,32 @@ describe('quoteAmountDisplay', () => {
 // Täckningsgrad (TG)
 // ---------------------------------------------------------------------------
 
-describe('lineItemMarginPercent', () => {
-  it('räknar TG på pris, inte på inköp', () => {
+describe('rowMarginPercent', () => {
+  it('räknar TG på intäkten, inte på inköpet', () => {
     // Köp 100, sälj 200 → 50 % TG. Samma affär är 100 % PÅSLAG; blandas de ihop blir tröskeln
     // dubbelt fel och en usel affär lyser grön.
-    expect(lineItemMarginPercent({ pricing_mode: 'item', unit_price: '200', quantity: '1' }, 100)).toBeCloseTo(50, 6);
-    expect(lineItemMarginPercent({ pricing_mode: 'item', unit_price: '150', quantity: '1' }, 100)).toBeCloseTo(33.333, 3);
+    expect(rowMarginPercent({ revenue: 200, quantity: 1, purchasePrice: 100 })).toBeCloseTo(50, 6);
+    expect(rowMarginPercent({ revenue: 150, quantity: 1, purchasePrice: 100 })).toBeCloseTo(33.333, 3);
   });
 
-  it('låter rabatten slå igenom — det är hela poängen', () => {
-    // 20 % rabatt på 200 → 160 intäkt mot 100 i inköp → 37,5 % i stället för 50 %.
-    expect(lineItemMarginPercent({ pricing_mode: 'item', unit_price: '200', quantity: '1', discount_percent: '20' }, 100))
-      .toBeCloseTo(37.5, 6);
+  it('räknar inköpet mot antalet', () => {
+    expect(rowMarginPercent({ revenue: 2000, quantity: 10, purchasePrice: 100 })).toBeCloseTo(50, 6);
   });
 
-  it('räknar på antalet, så en flerradsrad blir rätt', () => {
-    expect(lineItemMarginPercent({ pricing_mode: 'item', unit_price: '200', quantity: '10' }, 100)).toBeCloseTo(50, 6);
-  });
-
-  it('ger negativ TG när priset ligger under inköp', () => {
-    expect(lineItemMarginPercent({ pricing_mode: 'item', unit_price: '80', quantity: '1' }, 100)).toBeCloseTo(-25, 6);
+  it('ger negativ TG när intäkten ligger under inköpet', () => {
+    expect(rowMarginPercent({ revenue: 80, quantity: 1, purchasePrice: 100 })).toBeCloseTo(-25, 6);
   });
 
   it('ger null när inköpspriset saknas — 61 av 289 artiklar har inget', () => {
-    expect(lineItemMarginPercent({ pricing_mode: 'item', unit_price: '200', quantity: '1' }, null)).toBeNull();
-    expect(lineItemMarginPercent({ pricing_mode: 'item', unit_price: '200', quantity: '1' }, undefined)).toBeNull();
-    expect(lineItemMarginPercent({ pricing_mode: 'item', unit_price: '200', quantity: '1' }, 0)).toBeNull();
+    expect(rowMarginPercent({ revenue: 200, quantity: 1, purchasePrice: null })).toBeNull();
+    expect(rowMarginPercent({ revenue: 200, quantity: 1, purchasePrice: undefined })).toBeNull();
+    expect(rowMarginPercent({ revenue: 200, quantity: 1, purchasePrice: 0 })).toBeNull();
   });
 
   it('ger null för en tom rad i stället för att lysa rött', () => {
     // En nyss tillagd rad ska inte larma innan säljaren skrivit något.
-    expect(lineItemMarginPercent({ pricing_mode: 'item', unit_price: '', quantity: '' }, 100)).toBeNull();
-    expect(lineItemMarginPercent({ pricing_mode: 'item', unit_price: '0', quantity: '1' }, 100)).toBeNull();
+    expect(rowMarginPercent({ revenue: 0, quantity: 0, purchasePrice: 100 })).toBeNull();
+    expect(rowMarginPercent({ revenue: 0, quantity: 5, purchasePrice: 100 })).toBeNull();
   });
 });
 
@@ -231,13 +225,10 @@ describe('quoteMargin', () => {
   it('viktar efter belopp — inte ett ovägt snitt av radernas procent', () => {
     // 5-kronorsraden har 80 % TG, 50 000-raden har 20 %. Ett ovägt snitt vore 50 % och skulle
     // dölja att offerten som helhet är svag.
-    const result = quoteMargin(
-      [
-        { pricing_mode: 'item', unit_price: '5', quantity: '1' },      // inköp 1  → 4 kr vinst
-        { pricing_mode: 'item', unit_price: '50000', quantity: '1' },  // inköp 40000 → 10 000 kr vinst
-      ],
-      (i) => (i === 0 ? 1 : 40000),
-    );
+    const result = quoteMargin([
+      { revenue: 5, quantity: 1, purchasePrice: 1 },
+      { revenue: 50000, quantity: 1, purchasePrice: 40000 },
+    ]);
     expect(result.revenue).toBe(50005);
     expect(result.cost).toBe(40001);
     expect(result.marginPercent).toBeCloseTo(20.006, 2);
@@ -245,28 +236,38 @@ describe('quoteMargin', () => {
 
   it('håller rader utan inköpspris UTANFÖR summorna och rapporterar dem', () => {
     // Att räkna dem som kostnadsfria hade blåst upp TG:n till en farligt optimistisk siffra.
-    const result = quoteMargin(
-      [
-        { pricing_mode: 'item', unit_price: '200', quantity: '1' },
-        { pricing_mode: 'item', unit_price: '1000', quantity: '1' },
-      ],
-      (i) => (i === 0 ? 100 : null),
-    );
+    const result = quoteMargin([
+      { revenue: 200, quantity: 1, purchasePrice: 100 },
+      { revenue: 1000, quantity: 1, purchasePrice: null },
+    ]);
     expect(result.marginPercent).toBeCloseTo(50, 6);
     expect(result.revenue).toBe(200);
     expect(result.unpricedRows).toBe(1);
     expect(result.unpricedRevenue).toBe(1000);
   });
 
+  it('fångar den AUTO-PRISSATTA raden som obedömd i stället för att tappa den', () => {
+    // Regressionsvakt: formuläret prissätter auto-rader med sin egen stub, så de HAR en intäkt på
+    // skärmen men saknar artikel och därmed inköpspris. Räknades de inte skulle säljaren se en grön
+    // TG som ignorerade nästan hela offertvärdet — utan en enda varning.
+    const result = quoteMargin([
+      { revenue: 100, quantity: 1, purchasePrice: 40 },
+      { revenue: 18000, quantity: 20, purchasePrice: null }, // 20 m³ × 900 kr, ingen artikel vald
+    ]);
+    expect(result.marginPercent).toBeCloseTo(60, 6);
+    expect(result.unpricedRows).toBe(1);
+    expect(result.unpricedRevenue).toBe(18000);
+  });
+
   it('ger null när ingen rad går att bedöma', () => {
-    const result = quoteMargin([{ pricing_mode: 'item', unit_price: '200', quantity: '1' }], () => null);
+    const result = quoteMargin([{ revenue: 200, quantity: 1, purchasePrice: null }]);
     expect(result.marginPercent).toBeNull();
     expect(result.unpricedRows).toBe(1);
   });
 
   it('räknar inte tomma rader som obedömbara', () => {
     // En tom rad har ingen intäkt och ska varken påverka TG:n eller flaggas som "kunde inte bedömas".
-    const result = quoteMargin([{ pricing_mode: 'item', unit_price: '', quantity: '' }], () => null);
+    const result = quoteMargin([{ revenue: 0, quantity: 0, purchasePrice: null }]);
     expect(result.unpricedRows).toBe(0);
     expect(result.marginPercent).toBeNull();
   });

--- a/tests/crm/pricing.test.ts
+++ b/tests/crm/pricing.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from 'vitest';
-import { lineItemRowTotal, computePricing, resolveQuoteVatBreakdown, quoteAmountDisplay } from '@/lib/domains/crm/pricing';
+import {
+  lineItemRowTotal, computePricing, resolveQuoteVatBreakdown, quoteAmountDisplay,
+  lineItemMarginPercent, marginTier, quoteMargin, MARGIN_THRESHOLDS,
+} from '@/lib/domains/crm/pricing';
 
 describe('lineItemRowTotal', () => {
   it('item mode: quantity × unit_price', () => {
@@ -157,5 +160,114 @@ describe('quoteAmountDisplay', () => {
   it('private at 0 % VAT is NOT reverse charge (byggmoms is B2B only)', () => {
     const d = quoteAmountDisplay('private', { subtotal: 100_000, vat: 0, total: 100_000, vatPercent: 0 });
     expect(d.reverseCharge).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Täckningsgrad (TG)
+// ---------------------------------------------------------------------------
+
+describe('lineItemMarginPercent', () => {
+  it('räknar TG på pris, inte på inköp', () => {
+    // Köp 100, sälj 200 → 50 % TG. Samma affär är 100 % PÅSLAG; blandas de ihop blir tröskeln
+    // dubbelt fel och en usel affär lyser grön.
+    expect(lineItemMarginPercent({ pricing_mode: 'item', unit_price: '200', quantity: '1' }, 100)).toBeCloseTo(50, 6);
+    expect(lineItemMarginPercent({ pricing_mode: 'item', unit_price: '150', quantity: '1' }, 100)).toBeCloseTo(33.333, 3);
+  });
+
+  it('låter rabatten slå igenom — det är hela poängen', () => {
+    // 20 % rabatt på 200 → 160 intäkt mot 100 i inköp → 37,5 % i stället för 50 %.
+    expect(lineItemMarginPercent({ pricing_mode: 'item', unit_price: '200', quantity: '1', discount_percent: '20' }, 100))
+      .toBeCloseTo(37.5, 6);
+  });
+
+  it('räknar på antalet, så en flerradsrad blir rätt', () => {
+    expect(lineItemMarginPercent({ pricing_mode: 'item', unit_price: '200', quantity: '10' }, 100)).toBeCloseTo(50, 6);
+  });
+
+  it('ger negativ TG när priset ligger under inköp', () => {
+    expect(lineItemMarginPercent({ pricing_mode: 'item', unit_price: '80', quantity: '1' }, 100)).toBeCloseTo(-25, 6);
+  });
+
+  it('ger null när inköpspriset saknas — 61 av 289 artiklar har inget', () => {
+    expect(lineItemMarginPercent({ pricing_mode: 'item', unit_price: '200', quantity: '1' }, null)).toBeNull();
+    expect(lineItemMarginPercent({ pricing_mode: 'item', unit_price: '200', quantity: '1' }, undefined)).toBeNull();
+    expect(lineItemMarginPercent({ pricing_mode: 'item', unit_price: '200', quantity: '1' }, 0)).toBeNull();
+  });
+
+  it('ger null för en tom rad i stället för att lysa rött', () => {
+    // En nyss tillagd rad ska inte larma innan säljaren skrivit något.
+    expect(lineItemMarginPercent({ pricing_mode: 'item', unit_price: '', quantity: '' }, 100)).toBeNull();
+    expect(lineItemMarginPercent({ pricing_mode: 'item', unit_price: '0', quantity: '1' }, 100)).toBeNull();
+  });
+});
+
+describe('marginTier', () => {
+  it('delar in efter trösklarna, gränsvärdet inklusive', () => {
+    expect(marginTier(60)).toBe('good');
+    expect(marginTier(MARGIN_THRESHOLDS.good)).toBe('good');
+    expect(marginTier(MARGIN_THRESHOLDS.good - 0.1)).toBe('watch');
+    expect(marginTier(MARGIN_THRESHOLDS.watch)).toBe('watch');
+    expect(marginTier(MARGIN_THRESHOLDS.watch - 0.1)).toBe('bad');
+    expect(marginTier(-10)).toBe('bad');
+  });
+
+  it('okänt inköpspris är UNKNOWN, aldrig rött', () => {
+    // Ett saknat inköpspris är inte en dålig affär — att färga det rött hade fått säljaren att
+    // jaga godkännande för artiklar som ingen prissatt.
+    expect(marginTier(null)).toBe('unknown');
+    expect(marginTier(undefined)).toBe('unknown');
+    expect(marginTier(Number.NaN)).toBe('unknown');
+  });
+
+  it('respekterar egna trösklar när säljchefen satt sina', () => {
+    expect(marginTier(45, { good: 40, watch: 30 })).toBe('good');
+    expect(marginTier(35, { good: 40, watch: 30 })).toBe('watch');
+    expect(marginTier(25, { good: 40, watch: 30 })).toBe('bad');
+  });
+});
+
+describe('quoteMargin', () => {
+  it('viktar efter belopp — inte ett ovägt snitt av radernas procent', () => {
+    // 5-kronorsraden har 80 % TG, 50 000-raden har 20 %. Ett ovägt snitt vore 50 % och skulle
+    // dölja att offerten som helhet är svag.
+    const result = quoteMargin(
+      [
+        { pricing_mode: 'item', unit_price: '5', quantity: '1' },      // inköp 1  → 4 kr vinst
+        { pricing_mode: 'item', unit_price: '50000', quantity: '1' },  // inköp 40000 → 10 000 kr vinst
+      ],
+      (i) => (i === 0 ? 1 : 40000),
+    );
+    expect(result.revenue).toBe(50005);
+    expect(result.cost).toBe(40001);
+    expect(result.marginPercent).toBeCloseTo(20.006, 2);
+  });
+
+  it('håller rader utan inköpspris UTANFÖR summorna och rapporterar dem', () => {
+    // Att räkna dem som kostnadsfria hade blåst upp TG:n till en farligt optimistisk siffra.
+    const result = quoteMargin(
+      [
+        { pricing_mode: 'item', unit_price: '200', quantity: '1' },
+        { pricing_mode: 'item', unit_price: '1000', quantity: '1' },
+      ],
+      (i) => (i === 0 ? 100 : null),
+    );
+    expect(result.marginPercent).toBeCloseTo(50, 6);
+    expect(result.revenue).toBe(200);
+    expect(result.unpricedRows).toBe(1);
+    expect(result.unpricedRevenue).toBe(1000);
+  });
+
+  it('ger null när ingen rad går att bedöma', () => {
+    const result = quoteMargin([{ pricing_mode: 'item', unit_price: '200', quantity: '1' }], () => null);
+    expect(result.marginPercent).toBeNull();
+    expect(result.unpricedRows).toBe(1);
+  });
+
+  it('räknar inte tomma rader som obedömbara', () => {
+    // En tom rad har ingen intäkt och ska varken påverka TG:n eller flaggas som "kunde inte bedömas".
+    const result = quoteMargin([{ pricing_mode: 'item', unit_price: '', quantity: '' }], () => null);
+    expect(result.unpricedRows).toBe(0);
+    expect(result.marginPercent).toBeNull();
   });
 });

--- a/tests/crm/quotes.test.ts
+++ b/tests/crm/quotes.test.ts
@@ -555,3 +555,38 @@ describe('PATCH /api/crm/quotes/[id] — status won', () => {
     expect((await res.json()).errorDetails.code).toBe('crm_quote_won_failed');
   });
 });
+
+describe('article_note på offertraden', () => {
+  it('överlever Zod-valideringen — annars försvinner beskrivningen tyst vid varje sparning', () => {
+    // Samma fälla som is_rot_work och written_off gick i: ett fält som saknas i schemat strippas
+    // utan felmeddelande, och hjälptexten är borta så fort offerten öppnas igen.
+    const parsed = createCrmQuoteSchema.safeParse({
+      ...validQuoteBase,
+      // Rader kräver "Er referens" (kontaktperson) — annars fälls offerten på den regeln i stället.
+      customer_snapshot: { ...validQuoteBase.customer_snapshot, contact_name: 'Anna' },
+      line_items: [{
+        id: 'row-1',
+        article_number: '2410510',
+        article_name: 'EKOVILLA cellulosa',
+        article_note: 'Beställs på pall, 3 dagars ledtid',
+        unit_price: '420',
+        quantity: '2',
+      }],
+    });
+
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.line_items[0].article_note).toBe('Beställs på pall, 3 dagars ledtid');
+    }
+  });
+
+  it('saknad beskrivning blir null, inte undefined', () => {
+    const parsed = createCrmQuoteSchema.safeParse({
+      ...validQuoteBase,
+      customer_snapshot: { ...validQuoteBase.customer_snapshot, contact_name: 'Anna' },
+      line_items: [{ id: 'row-1', article_name: 'Utan artikel', unit_price: '100', quantity: '1' }],
+    });
+    expect(parsed.success).toBe(true);
+    if (parsed.success) expect(parsed.data.line_items[0].article_note).toBeNull();
+  });
+});

--- a/tests/fortnox/articles.test.ts
+++ b/tests/fortnox/articles.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildFortnoxArticlePayload } from '@/lib/domains/fortnox/articles';
+import { buildFortnoxArticlePayload, dedupeArticleNote } from '@/lib/domains/fortnox/articles';
 import { articleSearchTokens, matchesArticleSearch, sortArticlesFavoritesFirst } from '@/lib/domains/fortnox/articleSearch';
 import {
   fortnoxArticleInputSchema,
@@ -258,5 +258,40 @@ describe('fortnoxArticleInputSchema', () => {
       prices: [{ price_list: 'A', price: -1 }],
     });
     expect(parsed.success).toBe(false);
+  });
+});
+
+describe('dedupeArticleNote', () => {
+  it('tar bort upprepade segment och behåller ordningen', () => {
+    // Verkligt fall: artikel 10111 hade samma text fyra gånger, 83 tecken där 20 räckte.
+    expect(dedupeArticleNote('1RLL/FRP, 112FRP/PLL;1RLL/FRP, 112FRP/PLL;1RLL/FRP, 112FRP/PLL;1RLL/FRP, 112FRP/PLL'))
+      .toBe('1RLL/FRP, 112FRP/PLL');
+  });
+
+  it('behåller segment som verkligen skiljer sig, i ursprunglig ordning', () => {
+    // Två snarlika texter kan vara två riktiga upplysningar — bara exakta dubbletter tas bort.
+    expect(dedupeArticleNote('565X1220MM, 10PKT/PALL;Ensidig tejp;565X1220MM, 10PKT/PALL'))
+      .toBe('565X1220MM, 10PKT/PALL; Ensidig tejp');
+  });
+
+  it('lämnar en beskrivning utan dubbletter orörd (bortsett från normaliserade mellanrum)', () => {
+    expect(dedupeArticleNote('Slitstark vindduk anpassad för lösull.')).toBe('Slitstark vindduk anpassad för lösull.');
+  });
+
+  it('är idempotent — en omsynk får inte ge ett annat resultat', () => {
+    const once = dedupeArticleNote('A;A;B');
+    expect(dedupeArticleNote(once)).toBe(once);
+    expect(once).toBe('A; B');
+  });
+
+  it('ger null för tomt, blankt och saknat värde', () => {
+    expect(dedupeArticleNote(null)).toBeNull();
+    expect(dedupeArticleNote(undefined)).toBeNull();
+    expect(dedupeArticleNote('   ')).toBeNull();
+    expect(dedupeArticleNote(';;;')).toBeNull();
+  });
+
+  it('släpper tomma segment mellan semikolon', () => {
+    expect(dedupeArticleNote('A;;B;')).toBe('A; B');
   });
 });

--- a/tests/fortnox/offers.test.ts
+++ b/tests/fortnox/offers.test.ts
@@ -322,3 +322,32 @@ describe('snapshotToFortnoxSource → buildFortnoxCustomerPayload', () => {
     expect(payload.DeliveryCity).toBe('Södertälje');
   });
 });
+
+describe('article_note är INTERN', () => {
+  it('artikelns beskrivning når aldrig Fortnox-raden', () => {
+    // Beskrivningen är ett säljstöd i offertformuläret, inte något kunden ska se. Den ligger på
+    // raden (denormaliserad från artikelregistret) och MÅSTE hållas utanför payloaden — annars
+    // hamnar en intern registeranteckning på kundens offert.
+    const rows = buildOfferRows(
+      [{
+        article_number: '2410510',
+        article_name: 'EKOVILLA cellulosa',
+        unit_price: '420',
+        quantity: '2',
+        // @ts-expect-error – fältet finns på raden i appen men ingår inte i pushens radtyp,
+        // vilket i sig är skyddet: buildOfferRows kan inte råka läsa det.
+        article_note: 'Intern anteckning: beställs på pall, 3 dagars ledtid',
+      }],
+      25,
+      false,
+    );
+
+    const serialized = JSON.stringify(rows);
+    expect(serialized).not.toContain('Intern anteckning');
+    expect(serialized).not.toContain('article_note');
+    expect(serialized).not.toContain('ledtid');
+    // Raden i övrigt är oförändrad.
+    expect(rows[0].Description).toBe('EKOVILLA cellulosa');
+    expect(rows[0].Price).toBe(420);
+  });
+});

--- a/tests/offerter/quote-serializers.test.ts
+++ b/tests/offerter/quote-serializers.test.ts
@@ -5,6 +5,11 @@ import {
   buildRotDetails,
   buildInternalHandoff,
   buildMeasurementLines,
+  addDaysIso,
+  daysBetweenIso,
+  matchedValidityPreset,
+  OFFER_VALIDITY_DAYS,
+  OFFER_VALIDITY_PRESETS,
   type QuoteCustomerFields,
   type QuoteRotFields,
   type QuoteHandoffFields,
@@ -286,5 +291,77 @@ describe('buildInternalHandoff', () => {
   it('mappar fält, tomma blir null', () => {
     expect(buildInternalHandoff({ desired_installation_date: '2026-07-01', handoff_notes: '', work_scope: 'Tak' }))
       .toEqual({ desired_installation_date: '2026-07-01', handoff_notes: null, work_scope: 'Tak' });
+  });
+});
+
+describe('giltighetstid', () => {
+  it('30 dagar är standard och finns som val i rullgardinen', () => {
+    // Standarden får inte glida isär från valen — annars visar rullgardinen "Eget datum" på en
+    // splitterny offert, vilket ser ut som att något är fel.
+    expect(OFFER_VALIDITY_DAYS).toBe(30);
+    expect(OFFER_VALIDITY_PRESETS).toContain(OFFER_VALIDITY_DAYS);
+  });
+
+  describe('addDaysIso', () => {
+    it('lägger till dagar och håller sig till YYYY-MM-DD', () => {
+      expect(addDaysIso('2026-08-13', 30)).toBe('2026-09-12');
+      expect(addDaysIso('2026-08-13', 10)).toBe('2026-08-23');
+    });
+
+    it('går över månads- och årsskifte', () => {
+      expect(addDaysIso('2026-12-20', 20)).toBe('2027-01-09');
+      expect(addDaysIso('2028-02-20', 10)).toBe('2028-03-01'); // skottår
+    });
+
+    it('överlever sommartidsomställningen', () => {
+      // Datumen tolkas kl. 12 just för det här: vid midnatt kan omställningen tippa över dygnet
+      // och giltighetstiden bli en dag kort. Sverige ställer om sista söndagen i mars och oktober.
+      expect(addDaysIso('2026-03-25', 10)).toBe('2026-04-04');
+      expect(addDaysIso('2026-10-20', 15)).toBe('2026-11-04');
+    });
+
+    it('lämnar ett ogiltigt datum orört i stället för att svara NaN', () => {
+      expect(addDaysIso('inte-ett-datum', 30)).toBe('inte-ett-datum');
+    });
+  });
+
+  describe('daysBetweenIso', () => {
+    it('räknar dagar mellan två datum', () => {
+      expect(daysBetweenIso('2026-08-13', '2026-09-12')).toBe(30);
+      expect(daysBetweenIso('2026-08-13', '2026-08-13')).toBe(0);
+    });
+
+    it('räknar rätt över sommartid', () => {
+      expect(daysBetweenIso('2026-03-25', '2026-04-04')).toBe(10);
+      expect(daysBetweenIso('2026-10-20', '2026-11-04')).toBe(15);
+    });
+
+    it('ger null när ett datum saknas eller är trasigt', () => {
+      expect(daysBetweenIso('', '2026-09-12')).toBeNull();
+      expect(daysBetweenIso('2026-08-13', '')).toBeNull();
+      expect(daysBetweenIso('2026-08-13', 'skräp')).toBeNull();
+    });
+  });
+
+  describe('matchedValidityPreset', () => {
+    it('känner igen varje val i rullgardinen', () => {
+      for (const days of OFFER_VALIDITY_PRESETS) {
+        expect(matchedValidityPreset('2026-08-13', addDaysIso('2026-08-13', days))).toBe(days);
+      }
+    });
+
+    it('ger null för ett datum som inte motsvarar något val — då visas "Eget datum"', () => {
+      expect(matchedValidityPreset('2026-08-13', addDaysIso('2026-08-13', 37))).toBeNull();
+      expect(matchedValidityPreset('2026-08-13', '2026-08-13')).toBeNull();
+    });
+
+    it('ger null när giltighetsdatumet saknas', () => {
+      // Tomt fält får inte råka matcha ett val och visa fel giltighetstid.
+      expect(matchedValidityPreset('2026-08-13', '')).toBeNull();
+    });
+
+    it('ger null för ett datum FÖRE offertdatumet', () => {
+      expect(matchedValidityPreset('2026-08-13', '2026-08-01')).toBeNull();
+    });
   });
 });

--- a/tests/offerter/quote-serializers.test.ts
+++ b/tests/offerter/quote-serializers.test.ts
@@ -365,3 +365,13 @@ describe('giltighetstid', () => {
     });
   });
 });
+
+describe('addDaysIso — ogiltigt dagantal', () => {
+  it('lämnar datumet orört i stället för att kasta', () => {
+    // setDate(NaN) gör datumet ogiltigt och toISOString kastar RangeError. Utan vakten hade en
+    // anropare med ett härlett dagantal tagit ner hela formulärets rendering.
+    expect(addDaysIso('2026-08-13', Number.NaN)).toBe('2026-08-13');
+    expect(addDaysIso('2026-08-13', Number('custom'))).toBe('2026-08-13');
+    expect(addDaysIso('2026-08-13', Infinity)).toBe('2026-08-13');
+  });
+});


### PR DESCRIPTION
Tre önskemål från säljsidan, samlade på en gren. Varje commit går att revertera för sig.

## 1. Giltighetstid i rullgardin (`69a03d8`)

Giltighetstiden är nästan alltid ett jämnt antal dagar, och då ska ingen behöva räkna fram ett datum i kalendern. **10 / 15 / 20 / 30 / 45 / 60 dagar**, standard 30 som förut. Kalendern ligger kvar för de gånger ett specifikt datum gäller.

Valet **lagras inte** utan härleds ur avståndet mellan offertdatum och giltighetsdatum. Ett eget fält hade blivit en andra sanning vid sidan av `valid_until` — och det är `valid_until` som går till Fortnox.

Rättar samtidigt en befintlig skevhet: ändrades offertdatumet flyttades "Giltig till" med bara om giltigheten var exakt 30 dagar. En offert satt till 15 dagar hade tappat sina 15 dagar.

## 2. Artikelbeskrivning som intern hjälptext (`df9d6dc`, `077d4e2`)

Beskrivningen ur artikelregistret visas under vald artikel. **Intern** — garanterat på tre sätt: fältet ligger bara på raden, pushens radtyp känner inte till det, och ett regressionstest serialiserar `buildOfferRows` och slår fast att varken texten eller fältnamnet finns med.

**Datan fanns inte hos oss.** `GET /articles` returnerar inte `Note` — 0 av 289 cachade artiklar hade fältet. Att den ändå syns på artikelsidan beror på att den sidan gör ett live-anrop per artikel. Hämtas nu per artikel i synken, sekventiellt med paus (aldrig `Promise.all` — det sprängde kundimporten en gång, TD-3), och bara för artiklar vi inte redan frågat om.

**78 % av beskrivningarna var upprepad text** — samma mening två till fyra gånger, 19 843 tecken ren dubblering. Otvättad hade hjälptexten varit oläsbar. Dedupas vid skrivning till cachen; Fortnox egna register rörs inte.

## 3. Täckningsgrad (`69f030c`, `42a10c6`)

TG per rad och för hela offerten, färgad grön/gul/röd, med inköpspriset som underlag. TG = (pris − inköp) ÷ **pris** — inte påslag.

Offertens siffra är **viktad på belopp**, inte ett snitt av radernas procent: en femkronorsrad ska inte väga lika tungt som en 50 000-rad.

⚠️ **Inköpspriset lagras aldrig på offertraden.** `line_items` följer med offert → arbetsorder → fältvyn, och `redactWorkOrderForField` plockar bara bort `amount`/`pricing_summary`. Priserna hålls i komponent-state och slås upp ur artikelcachen.

Rött är en **varning, inte en spärr** — texten säger att offerten behöver godkännas av säljchef, men sparning och utskick är oförändrade.

## Granskningen (`62d349e`)

Fjorton fynd, varav ett blockerande:

**Varje redigering av en offert kraschade.** Hookarna för inköpspriserna hamnade under `if (loading) return`, och `loading` startar true vid redigering → React kastade "Rendered more hooks than during the previous render". Slapp igenom eftersom TG:n bara testades på nya offerter och repot saknar ESLint; type-check och 1085 tester var gröna hela tiden.

**TG:n ignorerade auto-prissatta rader tyst.** De prissätts med formulärets stub men fick 0 kr i beräkningen — och flaggades inte ens som obedömda. En offert kunde visa grön TG 60 % som ignorerade 99 % av värdet. Roten var att TG:n räknade om raden i stället för att använda beloppet på skärmen; `MarginRow` tar nu emot intäkten explicit.

**Ett misslyckat anrop förlorade en beskrivning för alltid** — ett 429 stämplade ändå `note_synced_at`.

**Migrationsfilen ljög om deployordningen** — `ARTICLE_CACHE_SELECT` begär `note`, och PostgREST svarar 400 på ett select mot en saknad kolumn. Additiv i schemat är inte samma sak som ofarlig ordning.

Plus åtta mindre: layout, avrundning som motsade färgen, negativ cachning, felräknad toast, tyst bortkastad parameter, NaN-vakt, SQL som inte matchade sin JS-motsvarighet, och en fjärde kopia av `sleep`.

## Migrationer

Båda är **redan körda och verifierade** i Supabase:

- `20260813_fortnox_article_notes.sql` — ⚠️ **SQL före kod** (se filens huvud)
- `20260813_fortnox_article_notes_dedupe.sql` — städar redan hämtade beskrivningar

## Verifierat

type-check ren, **1086 tester** gröna, `npm run build` avslutar 0. Skarpt testat av @prodigystudios: giltighetstid inklusive datumbyte och eget datum, artikelbeskrivning inklusive sparning och omöppning, TG med och utan inköpspris, redigering av befintlig offert efter hook-fixen.

## Kvar efter merge

⚠️ **`MARGIN_THRESHOLDS` är preliminära** (grön ≥50, gul ≥35), satta kring registrets faktiska median 53,7 %. Säljchefen ska ge de skarpa siffrorna — de ligger på ett ställe i `lib/domains/crm/pricing.ts` och styr en färg säljarna kommer att lita på.

🤖 Generated with [Claude Code](https://claude.com/claude-code)