### PR TITLE
fix(crm/rapportering): fakturerat räknas på när det fakturerades, inte när ordern skapades

### DIFF
--- a/app/crm/rapportering/ReportsClient.tsx
+++ b/app/crm/rapportering/ReportsClient.tsx
@@ -167,8 +167,15 @@ export default function ReportsClient() {
     () => (report?.perSeller || []).slice(0, 12).map((s) => ({ name: s.userName, Ordervärde: s.orderValue, Offertvärde: s.quoteValue })),
     [report],
   );
+  // Both series, same as the per-seller chart: a customer billed this period on an older
+  // order has no order value, and plotting order value alone would draw it as a labelled
+  // empty bar.
   const customerChartData = useMemo(
-    () => (report?.perCustomer || []).slice(0, 8).map((c) => ({ name: c.customer, Ordervärde: c.orderValue })),
+    () => (report?.perCustomer || []).slice(0, 8).map((c) => ({
+      name: c.customer,
+      Ordervärde: c.orderValue,
+      Fakturerat: c.invoicedValue,
+    })),
     [report],
   );
 
@@ -245,8 +252,8 @@ export default function ReportsClient() {
           <SectionCard
             title="Försäljning över tid"
             subtitle={singlePoint
-              ? 'Offertvärde, ordervärde och fakturerat för hela den valda perioden'
-              : 'Offertvärde, ordervärde och fakturerat per månad'}
+              ? 'Offert- och ordervärde skapat i perioden; fakturerat är det som fakturerades under perioden'
+              : 'Offert- och ordervärde per månad de skapades; fakturerat per månad det fakturerades'}
             action={<ExportButton onClick={() => downloadCsv(
               `forsaljning-over-tid_${report.range.from}_${report.range.to}.csv`,
               [singlePoint ? 'Period' : 'Månad', 'Offertvärde', 'Ordervärde', 'Fakturerat'],
@@ -280,7 +287,7 @@ export default function ReportsClient() {
           {/* 2. Per säljare */}
           <SectionCard
             title="Per säljare"
-            subtitle="Aktivitet och värde per säljare i perioden"
+            subtitle="Aktivitet och värde per säljare — ordervärde för det som skapades i perioden, fakturerat för det som fakturerades under den"
             action={<ExportButton onClick={() => downloadCsv(
               `per-saljare_${report.range.from}_${report.range.to}.csv`,
               ['Säljare', 'Samtal', 'Offerter', 'Offertvärde', 'Vunnet värde', 'Ordervärde', 'Fakturerat'],
@@ -335,7 +342,7 @@ export default function ReportsClient() {
           {/* 3. Konvertering (funnel) */}
           <SectionCard
             title="Konvertering"
-            subtitle="Offert → vunnen → arbetsorder → fakturerat"
+            subtitle="Offert → vunnen → arbetsorder → fakturerat, för det som skapades i perioden — faktureringen kan ha skett senare"
             action={<ExportButton onClick={() => downloadCsv(
               `konvertering_${report.range.from}_${report.range.to}.csv`,
               ['Steg', 'Antal', 'Värde', 'Konvertering'],
@@ -363,7 +370,7 @@ export default function ReportsClient() {
           {/* 4. Per kund */}
           <SectionCard
             title="Per kund"
-            subtitle="Topplista kunder på ordervärde"
+            subtitle="Topplista kunder på ordervärde och fakturerat i perioden"
             action={<ExportButton onClick={() => downloadCsv(
               `per-kund_${report.range.from}_${report.range.to}.csv`,
               ['Kund', 'Antal order', 'Ordervärde', 'Fakturerat'],
@@ -379,7 +386,9 @@ export default function ReportsClient() {
                       <XAxis type="number" tickFormatter={formatCompact} tick={{ fontSize: 12, fill: '#64748b' }} />
                       <YAxis type="category" dataKey="name" tick={{ fontSize: 11, fill: '#64748b' }} width={140} />
                       <Tooltip formatter={(value) => formatCurrency(Number(value))} />
+                      <Legend wrapperStyle={{ fontSize: 12 }} />
                       <Bar dataKey="Ordervärde" fill={COLOR_ORDER} radius={[0, 4, 4, 0]} />
+                      <Bar dataKey="Fakturerat" fill={COLOR_INVOICED} radius={[0, 4, 4, 0]} />
                     </BarChart>
                   </ResponsiveContainer>
                 </div>

--- a/lib/domains/crm/reports.ts
+++ b/lib/domains/crm/reports.ts
@@ -63,11 +63,52 @@ export function monthsInRange(from: string, to: string): string[] {
   return out;
 }
 
+// ── Order partitioning ──
+//
+// An order billed in August was usually created weeks or months earlier — median lag is a
+// month. Fetching orders on created_at alone therefore dropped that revenue from the
+// period it was actually billed in: for August 2026 it hid 371 323 kr of 450 101 kr, so
+// the report showed 18 % of what had really been invoiced. The fetch now pulls a superset
+// (created in range OR invoiced in range) and the rows are split here, so every figure is
+// keyed to the date that belongs to it: order value to when the order was won, invoiced
+// revenue to when it was billed.
+
+/** The date an order's revenue is attributed to. Rows predating fortnox_invoiced_at fall back to their creation date. */
+export function invoicedAt(order: ReportOrderRow): string {
+  return order.fortnox_invoiced_at || order.created_at;
+}
+
+/** Inclusive day comparison against the range, matching how the fetch filters. */
+function withinRange(timestamp: string | null | undefined, range: ReportRange): boolean {
+  if (!timestamp) return false;
+  const day = String(timestamp).slice(0, 10);
+  return day >= range.from && day <= range.to;
+}
+
+export type PartitionedOrders = {
+  /** Orders created inside the range — the basis for order value and the conversion funnel. */
+  created: ReportOrderRow[];
+  /** Orders billed inside the range, whenever they were created — the basis for invoiced revenue. */
+  invoiced: ReportOrderRow[];
+};
+
+export function partitionOrders(orders: ReportOrderRow[], range: ReportRange): PartitionedOrders {
+  return {
+    created: orders.filter((o) => withinRange(o.created_at, range)),
+    invoiced: orders.filter((o) => o.status === 'invoiced' && withinRange(invoicedAt(o), range)),
+  };
+}
+
 // ── Aggregations (pure) ──
 
 export type SalesOverTimePoint = { period: string; quoteValue: number; orderValue: number; invoicedValue: number };
 
-export function buildSalesOverTime(quotes: ReportQuoteRow[], orders: ReportOrderRow[], months: string[]): SalesOverTimePoint[] {
+export function buildSalesOverTime(
+  quotes: ReportQuoteRow[],
+  ordersCreated: ReportOrderRow[],
+  ordersInvoiced: ReportOrderRow[],
+  months: string[],
+): SalesOverTimePoint[] {
   const quoteByMonth = new Map<string, number>();
   const orderByMonth = new Map<string, number>();
   const invoicedByMonth = new Map<string, number>();
@@ -76,23 +117,20 @@ export function buildSalesOverTime(quotes: ReportQuoteRow[], orders: ReportOrder
     const key = monthKey(q.quote_date);
     if (key) quoteByMonth.set(key, (quoteByMonth.get(key) || 0) + num(q.amount));
   }
-  for (const o of orders) {
+  for (const o of ordersCreated) {
     const key = monthKey(o.created_at);
     if (key) orderByMonth.set(key, (orderByMonth.get(key) || 0) + num(o.amount));
-    if (o.status === 'invoiced') {
-      // Invoiced revenue belongs to the month it was INVOICED, not when the order was
-      // created (those can differ by months). Fall back to the creation month for older
-      // rows that predate fortnox_invoiced_at. NOTE: orders are fetched by created_at, so an
-      // order invoiced in-range but created before the range isn't included here.
-      //
-      // DELFAKTURERING CAVEAT (deferred): a `partially_invoiced` order is excluded here, so its
-      // already-billed amount is undercounted until the final round flips it to `invoiced` (then
-      // the FULL order amount lands in the final round's month). Precise per-round attribution —
-      // summing crm_work_order_invoices.amount by each round's created_at — is roadmap D2 and is
-      // intentionally not wired in yet. `orderValue` is status-agnostic and unaffected.
-      const invoicedKey = monthKey(o.fortnox_invoiced_at) || key;
-      if (invoicedKey) invoicedByMonth.set(invoicedKey, (invoicedByMonth.get(invoicedKey) || 0) + num(o.amount));
-    }
+  }
+  // Invoiced revenue belongs to the month it was INVOICED, not when the order was created.
+  //
+  // DELFAKTURERING CAVEAT (deferred): a `partially_invoiced` order is excluded here, so its
+  // already-billed amount is undercounted until the final round flips it to `invoiced` (then
+  // the FULL order amount lands in the final round's month). Precise per-round attribution —
+  // summing crm_work_order_invoices.amount by each round's created_at — is roadmap D2 and is
+  // intentionally not wired in yet. `orderValue` is status-agnostic and unaffected.
+  for (const o of ordersInvoiced) {
+    const key = monthKey(invoicedAt(o));
+    if (key) invoicedByMonth.set(key, (invoicedByMonth.get(key) || 0) + num(o.amount));
   }
 
   return months.map((period) => ({
@@ -116,7 +154,8 @@ export type SellerReportRow = {
 
 export function buildPerSeller(
   quotes: ReportQuoteRow[],
-  orders: ReportOrderRow[],
+  ordersCreated: ReportOrderRow[],
+  ordersInvoiced: ReportOrderRow[],
   calls: ReportCallRow[],
   sellers: ReportSellerRow[],
 ): SellerReportRow[] {
@@ -141,11 +180,15 @@ export function buildPerSeller(
     row.quoteValue += num(q.amount);
     if (q.status === 'won') row.wonValue += num(q.amount);
   }
-  for (const o of orders) {
+  // A seller can show invoiced revenue this period from an order won in an earlier one —
+  // that is the point of the split, not a bug.
+  for (const o of ordersCreated) {
     if (!o.assigned_to) continue;
-    const row = ensure(o.assigned_to);
-    row.orderValue += num(o.amount);
-    if (o.status === 'invoiced') row.invoicedValue += num(o.amount);
+    ensure(o.assigned_to).orderValue += num(o.amount);
+  }
+  for (const o of ordersInvoiced) {
+    if (!o.assigned_to) continue;
+    ensure(o.assigned_to).invoicedValue += num(o.amount);
   }
 
   return [...acc.values()].sort((a, b) => b.orderValue - a.orderValue || b.quoteValue - a.quoteValue || a.userName.localeCompare(b.userName, 'sv'));
@@ -154,34 +197,63 @@ export function buildPerSeller(
 export type FunnelStage = { count: number; value: number };
 export type SalesFunnel = { quotes: FunnelStage; won: FunnelStage; orders: FunnelStage; invoiced: FunnelStage };
 
-export function buildFunnel(quotes: ReportQuoteRow[], orders: ReportOrderRow[]): SalesFunnel {
+/**
+ * A cohort view, deliberately: of what ENTERED in this period, how far did it get. The
+ * invoiced stage therefore counts orders created in the range that have since been billed,
+ * not everything billed during it — a stage fed from other periods would break the chain
+ * and could push the last conversion above 100 %. That is why this figure can differ from
+ * the invoiced revenue in the chart and the per-seller table; they answer different
+ * questions, and the section subtitles say which.
+ */
+export function buildFunnel(quotes: ReportQuoteRow[], ordersCreated: ReportOrderRow[]): SalesFunnel {
   const won = quotes.filter((q) => q.status === 'won');
-  const invoiced = orders.filter((o) => o.status === 'invoiced');
+  const invoiced = ordersCreated.filter((o) => o.status === 'invoiced');
   const sum = (rows: Array<{ amount: number | string | null }>) => rows.reduce((t, r) => t + num(r.amount), 0);
   return {
     quotes: { count: quotes.length, value: sum(quotes) },
     won: { count: won.length, value: sum(won) },
-    orders: { count: orders.length, value: sum(orders) },
+    orders: { count: ordersCreated.length, value: sum(ordersCreated) },
     invoiced: { count: invoiced.length, value: sum(invoiced) },
   };
 }
 
 export type CustomerReportRow = { customer: string; orderValue: number; invoicedValue: number; orderCount: number };
 
-export function buildPerCustomer(orders: ReportOrderRow[], topN = 10): CustomerReportRow[] {
+export function buildPerCustomer(
+  ordersCreated: ReportOrderRow[],
+  ordersInvoiced: ReportOrderRow[],
+  topN = 10,
+): CustomerReportRow[] {
   const acc = new Map<string, CustomerReportRow>();
-  for (const o of orders) {
-    const customer = (o.client_name || '').trim() || 'Okänd kund';
+  const ensure = (order: ReportOrderRow): CustomerReportRow => {
+    const customer = (order.client_name || '').trim() || 'Okänd kund';
     let row = acc.get(customer);
     if (!row) {
       row = { customer, orderValue: 0, invoicedValue: 0, orderCount: 0 };
       acc.set(customer, row);
     }
+    return row;
+  };
+
+  for (const o of ordersCreated) {
+    const row = ensure(o);
     row.orderValue += num(o.amount);
     row.orderCount += 1;
-    if (o.status === 'invoiced') row.invoicedValue += num(o.amount);
   }
-  return [...acc.values()].sort((a, b) => b.orderValue - a.orderValue).slice(0, topN);
+  // A customer billed this period whose order was placed in an earlier one lands here with
+  // no order value of its own. Truthful: the money moved this period, the order did not.
+  for (const o of ordersInvoiced) {
+    ensure(o).invoicedValue += num(o.amount);
+  }
+
+  // Ranked on total activity, not order value alone: a customer billed 330 480 kr this
+  // period on an order placed earlier has no order value at all, and sorting on that field
+  // would push exactly the rows this split exists to surface off the end of the top ten —
+  // leaving the table and its CSV short of what the chart above them shows.
+  const activity = (row: CustomerReportRow) => row.orderValue + row.invoicedValue;
+  return [...acc.values()]
+    .sort((a, b) => activity(b) - activity(a) || b.orderValue - a.orderValue || a.customer.localeCompare(b.customer, 'sv'))
+    .slice(0, topN);
 }
 
 export type SalesReport = {
@@ -194,12 +266,13 @@ export type SalesReport = {
 
 export function composeSalesReport(data: ReportData, range: ReportRange): SalesReport {
   const months = monthsInRange(range.from, range.to);
+  const orders = partitionOrders(data.orders, range);
   return {
     range,
-    salesOverTime: buildSalesOverTime(data.quotes, data.orders, months),
-    perSeller: buildPerSeller(data.quotes, data.orders, data.calls, data.sellers),
-    funnel: buildFunnel(data.quotes, data.orders),
-    perCustomer: buildPerCustomer(data.orders),
+    salesOverTime: buildSalesOverTime(data.quotes, orders.created, orders.invoiced, months),
+    perSeller: buildPerSeller(data.quotes, orders.created, orders.invoiced, data.calls, data.sellers),
+    funnel: buildFunnel(data.quotes, orders.created),
+    perCustomer: buildPerCustomer(orders.created, orders.invoiced),
   };
 }
 
@@ -208,7 +281,12 @@ export async function fetchReportData(admin: SupabaseClient, range: ReportRange)
   const toEnd = `${range.to}T23:59:59.999Z`;
   const [quotesRes, ordersRes, callsRes, sellersRes] = await Promise.all([
     admin.from('crm_quotes').select('amount, status, quote_date, assigned_to, customer_name').gte('quote_date', range.from).lte('quote_date', range.to),
-    admin.from('crm_work_orders').select('amount, status, created_at, fortnox_invoiced_at, assigned_to, client_name').gte('created_at', range.from).lte('created_at', toEnd),
+    // Superset: created in range OR billed in range. Filtering on created_at alone dropped
+    // revenue from every order billed later than the period it was won in — see
+    // partitionOrders. The rows are split back apart there.
+    admin.from('crm_work_orders')
+      .select('amount, status, created_at, fortnox_invoiced_at, assigned_to, client_name')
+      .or(`and(created_at.gte.${range.from},created_at.lte.${toEnd}),and(fortnox_invoiced_at.gte.${range.from},fortnox_invoiced_at.lte.${toEnd})`),
     admin.from('crm_calls').select('user_id, call_at').gte('call_at', range.from).lte('call_at', toEnd),
     admin.from('profiles').select('id, full_name, role').in('role', ['sales', 'admin', 'konsult']),
   ]);

--- a/tests/crm/reports.test.ts
+++ b/tests/crm/reports.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import {
   monthsInRange,
+  partitionOrders,
+  invoicedAt,
   buildSalesOverTime,
   buildPerSeller,
   buildFunnel,
@@ -35,6 +37,11 @@ const sellers: ReportSellerRow[] = [
   { id: 'u2', full_name: 'Björn' },
 ];
 
+// Every fixture order above is both created and invoiced inside this range, so the split
+// leaves the original expectations intact — the new behaviour is exercised separately below.
+const RANGE = { from: '2026-01-01', to: '2026-02-28' };
+const split = partitionOrders(orders, RANGE);
+
 describe('monthsInRange', () => {
   it('lists inclusive months across a year boundary', () => {
     expect(monthsInRange('2025-11-01', '2026-02-28')).toEqual(['2025-11', '2025-12', '2026-01', '2026-02']);
@@ -46,7 +53,7 @@ describe('monthsInRange', () => {
 
 describe('buildSalesOverTime', () => {
   it('buckets quote/order/invoiced value by month', () => {
-    const result = buildSalesOverTime(quotes, orders, ['2026-01', '2026-02']);
+    const result = buildSalesOverTime(quotes, split.created, split.invoiced, ['2026-01', '2026-02']);
     expect(result).toEqual([
       { period: '2026-01', quoteValue: 3000, orderValue: 1000, invoicedValue: 1000 },
       { period: '2026-02', quoteValue: 500, orderValue: 4500, invoicedValue: 1500 },
@@ -60,7 +67,8 @@ describe('buildSalesOverTime', () => {
     const crossMonth: ReportOrderRow[] = [
       { amount: 2000, status: 'invoiced', created_at: '2026-01-30T10:00:00Z', fortnox_invoiced_at: '2026-02-04T08:00:00Z', assigned_to: 'u1', client_name: 'Kund A' },
     ];
-    const result = buildSalesOverTime([], crossMonth, ['2026-01', '2026-02']);
+    const crossSplit = partitionOrders(crossMonth, RANGE);
+    const result = buildSalesOverTime([], crossSplit.created, crossSplit.invoiced, ['2026-01', '2026-02']);
     expect(result).toEqual([
       { period: '2026-01', quoteValue: 0, orderValue: 2000, invoicedValue: 0 },
       { period: '2026-02', quoteValue: 0, orderValue: 0, invoicedValue: 2000 },
@@ -70,21 +78,21 @@ describe('buildSalesOverTime', () => {
 
 describe('buildPerSeller', () => {
   it('aggregates calls, quotes and order value per seller', () => {
-    const rows = buildPerSeller(quotes, orders, calls, sellers);
+    const rows = buildPerSeller(quotes, split.created, split.invoiced, calls, sellers);
     const anna = rows.find((r) => r.userId === 'u1')!;
     const bjorn = rows.find((r) => r.userId === 'u2')!;
     expect(anna).toMatchObject({ userName: 'Anna', calls: 2, quotes: 2, quoteValue: 1500, wonValue: 1000, orderValue: 2500, invoicedValue: 2500 });
     expect(bjorn).toMatchObject({ userName: 'Björn', calls: 1, quotes: 1, quoteValue: 2000, wonValue: 0, orderValue: 3000, invoicedValue: 0 });
   });
   it('sorts by order value descending', () => {
-    const rows = buildPerSeller(quotes, orders, calls, sellers);
+    const rows = buildPerSeller(quotes, split.created, split.invoiced, calls, sellers);
     expect(rows[0].userId).toBe('u2'); // 3000 > 2500
   });
 });
 
 describe('buildFunnel', () => {
   it('counts and sums each stage', () => {
-    const f = buildFunnel(quotes, orders);
+    const f = buildFunnel(quotes, split.created);
     expect(f.quotes).toEqual({ count: 3, value: 3500 });
     expect(f.won).toEqual({ count: 1, value: 1000 });
     expect(f.orders).toEqual({ count: 3, value: 5500 });
@@ -93,14 +101,16 @@ describe('buildFunnel', () => {
 });
 
 describe('buildPerCustomer', () => {
-  it('aggregates by customer and sorts by order value', () => {
-    const rows = buildPerCustomer(orders);
-    // Sorted by order value descending → Kund B (3000) before Kund A (2500).
-    expect(rows[0]).toEqual({ customer: 'Kund B', orderValue: 3000, invoicedValue: 0, orderCount: 1 });
-    expect(rows[1]).toEqual({ customer: 'Kund A', orderValue: 2500, invoicedValue: 2500, orderCount: 2 });
+  it('aggregates by customer and ranks on total activity in the period', () => {
+    const rows = buildPerCustomer(split.created, split.invoiced);
+    // Ordered on order value + invoiced value, so Kund A (2500 + 2500) outranks Kund B
+    // (3000 + 0). Ranking on order value alone would bury customers whose activity in the
+    // period was an invoice against an order placed earlier.
+    expect(rows[0]).toEqual({ customer: 'Kund A', orderValue: 2500, invoicedValue: 2500, orderCount: 2 });
+    expect(rows[1]).toEqual({ customer: 'Kund B', orderValue: 3000, invoicedValue: 0, orderCount: 1 });
   });
   it('falls back to a placeholder for missing client names', () => {
-    const rows = buildPerCustomer([{ amount: 100, status: 'draft', created_at: '2026-01-01T00:00:00Z', fortnox_invoiced_at: null, assigned_to: null, client_name: null }]);
+    const rows = buildPerCustomer([{ amount: 100, status: 'draft', created_at: '2026-01-01T00:00:00Z', fortnox_invoiced_at: null, assigned_to: null, client_name: null }], []);
     expect(rows[0].customer).toBe('Okänd kund');
   });
 });
@@ -113,5 +123,128 @@ describe('composeSalesReport', () => {
     expect(report.funnel.quotes.count).toBe(3);
     expect(report.perCustomer).toHaveLength(2);
     expect(report.range).toEqual({ from: '2026-01-01', to: '2026-02-28' });
+  });
+});
+
+// ── Revenue billed in the range from an order won earlier ──
+//
+// The regression this whole split exists for. Orders used to be fetched on created_at
+// alone, so an order won in June and billed in August vanished from August entirely —
+// against live data that hid 371 323 kr of 450 101 kr, i.e. the report showed 18 % of what
+// had actually been invoiced. The short-period presets made it a one-click trap.
+describe('orders billed in-range but created earlier', () => {
+  const FEB = { from: '2026-02-01', to: '2026-02-28' };
+  // Won in January for 9000, billed in February — only the invoice lands in February.
+  const earlierOrder: ReportOrderRow = {
+    amount: 9000, status: 'invoiced', created_at: '2026-01-05T10:00:00Z',
+    fortnox_invoiced_at: '2026-02-09T08:00:00Z', assigned_to: 'u1', client_name: 'Kund C',
+  };
+  const febOrder: ReportOrderRow = {
+    amount: 1000, status: 'in_progress', created_at: '2026-02-03T10:00:00Z',
+    fortnox_invoiced_at: null, assigned_to: 'u2', client_name: 'Kund D',
+  };
+  const febSplit = partitionOrders([earlierOrder, febOrder], FEB);
+
+  it('counts it as invoiced but not as order value', () => {
+    expect(febSplit.invoiced).toEqual([earlierOrder]);
+    expect(febSplit.created).toEqual([febOrder]);
+  });
+
+  it('puts its revenue in the invoiced line and leaves order value alone', () => {
+    const result = buildSalesOverTime([], febSplit.created, febSplit.invoiced, ['2026-02']);
+    expect(result).toEqual([{ period: '2026-02', quoteValue: 0, orderValue: 1000, invoicedValue: 9000 }]);
+  });
+
+  it('credits the seller with the revenue without inflating their order value', () => {
+    const rows = buildPerSeller([], febSplit.created, febSplit.invoiced, [], sellers);
+    expect(rows.find((r) => r.userId === 'u1')).toMatchObject({ orderValue: 0, invoicedValue: 9000 });
+    expect(rows.find((r) => r.userId === 'u2')).toMatchObject({ orderValue: 1000, invoicedValue: 0 });
+  });
+
+  it('lists the customer with the money that moved and no order of its own', () => {
+    const rows = buildPerCustomer(febSplit.created, febSplit.invoiced);
+    expect(rows.find((r) => r.customer === 'Kund C')).toEqual({ customer: 'Kund C', orderValue: 0, invoicedValue: 9000, orderCount: 0 });
+  });
+
+  // Ranking on order value alone would drop exactly these rows off the end of the top ten,
+  // leaving the per-customer table and CSV short of what the chart above them shows.
+  it('keeps a big invoice-only customer inside the top list instead of truncating it', () => {
+    const tenOrderingCustomers: ReportOrderRow[] = Array.from({ length: 10 }, (_, i) => ({
+      amount: 1000, status: 'in_progress', created_at: '2026-02-05T10:00:00Z',
+      fortnox_invoiced_at: null, assigned_to: null, client_name: `Kund ${i}`,
+    }));
+    const rows = buildPerCustomer(tenOrderingCustomers, [earlierOrder]);
+    expect(rows).toHaveLength(10);
+    expect(rows[0]).toMatchObject({ customer: 'Kund C', invoicedValue: 9000 });
+  });
+
+  // Below the top-N cut the two must agree to the krona — anything else means the split
+  // dropped or double-counted a row. (Above the cut they legitimately differ: the table is
+  // a top list, and rows 11+ are simply not shown.)
+  it('accounts for every invoiced krona the chart shows when nothing is truncated', () => {
+    const rows = buildPerCustomer(febSplit.created, febSplit.invoiced);
+    const tableTotal = rows.reduce((t, r) => t + r.invoicedValue, 0);
+    const chartTotal = buildSalesOverTime([], febSplit.created, febSplit.invoiced, ['2026-02'])[0].invoicedValue;
+    expect(rows.length).toBeLessThan(10);
+    expect(tableTotal).toBe(chartTotal);
+  });
+
+  // The funnel is a cohort view on purpose: of what entered in February, how far did it
+  // get. Feeding it revenue from January's orders would break the chain and could push the
+  // last conversion above 100 %.
+  it('keeps the funnel on the period cohort and excludes it', () => {
+    const f = buildFunnel([], febSplit.created);
+    expect(f.orders).toEqual({ count: 1, value: 1000 });
+    expect(f.invoiced).toEqual({ count: 0, value: 0 });
+  });
+
+  it('survives the whole composition end to end', () => {
+    const report = composeSalesReport({ quotes: [], orders: [earlierOrder, febOrder], calls: [], sellers }, FEB);
+    expect(report.salesOverTime[0].invoicedValue).toBe(9000);
+    expect(report.funnel.invoiced.value).toBe(0);
+  });
+});
+
+describe('invoicedAt', () => {
+  it('uses the Fortnox invoice date when present', () => {
+    expect(invoicedAt({ ...orders[0], fortnox_invoiced_at: '2026-03-01T00:00:00Z' })).toBe('2026-03-01T00:00:00Z');
+  });
+
+  // Rows created before the column existed carry no invoice date; attributing them to their
+  // creation date is what the report did before and keeps history stable.
+  it('falls back to the creation date for legacy rows', () => {
+    expect(invoicedAt(orders[0])).toBe('2026-01-18T10:00:00Z');
+  });
+});
+
+describe('partitionOrders', () => {
+  const RANGE_JAN = { from: '2026-01-01', to: '2026-01-31' };
+
+  it('excludes an order that is not invoiced even if it carries an invoice date', () => {
+    const odd: ReportOrderRow = {
+      amount: 500, status: 'in_progress', created_at: '2025-12-01T10:00:00Z',
+      fortnox_invoiced_at: '2026-01-10T10:00:00Z', assigned_to: null, client_name: null,
+    };
+    expect(partitionOrders([odd], RANGE_JAN).invoiced).toEqual([]);
+  });
+
+  it('includes both ends of the range inclusively', () => {
+    const edges: ReportOrderRow[] = [
+      { amount: 1, status: 'invoiced', created_at: '2026-01-01T00:00:00Z', fortnox_invoiced_at: null, assigned_to: null, client_name: null },
+      { amount: 2, status: 'invoiced', created_at: '2026-01-31T23:59:00Z', fortnox_invoiced_at: null, assigned_to: null, client_name: null },
+    ];
+    const result = partitionOrders(edges, RANGE_JAN);
+    expect(result.created).toHaveLength(2);
+    expect(result.invoiced).toHaveLength(2);
+  });
+
+  it('drops an order that falls outside the range on both dates', () => {
+    const outside: ReportOrderRow = {
+      amount: 700, status: 'invoiced', created_at: '2025-11-01T10:00:00Z',
+      fortnox_invoiced_at: '2025-12-01T10:00:00Z', assigned_to: null, client_name: null,
+    };
+    const result = partitionOrders([outside], RANGE_JAN);
+    expect(result.created).toEqual([]);
+    expect(result.invoiced).toEqual([]);
   });
 });


### PR DESCRIPTION
Rapporten hämtade arbetsordrar enbart på `created_at`. En order som vanns i juni och fakturerades i augusti föll därför utanför augusti helt — och medianeftersläpningen mellan order och faktura är **en månad**, alltså normalfallet, inte undantaget.

**Mot skarp data dolde det 371 323 kr av 450 101 kr — augusti visade 18 % av vad som faktiskt fakturerats.**

Felet doldes av att standardintervallet var tolv månader, där ordern ändå hämtades och hamnade i rätt månadsfack. Snabbvalen i #69 gjorde det till ett klick.

## Ändringen

Ordrarna hämtas som en supermängd — skapade i perioden **eller** fakturerade i perioden — och delas i `partitionOrders`, så varje siffra hänger på det datum som faktiskt hör till den: ordervärde på när ordern vanns, fakturerat på när den fakturerades.

**Tratten förblir en kohortvy med flit.** Av det som kom in i perioden, hur långt har det gått. Ett steg som matas från andra perioder bryter kedjan och kan trycka sista konverteringen över 100 %. Därför *kan* tratten och diagrammet visa olika fakturerat för samma period — i juli 379 103 kr respektive 7 780 kr — och undertexterna säger nu vilken fråga var och en svarar på.

**Per kund rankas på ordervärde + fakturerat.** Sortering på enbart ordervärde sköt ut just de rader ändringen finns till för ur topp tio (en kund fakturerad 330 480 kr på en tidigare order har inget ordervärde alls). Diagrammet fick en fakturerat-stapel, annars ritas en sådan kund som en tom stapel med etikett.

**Äldre rader utan `fortnox_invoiced_at`** faller tillbaka på skapandedatum som förut, så historiken ligger stilla.

## Verifierat mot skarp data

Med den levererade koden, inte en simulering:

| Period | Diagram/säljare (periodbaserat) | Tratten (kohort) | Ordervärde |
|---|---|---|---|
| Augusti | **473 716 kr** (var 102 393) | 102 393 kr | oförändrat |
| Juli | 7 780 kr | 379 103 kr | oförändrat |

Summan över **alla** kunder stämmer på kronan mot diagrammet (481 495 kr på tolv månader); differensen i tabellen är enbart topp-10-snittet, som är avsiktligt och fanns före ändringen.

`npm run type-check`, `npm run build` och `npm test` (1123 tester) gröna. 13 nya tester låser fast regressionen, kohortgränsen och att en stor fakturera-bara-kund inte kan trilla av topplistan.

## Utanför den här ändringen

Veckotopplistan på CRM-översikten (`CrmOverview.tsx`) räknar sitt "Fakturerat" ur en orderlista som inte heller hämtas på fakturadatum — samma felklass, egen yta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)