### PR TITLE
feat(crm/rapportering): snabbval för period i stället för bara manuella datum

### DIFF
--- a/app/crm/rapportering/ReportsClient.tsx
+++ b/app/crm/rapportering/ReportsClient.tsx
@@ -6,6 +6,12 @@ import {
 } from 'recharts';
 import { cn } from '@/lib/shared/cn';
 import { crm } from '@/app/crm/lib/crmTokens';
+import {
+  REPORT_RANGE_LABELS,
+  reportRange,
+  today,
+  type ReportRangeKey,
+} from './reportRanges';
 
 // ── Types (mirror lib/domains/crm/reports.ts) ──
 type SalesOverTimePoint = { period: string; quoteValue: number; orderValue: number; invoicedValue: number };
@@ -35,6 +41,14 @@ function formatMonth(period: string) {
   if (!y || !m) return period;
   return new Intl.DateTimeFormat('sv-SE', { month: 'short', year: '2-digit' }).format(new Date(Date.UTC(y, m - 1, 1)));
 }
+// UTC-pinned: the bare dates are calendar days, and letting the browser's zone touch them
+// would shift the label a day for anyone west of Greenwich.
+function formatRangeLabel(from: string, to: string) {
+  const fmt = new Intl.DateTimeFormat('sv-SE', { day: 'numeric', month: 'short', timeZone: 'UTC' });
+  const start = fmt.format(new Date(`${from}T00:00:00Z`));
+  const end = fmt.format(new Date(`${to}T00:00:00Z`));
+  return start === end ? start : `${start} – ${end}`;
+}
 function percent(part: number, whole: number) {
   if (whole <= 0) return '–';
   return `${Math.round((part / whole) * 100)} %`;
@@ -56,11 +70,11 @@ function downloadCsv(filename: string, header: string[], rows: Array<Array<strin
   setTimeout(() => URL.revokeObjectURL(url), 1000);
 }
 
-function defaultFrom() {
-  const now = new Date();
-  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - 11, 1)).toISOString().slice(0, 10);
-}
-function today() { return new Date().toISOString().slice(0, 10); }
+// The last-12-months preset is also the landing state, so the page opens on a range the
+// quick filters can recognise and highlight.
+const DEFAULT_RANGE_KEY: ReportRangeKey = 'last12';
+
+function defaultFrom() { return reportRange(DEFAULT_RANGE_KEY).from; }
 
 function ExportButton({ onClick }: { onClick: () => void }) {
   return (
@@ -92,26 +106,61 @@ export default function ReportsClient() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  const load = useCallback(async () => {
+  // The highlight tracks what was clicked rather than being derived back from the dates:
+  // presets collide (on a Monday the 1st, this week and this month are the same range),
+  // and no amount of comparing could tell which one the user meant.
+  const [activeRangeKey, setActiveRangeKey] = useState<ReportRangeKey | null>(DEFAULT_RANGE_KEY);
+
+  const applyRange = (key: ReportRangeKey) => {
+    const range = reportRange(key);
+    setActiveRangeKey(key);
+    setFrom(range.from);
+    setTo(range.to);
+  };
+
+  // One click per period makes it easy to outrun the previous request, and a 12-month
+  // report takes far longer than a one-week one. Without the abort, the slower earlier
+  // request resolves last and paints a year's data under a "Denna vecka" chip.
+  const load = useCallback(async (signal: AbortSignal) => {
     setLoading(true);
     setError(null);
     try {
-      const res = await fetch(`/api/crm/reports?from=${from}&to=${to}`, { cache: 'no-store' });
+      const res = await fetch(`/api/crm/reports?from=${from}&to=${to}`, { cache: 'no-store', signal });
+      if (signal.aborted) return;
+      // The abort can land mid-body, and this catch would turn that into an empty object
+      // that reads as a failed report — a stale error banner over the successor's data.
       const json = await res.json().catch(() => ({}));
+      if (signal.aborted) return;
       if (!res.ok || !json.ok) { setError(json?.error || 'Kunde inte ladda rapporten.'); setReport(null); return; }
       setReport(json.data as SalesReport);
-    } catch {
+    } catch (e) {
+      if (signal.aborted || (e instanceof DOMException && e.name === 'AbortError')) return;
       setError('Kunde inte ladda rapporten.');
       setReport(null);
     } finally {
-      setLoading(false);
+      // An aborted request has a successor already loading; clearing the flag here would
+      // flash the charts back in between periods.
+      if (!signal.aborted) setLoading(false);
     }
   }, [from, to]);
 
-  useEffect(() => { void load(); }, [load]);
+  useEffect(() => {
+    const controller = new AbortController();
+    void load(controller.signal);
+    return () => controller.abort();
+  }, [load]);
 
+  // A range inside one calendar month collapses to a single monthly bucket. Labelling that
+  // point "aug -26" would present a week's figures as the whole month's — so when there is
+  // only one bucket it is named after the period actually asked for.
+  const singlePoint = (report?.salesOverTime.length ?? 0) === 1;
   const salesChartData = useMemo(
-    () => (report?.salesOverTime || []).map((p) => ({ ...p, label: formatMonth(p.period) })),
+    () => (report?.salesOverTime || []).map((p) => ({
+      ...p,
+      label: report && report.salesOverTime.length === 1
+        ? formatRangeLabel(report.range.from, report.range.to)
+        : formatMonth(p.period),
+    })),
     [report],
   );
   const sellerChartData = useMemo(
@@ -138,20 +187,44 @@ export default function ReportsClient() {
   return (
     <div className="grid grid-cols-1 gap-6">
       {/* Header */}
-      <div className="flex flex-wrap items-end justify-between gap-4">
+      <div className="grid gap-3">
         <div>
           <h1 className={cn('m-0', crm.pageTitle)}>Rapportering</h1>
           <p className={cn('m-0 mt-1', crm.pageSubtitle)}>Försäljning, säljarprestation och konvertering för vald period.</p>
         </div>
-        <div className="flex flex-wrap items-end gap-2">
-          <label className="grid gap-1">
-            <span className="text-[11px] font-semibold uppercase tracking-[0.12em] text-slate-400">Från</span>
-            <input type="date" value={from} max={to} onChange={(e) => setFrom(e.target.value)} className="h-10 rounded-xl border border-slate-200 bg-white px-3 text-sm text-slate-700" />
-          </label>
-          <label className="grid gap-1">
-            <span className="text-[11px] font-semibold uppercase tracking-[0.12em] text-slate-400">Till</span>
-            <input type="date" value={to} min={from} max={today()} onChange={(e) => setTo(e.target.value)} className="h-10 rounded-xl border border-slate-200 bg-white px-3 text-sm text-slate-700" />
-          </label>
+        {/* Quick periods on the left as the everyday control, the manual dates on the
+            right for the odd range that no preset covers. */}
+        <div className="flex flex-wrap items-end justify-between gap-3">
+          <div className="flex flex-wrap gap-2">
+            {REPORT_RANGE_LABELS.map(([key, label]) => {
+              const active = activeRangeKey === key;
+              return (
+                <button
+                  key={key}
+                  type="button"
+                  aria-pressed={active}
+                  onClick={() => applyRange(key)}
+                  className={cn(
+                    'rounded-full border px-2.5 py-1 text-[13px] font-semibold transition',
+                    active ? 'text-white' : 'border-[#e0e8dc] bg-[#f9fbf7] text-slate-600 hover:border-[#cfdcc9]',
+                  )}
+                  style={active ? { backgroundColor: 'var(--crm-primary)', borderColor: 'var(--crm-primary)' } : undefined}
+                >
+                  {label}
+                </button>
+              );
+            })}
+          </div>
+          <div className="flex flex-wrap items-end gap-2">
+            <label className="grid gap-1">
+              <span className="text-[11px] font-semibold uppercase tracking-[0.12em] text-slate-400">Från</span>
+              <input type="date" value={from} max={to} onChange={(e) => { setActiveRangeKey(null); setFrom(e.target.value); }} className="h-10 rounded-xl border border-slate-200 bg-white px-3 text-sm text-slate-700" />
+            </label>
+            <label className="grid gap-1">
+              <span className="text-[11px] font-semibold uppercase tracking-[0.12em] text-slate-400">Till</span>
+              <input type="date" value={to} min={from} max={today()} onChange={(e) => { setActiveRangeKey(null); setTo(e.target.value); }} className="h-10 rounded-xl border border-slate-200 bg-white px-3 text-sm text-slate-700" />
+            </label>
+          </div>
         </div>
       </div>
 
@@ -171,11 +244,16 @@ export default function ReportsClient() {
           {/* 1. Försäljning över tid */}
           <SectionCard
             title="Försäljning över tid"
-            subtitle="Offertvärde, ordervärde och fakturerat per månad"
+            subtitle={singlePoint
+              ? 'Offertvärde, ordervärde och fakturerat för hela den valda perioden'
+              : 'Offertvärde, ordervärde och fakturerat per månad'}
             action={<ExportButton onClick={() => downloadCsv(
               `forsaljning-over-tid_${report.range.from}_${report.range.to}.csv`,
-              ['Månad', 'Offertvärde', 'Ordervärde', 'Fakturerat'],
-              report.salesOverTime.map((p) => [p.period, p.quoteValue, p.orderValue, p.invoicedValue]),
+              [singlePoint ? 'Period' : 'Månad', 'Offertvärde', 'Ordervärde', 'Fakturerat'],
+              report.salesOverTime.map((p) => [
+                singlePoint ? `${report.range.from} – ${report.range.to}` : p.period,
+                p.quoteValue, p.orderValue, p.invoicedValue,
+              ]),
             )} />}
           >
             {salesChartData.length === 0 ? <EmptyChart /> : (
@@ -187,9 +265,12 @@ export default function ReportsClient() {
                     <YAxis tickFormatter={formatCompact} tick={{ fontSize: 12, fill: '#64748b' }} width={56} />
                     <Tooltip formatter={(value) => formatCurrency(Number(value))} labelStyle={{ color: '#0f172a' }} />
                     <Legend wrapperStyle={{ fontSize: 12 }} />
-                    <Line type="monotone" dataKey="quoteValue" name="Offertvärde" stroke={COLOR_QUOTE} strokeWidth={2} dot={false} />
-                    <Line type="monotone" dataKey="orderValue" name="Ordervärde" stroke={COLOR_ORDER} strokeWidth={2} dot={false} />
-                    <Line type="monotone" dataKey="invoicedValue" name="Fakturerat" stroke={COLOR_INVOICED} strokeWidth={2} dot={false} />
+                    {/* Buckets are monthly, so a week/month range yields a single point —
+                        and a line through one point draws nothing. Show the dot instead of
+                        an empty canvas. */}
+                    <Line type="monotone" dataKey="quoteValue" name="Offertvärde" stroke={COLOR_QUOTE} strokeWidth={2} dot={singlePoint} />
+                    <Line type="monotone" dataKey="orderValue" name="Ordervärde" stroke={COLOR_ORDER} strokeWidth={2} dot={singlePoint} />
+                    <Line type="monotone" dataKey="invoicedValue" name="Fakturerat" stroke={COLOR_INVOICED} strokeWidth={2} dot={singlePoint} />
                   </LineChart>
                 </ResponsiveContainer>
               </div>

--- a/app/crm/rapportering/reportRanges.ts
+++ b/app/crm/rapportering/reportRanges.ts
@@ -1,0 +1,95 @@
+// Date ranges for the reporting filter. Pure and side-effect free — every function takes
+// the instant as an argument, so the presets are unit-testable without freezing clocks.
+//
+// Everything is anchored to Europe/Stockholm rather than to the runtime's own clock.
+// ReportsClient is server-rendered before it hydrates, and the server runs on UTC: a
+// range derived from local calendar fields would be computed as one day on the server
+// and another in the browser between midnight and 02:00 Swedish time — a hydration
+// mismatch on the date inputs, and a `defaultFrom` a whole month off on the 1st.
+// Pinning the zone makes both sides agree AND makes "today" mean today in Sweden.
+//
+// (lib/domains/crm/goals.ts has its own week/month helpers for the leaderboard. Those
+// read browser-local fields, which is fine for client-only code but not here. The two
+// only disagree between 00:00 and 02:00; unifying them is a separate change.)
+
+const REPORT_TIME_ZONE = 'Europe/Stockholm';
+
+const zoneParts = new Intl.DateTimeFormat('sv-SE', {
+  timeZone: REPORT_TIME_ZONE,
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+});
+
+export type ReportRangeKey = 'week' | 'month' | 'prevMonth' | 'year' | 'last12';
+
+export type ReportRange = { from: string; to: string };
+
+/**
+ * The Swedish calendar date an instant falls on, as a UTC-anchored midnight. Anchoring
+ * to UTC keeps the arithmetic below a pure calendar walk — no DST hour to trip over,
+ * because these values are never treated as points in time.
+ */
+export function stockholmDay(now: Date): Date {
+  const parts = zoneParts.formatToParts(now);
+  const part = (type: string) => Number(parts.find((p) => p.type === type)?.value);
+  return new Date(Date.UTC(part('year'), part('month') - 1, part('day')));
+}
+
+/** YYYY-MM-DD for a day produced by the helpers here. */
+export function dayString(day: Date): string {
+  return day.toISOString().slice(0, 10);
+}
+
+function addDays(day: Date, days: number): Date {
+  return new Date(Date.UTC(day.getUTCFullYear(), day.getUTCMonth(), day.getUTCDate() + days));
+}
+
+function startOfMonth(day: Date): Date {
+  return new Date(Date.UTC(day.getUTCFullYear(), day.getUTCMonth(), 1));
+}
+
+/** Monday of the week the day falls in — ISO-8601 / Swedish week start, so Sunday looks back six days. */
+export function startOfWeek(day: Date): Date {
+  const weekday = day.getUTCDay(); // 0 = Sunday
+  return addDays(day, weekday === 0 ? -6 : 1 - weekday);
+}
+
+export function today(now: Date = new Date()): string {
+  return dayString(stockholmDay(now));
+}
+
+/**
+ * The ranges behind the quick presets. The open-ended ones end today rather than at the
+ * period's calendar end: the report has no future data, and a `to` in the future would
+ * exceed the date picker's own max. A period that is already over keeps its real end.
+ */
+export function reportRange(key: ReportRangeKey, now: Date = new Date()): ReportRange {
+  const day = stockholmDay(now);
+  const to = dayString(day);
+  switch (key) {
+    case 'week':
+      return { from: dayString(startOfWeek(day)), to };
+    case 'month':
+      return { from: dayString(startOfMonth(day)), to };
+    case 'prevMonth': {
+      // Day 0 of this month is the last day of the previous one, which also handles January.
+      const last = new Date(Date.UTC(day.getUTCFullYear(), day.getUTCMonth(), 0));
+      return { from: dayString(startOfMonth(last)), to: dayString(last) };
+    }
+    case 'year':
+      return { from: dayString(new Date(Date.UTC(day.getUTCFullYear(), 0, 1))), to };
+    case 'last12':
+      // Eleven months back to the 1st, so the current month is the twelfth and the
+      // monthly chart fills exactly twelve buckets.
+      return { from: dayString(new Date(Date.UTC(day.getUTCFullYear(), day.getUTCMonth() - 11, 1))), to };
+  }
+}
+
+export const REPORT_RANGE_LABELS: Array<[ReportRangeKey, string]> = [
+  ['week', 'Denna vecka'],
+  ['month', 'Denna månad'],
+  ['prevMonth', 'Förra månaden'],
+  ['year', 'I år'],
+  ['last12', 'Senaste 12 mån'],
+];

--- a/tests/crm/reportRanges.test.ts
+++ b/tests/crm/reportRanges.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect } from 'vitest';
+import {
+  stockholmDay,
+  dayString,
+  startOfWeek,
+  today,
+  reportRange,
+  REPORT_RANGE_LABELS,
+} from '@/app/crm/rapportering/reportRanges';
+
+// Fixtures are explicit UTC instants, never local-time constructors: the module pins the
+// zone to Europe/Stockholm, so these assertions hold on a developer's machine, on the
+// UTC server that renders the page, and in CI alike.
+const utc = (iso: string) => new Date(iso);
+
+// Midday UTC is the same calendar day in Sweden year-round — the boring case.
+const midday = (date: string) => utc(`${date}T12:00:00Z`);
+
+describe('stockholmDay', () => {
+  it('resolves a midday instant to that calendar day', () => {
+    expect(dayString(stockholmDay(midday('2026-08-14')))).toBe('2026-08-14');
+  });
+
+  it('counts 00:30 Swedish summer time as the new day, though UTC is still on the old one', () => {
+    // CEST is UTC+2, so 2026-08-13T22:30Z is 2026-08-14 00:30 in Sweden.
+    expect(dayString(stockholmDay(utc('2026-08-13T22:30:00Z')))).toBe('2026-08-14');
+  });
+
+  it('counts 00:30 Swedish winter time as the new day', () => {
+    // CET is UTC+1, so 2026-01-05T23:30Z is 2026-01-06 00:30 in Sweden.
+    expect(dayString(stockholmDay(utc('2026-01-05T23:30:00Z')))).toBe('2026-01-06');
+  });
+
+  it('still counts 23:30 Swedish time as the old day', () => {
+    expect(dayString(stockholmDay(utc('2026-08-14T21:30:00Z')))).toBe('2026-08-14');
+  });
+
+  it('rolls the month over at Swedish midnight, not UTC midnight', () => {
+    // 2026-07-31T22:30Z is 2026-08-01 00:30 in Sweden.
+    expect(dayString(stockholmDay(utc('2026-07-31T22:30:00Z')))).toBe('2026-08-01');
+  });
+
+  it('zero-pads month and day', () => {
+    expect(dayString(stockholmDay(midday('2026-01-05')))).toBe('2026-01-05');
+  });
+});
+
+describe('today', () => {
+  it('is the Swedish date, not the UTC one, just after local midnight', () => {
+    expect(today(utc('2026-08-13T22:30:00Z'))).toBe('2026-08-14');
+  });
+});
+
+describe('startOfWeek', () => {
+  const weekOf = (date: string) => dayString(startOfWeek(stockholmDay(midday(date))));
+
+  it('returns Monday for a midweek day', () => {
+    expect(weekOf('2026-08-14')).toBe('2026-08-10'); // Friday → Monday
+  });
+
+  it('returns the same day when it is already Monday', () => {
+    expect(weekOf('2026-08-10')).toBe('2026-08-10');
+  });
+
+  it('looks back six days on Sunday rather than forward one', () => {
+    expect(weekOf('2026-08-16')).toBe('2026-08-10'); // Sunday belongs to the week that began the 10th
+  });
+
+  it('crosses a month boundary', () => {
+    expect(weekOf('2026-09-02')).toBe('2026-08-31'); // Wednesday whose Monday is in August
+  });
+
+  it('crosses a year boundary', () => {
+    expect(weekOf('2027-01-01')).toBe('2026-12-28'); // Friday whose Monday is in December
+  });
+});
+
+describe('reportRange', () => {
+  const now = midday('2026-08-14'); // Friday
+
+  it('runs this week from Monday to today', () => {
+    expect(reportRange('week', now)).toEqual({ from: '2026-08-10', to: '2026-08-14' });
+  });
+
+  it('runs this month from the 1st to today', () => {
+    expect(reportRange('month', now)).toEqual({ from: '2026-08-01', to: '2026-08-14' });
+  });
+
+  it('runs the previous month end to end, not up to today', () => {
+    expect(reportRange('prevMonth', now)).toEqual({ from: '2026-07-01', to: '2026-07-31' });
+  });
+
+  it('handles February in a leap year as the previous month', () => {
+    expect(reportRange('prevMonth', midday('2028-03-10'))).toEqual({ from: '2028-02-01', to: '2028-02-29' });
+  });
+
+  it('rolls the previous month back into the prior year in January', () => {
+    expect(reportRange('prevMonth', midday('2026-01-09'))).toEqual({ from: '2025-12-01', to: '2025-12-31' });
+  });
+
+  it('runs this year from January 1st to today', () => {
+    expect(reportRange('year', now)).toEqual({ from: '2026-01-01', to: '2026-08-14' });
+  });
+
+  it('runs the last 12 months from the 1st eleven months back, so the chart fills twelve buckets', () => {
+    expect(reportRange('last12', now)).toEqual({ from: '2025-09-01', to: '2026-08-14' });
+  });
+
+  it('never ends in the future for any open-ended preset', () => {
+    for (const key of ['week', 'month', 'year', 'last12'] as const) {
+      expect(reportRange(key, now).to).toBe('2026-08-14');
+    }
+  });
+
+  it('never starts after it ends', () => {
+    for (const [key] of REPORT_RANGE_LABELS) {
+      const range = reportRange(key, now);
+      expect(range.from <= range.to).toBe(true);
+    }
+  });
+
+  it('produces a valid single-day week on a Monday, where a Sunday-start week would invert', () => {
+    expect(reportRange('week', midday('2026-08-10'))).toEqual({ from: '2026-08-10', to: '2026-08-10' });
+  });
+
+  it('uses the Swedish day just after local midnight, so the range does not lag by one', () => {
+    // 2026-08-09T22:30Z is Monday 2026-08-10 00:30 in Sweden — the first minutes of a new week.
+    expect(reportRange('week', utc('2026-08-09T22:30:00Z'))).toEqual({ from: '2026-08-10', to: '2026-08-10' });
+  });
+
+  it('covers every preset key exactly once in the label list', () => {
+    const keys = REPORT_RANGE_LABELS.map(([key]) => key);
+    expect(new Set(keys).size).toBe(keys.length);
+    expect(keys).toEqual(['week', 'month', 'prevMonth', 'year', 'last12']);
+  });
+});


### PR DESCRIPTION
Perioden i rapporteringen sattes bara med två datumfält. Nu finns fem snabbval — **Denna vecka · Denna månad · Förra månaden · I år · Senaste 12 mån** — till vänster i periodraden, med datumfälten kvar till höger för det som inget preset täcker. Väljer man datum för hand släcks markeringen.

Intervallogiken ligger i en ren modul, `app/crm/rapportering/reportRanges.ts`, med 24 tester — inte inbakad i vyn.

## Det som var värt mest i granskningarna

**Datumen är förankrade i `Europe/Stockholm`, inte i maskinens klocka.** Sidan server-renderas innan den hydreras och servern går på UTC. Räknar man på lokala kalenderfält får server och webbläsare olika datum mellan midnatt och 02:00 svensk tid: hydreringsfel på datumfältens `value`/`max`, och den 1:a i månaden blir `defaultFrom` en hel månad fel. Att pinna zonen ger både SSR-determinism *och* att "idag" betyder idag i Sverige. Testerna använder explicita UTC-instanser och ger identiskt resultat under `TZ=UTC`, `TZ=Europe/Stockholm` och `TZ=America/Los_Angeles`.

**Hämtningen avbryts när perioden byts.** Ett klick per period gör det lätt att springa om föregående anrop, och en 12-månadersrapport tar långt mer tid än en vecka — utan avbrott resolvar det tidigare, tyngre svaret sist och målar ett års data under chippet "Denna vecka". `aborted` kollas efter varje `await`: `res.json().catch(() => ({}))` sväljer annars avbrottet, tar `!json.ok`-grenen och lämnar en permanent felbanner ovanför korrekt laddad data.

**Markerat chip är state, inte härlett ur datumen.** På en måndag som är den 1:a är "denna vecka" och "denna månad" exakt samma intervall — ingen jämförelse kan avgöra vilket som klickades.

**Diagrammet ljög för korta perioder.** "Försäljning över tid" bucketar strikt per månad, så en vecka blev en enda punkt märkt "aug -26", under undertexten "per månad" och med CSV-huvudet "Månad" — en veckas siffror presenterade som augusti månads total. Punkten heter nu perioden den avser ("10 aug – 14 aug"), och undertext och CSV-huvud följer med.

## Två saker som medvetet lämnats utanför

- **Dagsupplösning för korta perioder.** En ensam punkt är fortfarande inte "försäljning över tid". Att bucketa per dag när perioden är kort gör veckovyn användbar, men ändrar rapportdomänen och API-svarets form — egen ändring, inte insmugen här.
- **`fetchReportData` jämför datum mot `timestamptz` vid UTC-midnatt.** En arbetsorder skapad 00:30 svensk tid den 1:a hamnar utanför "Denna månad" och inne i "Förra månaden". Befintligt beteende som gäller alla perioder lika; att ändra det flyttar siffror för alla och hör hemma i routen.

## Verifiering

`npm run type-check`, `npm run build` och `npm test` (1110 tester, 80 filer) gröna. 24 av testerna är nya och täcker skottår, årsskifte, söndag, månadsgräns och midnattsfönstret i både sommar- och vintertid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)