### PR TITLE
feat(tid): dagvy per person i attesten + tvingande klockslag på arbetstid

### DIFF
--- a/app/admin/tid/AdminTimeApprovals.tsx
+++ b/app/admin/tid/AdminTimeApprovals.tsx
@@ -11,6 +11,12 @@ import {
   type TimeApprovalOverviewRow,
   type TimePeriodStatus,
 } from '../../../lib/domains/time/approvals';
+import {
+  COMPENSATION_LABELS,
+  COMPENSATION_UNITS,
+  type CompensationItem,
+} from '../../../lib/domains/time/compensations';
+import type { PersonPeriodSummary } from '../../../lib/domains/time/summary';
 
 // Admin → Attest. Fas 4.4: en kalendermånad per person, och knappen som fryser den.
 //
@@ -51,6 +57,29 @@ function currentPeriod(): string {
   return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
 }
 
+/** '2026-08-14' → 'fre 14 aug'. Fälten plockas ur strängen och formateras i UTC, så ingen
+ *  tidszon kan flytta datumet en dag — samma skäl som periodStartOf räknar på strängar. */
+function formatDay(iso: string): string {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(iso);
+  if (!match) return iso;
+  const date = new Date(Date.UTC(Number(match[1]), Number(match[2]) - 1, Number(match[3])));
+  return new Intl.DateTimeFormat('sv-SE', { weekday: 'short', day: 'numeric', month: 'short', timeZone: 'UTC' }).format(date);
+}
+
+/** Postgres `time` serialiseras som 'HH:MM:SS'. Sekunderna är alltid noll här och bara brus. */
+function formatClock(value: string | null): string | null {
+  return value ? value.slice(0, 5) : null;
+}
+
+type PersonDetail = {
+  loading: boolean;
+  error: string | null;
+  summary: PersonPeriodSummary | null;
+  compensations: CompensationItem[];
+};
+
+const EMPTY_DETAIL: PersonDetail = { loading: true, error: null, summary: null, compensations: [] };
+
 export default function AdminTimeApprovals() {
   const [period, setPeriod] = React.useState(currentPeriod);
   const [people, setPeople] = React.useState<TimeApprovalOverviewRow[]>([]);
@@ -58,10 +87,15 @@ export default function AdminTimeApprovals() {
   const [error, setError] = React.useState<string | null>(null);
   const [notice, setNotice] = React.useState<string | null>(null);
   const [busyId, setBusyId] = React.useState<string | null>(null);
+  // En person i taget öppen. Fler samtidiga hade betytt fler tillstånd att hålla i takt med
+  // perioden, och dagvyn läses en person åt gången ändå.
+  const [expandedId, setExpandedId] = React.useState<string | null>(null);
+  const [detail, setDetail] = React.useState<PersonDetail | null>(null);
 
   // Samma kapplöpningsvakt som i /tid: bläddrar man snabbt mellan månader kan ett tidigare svar
   // komma sist och rita fel månads status — på en attestyta vore det ett dyrt misstag.
   const loadSeq = React.useRef(0);
+  const detailSeq = React.useRef(0);
 
   const load = React.useCallback(async () => {
     const seq = ++loadSeq.current;
@@ -87,6 +121,52 @@ export default function AdminTimeApprovals() {
   }, [period]);
 
   React.useEffect(() => { void load(); }, [load]);
+
+  // En öppen dagvy hör till den månad den hämtades för. Bläddrar man vidare måste den stängas —
+  // annars ligger juli-dagarna kvar under augusti-raden och ser ut som augusti. Sekvensnumret
+  // räknas upp så ett svar som redan är på väg inte kan rita upp den igen.
+  React.useEffect(() => {
+    detailSeq.current++;
+    setExpandedId(null);
+    setDetail(null);
+  }, [period]);
+
+  const loadDetail = React.useCallback(async (userId: string) => {
+    const seq = ++detailSeq.current;
+    setDetail(EMPTY_DETAIL);
+    try {
+      const res = await fetch(`/api/admin/time/entries?period=${period}&user_id=${userId}`, {
+        cache: 'no-store',
+        credentials: 'same-origin',
+      });
+      const body = await res.json().catch(() => null);
+      if (seq !== detailSeq.current) return;
+      if (!res.ok || !body?.ok) throw new Error(body?.error || `Fel (${res.status})`);
+      setDetail({
+        loading: false,
+        error: null,
+        summary: body.data as PersonPeriodSummary,
+        compensations: (body.data.compensations || []) as CompensationItem[],
+      });
+    } catch (e) {
+      // Hela tillståndet skrivs om, inte bara felet: lämnas summary kvar visas föregående persons
+      // dagar under felrutan. Samma fälla som redan kostat en gång i den här vyn.
+      if (seq === detailSeq.current) {
+        setDetail({ loading: false, error: (e as Error).message, summary: null, compensations: [] });
+      }
+    }
+  }, [period]);
+
+  function toggleDetail(userId: string) {
+    if (expandedId === userId) {
+      detailSeq.current++;
+      setExpandedId(null);
+      setDetail(null);
+      return;
+    }
+    setExpandedId(userId);
+    void loadDetail(userId);
+  }
 
   async function setStatus(row: TimeApprovalOverviewRow, status: TimePeriodStatus, note?: string) {
     setBusyId(row.user_id);
@@ -192,11 +272,27 @@ export default function AdminTimeApprovals() {
             <tbody>
               {people.map((row) => {
                 const locked = isPeriodLocked(row.status);
+                const isExpanded = expandedId === row.user_id;
                 return (
-                  <tr key={row.user_id} className="border-b border-solid border-slate-100 align-top">
+                  <React.Fragment key={row.user_id}>
+                  <tr className="border-b border-solid border-slate-100 align-top">
                     <td className="px-3 py-2">
-                      <div className="font-medium text-slate-900">{row.full_name || '(namn saknas)'}</div>
-                      <div className="text-xs text-slate-400">{row.role}</div>
+                      {/* Ikonknapp: globals.css ger varje <button> padding och centrering utan att
+                          ligga i ett lager, så Tailwind måste gå före med `!`. */}
+                      <button
+                        type="button"
+                        onClick={() => toggleDetail(row.user_id)}
+                        aria-expanded={isExpanded}
+                        className="!inline-flex !items-start !justify-start !p-0 !text-left"
+                      >
+                        <span aria-hidden className={`mt-0.5 text-slate-400 transition-transform ${isExpanded ? 'rotate-90' : ''}`}>›</span>
+                        <span>
+                          <span className="block font-medium text-slate-900 underline-offset-2 hover:underline">
+                            {row.full_name || '(namn saknas)'}
+                          </span>
+                          <span className="block text-xs text-slate-400">{row.role}</span>
+                        </span>
+                      </button>
                     </td>
                     <td className="px-3 py-2">
                       <span className={`inline-block rounded-lg px-2 py-1 text-xs font-semibold ${STATUS_TONE[row.status]}`}>
@@ -245,12 +341,153 @@ export default function AdminTimeApprovals() {
                       ) : null}
                     </td>
                   </tr>
+                  {isExpanded ? (
+                    <tr className="border-b border-solid border-slate-100">
+                      <td colSpan={7} className="bg-slate-50 px-3 py-3">
+                        <PersonDays detail={detail} name={row.full_name} />
+                      </td>
+                    </tr>
+                  ) : null}
+                  </React.Fragment>
                 );
               })}
             </tbody>
           </table>
         </div>
       )}
+    </div>
+  );
+}
+
+/**
+ * En persons månad, dag för dag.
+ *
+ * Lönepersonens enda uttryckliga krav (William 2026-08-14): hon vill se **starttid, sluttid och
+ * total arbetad tid** när hon kontrollerar någons arbetstider. Aggregatet i tabellen ovanför går
+ * inte att kontrollera — det ÄR summan av det man vill titta på.
+ *
+ * Kolumnerna följer byråns underlag (se TIME_AND_PAYROLL.md): datum, klockslag, arbetade timmar,
+ * frånvarotimmar med orsak, anteckning. "Orsak / jobb" bär dessutom arbetsordern, vilket byrån inte
+ * bett om — det är för kontorets egen granskning, som sedan piloten blåstes av är den enda
+ * kontrollen som finns.
+ *
+ * Rader utan klockslag flaggas i stället för att visa ett tankstreck: de är kvar från kontorets
+ * Tid-flik och ska bort innan klockslagen blir obligatoriska. En tom ruta hade sett ut som en
+ * detalj; "saknas" är en uppgift.
+ */
+function PersonDays({ detail, name }: { detail: PersonDetail | null; name: string | null }) {
+  if (!detail || detail.loading) return <p className="m-0 text-sm text-slate-400">Laddar dagar…</p>;
+  if (detail.error) {
+    return (
+      <div className="rounded-lg border border-solid border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-700">
+        {detail.error}
+      </div>
+    );
+  }
+
+  const summary = detail.summary;
+  if (!summary) return null;
+
+  if (summary.rows.length === 0 && detail.compensations.length === 0) {
+    return (
+      <p className="m-0 text-sm text-slate-500">
+        {name || 'Personen'} har inte rapporterat något den här månaden.
+      </p>
+    );
+  }
+
+  return (
+    <div className="grid gap-3">
+      {summary.rows.length > 0 ? (
+        <div className="overflow-x-auto">
+          <table className="w-full min-w-[640px] border-collapse text-sm">
+            <thead>
+              <tr className="text-left text-[11px] font-extrabold uppercase tracking-wide text-slate-500">
+                <th className="px-2 py-1.5">Datum</th>
+                <th className="px-2 py-1.5">Klockslag</th>
+                <th className="px-2 py-1.5 text-right">Arbetat</th>
+                <th className="px-2 py-1.5 text-right">Frånvaro</th>
+                <th className="px-2 py-1.5">Orsak / jobb</th>
+                <th className="px-2 py-1.5">Anteckning</th>
+              </tr>
+            </thead>
+            <tbody>
+              {summary.rows.map((day, index) => {
+                const start = formatClock(day.startTime);
+                const end = formatClock(day.endTime);
+                const isAbsence = day.absenceMinutes > 0;
+                return (
+                  <tr key={`${day.date}-${index}`} className="border-t border-solid border-slate-200 align-top">
+                    <td className="whitespace-nowrap px-2 py-1.5 text-slate-700">{formatDay(day.date)}</td>
+                    <td className="whitespace-nowrap px-2 py-1.5 tabular-nums text-slate-700">
+                      {start && end ? (
+                        `${start}–${end}`
+                      ) : isAbsence ? (
+                        <span className="text-slate-400">—</span>
+                      ) : (
+                        <span className="font-semibold text-amber-700">saknas</span>
+                      )}
+                    </td>
+                    <td className="whitespace-nowrap px-2 py-1.5 text-right tabular-nums text-slate-900">
+                      {day.workMinutes > 0 ? `${formatHours(day.workMinutes)} h` : '—'}
+                    </td>
+                    <td className="whitespace-nowrap px-2 py-1.5 text-right tabular-nums text-slate-600">
+                      {day.absenceMinutes > 0 ? `${formatHours(day.absenceMinutes)} h` : '—'}
+                    </td>
+                    <td className="px-2 py-1.5 text-slate-600">
+                      {day.absenceReasons.length > 0 ? day.absenceReasons.join(', ') : day.label || '—'}
+                    </td>
+                    <td className="px-2 py-1.5 text-slate-500">{day.note || ''}</td>
+                  </tr>
+                );
+              })}
+            </tbody>
+            <tfoot>
+              <tr className="border-t-2 border-solid border-slate-300 font-semibold text-slate-900">
+                <td className="px-2 py-2" colSpan={2}>Totalt</td>
+                <td className="whitespace-nowrap px-2 py-2 text-right tabular-nums">{formatHours(summary.workMinutes)} h</td>
+                <td className="whitespace-nowrap px-2 py-2 text-right tabular-nums">
+                  {summary.absenceMinutes > 0 ? `${formatHours(summary.absenceMinutes)} h` : '—'}
+                </td>
+                <td colSpan={2} />
+              </tr>
+            </tfoot>
+          </table>
+        </div>
+      ) : null}
+
+      {/* Byrån behöver veta VILKEN ledighet, inte bara hur mycket — orsakerna har olika lönesort. */}
+      {summary.absenceByReason.length > 0 ? (
+        <div className="flex flex-wrap gap-2 text-xs text-slate-600">
+          {summary.absenceByReason.map((item) => (
+            <span key={item.reason} className="rounded-lg border border-solid border-slate-200 bg-white px-2 py-1">
+              {item.reason}: {formatHours(item.minutes)} h
+            </span>
+          ))}
+        </div>
+      ) : null}
+
+      {detail.compensations.length > 0 ? (
+        <div className="grid gap-1">
+          <p className="m-0 text-[11px] font-extrabold uppercase tracking-wide text-slate-500">Ersättningar</p>
+          <ul className="m-0 grid list-none gap-1 p-0 text-sm text-slate-700">
+            {detail.compensations.map((item) => {
+              const unit = COMPENSATION_UNITS[item.kind];
+              return (
+                <li key={item.id} className="flex flex-wrap items-baseline gap-x-2">
+                  <span className="text-slate-500">{formatDay(item.entry_date)}</span>
+                  <span className="font-medium">{COMPENSATION_LABELS[item.kind] || item.kind}</span>
+                  {unit && item.quantity != null ? (
+                    <span className="text-slate-500">{formatAmount(item.quantity)} {unit}</span>
+                  ) : null}
+                  <span className="font-medium">{formatAmount(item.amount)} kr</span>
+                  {item.note ? <span className="text-slate-500">· {item.note}</span> : null}
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/app/api/admin/time/entries/route.ts
+++ b/app/api/admin/time/entries/route.ts
@@ -1,0 +1,66 @@
+import { cookies } from 'next/headers';
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
+import { periodRange, periodStartOf } from '@/lib/domains/time/approvals';
+import { listCompensations } from '@/lib/domains/time/compensations';
+import { listTimeEntries, toSummarizableEntry, type TimeEntryRow } from '@/lib/domains/time/entries';
+import { summarizePerson } from '@/lib/domains/time/summary';
+import { ok, personPeriodQuerySchema, requirePermission, routeError, validationError } from '@/app/api/time/_lib';
+
+// GET /api/admin/time/entries?period=YYYY-MM&user_id=<uuid> — en persons månad, dag för dag.
+//
+// Det lönepersonen bad om, ordagrant: "starttid, sluttid och total arbetad tid". Attestöversikten
+// (../approvals) svarar bara med månadsaggregat, och ett aggregat går inte att granska — det är
+// summan av det man vill titta på. Den här routen är därför inte en bekvämlighet: den är det enda
+// stället där någon annan än den anställde kan se HUR timmarna uppstod.
+//
+// Extra vikt sedan piloten blåstes av (2026-08-14): parallellkörningen mot Blikk, som skulle ha
+// jämfört summorna maskinellt, blir inte av. Kontroller görs i stället för hand — och då är
+// läsbarheten här ersättningen för kvittot.
+//
+// ⚠️ NYCKELN ÄR `time.entry.read.all`, INTE `time.approve`. De sitter på samma roll i seeden, så
+// valet syns inte i dag — men RLS:en på crm_time_entries och crm_time_compensations släpper igenom
+// andras rader på just read.all. Vaktade routen på time.approve skulle en person som fått
+// attesträtt per användarundantag (`set_user_permission`) få ett TOMT svar i stället för ett nekat:
+// noll rader ser likadant ut som "har inte rapporterat något", och det är fel besked att ge någon
+// som ska attestera en månad.
+export async function GET(req: Request) {
+  try {
+    const gate = await requirePermission('time.entry.read.all');
+    if (gate.response || !gate.currentUser) return gate.response;
+
+    const url = new URL(req.url);
+    const parsed = personPeriodQuerySchema.safeParse({
+      period: url.searchParams.get('period'),
+      user_id: url.searchParams.get('user_id'),
+    });
+    if (!parsed.success) return validationError(parsed.error);
+
+    const periodStart = periodStartOf(parsed.data.period);
+    const range = periodRange(periodStart);
+    const supabase = createRouteHandlerClient({ cookies });
+
+    // Sessionsklient, inte getSupabaseAdmin(): read.all-grenen i RLS är redan svaret på "får den
+    // här personen se andras tid", och service-role hade öppnat hela databasen för att slippa den.
+    const [entries, compensations] = await Promise.all([
+      listTimeEntries(supabase, range, { userId: parsed.data.user_id }),
+      listCompensations(supabase, range, { userId: parsed.data.user_id }),
+    ]);
+    if (entries.error) return routeError(500, 'time_entries_failed', entries.error.message);
+    if (compensations.error) return routeError(500, 'time_compensations_failed', compensations.error.message);
+
+    const summary = summarizePerson(
+      ((entries.data ?? []) as unknown as TimeEntryRow[]).map(toSummarizableEntry),
+      range,
+      parsed.data.user_id,
+    );
+
+    return ok({
+      period_start: periodStart,
+      user_id: parsed.data.user_id,
+      ...summary,
+      compensations: compensations.data ?? [],
+    });
+  } catch (e: any) {
+    return routeError(500, 'admin_time_entries_unexpected', e?.message || 'Kunde inte hämta personens tid');
+  }
+}

--- a/app/api/admin/time/entries/route.ts
+++ b/app/api/admin/time/entries/route.ts
@@ -37,13 +37,18 @@ export async function GET(req: Request) {
 
     const periodStart = periodStartOf(parsed.data.period);
     const range = periodRange(periodStart);
+    // Gemener. Postgres jämför `uuid` skiftlägesokänsligt och zods uuid() släpper igenom versaler,
+    // så en versal parameter hade gett rader tillbaka — med gemena user_id, som summarizePersons
+    // strikta jämförelse sedan filtrerat bort allihop. Svaret hade blivit en tom månad med status
+    // 200: "har inte rapporterat något" om någon som rapporterat hela augusti.
+    const userId = parsed.data.user_id.toLowerCase();
     const supabase = createRouteHandlerClient({ cookies });
 
     // Sessionsklient, inte getSupabaseAdmin(): read.all-grenen i RLS är redan svaret på "får den
     // här personen se andras tid", och service-role hade öppnat hela databasen för att slippa den.
     const [entries, compensations] = await Promise.all([
-      listTimeEntries(supabase, range, { userId: parsed.data.user_id }),
-      listCompensations(supabase, range, { userId: parsed.data.user_id }),
+      listTimeEntries(supabase, range, { userId }),
+      listCompensations(supabase, range, { userId }),
     ]);
     if (entries.error) return routeError(500, 'time_entries_failed', entries.error.message);
     if (compensations.error) return routeError(500, 'time_compensations_failed', compensations.error.message);
@@ -51,12 +56,12 @@ export async function GET(req: Request) {
     const summary = summarizePerson(
       ((entries.data ?? []) as unknown as TimeEntryRow[]).map(toSummarizableEntry),
       range,
-      parsed.data.user_id,
+      userId,
     );
 
     return ok({
       period_start: periodStart,
-      user_id: parsed.data.user_id,
+      user_id: userId,
       ...summary,
       compensations: compensations.data ?? [],
     });

--- a/app/api/crm/work-orders/[id]/time-entries/[entryId]/route.ts
+++ b/app/api/crm/work-orders/[id]/time-entries/[entryId]/route.ts
@@ -1,6 +1,7 @@
 import { cookies } from 'next/headers';
 import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
 import { deleteCrmWorkOrderTimeEntry, updateCrmWorkOrderTimeEntry } from '@/lib/domains/crm/work-orders';
+import { buildTimeEntryRow } from '@/lib/domains/time/entries';
 import { explainWriteMiss, periodLockError } from '@/lib/domains/time/approvals';
 import { createWorkOrderTimeEntrySchema, ok, requireSignedInUser, routeError, validationError } from '../../../_lib';
 
@@ -34,12 +35,22 @@ export async function PATCH(req: Request, context: RouteContext) {
     const parsedBody = createWorkOrderTimeEntrySchema.safeParse(await req.json().catch(() => null));
     if (!parsedBody.success) return validationError(parsedBody.error);
 
-    const supabase = createRouteHandlerClient({ cookies });
-    const { data, error } = await updateCrmWorkOrderTimeEntry(supabase, context.params.entryId, currentUser.currentUser.id, {
+    // Ordern skickas med bara för att buildTimeEntryRow ska kunna validera en arbetsorderrad —
+    // updateCrmWorkOrderTimeEntry skalar bort den igen, så en PATCH kan aldrig flytta raden till
+    // ett annat jobb.
+    const built = buildTimeEntryRow({
+      kind: 'work_order',
       work_date: parsedBody.data.work_date,
-      hours: parsedBody.data.hours,
+      work_order_id: context.params.id,
+      start_time: parsedBody.data.start_time,
+      end_time: parsedBody.data.end_time,
+      break_minutes: parsedBody.data.break_minutes,
       note: parsedBody.data.note,
-    });
+    }, currentUser.currentUser.id);
+    if (built.error || !built.row) return routeError(400, 'crm_work_order_time_entry_invalid', built.error || 'Ogiltig tidrad');
+
+    const supabase = createRouteHandlerClient({ cookies });
+    const { data, error } = await updateCrmWorkOrderTimeEntry(supabase, context.params.entryId, currentUser.currentUser.id, built.row);
 
     if (error) {
       const locked = periodLockError(error);

--- a/app/api/crm/work-orders/[id]/time-entries/route.ts
+++ b/app/api/crm/work-orders/[id]/time-entries/route.ts
@@ -1,6 +1,7 @@
 import { cookies } from 'next/headers';
 import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
 import { createCrmWorkOrderTimeEntry, listCrmWorkOrderTimeEntries } from '@/lib/domains/crm/work-orders';
+import { buildTimeEntryRow } from '@/lib/domains/time/entries';
 import { periodLockError } from '@/lib/domains/time/approvals';
 import { createWorkOrderTimeEntrySchema, ok, requireSignedInUser, routeError, validationError } from '../../_lib';
 
@@ -41,14 +42,22 @@ export async function POST(req: Request, context: RouteContext) {
     const parsedBody = createWorkOrderTimeEntrySchema.safeParse(await req.json().catch(() => null));
     if (!parsedBody.success) return validationError(parsedBody.error);
 
-    const supabase = createRouteHandlerClient({ cookies });
-    const { data, error } = await createCrmWorkOrderTimeEntry(supabase, {
-      work_order_id: context.params.id,
-      user_id: currentUser.currentUser.id,
+    // Samma rulle som /tid: buildTimeEntryRow räknar minuterna ur klockslagen och lämnar `hours`
+    // till databastriggern. Fliken skrev tidigare timmar direkt, vilket gjorde de raderna omöjliga
+    // att räkna övertid på — de är löneunderlag, inte bara kontorets uppföljning.
+    const built = buildTimeEntryRow({
+      kind: 'work_order',
       work_date: parsedBody.data.work_date,
-      hours: parsedBody.data.hours,
+      work_order_id: context.params.id,
+      start_time: parsedBody.data.start_time,
+      end_time: parsedBody.data.end_time,
+      break_minutes: parsedBody.data.break_minutes,
       note: parsedBody.data.note,
-    });
+    }, currentUser.currentUser.id);
+    if (built.error || !built.row) return routeError(400, 'crm_work_order_time_entry_invalid', built.error || 'Ogiltig tidrad');
+
+    const supabase = createRouteHandlerClient({ cookies });
+    const { data, error } = await createCrmWorkOrderTimeEntry(supabase, built.row);
 
     if (error) {
       // Kontorets uppföljningstid ligger i SAMMA tabell som löneunderlaget (crm_time_entries), så

--- a/app/api/crm/work-orders/_lib.ts
+++ b/app/api/crm/work-orders/_lib.ts
@@ -44,9 +44,19 @@ export const createStandaloneWorkOrderSchema = z.object({
   desired_installation_date: z.preprocess((value) => normalizeOptionalText(value), dateSchema.nullable()).optional().default(null),
 });
 
+// Klockslag, inte ett timtal. Raden ligger i crm_time_entries — SAMMA tabell som löneunderlaget —
+// och lönen härleder OB och övertid ur start och slut (William 2026-08-14). Ett timtal går inte att
+// räkna övertid på: nio timmar säger inte om de låg 07–16 eller 14–23.
+//
+// Rasten anges separat och dras av på servern. Byråns exempel: 08–18 med en timmes rast är nio
+// timmar, inte tio.
+const clockSchema = z.string().regex(/^\d{2}:\d{2}(:\d{2})?$/, 'Ogiltigt klockslag (TT:MM)');
+
 export const createWorkOrderTimeEntrySchema = z.object({
   work_date: dateSchema,
-  hours: z.coerce.number().positive('Timmar måste vara större än 0').max(24, 'Timmar får inte överstiga 24'),
+  start_time: clockSchema,
+  end_time: clockSchema,
+  break_minutes: z.coerce.number().int().min(0).max(1439).optional().default(0),
   note: z.preprocess((value) => normalizeOptionalText(value), z.string().nullable()).optional().default(null),
 });
 

--- a/app/api/time/_lib.ts
+++ b/app/api/time/_lib.ts
@@ -82,6 +82,14 @@ export const periodQuerySchema = z.object({
   period: monthSchema,
 });
 
+// Attestens dagvy: en namngiven persons månad. Ligger bara på /api/admin/time/** — /api/time/**
+// ska förbli "min egen tid" utan en enda parameter som öppnar för andras (se kommentaren i
+// app/api/time/entries/route.ts om Blikk-motsvarigheten som tar ?userId= utan behörighetskontroll).
+export const personPeriodQuerySchema = z.object({
+  period: monthSchema,
+  user_id: z.string().uuid('Ogiltigt användar-id'),
+});
+
 export const setPeriodStatusSchema = z.object({
   period: monthSchema,
   status: z.enum(TIME_PERIOD_STATUSES),

--- a/app/crm/arbetsorder/WorkOrderTimeTab.tsx
+++ b/app/crm/arbetsorder/WorkOrderTimeTab.tsx
@@ -6,12 +6,28 @@ import Textarea from '../../../components/ui/Textarea';
 import { cn } from '@/lib/shared/cn';
 import { crm } from '@/app/crm/lib/crmTokens';
 import { formatDate, formatDateTime } from '@/app/crm/lib/format';
+import { minutesToHours, workedMinutes } from '@/lib/domains/time/hours';
+
+// Kontorets Tid-flik. Den skriver i `crm_time_entries` — SAMMA tabell som löneunderlaget — och
+// därför fångar den klockslag sedan 2026-08-14. Ett timtal går inte att räkna övertid eller OB på:
+// nio timmar säger inte om de låg 07–16 eller 14–23, och lönebyrån härleder båda ur just start och
+// slut.
+//
+// Fliken är fortfarande "min egen tid på det här jobbet": RLS tillåter bara egna rader, så knapparna
+// för att ändra och ta bort visas bara på dem.
+//
+// Timsumman här är en FÖRHANDSVISNING. Servern räknar om minuterna ur klockslagen med samma
+// funktion (workedMinutes → buildTimeEntryRow), och `hours` skrivs av en databastrigger — klientens
+// siffra kan alltså aldrig bli någons lön.
 
 export type TimeEntryItem = {
   id: string;
   work_order_id: string;
   user_id: string;
   work_date: string;
+  start_time: string | null;
+  end_time: string | null;
+  break_minutes: number | null;
   hours: number;
   note: string | null;
   created_at: string;
@@ -19,10 +35,35 @@ export type TimeEntryItem = {
   user?: { full_name?: string | null } | null;
 };
 
-export type TimeDraft = { work_date: string; hours: string; note: string };
+export type TimeDraft = { work_date: string; start_time: string; end_time: string; break_minutes: string; note: string };
 
 function todayIso() {
   return new Date().toISOString().slice(0, 10);
+}
+
+function emptyDraft(): TimeDraft {
+  // 60 minuters rast som utgångsvärde är byråns eget exempel (08–18 med en timmes rast är nio
+  // timmar). Det är en gissning man ser och kan ändra, inte en regel — till skillnad från ett tomt
+  // fält, som tyst blir noll.
+  return { work_date: todayIso(), start_time: '', end_time: '', break_minutes: '60', note: '' };
+}
+
+/** Postgres `time` kommer som 'HH:MM:SS'; <input type="time"> vill ha 'HH:MM'. */
+function toClockInput(value: string | null): string {
+  return value ? value.slice(0, 5) : '';
+}
+
+/** Förhandsvisning av arbetad tid. Tom sträng när passet inte går att räkna ut än. */
+function draftHours(draft: TimeDraft): string | null {
+  if (!draft.start_time || !draft.end_time) return null;
+  const minutes = workedMinutes({
+    workDate: draft.work_date,
+    startTime: draft.start_time,
+    endTime: draft.end_time,
+    breakMinutes: Number(draft.break_minutes || 0),
+  });
+  if (minutes <= 0) return null;
+  return `${minutesToHours(minutes).toFixed(2).replace('.', ',')} h`;
 }
 
 type Props = {
@@ -35,25 +76,60 @@ type Props = {
   onDelete: (id: string) => Promise<boolean>;
 };
 
+function DraftFields({ draft, onChange }: { draft: TimeDraft; onChange: (next: TimeDraft) => void }) {
+  const preview = draftHours(draft);
+  return (
+    <>
+      <div className="grid gap-2 sm:grid-cols-2">
+        <label className="grid gap-1 text-sm text-slate-600">
+          <span className={crm.sectionTitle}>Datum</span>
+          <Input value={draft.work_date} onChange={(e) => onChange({ ...draft, work_date: e.target.value })} type="date" />
+        </label>
+        <label className="grid gap-1 text-sm text-slate-600">
+          <span className={crm.sectionTitle}>Rast (min)</span>
+          <Input value={draft.break_minutes} onChange={(e) => onChange({ ...draft, break_minutes: e.target.value })} inputMode="numeric" placeholder="60" />
+        </label>
+        <label className="grid gap-1 text-sm text-slate-600">
+          <span className={crm.sectionTitle}>Starttid</span>
+          <Input value={draft.start_time} onChange={(e) => onChange({ ...draft, start_time: e.target.value })} type="time" />
+        </label>
+        <label className="grid gap-1 text-sm text-slate-600">
+          <span className={crm.sectionTitle}>Sluttid</span>
+          <Input value={draft.end_time} onChange={(e) => onChange({ ...draft, end_time: e.target.value })} type="time" />
+        </label>
+      </div>
+      <p className="m-0 text-xs text-slate-500">
+        {preview ? <>Arbetad tid efter rastavdrag: <strong className="text-slate-700">{preview}</strong></> : 'Fyll i start- och sluttid.'}
+      </p>
+    </>
+  );
+}
+
 export default function WorkOrderTimeTab({ entries, loading, totalHours, currentUserId, onCreate, onUpdate, onDelete }: Props) {
-  const [createDraft, setCreateDraft] = useState<TimeDraft>({ work_date: todayIso(), hours: '', note: '' });
+  const [createDraft, setCreateDraft] = useState<TimeDraft>(emptyDraft);
   const [creating, setCreating] = useState(false);
   const [editingId, setEditingId] = useState<string | null>(null);
-  const [editDraft, setEditDraft] = useState<TimeDraft>({ work_date: '', hours: '', note: '' });
+  const [editDraft, setEditDraft] = useState<TimeDraft>(emptyDraft);
   const [busyId, setBusyId] = useState<string | null>(null);
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
 
   async function submitCreate() {
     setCreating(true);
     const ok = await onCreate(createDraft);
-    if (ok) setCreateDraft({ work_date: todayIso(), hours: '', note: '' });
+    if (ok) setCreateDraft(emptyDraft());
     setCreating(false);
   }
 
   function startEdit(item: TimeEntryItem) {
     setConfirmDeleteId(null);
     setEditingId(item.id);
-    setEditDraft({ work_date: item.work_date, hours: String(item.hours), note: item.note || '' });
+    setEditDraft({
+      work_date: item.work_date,
+      start_time: toClockInput(item.start_time),
+      end_time: toClockInput(item.end_time),
+      break_minutes: String(item.break_minutes ?? 0),
+      note: item.note || '',
+    });
   }
 
   async function submitEdit(id: string) {
@@ -86,11 +162,8 @@ export default function WorkOrderTimeTab({ entries, loading, totalHours, current
           const isEditing = editingId === item.id;
           if (isEditing) {
             return (
-              <div key={item.id} className="grid gap-2 rounded-xl border border-emerald-200 bg-[#f1f5ee] px-3 py-3">
-                <div className="grid gap-2 sm:grid-cols-2">
-                  <Input value={editDraft.work_date} onChange={(e) => setEditDraft((c) => ({ ...c, work_date: e.target.value }))} type="date" />
-                  <Input value={editDraft.hours} onChange={(e) => setEditDraft((c) => ({ ...c, hours: e.target.value }))} inputMode="decimal" placeholder="8" />
-                </div>
+              <div key={item.id} className="grid gap-2 rounded-xl border border-solid border-emerald-200 bg-[#f1f5ee] px-3 py-3">
+                <DraftFields draft={editDraft} onChange={setEditDraft} />
                 <Textarea value={editDraft.note} onChange={(e) => setEditDraft((c) => ({ ...c, note: e.target.value }))} rows={2} placeholder="Vad gjordes?" />
                 <div className="flex items-center justify-end gap-2">
                   <button type="button" onClick={() => setEditingId(null)} className={crm.ghostButton}>Avbryt</button>
@@ -101,11 +174,17 @@ export default function WorkOrderTimeTab({ entries, loading, totalHours, current
               </div>
             );
           }
+          const start = toClockInput(item.start_time);
+          const end = toClockInput(item.end_time);
           return (
-            <div key={item.id} className="grid gap-1 rounded-xl border border-[#e0e8dc] bg-[#f1f5ee] px-3 py-3 text-sm">
+            <div key={item.id} className="grid gap-1 rounded-xl border border-solid border-[#e0e8dc] bg-[#f1f5ee] px-3 py-3 text-sm">
               <div className="flex flex-wrap items-center justify-between gap-3">
                 <strong className="text-slate-900">{item.user?.full_name || 'Medarbetare'}</strong>
-                <span className="text-slate-500">{item.hours} h · {formatDate(item.work_date)}</span>
+                <span className="text-slate-500">
+                  {/* Rader från före klockslagskravet har bara ett timtal. De visas som de är i
+                      stället för att gömmas — de ska rättas, inte försvinna. */}
+                  {start && end ? `${start}–${end} · ` : null}{item.hours} h · {formatDate(item.work_date)}
+                </span>
               </div>
               {item.note ? <div className="text-slate-600">{item.note}</div> : null}
               <div className="flex items-center justify-between gap-3">
@@ -132,14 +211,7 @@ export default function WorkOrderTimeTab({ entries, loading, totalHours, current
 
       <div className={cn(crm.cardInner, 'grid gap-3 lg:content-start')}>
         <p className={crm.sectionTitle}>Ny tidrad</p>
-        <label className="grid gap-1 text-sm text-slate-600">
-          <span className={crm.sectionTitle}>Datum</span>
-          <Input value={createDraft.work_date} onChange={(e) => setCreateDraft((c) => ({ ...c, work_date: e.target.value }))} type="date" />
-        </label>
-        <label className="grid gap-1 text-sm text-slate-600">
-          <span className={crm.sectionTitle}>Timmar</span>
-          <Input value={createDraft.hours} onChange={(e) => setCreateDraft((c) => ({ ...c, hours: e.target.value }))} inputMode="decimal" placeholder="8" />
-        </label>
+        <DraftFields draft={createDraft} onChange={setCreateDraft} />
         <label className="grid gap-1 text-sm text-slate-600">
           <span className={crm.sectionTitle}>Kommentar</span>
           <Textarea value={createDraft.note} onChange={(e) => setCreateDraft((c) => ({ ...c, note: e.target.value }))} rows={4} placeholder="Vad gjordes?" />

--- a/app/crm/arbetsorder/WorkOrderTimeTab.tsx
+++ b/app/crm/arbetsorder/WorkOrderTimeTab.tsx
@@ -53,17 +53,23 @@ function toClockInput(value: string | null): string {
   return value ? value.slice(0, 5) : '';
 }
 
-/** Förhandsvisning av arbetad tid. Tom sträng när passet inte går att räkna ut än. */
-function draftHours(draft: TimeDraft): string | null {
-  if (!draft.start_time || !draft.end_time) return null;
+/**
+ * Förhandsvisning av arbetad tid.
+ *
+ * Tre utfall, inte två: ofyllt, orimligt och räknat. Slås de två första ihop står det "fyll i
+ * start- och sluttid" på fält som ÄR ifyllda, och den verkliga orsaken — att rasten är längre än
+ * passet — dyker upp först som ett rött meddelande när man redan tryckt spara.
+ */
+function draftHours(draft: TimeDraft): { tone: 'hint' | 'error' | 'ok'; text: string } {
+  if (!draft.start_time || !draft.end_time) return { tone: 'hint', text: 'Fyll i start- och sluttid.' };
   const minutes = workedMinutes({
     workDate: draft.work_date,
     startTime: draft.start_time,
     endTime: draft.end_time,
     breakMinutes: Number(draft.break_minutes || 0),
   });
-  if (minutes <= 0) return null;
-  return `${minutesToHours(minutes).toFixed(2).replace('.', ',')} h`;
+  if (minutes <= 0) return { tone: 'error', text: 'Rasten är längre än passet.' };
+  return { tone: 'ok', text: `${minutesToHours(minutes).toFixed(2).replace('.', ',')} h` };
 }
 
 type Props = {
@@ -98,8 +104,10 @@ function DraftFields({ draft, onChange }: { draft: TimeDraft; onChange: (next: T
           <Input value={draft.end_time} onChange={(e) => onChange({ ...draft, end_time: e.target.value })} type="time" />
         </label>
       </div>
-      <p className="m-0 text-xs text-slate-500">
-        {preview ? <>Arbetad tid efter rastavdrag: <strong className="text-slate-700">{preview}</strong></> : 'Fyll i start- och sluttid.'}
+      <p className={cn('m-0 text-xs', preview.tone === 'error' ? 'text-rose-600' : 'text-slate-500')}>
+        {preview.tone === 'ok'
+          ? <>Arbetad tid efter rastavdrag: <strong className="text-slate-700">{preview.text}</strong></>
+          : preview.text}
       </p>
     </>
   );

--- a/app/crm/arbetsorder/useWorkOrderActivity.ts
+++ b/app/crm/arbetsorder/useWorkOrderActivity.ts
@@ -47,12 +47,30 @@ export function useWorkOrderActivity(workOrderId: string, options?: { includeTim
     return () => { active = false; };
   }, [workOrderId, includeTimeEntries]);
 
+  // Klockslagen är obligatoriska sedan 2026-08-14: raden är löneunderlag, och lönen härleder OB och
+  // övertid ur start och slut. Timmarna räknas på servern och skickas aldrig härifrån.
+  function timeEntryBody(data: TimeDraft) {
+    return {
+      work_date: data.work_date,
+      start_time: data.start_time,
+      end_time: data.end_time,
+      break_minutes: Number(data.break_minutes || 0),
+      note: data.note,
+    };
+  }
+
+  function missingClock(data: TimeDraft): boolean {
+    if (data.work_date && data.start_time && data.end_time) return false;
+    toast.error('Datum, starttid och sluttid krävs');
+    return true;
+  }
+
   async function createTimeEntry(data: TimeDraft): Promise<boolean> {
-    if (!data.work_date || !data.hours.trim()) { toast.error('Datum och timmar krävs'); return false; }
+    if (missingClock(data)) return false;
     try {
       const res = await fetch(`/api/crm/work-orders/${workOrderId}/time-entries`, {
         method: 'POST', headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ work_date: data.work_date, hours: Number(data.hours.replace(',', '.')), note: data.note }),
+        body: JSON.stringify(timeEntryBody(data)),
       });
       const json = await res.json().catch(() => ({}));
       if (!res.ok || !json.ok) { toast.error(json?.error || 'Kunde inte logga tid'); return false; }
@@ -63,11 +81,11 @@ export function useWorkOrderActivity(workOrderId: string, options?: { includeTim
   }
 
   async function updateTimeEntry(id: string, data: TimeDraft): Promise<boolean> {
-    if (!data.work_date || !data.hours.trim()) { toast.error('Datum och timmar krävs'); return false; }
+    if (missingClock(data)) return false;
     try {
       const res = await fetch(`/api/crm/work-orders/${workOrderId}/time-entries/${id}`, {
         method: 'PATCH', headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ work_date: data.work_date, hours: Number(data.hours.replace(',', '.')), note: data.note }),
+        body: JSON.stringify(timeEntryBody(data)),
       });
       const json = await res.json().catch(() => ({}));
       if (!res.ok || !json.ok) { toast.error(json?.error || 'Kunde inte uppdatera tidrad'); return false; }

--- a/lib/domains/crm/work-orders.ts
+++ b/lib/domains/crm/work-orders.ts
@@ -808,10 +808,19 @@ export async function updateCrmWorkOrderTimeEntry(
   userId: string,
   row: Record<string, unknown>,
 ) {
-  // `user_id` och `work_order_id` skalas bort. Ägarbytet är självklart, men orderbytet är det inte:
-  // raden byggs med ordern ur URL:en, så en PATCH mot fel orders adress hade FLYTTAT tidraden dit.
-  // Fliken kan bara ändra sin egen rads innehåll, aldrig vilket jobb den tillhör.
-  const { user_id: _ignoredUser, work_order_id: _ignoredOrder, ...patch } = row;
+  // Tre fält skalas bort ur den byggda raden.
+  //
+  // `user_id` — ägarbytet, självklart.
+  //
+  // `work_order_id` — raden byggs med ordern ur URL:en, så en PATCH mot fel orders adress hade
+  // FLYTTAT tidraden dit. Fliken ändrar sin rads innehåll, aldrig vilket jobb den hör till.
+  //
+  // `time_code_id` — mindre uppenbart och därför farligare: buildTimeEntryRow sätter alltid fältet,
+  // och kontorsfliken har ingen tidkodsväljare, så den skulle skicka null. En rad som skapats i
+  // /tid MED en tidkod syns i den här fliken (listan filtrerar bara på ordern), och att rätta ett
+  // stavfel i anteckningen hade då tyst raderat radens lönesort. Fältet lämnas orört i stället —
+  // det som inte går att sätta här får inte heller gå att nollställa här.
+  const { user_id: _ignoredUser, work_order_id: _ignoredOrder, time_code_id: _ignoredCode, ...patch } = row;
   return supabase
     .from('crm_time_entries')
     .update(patch)

--- a/lib/domains/crm/work-orders.ts
+++ b/lib/domains/crm/work-orders.ts
@@ -46,6 +46,9 @@ export const crmWorkOrderTimeEntrySelect = `
   work_order_id,
   user_id,
   work_date,
+  start_time,
+  end_time,
+  break_minutes,
   hours,
   note,
   created_at,
@@ -85,14 +88,6 @@ type WorkOrderUpdateInput = {
   internal_handoff: Record<string, any>;
   work_address: WorkOrderAddress;
   assigned_to?: string | null;
-};
-
-type CreateWorkOrderTimeEntryInput = {
-  work_order_id: string;
-  user_id: string;
-  work_date: string;
-  hours: number;
-  note: string | null;
 };
 
 type CreateWorkOrderCommentInput = {
@@ -781,13 +776,14 @@ export async function listCrmWorkOrderTimeEntries(supabase: SupabaseClient, work
     .order('created_at', { ascending: false });
 }
 
-export async function createCrmWorkOrderTimeEntry(supabase: SupabaseClient, input: CreateWorkOrderTimeEntryInput) {
-  // `kind` är NOT NULL sedan omformningen och CHECK:en binder den till vilket mål som är ifyllt.
-  // Den här vägen skapar per definition arbetsordertid, så den sätts här i stället för att läggas
-  // på anroparen — kontorsfliken vet inget om diskriminatorn.
+// Raden byggs av buildTimeEntryRow (lib/domains/time/entries.ts), inte här: den äger regeln att
+// SERVERN räknar minuterna ur klockslagen, sätter `kind` och utelämnar `hours` så databastriggern
+// får härleda den. Två vägar in i samma tabell får inte ha två uträkningar — kontorets timmar och
+// löneunderlaget ÄR samma rad.
+export async function createCrmWorkOrderTimeEntry(supabase: SupabaseClient, row: Record<string, unknown>) {
   return supabase
     .from('crm_time_entries')
-    .insert({ ...input, kind: 'work_order' })
+    .insert(row)
     .select(crmWorkOrderTimeEntrySelect)
     .single();
 }
@@ -810,11 +806,15 @@ export async function updateCrmWorkOrderTimeEntry(
   supabase: SupabaseClient,
   id: string,
   userId: string,
-  input: { work_date: string; hours: number; note: string | null },
+  row: Record<string, unknown>,
 ) {
+  // `user_id` och `work_order_id` skalas bort. Ägarbytet är självklart, men orderbytet är det inte:
+  // raden byggs med ordern ur URL:en, så en PATCH mot fel orders adress hade FLYTTAT tidraden dit.
+  // Fliken kan bara ändra sin egen rads innehåll, aldrig vilket jobb den tillhör.
+  const { user_id: _ignoredUser, work_order_id: _ignoredOrder, ...patch } = row;
   return supabase
     .from('crm_time_entries')
-    .update(input)
+    .update(patch)
     .eq('id', id)
     .eq('user_id', userId)
     .select(crmWorkOrderTimeEntrySelect)

--- a/lib/domains/time/entries.ts
+++ b/lib/domains/time/entries.ts
@@ -32,7 +32,7 @@ export const timeEntrySelect = `
   work_order:crm_work_orders(id, order_number, fortnox_order_number, project_name, client_name),
   internal_project:crm_internal_projects(id, name),
   absence_type:crm_absence_types(id, name, payroll_code),
-  time_code:crm_time_codes(id, name, code, payroll_code)
+  time_code:crm_time_codes(id, name, code)
 `;
 
 export type TimeEntryRow = {
@@ -54,7 +54,7 @@ export type TimeEntryRow = {
   work_order?: { id: string; order_number: string | null; fortnox_order_number: string | null; project_name: string | null; client_name: string | null } | null;
   internal_project?: { id: string; name: string } | null;
   absence_type?: { id: string; name: string; payroll_code: string | null } | null;
-  time_code?: { id: string; name: string; code: string | null; payroll_code?: string | null } | null;
+  time_code?: { id: string; name: string; code: string | null } | null;
 };
 
 export type TimeEntryInput = {
@@ -143,9 +143,14 @@ export function buildTimeEntryRow(input: TimeEntryInput, userId: string): BuiltT
  * `listTimeEntries` känner inte till byråns kolumner — den här funktionen är fogen, och den är ren
  * så den går att testa utan databas.
  *
- * `minutesWorked` skickas med för raderna som saknar klockslag: frånvaro (som anges i timmar med
- * flit) och `legacy_office`-raderna från tiden före omformningen. workedMinutes faller tillbaka på
- * den när grossMinutes inte kan räknas.
+ * `minutesWorked` skickas med för raderna som saknar klockslag, och `hours` är fallbacken för den.
+ *
+ * ⚠️ `minutes_worked` ÄR NULL PÅ DE GAMLA KONTORSRADERNA. Kolumnen lades till nullbar utan backfill
+ * (20260811_time_entries_reshape.sql), CHECK:en tillåter null, och triggern härleder `hours` UR
+ * minuterna — aldrig tvärtom. Kontorets Tid-flik skriver fortfarande bara datum + timmar, så de
+ * raderna har timmar men inga minuter. Utan fallbacken blir de noll timmar i dagvyn, tyst, och
+ * summan längst ner motsäger aggregatet i raden ovanför. Samma coalesce finns i RPC:n
+ * time_approval_overview (20260812_time_approvals.sql) — ändras den ena måste den andra följa med.
  */
 export function toSummarizableEntry(row: TimeEntryRow): SummarizableEntry {
   const workOrder = row.work_order;
@@ -162,14 +167,13 @@ export function toSummarizableEntry(row: TimeEntryRow): SummarizableEntry {
     startTime: row.start_time,
     endTime: row.end_time,
     breakMinutes: row.break_minutes ?? 0,
-    minutesWorked: row.minutes_worked,
+    minutesWorked: row.minutes_worked ?? (row.hours != null ? Math.round(row.hours * 60) : null),
     kind: row.kind,
     userId: row.user_id,
     absenceReason: row.absence_type?.name ?? null,
-    // Lönesorten tas från den referensrad som faktiskt valdes på tidraden: frånvaroorsaken för
-    // frånvaro, tidkoden för arbetad tid. Internprojektets egen payroll_code används inte — raden
-    // bär en tidkod, och två källor hade kunnat säga olika.
-    payrollCode: row.kind === 'absence' ? row.absence_type?.payroll_code ?? null : row.time_code?.payroll_code ?? null,
+    // Frånvaroorsakens lönesort. Arbetstidens (tidkodens) hämtas inte: ingen läser den i dag, och
+    // en kolumn i timEntrySelect kostar payload på varje läsning av /tid utan att någon ser den.
+    payrollCode: row.absence_type?.payroll_code ?? null,
     note: row.note,
     label: row.kind === 'internal' ? row.internal_project?.name ?? null : workOrderLabel,
   };

--- a/lib/domains/time/entries.ts
+++ b/lib/domains/time/entries.ts
@@ -1,6 +1,6 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { workedMinutes } from './hours';
-import type { TimeEntryKind } from './summary';
+import type { SummarizableEntry, TimeEntryKind } from './summary';
 
 // Tidrader — läsning, skrivning och den regel som gör underlaget trovärdigt:
 // SERVERN RÄKNAR MINUTERNA, aldrig klienten.
@@ -32,7 +32,7 @@ export const timeEntrySelect = `
   work_order:crm_work_orders(id, order_number, fortnox_order_number, project_name, client_name),
   internal_project:crm_internal_projects(id, name),
   absence_type:crm_absence_types(id, name, payroll_code),
-  time_code:crm_time_codes(id, name, code)
+  time_code:crm_time_codes(id, name, code, payroll_code)
 `;
 
 export type TimeEntryRow = {
@@ -54,7 +54,7 @@ export type TimeEntryRow = {
   work_order?: { id: string; order_number: string | null; fortnox_order_number: string | null; project_name: string | null; client_name: string | null } | null;
   internal_project?: { id: string; name: string } | null;
   absence_type?: { id: string; name: string; payroll_code: string | null } | null;
-  time_code?: { id: string; name: string; code: string | null } | null;
+  time_code?: { id: string; name: string; code: string | null; payroll_code?: string | null } | null;
 };
 
 export type TimeEntryInput = {
@@ -133,6 +133,45 @@ export function buildTimeEntryRow(input: TimeEntryInput, userId: string): BuiltT
       // skrivs den ändå över — det är hela poängen.
     },
     error: null,
+  };
+}
+
+/**
+ * Databasrad → löneunderlagets form (lib/domains/time/summary.ts).
+ *
+ * Enda stället där kolumnnamn möter summeringen. `summarizePerson` känner inte till PostgREST och
+ * `listTimeEntries` känner inte till byråns kolumner — den här funktionen är fogen, och den är ren
+ * så den går att testa utan databas.
+ *
+ * `minutesWorked` skickas med för raderna som saknar klockslag: frånvaro (som anges i timmar med
+ * flit) och `legacy_office`-raderna från tiden före omformningen. workedMinutes faller tillbaka på
+ * den när grossMinutes inte kan räknas.
+ */
+export function toSummarizableEntry(row: TimeEntryRow): SummarizableEntry {
+  const workOrder = row.work_order;
+  // Ordernumret först: det är vad kontoret känner igen ett jobb på. Projekt- eller kundnamn läggs
+  // till när det finns, så en rad går att placera utan att slå upp ordern.
+  const workOrderLabel = workOrder
+    ? [workOrder.order_number || workOrder.fortnox_order_number, workOrder.project_name || workOrder.client_name]
+        .filter(Boolean)
+        .join(' · ') || null
+    : null;
+
+  return {
+    workDate: row.work_date,
+    startTime: row.start_time,
+    endTime: row.end_time,
+    breakMinutes: row.break_minutes ?? 0,
+    minutesWorked: row.minutes_worked,
+    kind: row.kind,
+    userId: row.user_id,
+    absenceReason: row.absence_type?.name ?? null,
+    // Lönesorten tas från den referensrad som faktiskt valdes på tidraden: frånvaroorsaken för
+    // frånvaro, tidkoden för arbetad tid. Internprojektets egen payroll_code används inte — raden
+    // bär en tidkod, och två källor hade kunnat säga olika.
+    payrollCode: row.kind === 'absence' ? row.absence_type?.payroll_code ?? null : row.time_code?.payroll_code ?? null,
+    note: row.note,
+    label: row.kind === 'internal' ? row.internal_project?.name ?? null : workOrderLabel,
   };
 }
 

--- a/lib/domains/time/summary.ts
+++ b/lib/domains/time/summary.ts
@@ -20,6 +20,14 @@ export type SummarizableEntry = ShiftInput & {
   /** Byråns lönesort, från referensraden. */
   payrollCode?: string | null;
   note?: string | null;
+  /**
+   * Vad tiden lades på — arbetsordern eller internprojektet, i klartext.
+   *
+   * Ingen av byråns kolumner. Den finns för attestens dagvy, där kontoret granskar rapporteringen
+   * för hand: "9 timmar den 14:e" säger inget om raden är rimlig, "9 timmar på AO-20260729-42E7C4"
+   * gör det. Frånvaro har ingen — där bär absenceReason samma roll.
+   */
+  label?: string | null;
 };
 
 export type DayRow = {
@@ -32,6 +40,8 @@ export type DayRow = {
   /** Flera frånvaroorsaker samma dag listas var för sig — de kan ha olika lönesort. */
   absenceReasons: string[];
   note: string | null;
+  /** Arbetsordern eller internprojektet raden hör till. Null på frånvaro. */
+  label: string | null;
 };
 
 // En rad per tidrad, inte per dag: byrån vill se klockslagen, och två pass samma dag har två par.
@@ -50,6 +60,7 @@ export function buildDayRows(entries: SummarizableEntry[]): DayRow[] {
         absenceMinutes: isAbsence ? minutes : 0,
         absenceReasons: isAbsence && entry.absenceReason ? [entry.absenceReason] : [],
         note: entry.note ?? null,
+        label: isAbsence ? null : entry.label ?? null,
       };
     });
 }

--- a/supabase/sql/20260814_time_entries_clock_check.sql
+++ b/supabase/sql/20260814_time_entries_clock_check.sql
@@ -1,0 +1,75 @@
+-- Klockslag blir obligatoriska på arbetstid (fas 4.6)
+--
+-- William 2026-08-14: "klockslag bör vara tvingade då det är dom vi kommer räkna emot så vi
+-- faktiskt kan ge ob och övertid där det krävs". Villkoret låg färdigskrivet som kommentar i
+-- 20260811_time_entries_reshape.sql (kring rad 146) och flyttas hit oförändrat.
+--
+-- ⚠️ KÖR DEN HÄR FILEN EFTER ATT KODEN ÄR DEPLOYAD, inte före.
+-- Villkoret avvisar precis det som kontorets Tid-flik skrev tidigare (datum + timmar). Körs det
+-- först slutar fliken fungera för alla som hunnit ladda den gamla sidan. Additiva migreringar får
+-- köras i vilken ordning som helst — den här är inte additiv.
+--
+-- ⚠️ `kind = 'absence'` i undantaget är INTE slarv. Lönebyrån vill ha frånvaro i TIMMAR
+-- ("Frånvarotimmar" i hennes layout), inte som ett pass: en halv dag VAB är fyra timmar, inte
+-- 08:00–12:00. Bara ARBETSTID kräver klockslag. Ta inte bort undantaget.
+--
+-- `source <> 'crm'` friar de gamla kontorsraderna för alltid. Det är inte en eftergift utan
+-- mekanismen: reshapen lade till kolumnen med `default 'legacy_office'` och flippade defaulten till
+-- 'crm' efteråt, så allt som fanns före 2026-08-11 bär `legacy_office` och allt nytt bär `crm`.
+-- Gränsen mellan "det vi ärvde" och "det vi lovar" är alltså redan dragen i datat.
+
+
+-- ── 1. Preflight — KÖR DEN HÄR FÖRST, FÖR SIG ────────────────────────────────
+-- Raderna som villkoret skulle avvisa: skrivna av den nya koden (source='crm') men utan klockslag.
+-- I praktiken rader som kontorets Tid-flik skapade mellan reshapen 2026-08-11 och den här deployen.
+--
+--   select id, user_id, work_date, hours, minutes_worked, note, created_at
+--   from public.crm_time_entries
+--   where source = 'crm' and kind <> 'absence'
+--     and (start_time is null or end_time is null or minutes_worked is null)
+--   order by work_date;
+--
+-- Noll rader → hoppa direkt till steg 3 och kör constraint:et VALIDERAT.
+-- Några rader → antingen komplettera dem med klockslag, eller radera dem om de är testdata:
+--
+--   -- komplettera (exempel; sätt riktiga tider per rad):
+--   update public.crm_time_entries
+--      set start_time = '07:00', end_time = '16:00', break_minutes = 60, minutes_worked = 480
+--    where id = '<uuid>';
+--
+--   -- eller radera, men BARA efter att du tittat på dem ovan:
+--   delete from public.crm_time_entries
+--    where source = 'crm' and kind <> 'absence'
+--      and (start_time is null or end_time is null or minutes_worked is null);
+--
+-- ⚠️ En delete här tar bort någons rapporterade tid. Läs listan innan, inte efter.
+
+
+-- ── 2. Villkoret ─────────────────────────────────────────────────────────────
+-- NOT VALID: regeln tvingas på alla NYA och ÄNDRADE rader direkt, men befintliga rader prövas inte.
+-- Det gör steget ögonblickligt och riskfritt även om preflighten hoppades över — låset finns på
+-- plats från och med nu, oavsett vad som ligger bakåt.
+--
+-- `create constraint` har inget `or replace`, så drop först. Filen är därmed körbar mer än en gång.
+alter table public.crm_time_entries drop constraint if exists crm_time_entries_clock_check;
+alter table public.crm_time_entries add constraint crm_time_entries_clock_check check (
+  source <> 'crm' or kind = 'absence'
+  or (start_time is not null and end_time is not null and minutes_worked is not null)
+) not valid;
+
+
+-- ── 3. Befordra till validerat — när preflighten ger noll rader ──────────────
+-- Först då gäller villkoret även bakåt, och `pg_constraint.convalidated` blir true. Kör som eget
+-- steg; misslyckas det betyder det att steg 1 inte är avklarat, inte att något är trasigt.
+--
+--   alter table public.crm_time_entries validate constraint crm_time_entries_clock_check;
+
+
+-- ── Verifiering ──────────────────────────────────────────────────────────────
+--   select conname, convalidated
+--   from pg_constraint
+--   where conrelid = 'public.crm_time_entries'::regclass and conname = 'crm_time_entries_clock_check';
+--
+-- Och att det faktiskt biter (ska ge ett fel, inte en rad):
+--   insert into public.crm_time_entries (user_id, kind, work_order_id, work_date, hours)
+--   values (auth.uid(), 'work_order', '<order-uuid>', current_date, 8);

--- a/tests/crm/work-orders.test.ts
+++ b/tests/crm/work-orders.test.ts
@@ -213,3 +213,42 @@ describe('createCrmWorkOrderFromQuote — Er referens fryses vid orderskapandet'
     expect(captured.insert!.customer_snapshot.your_reference).toBeNull();
   });
 });
+
+// ---------------------------------------------------------------------------
+// Tidraden på arbetsordern
+// ---------------------------------------------------------------------------
+// Fliken skriver i crm_time_entries — samma tabell som löneunderlaget. Raden byggs av
+// buildTimeEntryRow, och domänen ansvarar för att en ändring inte kan flytta den någonstans.
+
+import { updateCrmWorkOrderTimeEntry } from '@/lib/domains/crm/work-orders';
+import { makeSupabaseMock } from './helpers/supabase';
+
+describe('updateCrmWorkOrderTimeEntry', () => {
+  // Raden byggs med ordern ur URL:en. Gick den vidare till patchen kunde en PATCH mot en ANNAN
+  // orders adress flytta någons tidrad dit — och timmarna hade följt med till fel jobb.
+  it('skalar bort work_order_id och user_id ur patchen', async () => {
+    const supabase = makeSupabaseMock({ data: { id: 'e1' }, error: null });
+    await updateCrmWorkOrderTimeEntry(supabase as any, 'e1', 'anna', {
+      user_id: 'någon-annan',
+      work_order_id: 'en-annan-order',
+      work_date: '2026-08-14',
+      start_time: '08:00',
+      end_time: '18:00',
+      break_minutes: 60,
+      minutes_worked: 540,
+      note: null,
+    });
+
+    const patch = (supabase._query.update as any).mock.calls[0][0];
+    expect(patch).not.toHaveProperty('work_order_id');
+    expect(patch).not.toHaveProperty('user_id');
+    expect(patch.minutes_worked).toBe(540);
+    expect(patch.start_time).toBe('08:00');
+  });
+
+  it('skopar alltid på raden och ägaren', async () => {
+    const supabase = makeSupabaseMock({ data: { id: 'e1' }, error: null });
+    await updateCrmWorkOrderTimeEntry(supabase as any, 'e1', 'anna', { work_date: '2026-08-14' });
+    expect((supabase._query.eq as any).mock.calls).toEqual([['id', 'e1'], ['user_id', 'anna']]);
+  });
+});

--- a/tests/crm/work-orders.test.ts
+++ b/tests/crm/work-orders.test.ts
@@ -226,11 +226,15 @@ import { makeSupabaseMock } from './helpers/supabase';
 describe('updateCrmWorkOrderTimeEntry', () => {
   // Raden byggs med ordern ur URL:en. Gick den vidare till patchen kunde en PATCH mot en ANNAN
   // orders adress flytta någons tidrad dit — och timmarna hade följt med till fel jobb.
-  it('skalar bort work_order_id och user_id ur patchen', async () => {
+  it('skalar bort work_order_id, user_id och time_code_id ur patchen', async () => {
     const supabase = makeSupabaseMock({ data: { id: 'e1' }, error: null });
     await updateCrmWorkOrderTimeEntry(supabase as any, 'e1', 'anna', {
       user_id: 'någon-annan',
       work_order_id: 'en-annan-order',
+      // buildTimeEntryRow sätter ALLTID time_code_id, och kontorsfliken har ingen väljare — den
+      // skickar alltså null. En rad som skapats i /tid med en tidkod syns i fliken, så en ändrad
+      // anteckning hade tyst raderat radens lönesort.
+      time_code_id: null,
       work_date: '2026-08-14',
       start_time: '08:00',
       end_time: '18:00',
@@ -242,6 +246,7 @@ describe('updateCrmWorkOrderTimeEntry', () => {
     const patch = (supabase._query.update as any).mock.calls[0][0];
     expect(patch).not.toHaveProperty('work_order_id');
     expect(patch).not.toHaveProperty('user_id');
+    expect(patch).not.toHaveProperty('time_code_id');
     expect(patch.minutes_worked).toBe(540);
     expect(patch.start_time).toBe('08:00');
   });

--- a/tests/crm/workOrderTimeEntries.route.test.ts
+++ b/tests/crm/workOrderTimeEntries.route.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { memberUser } from './helpers/supabase';
+
+// Kontorets Tid-flik på arbetsordern. Raderna hamnar i `crm_time_entries` — SAMMA tabell som
+// löneunderlaget — och sedan 2026-08-14 måste de bära klockslag: lönen härleder OB och övertid ur
+// start och slut, och ett timtal går inte att räkna någotdera på.
+//
+// Det som prövas här är att vägen in verkligen går genom buildTimeEntryRow. Skulle den någon gång
+// börja skriva timmar direkt igen slutar CHECK:en på tabellen släppa igenom raden — och felet syns
+// först i produktion, på någons lön.
+
+vi.mock('@/lib/auth/route', () => ({ getCurrentUser: vi.fn() }));
+
+vi.mock('@/lib/domains/crm/work-orders', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/domains/crm/work-orders')>();
+  return {
+    ...actual,
+    listCrmWorkOrderTimeEntries: vi.fn(),
+    createCrmWorkOrderTimeEntry: vi.fn(),
+    updateCrmWorkOrderTimeEntry: vi.fn(),
+    deleteCrmWorkOrderTimeEntry: vi.fn(),
+  };
+});
+
+vi.mock('@supabase/auth-helpers-nextjs', () => ({ createRouteHandlerClient: vi.fn(() => ({})) }));
+vi.mock('next/headers', () => ({ cookies: vi.fn() }));
+
+import { getCurrentUser } from '@/lib/auth/route';
+import { createCrmWorkOrderTimeEntry, updateCrmWorkOrderTimeEntry } from '@/lib/domains/crm/work-orders';
+
+const { POST } = await import('@/app/api/crm/work-orders/[id]/time-entries/route');
+const { PATCH } = await import('@/app/api/crm/work-orders/[id]/time-entries/[entryId]/route');
+
+const mockUser = vi.mocked(getCurrentUser);
+const mockCreate = vi.mocked(createCrmWorkOrderTimeEntry);
+const mockUpdate = vi.mocked(updateCrmWorkOrderTimeEntry);
+
+const WORK_ORDER_ID = '55555555-5555-4555-8555-555555555555';
+const ENTRY_ID = '66666666-6666-4666-8666-666666666666';
+
+const ctx = { params: { id: WORK_ORDER_ID } };
+const entryCtx = { params: { id: WORK_ORDER_ID, entryId: ENTRY_ID } };
+
+function jsonReq(method: 'POST' | 'PATCH', payload: unknown) {
+  return new Request('http://localhost/api/crm/work-orders/x/time-entries', {
+    method,
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+}
+
+// Byråns eget exempel: 08–18 med en timmes rast är nio timmar, inte tio.
+const SHIFT = { work_date: '2026-08-14', start_time: '08:00', end_time: '18:00', break_minutes: 60 };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockUser.mockResolvedValue(memberUser);
+  mockCreate.mockResolvedValue({ data: { id: ENTRY_ID }, error: null } as any);
+  mockUpdate.mockResolvedValue({ data: { id: ENTRY_ID }, error: null } as any);
+});
+
+describe('POST /api/crm/work-orders/[id]/time-entries', () => {
+  it('kräver inloggning', async () => {
+    mockUser.mockResolvedValue(null);
+    expect((await POST(jsonReq('POST', SHIFT), ctx)).status).toBe(401);
+  });
+
+  it('kräver klockslag — ett timtal räcker inte längre', async () => {
+    const res = await POST(jsonReq('POST', { work_date: '2026-08-14', hours: 9 }), ctx);
+    expect(res.status).toBe(400);
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it('räknar minuterna på servern och lämnar hours till databastriggern', async () => {
+    expect((await POST(jsonReq('POST', SHIFT), ctx)).status).toBe(201);
+    const row = mockCreate.mock.calls[0][1] as Record<string, unknown>;
+    expect(row.minutes_worked).toBe(540);
+    expect(row).not.toHaveProperty('hours');
+  });
+
+  it('sätter kind och binder raden till ordern i adressen', async () => {
+    await POST(jsonReq('POST', SHIFT), ctx);
+    const row = mockCreate.mock.calls[0][1] as Record<string, unknown>;
+    expect(row.kind).toBe('work_order');
+    expect(row.work_order_id).toBe(WORK_ORDER_ID);
+    expect(row.user_id).toBe(memberUser.id);
+  });
+
+  it('avvisar en rast som är längre än passet i stället för att skriva noll', async () => {
+    const res = await POST(jsonReq('POST', { ...SHIFT, break_minutes: 700 }), ctx);
+    expect(res.status).toBe(400);
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  // end <= start betyder midnattspassage, inte ett fel — ett nattpass 22:00–06:00 är åtta timmar.
+  it('tolkar ett pass över midnatt', async () => {
+    await POST(jsonReq('POST', { work_date: '2026-08-14', start_time: '22:00', end_time: '06:00', break_minutes: 0 }), ctx);
+    expect((mockCreate.mock.calls[0][1] as Record<string, unknown>).minutes_worked).toBe(480);
+  });
+
+  it('avvisar skräp i klockslagen', async () => {
+    expect((await POST(jsonReq('POST', { ...SHIFT, start_time: 'morgon' }), ctx)).status).toBe(400);
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it('svarar 409 när perioden är attesterad, inte 500', async () => {
+    mockCreate.mockResolvedValue({ data: null, error: { code: 'P0001', message: 'augusti 2026 är attesterad' } } as any);
+    const res = await POST(jsonReq('POST', SHIFT), ctx);
+    expect(res.status).toBe(409);
+  });
+});
+
+describe('PATCH /api/crm/work-orders/[id]/time-entries/[entryId]', () => {
+  it('kräver klockslag även vid ändring', async () => {
+    expect((await PATCH(jsonReq('PATCH', { work_date: '2026-08-14', hours: 9 }), entryCtx)).status).toBe(400);
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it('räknar om minuterna ur de nya klockslagen', async () => {
+    await PATCH(jsonReq('PATCH', { ...SHIFT, break_minutes: 30 }), entryCtx);
+    expect((mockUpdate.mock.calls[0][3] as Record<string, unknown>).minutes_worked).toBe(570);
+  });
+
+  // Ordern skickas med till buildTimeEntryRow för att raden ska gå att validera, men den får inte
+  // gå vidare till patchen: en PATCH mot fel orders adress hade annars FLYTTAT tidraden dit.
+  it('skickar med ordern till byggaren men låter domänen skala bort den', async () => {
+    await PATCH(jsonReq('PATCH', SHIFT), entryCtx);
+    const row = mockUpdate.mock.calls[0][3] as Record<string, unknown>;
+    expect(row.work_order_id).toBe(WORK_ORDER_ID);
+    expect(mockUpdate.mock.calls[0][1]).toBe(ENTRY_ID);
+    expect(mockUpdate.mock.calls[0][2]).toBe(memberUser.id);
+  });
+});

--- a/tests/time/adminEntries.route.test.ts
+++ b/tests/time/adminEntries.route.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { adminUser, memberUser, konsultUser, salesUser, effectivePermissionsForRole } from '../crm/helpers/supabase';
+
+// GET /api/admin/time/entries — attestens dagvy: en namngiven persons månad, dag för dag.
+//
+// Det som prövas här är gränsen och fogen, inte matematiken (den bor i summary.test.ts): att bara
+// den som får läsa andras tid kommer in, att perioden blir ett riktigt månadsintervall, och att
+// raderna som hämtas verkligen går genom summeringen — en route som svarar med råa databasrader
+// hade lagt tillbaka kolumnkännedomen i webbläsaren.
+
+vi.mock('@/lib/auth/route', () => ({ getCurrentUser: vi.fn() }));
+
+vi.mock('@/lib/auth/permissions', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/auth/permissions')>();
+  return { ...actual, getEffectivePermissions: vi.fn() };
+});
+
+// toSummarizableEntry och summarizePerson körs på riktigt — de ÄR det routen finns för.
+vi.mock('@/lib/domains/time/entries', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/domains/time/entries')>();
+  return { ...actual, listTimeEntries: vi.fn() };
+});
+
+vi.mock('@/lib/domains/time/compensations', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/domains/time/compensations')>();
+  return { ...actual, listCompensations: vi.fn() };
+});
+
+vi.mock('@supabase/auth-helpers-nextjs', () => ({ createRouteHandlerClient: vi.fn(() => ({})) }));
+vi.mock('next/headers', () => ({ cookies: vi.fn() }));
+
+import { getCurrentUser } from '@/lib/auth/route';
+import { getEffectivePermissions } from '@/lib/auth/permissions';
+import { listTimeEntries } from '@/lib/domains/time/entries';
+import { listCompensations } from '@/lib/domains/time/compensations';
+
+const { GET } = await import('@/app/api/admin/time/entries/route');
+
+const mockUser = vi.mocked(getCurrentUser);
+const mockEntries = vi.mocked(listTimeEntries);
+const mockCompensations = vi.mocked(listCompensations);
+
+const ANNA = '44444444-4444-4444-8444-444444444444';
+
+function req(url: string) {
+  return new Request(`http://localhost${url}`);
+}
+
+const URL_OK = `/api/admin/time/entries?period=2026-08&user_id=${ANNA}`;
+
+// En rad som den kommer ur PostgREST: `time` blir 'HH:MM:SS' och referensraderna är inbäddade.
+const shiftRow = {
+  id: 'e1',
+  user_id: ANNA,
+  kind: 'work_order',
+  work_date: '2026-08-14',
+  start_time: '08:00:00',
+  end_time: '18:00:00',
+  break_minutes: 60,
+  minutes_worked: 540,
+  hours: 9,
+  note: 'Vindsbjälklag',
+  source: 'crm',
+  work_order: { id: 'wo1', order_number: 'AO-20260729-42E7C4', fortnox_order_number: null, project_name: 'Villa Ek', client_name: 'Ekbergs' },
+  time_code: { id: 'tc1', name: 'Arbetstid', code: '1', payroll_code: 'LÖN100' },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getEffectivePermissions).mockImplementation(async () =>
+    effectivePermissionsForRole((await vi.mocked(getCurrentUser)())?.role));
+  mockEntries.mockResolvedValue({ data: [], error: null } as any);
+  mockCompensations.mockResolvedValue({ data: [], error: null } as any);
+});
+
+describe('GET /api/admin/time/entries — åtkomst', () => {
+  it('kräver inloggning', async () => {
+    mockUser.mockResolvedValue(null);
+    expect((await GET(req(URL_OK))).status).toBe(401);
+  });
+
+  // Nyckeln är read.all och inte time.approve med flit: RLS släpper igenom andras rader på just
+  // read.all, så en attestansvarig utan den nyckeln hade fått noll rader — vilket ser likadant ut
+  // som "har inte rapporterat något". Hellre 403 än ett tomt svar som ljuger.
+  it('kräver time.entry.read.all — installatör och konsult nekas', async () => {
+    for (const user of [memberUser, salesUser, konsultUser]) {
+      mockUser.mockResolvedValue(user);
+      expect((await GET(req(URL_OK))).status).toBe(403);
+    }
+    expect(mockEntries).not.toHaveBeenCalled();
+  });
+
+  it('släpper igenom admin', async () => {
+    mockUser.mockResolvedValue(adminUser);
+    expect((await GET(req(URL_OK))).status).toBe(200);
+  });
+});
+
+describe('GET /api/admin/time/entries — inmatning', () => {
+  beforeEach(() => { mockUser.mockResolvedValue(adminUser); });
+
+  it('kräver både period och user_id', async () => {
+    expect((await GET(req('/api/admin/time/entries'))).status).toBe(400);
+    expect((await GET(req('/api/admin/time/entries?period=2026-08'))).status).toBe(400);
+    expect((await GET(req(`/api/admin/time/entries?user_id=${ANNA}`))).status).toBe(400);
+  });
+
+  // '2026-13' matchar `\d{2}` men blir datumet '2026-13-01' och ett Postgres-fel — ett 500 för en
+  // ren inmatningsmiss. Samma fälla som redan kostat på attestroutens period.
+  it('avvisar en period som inte är en riktig månad', async () => {
+    expect((await GET(req(`/api/admin/time/entries?period=2026-13&user_id=${ANNA}`))).status).toBe(400);
+    expect((await GET(req(`/api/admin/time/entries?period=2026-08-14&user_id=${ANNA}`))).status).toBe(400);
+  });
+
+  it('avvisar ett user_id som inte är ett uuid', async () => {
+    expect((await GET(req('/api/admin/time/entries?period=2026-08&user_id=anna'))).status).toBe(400);
+    expect(mockEntries).not.toHaveBeenCalled();
+  });
+
+  it('hämtar hela månaden för den efterfrågade personen', async () => {
+    await GET(req(URL_OK));
+    const range = { from: '2026-08-01', to: '2026-08-31' };
+    expect(mockEntries).toHaveBeenCalledWith(expect.anything(), range, { userId: ANNA });
+    expect(mockCompensations).toHaveBeenCalledWith(expect.anything(), range, { userId: ANNA });
+  });
+
+  it('räknar februari rätt — sista dagen härleds, den antas inte', async () => {
+    await GET(req(`/api/admin/time/entries?period=2026-02&user_id=${ANNA}`));
+    expect(mockEntries).toHaveBeenCalledWith(expect.anything(), { from: '2026-02-01', to: '2026-02-28' }, { userId: ANNA });
+  });
+});
+
+describe('GET /api/admin/time/entries — underlaget', () => {
+  beforeEach(() => { mockUser.mockResolvedValue(adminUser); });
+
+  it('svarar med klockslag och total arbetad tid — lönepersonens enda uttryckliga krav', async () => {
+    mockEntries.mockResolvedValue({ data: [shiftRow], error: null } as any);
+    const json = await (await GET(req(URL_OK))).json();
+
+    expect(json.data.rows).toHaveLength(1);
+    expect(json.data.rows[0]).toMatchObject({
+      date: '2026-08-14',
+      startTime: '08:00:00',
+      endTime: '18:00:00',
+      workMinutes: 540, // 08–18 med en timmes rast är 9 h, inte 10 — byråns eget exempel
+    });
+    expect(json.data.workMinutes).toBe(540);
+  });
+
+  it('bär med arbetsordern så en rad går att placera utan att slå upp den', async () => {
+    mockEntries.mockResolvedValue({ data: [shiftRow], error: null } as any);
+    const json = await (await GET(req(URL_OK))).json();
+    expect(json.data.rows[0].label).toBe('AO-20260729-42E7C4 · Villa Ek');
+  });
+
+  it('håller frånvaro utanför arbetstiden och namnger orsaken', async () => {
+    mockEntries.mockResolvedValue({
+      data: [
+        shiftRow,
+        {
+          ...shiftRow,
+          id: 'e2',
+          kind: 'absence',
+          work_date: '2026-08-15',
+          start_time: null,
+          end_time: null,
+          break_minutes: 0,
+          minutes_worked: 240,
+          work_order: null,
+          absence_type: { id: 'a1', name: 'VAB', payroll_code: 'LÖN300' },
+        },
+      ],
+      error: null,
+    } as any);
+    const json = await (await GET(req(URL_OK))).json();
+
+    expect(json.data.workMinutes).toBe(540);
+    expect(json.data.absenceMinutes).toBe(240);
+    expect(json.data.absenceByReason).toEqual([{ reason: 'VAB', minutes: 240 }]);
+  });
+
+  it('svarar med ersättningarna i samma underlag', async () => {
+    const comp = { id: 'c1', user_id: ANNA, entry_date: '2026-08-14', kind: 'travel', quantity: 4.5, amount: 112.5, note: null };
+    mockCompensations.mockResolvedValue({ data: [comp], error: null } as any);
+    const json = await (await GET(req(URL_OK))).json();
+    expect(json.data.compensations).toEqual([comp]);
+  });
+
+  it('en person utan rader ger ett tomt underlag, inte ett fel', async () => {
+    const res = await GET(req(URL_OK));
+    const json = await res.json();
+    expect(res.status).toBe(200);
+    expect(json.data.rows).toEqual([]);
+    expect(json.data.workMinutes).toBe(0);
+  });
+
+  it('svarar 500 med databasens meddelande när läsningen fallerar', async () => {
+    mockEntries.mockResolvedValue({ data: null, error: { message: 'permission denied' } } as any);
+    const res = await GET(req(URL_OK));
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toContain('permission denied');
+  });
+});

--- a/tests/time/adminEntries.route.test.ts
+++ b/tests/time/adminEntries.route.test.ts
@@ -194,6 +194,30 @@ describe('GET /api/admin/time/entries — underlaget', () => {
     expect(json.data.workMinutes).toBe(0);
   });
 
+  // Regression från kodgranskningen. Zods uuid() släpper igenom versaler och Postgres jämför uuid
+  // skiftlägesokänsligt, så raderna kommer tillbaka — med gemena user_id, som summarizePersons
+  // strikta jämförelse annars filtrerar bort allihop. Utfallet vore en tom månad med status 200
+  // för någon som rapporterat hela augusti, alltså ett falskt negativt på en attestyta.
+  it('normaliserar ett versalt user_id i stället för att svara med en tom månad', async () => {
+    mockEntries.mockResolvedValue({ data: [shiftRow], error: null } as any);
+    const json = await (await GET(req(`/api/admin/time/entries?period=2026-08&user_id=${ANNA.toUpperCase()}`))).json();
+    expect(mockEntries).toHaveBeenCalledWith(expect.anything(), expect.anything(), { userId: ANNA });
+    expect(json.data.rows).toHaveLength(1);
+    expect(json.data.workMinutes).toBe(540);
+  });
+
+  // Kontorets Tid-flik skriver rader utan minutes_worked. Utan hours-fallbacken i mapparen visar
+  // dagvyn "Totalt 0,00 h" rakt under en aggregatrad som säger något helt annat.
+  it('räknar de gamla kontorsraderna på hours i stället för att visa noll', async () => {
+    mockEntries.mockResolvedValue({
+      data: [{ ...shiftRow, source: 'legacy_office', start_time: null, end_time: null, minutes_worked: null, hours: 7.5, work_order: null }],
+      error: null,
+    } as any);
+    const json = await (await GET(req(URL_OK))).json();
+    expect(json.data.rows[0].workMinutes).toBe(450);
+    expect(json.data.workMinutes).toBe(450);
+  });
+
   it('svarar 500 med databasens meddelande när läsningen fallerar', async () => {
     mockEntries.mockResolvedValue({ data: null, error: { message: 'permission denied' } } as any);
     const res = await GET(req(URL_OK));

--- a/tests/time/entries.test.ts
+++ b/tests/time/entries.test.ts
@@ -138,3 +138,81 @@ describe('buildTimeEntryRow — avrundning', () => {
     expect(built.row!.minutes_worked).toBe(1);
   });
 });
+
+// ---------------------------------------------------------------------------
+// toSummarizableEntry — fogen mellan databasraden och löneunderlaget
+// ---------------------------------------------------------------------------
+// Enda stället där kolumnnamn möter summeringen. Går den sönder tyst blir underlaget fel utan att
+// någon uträkning gjort något galet — därför egna fall och inte bara route-testet.
+
+import { toSummarizableEntry, type TimeEntryRow } from '@/lib/domains/time/entries';
+
+const row = (over: Partial<TimeEntryRow> = {}): TimeEntryRow => ({
+  id: 'e1',
+  user_id: ANNA,
+  kind: 'work_order',
+  work_order_id: 'wo1',
+  internal_project_id: null,
+  absence_type_id: null,
+  work_date: '2026-08-14',
+  start_time: '08:00:00',
+  end_time: '18:00:00',
+  break_minutes: 60,
+  minutes_worked: 540,
+  hours: 9,
+  time_code_id: 'tc1',
+  note: null,
+  source: 'crm',
+  ...over,
+});
+
+describe('toSummarizableEntry', () => {
+  it('bär klockslagen vidare orörda — de är underlaget byrån räknar övertid ur', () => {
+    const mapped = toSummarizableEntry(row());
+    expect(mapped.startTime).toBe('08:00:00');
+    expect(mapped.endTime).toBe('18:00:00');
+    expect(mapped.breakMinutes).toBe(60);
+  });
+
+  // Frånvaro och gamla kontorsrader har inga klockslag. workedMinutes faller tillbaka på
+  // minutesWorked — glöms den i mapparen blir de raderna noll timmar, tyst.
+  it('skickar med minutesWorked för rader utan klockslag', () => {
+    const mapped = toSummarizableEntry(row({ kind: 'absence', start_time: null, end_time: null, minutes_worked: 240 }));
+    expect(mapped.minutesWorked).toBe(240);
+  });
+
+  it('namnger arbetsordern med ordernummer och projekt', () => {
+    const mapped = toSummarizableEntry(row({
+      work_order: { id: 'wo1', order_number: 'AO-1', fortnox_order_number: '12', project_name: 'Villa Ek', client_name: 'Ekbergs' },
+    }));
+    expect(mapped.label).toBe('AO-1 · Villa Ek');
+  });
+
+  it('faller tillbaka på Fortnox-numret och kundnamnet när CRM-fälten saknas', () => {
+    const mapped = toSummarizableEntry(row({
+      work_order: { id: 'wo1', order_number: null, fortnox_order_number: '12', project_name: null, client_name: 'Ekbergs' },
+    }));
+    expect(mapped.label).toBe('12 · Ekbergs');
+  });
+
+  it('använder internprojektets namn på interntid', () => {
+    const mapped = toSummarizableEntry(row({
+      kind: 'internal', work_order_id: null, work_order: null,
+      internal_project_id: 'ip1', internal_project: { id: 'ip1', name: 'Verkstad' },
+    }));
+    expect(mapped.label).toBe('Verkstad');
+  });
+
+  it('tar lönesorten från frånvaroorsaken vid frånvaro och från tidkoden annars', () => {
+    const absence = toSummarizableEntry(row({
+      kind: 'absence', start_time: null, end_time: null,
+      absence_type: { id: 'a1', name: 'VAB', payroll_code: 'LÖN300' },
+      time_code: { id: 'tc1', name: 'Arbetstid', code: '1', payroll_code: 'LÖN100' },
+    }));
+    expect(absence.absenceReason).toBe('VAB');
+    expect(absence.payrollCode).toBe('LÖN300');
+
+    const work = toSummarizableEntry(row({ time_code: { id: 'tc1', name: 'Arbetstid', code: '1', payroll_code: 'LÖN100' } }));
+    expect(work.payrollCode).toBe('LÖN100');
+  });
+});

--- a/tests/time/entries.test.ts
+++ b/tests/time/entries.test.ts
@@ -181,6 +181,26 @@ describe('toSummarizableEntry', () => {
     expect(mapped.minutesWorked).toBe(240);
   });
 
+  // Regression från kodgranskningen. minutes_worked lades till NULLBAR utan backfill, och kontorets
+  // Tid-flik skriver fortfarande bara datum + timmar — triggern härleder hours UR minuterna, aldrig
+  // tvärtom. Utan fallbacken visar dagvyn noll timmar på just de raderna, och summan längst ner
+  // motsäger aggregatet i raden ovanför. Samma coalesce som i RPC:n time_approval_overview.
+  it('faller tillbaka på hours när minutes_worked är null — de gamla kontorsraderna', () => {
+    const mapped = toSummarizableEntry(row({
+      source: 'legacy_office', start_time: null, end_time: null, minutes_worked: null, hours: 7.5,
+    }));
+    expect(mapped.minutesWorked).toBe(450);
+  });
+
+  it('avrundar den fallbacken till hela minuter', () => {
+    expect(toSummarizableEntry(row({ start_time: null, end_time: null, minutes_worked: null, hours: 0.51 })).minutesWorked).toBe(31);
+  });
+
+  it('låter minutes_worked vinna när båda finns — minuterna är sanningen', () => {
+    const mapped = toSummarizableEntry(row({ start_time: null, end_time: null, minutes_worked: 455, hours: 7.5 }));
+    expect(mapped.minutesWorked).toBe(455);
+  });
+
   it('namnger arbetsordern med ordernummer och projekt', () => {
     const mapped = toSummarizableEntry(row({
       work_order: { id: 'wo1', order_number: 'AO-1', fortnox_order_number: '12', project_name: 'Villa Ek', client_name: 'Ekbergs' },
@@ -203,16 +223,12 @@ describe('toSummarizableEntry', () => {
     expect(mapped.label).toBe('Verkstad');
   });
 
-  it('tar lönesorten från frånvaroorsaken vid frånvaro och från tidkoden annars', () => {
+  it('tar frånvaroorsakens namn och lönesort', () => {
     const absence = toSummarizableEntry(row({
-      kind: 'absence', start_time: null, end_time: null,
+      kind: 'absence', start_time: null, end_time: null, minutes_worked: 240,
       absence_type: { id: 'a1', name: 'VAB', payroll_code: 'LÖN300' },
-      time_code: { id: 'tc1', name: 'Arbetstid', code: '1', payroll_code: 'LÖN100' },
     }));
     expect(absence.absenceReason).toBe('VAB');
     expect(absence.payrollCode).toBe('LÖN300');
-
-    const work = toSummarizableEntry(row({ time_code: { id: 'tc1', name: 'Arbetstid', code: '1', payroll_code: 'LÖN100' } }));
-    expect(work.payrollCode).toBe('LÖN100');
   });
 });

--- a/tests/time/summary.test.ts
+++ b/tests/time/summary.test.ts
@@ -129,3 +129,20 @@ describe('summarizePerson', () => {
     expect(summary.absenceByReason).toEqual([]);
   });
 });
+
+// `label` är inte en av byråns kolumner — den finns för kontorets egen granskning i attestens
+// dagvy. Den ska aldrig hamna på en frånvarorad: frånvaro hör inte till ett jobb, och en etikett
+// som följt med från formuläret hade sett ut som att någon arbetat på ordern under sin sjukdag.
+describe('buildDayRows — vad tiden lades på', () => {
+  it('bär arbetsorderns etikett på arbetad tid', () => {
+    expect(buildDayRows([entry({ label: 'AO-1 · Villa Ek' })])[0].label).toBe('AO-1 · Villa Ek');
+  });
+
+  it('lämnar etiketten tom på frånvaro även om den skickas med', () => {
+    const rows = buildDayRows([
+      entry({ kind: 'absence', startTime: null, endTime: null, minutesWorked: 240, absenceReason: 'VAB', label: 'AO-1' }),
+    ]);
+    expect(rows[0].label).toBeNull();
+    expect(rows[0].absenceReasons).toEqual(['VAB']);
+  });
+});


### PR DESCRIPTION
Två steg i fas 4, byggda i följd.

## 1. Dagvy per person i attesten

Attestöversikten visade bara månadsaggregat, och ett aggregat går inte att granska — det **är** summan av det man vill titta på. Lönepersonen var uttrycklig (2026-08-14) med att hon behöver se **starttid, sluttid och total arbetad tid** när hon kontrollerar någons arbetstider. Datan fanns redan i `crm_time_entries`; vyn gjorde det inte.

Varje personrad går nu att fälla ut till dag-för-dag-rader i byråns kolumnform: datum, klockslag, arbetade timmar, frånvarotimmar med orsak, anteckning — plus månadssumma, frånvaro per orsak och ersättningarna.

- `GET /api/admin/time/entries?period&user_id`, vaktad av **`time.entry.read.all`** och inte `time.approve`: RLS släpper igenom andras rader på just read.all, så fel nyckel hade gett noll rader i stället för ett nekande — och noll rader ser likadant ut som "har inte rapporterat något".
- `toSummarizableEntry` är fogen databasrad → löneunderlag. Beräkningen fanns redan (`summarizePerson`/`buildDayRows` sedan 4.3).
- Rader **utan klockslag flaggas i gult** i stället för att visa ett tankstreck — de ska rättas, inte gömmas.

Extra vikt sedan piloten blåstes av: parallellkörningen mot Blikk blir inte av, så granskningen sker för hand. Läsbarheten här är ersättningen för kvittot.

## 2. Klockslag obligatoriska på arbetstid

*"klockslag bör vara tvingade då det är dom vi kommer räkna emot så vi faktiskt kan ge ob och övertid där det krävs"* — ett timtal går inte att räkna någotdera på. Nio timmar säger inte om de låg 07–16 eller 14–23.

Blockeraren var kontorets Tid-flik, som skrev datum + timmar rakt in i `crm_time_entries` (samma tabell som löneunderlaget). Den fångar nu start, slut och rast.

Fliken **får fortsätta skriva**. Det krockar inte med att ingen ändrar någon annans timmar: RLS tillåter ändå bara egna rader, så fliken är "rapportera min tid på det här jobbet".

- Skrivvägen går genom `buildTimeEntryRow`, samma som `/tid`. Två vägar in i samma tabell får inte ha två uträkningar av minuterna.
- `hours` skickas inte längre — databastriggern härleder den.
- `updateCrmWorkOrderTimeEntry` skalar bort `work_order_id` och `time_code_id` ur patchen. Se granskningsfynden nedan.

## ⚠️ Migrering — körs EFTER deployen

`supabase/sql/20260814_time_entries_clock_check.sql` är **inte additiv**: villkoret avvisar precis det gamla fliken skrev. Körs den först slutar Tid-fliken ta emot tid, med ett rått 500 (routen översätter bara P0001, en CHECK-överträdelse är 23514).

Filen är byggd i tre steg: **preflight** (vilka rader skulle avvisas) → `not valid` → `validate constraint` som eget steg när listan är tom. `source <> 'crm'` friar allt före reshapen automatiskt. Frånvaroundantaget är avsiktligt — lön vill ha frånvaro i timmar.

## Granskning

Två omgångar, fyra fynd, **alla fyra verkliga** och åtgärdade. Genomgående mönster: *fel som ser ut som tomma värden i stället för som buggar.*

1. `minutes_worked` är NULL på de gamla kontorsraderna (kolumnen lades till nullbar utan backfill; triggern härleder `hours` ur minuterna, aldrig tvärtom). Dagvyn hade visat "Totalt 0,00 h" rakt under en aggregatrad med 143 h — på just de rader man öppnar den för att hitta.
2. Versalt `user_id` gav en tyst tom månad med status 200 (zods `uuid()` släpper igenom versaler, Postgres jämför skiftlägesokänsligt, JS-jämförelsen inte).
3. `buildTimeEntryRow` sätter alltid `time_code_id`, och AO-fliken har ingen tidkodsväljare → den skickade null. En rad skapad i `/tid` med tidkod syns i fliken, så att rätta ett stavfel i anteckningen hade tyst raderat radens lönesort.
4. Förhandsvisningen ritade "rasten är längre än passet" som "fyll i start- och sluttid" på ifyllda fält.

## Verifiering

`npm run type-check` ren · `npm test` 1163 gröna (82 filer) · `npm run build` kompilerar. Inga CI-workflows i repot, så det är facit.

**Blikk-vägen är orörd** — ingen ändrad rad nämner den.

🤖 Generated with [Claude Code](https://claude.com/claude-code)