### PR TITLE
feat(fält): Tid-flik på arbetsordern, öppen bara för attestansvariga

### DIFF
--- a/app/api/crm/work-orders/[id]/time-entries/route.ts
+++ b/app/api/crm/work-orders/[id]/time-entries/route.ts
@@ -5,10 +5,14 @@ import { buildTimeEntryRow } from '@/lib/domains/time/entries';
 import { periodLockError } from '@/lib/domains/time/approvals';
 import { createWorkOrderTimeEntrySchema, ok, requireSignedInUser, routeError, validationError } from '../../_lib';
 
-// NOTE: the installer field view has no time tab during the CRM cutover — Blikk is still the
-// payroll system of record and CRM cannot hand hours over yet (fas 4). This endpoint stays live
-// for the office view (/crm/arbetsorder/[id]), where time logged is internal follow-up rather
-// than payroll input. See app/arbetsorder/WorkOrderInstallerClient.tsx.
+// Två klienter skriver hit: kontorets vy (/crm/arbetsorder/[id]) och fältvyn
+// (/arbetsorder/[id]) — den senare bara för attestansvariga, som ett testfönster. Besättningen
+// rapporterar fortfarande i Blikk, som läses ut för hand före varje lönekörning, och en öppen flik
+// i fält hade blivit en andra plats att rapportera på. Villkoret bor i
+// app/arbetsorder/[id]/page.tsx (`canReportTime`) och tas bort vid cutovern.
+//
+// Raderna är INTE bara intern uppföljning: de ligger i crm_time_entries, alltså samma tabell som
+// löneunderlaget, och bär klockslag sedan 20260814_time_entries_clock_check.sql.
 
 type RouteContext = {
   params: {

--- a/app/arbetsorder/WorkOrderInstallerClient.tsx
+++ b/app/arbetsorder/WorkOrderInstallerClient.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { cn } from '@/lib/shared/cn';
 import { crm, workOrderStatusLabel, workOrderStatusClass } from '@/app/crm/lib/crmTokens';
 import { PhoneLink, EmailLink, AddressLink } from '@/app/crm/components/ContactLinks';
 import WorkOrderCommentsTab from '@/app/crm/arbetsorder/WorkOrderCommentsTab';
 import WorkOrderArticlesTab, { type ArticleLineItem } from '@/app/crm/arbetsorder/WorkOrderArticlesTab';
+import WorkOrderTimeTab from '@/app/crm/arbetsorder/WorkOrderTimeTab';
 import { useWorkOrderActivity } from '@/app/crm/arbetsorder/useWorkOrderActivity';
 import { useCustomerContact } from '@/app/crm/arbetsorder/useCustomerContact';
 import { formatDate, joinAddress, documentRef } from '@/app/crm/lib/format';
@@ -34,9 +35,18 @@ type InstallerWorkOrder = {
   status: WorkOrderStatus;
 };
 
-type InstallerTab = 'info' | 'articles';
+type InstallerTab = 'info' | 'articles' | 'time';
 
-export default function WorkOrderInstallerClient({ workOrderId, currentUserId }: { workOrderId: string; currentUserId: string | null }) {
+export default function WorkOrderInstallerClient({
+  workOrderId,
+  currentUserId,
+  canReportTime = false,
+}: {
+  workOrderId: string;
+  currentUserId: string | null;
+  /** Testfönstret för Tid-fliken — se app/arbetsorder/[id]/page.tsx. */
+  canReportTime?: boolean;
+}) {
   const router = useRouter();
   const [workOrder, setWorkOrder] = useState<InstallerWorkOrder | null>(null);
   const [loading, setLoading] = useState(true);
@@ -44,8 +54,8 @@ export default function WorkOrderInstallerClient({ workOrderId, currentUserId }:
   const [activeTab, setActiveTab] = useState<InstallerTab>('info');
   const customerInfo = useCustomerContact(workOrderId);
 
-  // No time tab here (see the tabs comment below), so don't pay for the time-entries request.
-  const activity = useWorkOrderActivity(workOrderId, { includeTimeEntries: false });
+  // Utan Tid-fliken finns ingen konsument för tidraderna — hämta dem inte då.
+  const activity = useWorkOrderActivity(workOrderId, { includeTimeEntries: canReportTime });
 
   useEffect(() => {
     let active = true;
@@ -93,15 +103,26 @@ export default function WorkOrderInstallerClient({ workOrderId, currentUserId }:
   // Comments render at the bottom of the Info tab (not a separate tab) so an @-mention notification
   // lands straight on the thread.
   //
-  // NO TIME TAB during the cutover. Blikk is still the payroll system of record — someone reads the
-  // hours out of it before each payroll run — and CRM has no way to hand those hours over yet
-  // (no absence/internal time, no travel allowance, no export; that is fas 4). Hours logged here
-  // would live only in CRM and vanish from payroll, so the tab stays closed until CRM can carry
-  // the whole picture and time moves across in one step. Until then all time is reported in
-  // /tidrapport → Blikk, exactly as before.
+  // TID-FLIKEN ÄR STÄNGD FÖR BESÄTTNINGEN, öppen bara för attestansvariga (`canReportTime`).
+  //
+  // Skälet är inte längre tekniskt: fas 4 är byggd, klockslag är obligatoriska och CRM kan bära
+  // hela bilden. Skälet är att besättningen fortfarande rapporterar i Blikk, som läses ut för hand
+  // före varje lönekörning. En flik här hade blivit en ANDRA plats att rapportera på — och timmar
+  // som hamnar i CRM i stället för i Blikk når aldrig lönen. Att flytta någon från Blikk ger samma
+  // utfall som att stänga vägen.
+  //
+  // Villkoret är alltså ett testfönster (William 2026-08-14: "jag måste ändå kunna testa"), inte en
+  // behörighetsmodell. Vid cutovern tas `canReportTime` bort härifrån och ur page.tsx, och den gula
+  // rutan nedan med den.
   const tabs: Array<[InstallerTab, string]> = [
     ['info', 'Info'], ['articles', 'Artiklar'],
+    ...(canReportTime ? [['time', 'Tid'] as [InstallerTab, string]] : []),
   ];
+
+  const totalLoggedHours = useMemo(
+    () => activity.timeEntries.reduce((sum, item) => sum + Number(item.hours || 0), 0),
+    [activity.timeEntries],
+  );
 
   return (
     <div className="mx-auto grid max-w-2xl gap-5 px-4 py-6" style={{ minHeight: '100dvh', backgroundColor: '#e5ede5' }}>
@@ -167,15 +188,21 @@ export default function WorkOrderInstallerClient({ workOrderId, currentUserId }:
           {/* Where to report time. A CRM-planned job has no Blikk project, so it cannot be picked
               in /tidrapport the usual way — without this the crew opens the job, finds no time tab
               and no matching project, and guesses. Says the convention plainly until fas 4 brings
-              time into CRM. */}
-          <div className="grid gap-1.5 rounded-2xl border border-solid border-amber-200 bg-amber-50 p-3.5">
-            <p className={cn(crm.sectionTitle, 'text-amber-700')}>Tidrapportering</p>
-            <p className="text-sm leading-relaxed text-amber-900">
-              Rapportera tiden i <strong className="font-semibold">Tidrapport</strong> som <strong className="font-semibold">internt projekt</strong>, och skriv ordernumret{' '}
-              <strong className="font-semibold">{documentRef(workOrder.fortnox_order_number, workOrder.order_number)}</strong> i kommentaren.
-            </p>
-            <p className="text-xs text-amber-700">Tidrapporteringen flyttar hit när Blikk kopplas bort.</p>
-          </div>
+              time into CRM.
+
+              Döljs för den som HAR Tid-fliken: två anvisningar som pekar åt olika håll är värre än
+              ingen alls, och den som testar den nya vägen ska inte samtidigt läsa att tiden hör
+              hemma i Blikk. Besättningen ser rutan oförändrad. */}
+          {!canReportTime ? (
+            <div className="grid gap-1.5 rounded-2xl border border-solid border-amber-200 bg-amber-50 p-3.5">
+              <p className={cn(crm.sectionTitle, 'text-amber-700')}>Tidrapportering</p>
+              <p className="text-sm leading-relaxed text-amber-900">
+                Rapportera tiden i <strong className="font-semibold">Tidrapport</strong> som <strong className="font-semibold">internt projekt</strong>, och skriv ordernumret{' '}
+                <strong className="font-semibold">{documentRef(workOrder.fortnox_order_number, workOrder.order_number)}</strong> i kommentaren.
+              </p>
+              <p className="text-xs text-amber-700">Tidrapporteringen flyttar hit när Blikk kopplas bort.</p>
+            </div>
+          ) : null}
 
           {/* Comments (write) — at the bottom of Info, no longer a separate tab */}
           <WorkOrderCommentsTab
@@ -202,6 +229,20 @@ export default function WorkOrderInstallerClient({ workOrderId, currentUserId }:
           fortnoxConnected={false}
           canEdit={false}
           onSave={async () => false}
+        />
+      ) : null}
+
+      {/* Tid — samma komponent som kontorets flik, alltså samma klockslagskrav och samma
+          serveruträkning av minuterna. Fältet ska inte ha en egen variant av regeln. */}
+      {activeTab === 'time' && canReportTime ? (
+        <WorkOrderTimeTab
+          entries={activity.timeEntries}
+          loading={activity.timeEntriesLoading}
+          totalHours={totalLoggedHours}
+          currentUserId={currentUserId}
+          onCreate={activity.createTimeEntry}
+          onUpdate={activity.updateTimeEntry}
+          onDelete={activity.deleteTimeEntry}
         />
       ) : null}
 

--- a/app/arbetsorder/WorkOrderInstallerClient.tsx
+++ b/app/arbetsorder/WorkOrderInstallerClient.tsx
@@ -57,6 +57,16 @@ export default function WorkOrderInstallerClient({
   // Utan Tid-fliken finns ingen konsument för tidraderna — hämta dem inte då.
   const activity = useWorkOrderActivity(workOrderId, { includeTimeEntries: canReportTime });
 
+  // ⚠️ ALLA HOOKS MÅSTE LIGGA FÖRE DE TIDIGA RETURERNA NEDAN (`if (loading)`, `if (error)`).
+  // Den här summan används först längst ner, men får inte deklareras där: första rendern går ut
+  // genom laddningsgrenen, nästa gör det inte, och en hook som bara körs i den andra ger
+  // "Rendered more hooks than during the previous render" — en krasch för ALLA som öppnar sidan,
+  // inte bara för dem som ser fliken. Repot har ingen ESLint som fångar det.
+  const totalLoggedHours = useMemo(
+    () => activity.timeEntries.reduce((sum, item) => sum + Number(item.hours || 0), 0),
+    [activity.timeEntries],
+  );
+
   useEffect(() => {
     let active = true;
     async function load() {
@@ -118,11 +128,6 @@ export default function WorkOrderInstallerClient({
     ['info', 'Info'], ['articles', 'Artiklar'],
     ...(canReportTime ? [['time', 'Tid'] as [InstallerTab, string]] : []),
   ];
-
-  const totalLoggedHours = useMemo(
-    () => activity.timeEntries.reduce((sum, item) => sum + Number(item.hours || 0), 0),
-    [activity.timeEntries],
-  );
 
   return (
     <div className="mx-auto grid max-w-2xl gap-5 px-4 py-6" style={{ minHeight: '100dvh', backgroundColor: '#e5ede5' }}>

--- a/app/arbetsorder/[id]/page.tsx
+++ b/app/arbetsorder/[id]/page.tsx
@@ -1,4 +1,6 @@
+import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
+import { createServerComponentClient } from '@supabase/auth-helpers-nextjs';
 import { getCurrentUser } from '@/lib/auth/route';
 import WorkOrderInstallerClient from '../WorkOrderInstallerClient';
 
@@ -11,5 +13,26 @@ export default async function InstallerWorkOrderPage({ params }: { params: Promi
   const { id } = await params;
   const user = await getCurrentUser();
   if (!user) redirect('/auth/sign-in');
-  return <WorkOrderInstallerClient workOrderId={id} currentUserId={user.id} />;
+
+  // Tid-fliken i fältvyn är ÖPPEN BARA FÖR ATTESTANSVARIGA, tills vidare.
+  //
+  // Den är byggd och fungerar — endpointen finns, och RLS släpper redan igenom en installatör på
+  // sin egen order. Det som håller den stängd är inte teknik utan att besättningen fortfarande
+  // rapporterar i Blikk: en flik här hade blivit en andra plats att rapportera på, och timmar som
+  // hamnar i CRM i stället för i Blikk når aldrig lönekörningen. Nyckeln är alltså ett testfönster
+  // (William 2026-08-14), inte en behörighetsmodell — när cutovern beslutas tas villkoret bort och
+  // fliken visas för alla som når ordern.
+  //
+  // Behörigheten läses här och inte i klienten: sidan är rätt ställe för åtkomstbeslut, och en
+  // klient som frågar själv hade blinkat till med fel flikrad medan svaret var på väg.
+  //
+  // `createServerComponentClient` och inte getEffectivePermissions(): den senare bygger en
+  // route-handler-klient, som försöker skriva cookies vid tokenförnyelse och därför inte hör hemma
+  // i en server-komponent.
+  const supabase = createServerComponentClient({ cookies });
+  const { data: permissions } = await supabase.rpc('effective_permissions');
+  const canReportTime = Array.isArray(permissions)
+    && permissions.some((row) => (typeof row === 'string' ? row : String(row)) === 'time.approve');
+
+  return <WorkOrderInstallerClient workOrderId={id} currentUserId={user.id} canReportTime={canReportTime} />;
 }

--- a/app/crm/arbetsorder/useWorkOrderActivity.ts
+++ b/app/crm/arbetsorder/useWorkOrderActivity.ts
@@ -10,9 +10,10 @@ import type { MentionUser } from '@/app/crm/components/MentionTextarea';
 // order. Used by both the full editor (/crm) and the installer field view (/arbetsorder)
 // so the write logic lives in one place. Handlers return a boolean so callers can reset
 // their own form/edit state on success.
-// `includeTimeEntries: false` skips the time-entries request entirely. The installer field view has
-// no time tab during the CRM cutover (Blikk still owns payroll), so fetching a list nothing renders
-// costs an extra round trip on a phone in a field, every time a job is opened.
+// `includeTimeEntries: false` skips the time-entries request entirely. Fältvyn döljer Tid-fliken
+// för alla utom attestansvariga (besättningen rapporterar fortfarande i Blikk), och att hämta en
+// lista som ingenting renderar kostar en extra rundtur på en telefon i fält, varje gång ett jobb
+// öppnas.
 export function useWorkOrderActivity(workOrderId: string, options?: { includeTimeEntries?: boolean }) {
   const includeTimeEntries = options?.includeTimeEntries !== false;
   const toast = useToast();


### PR DESCRIPTION
Fältvyn visade ordern men gav ingen väg att rapportera tid på den. Besättningen hänvisades via en gul ruta till Blikks *Tidrapport* — som internt projekt, med ordernumret i kommentaren.

Fliken är nu byggd men **stängd för besättningen**. Den visas bara för den som har `time.approve`, alltså admin i seeden.

## Varför den är stängd

Skälet är inte längre tekniskt: fas 4 är byggd, klockslag är obligatoriska och CRM kan bära hela bilden. Skälet är att **besättningen fortfarande rapporterar i Blikk**, som läses ut för hand före varje lönekörning. En öppen flik här hade blivit en *andra* plats att rapportera på, och timmar som hamnar i CRM i stället för i Blikk når aldrig lönen. Att flytta någon från Blikk ger samma utfall som att stänga vägen.

Villkoret är alltså ett **testfönster**, inte en behörighetsmodell. Vid cutovern tas `canReportTime` bort på båda ställena — `app/arbetsorder/[id]/page.tsx` och `WorkOrderInstallerClient.tsx` — och den gula rutan med dem.

## Detaljer

- Behörigheten resolvas i `page.tsx`, inte i klienten: sidan är rätt ställe för åtkomstbeslut, och en klient som frågar själv hade blinkat till med fel flikrad medan svaret var på väg. **Fail-closed** om RPC:n fallerar.
- `createServerComponentClient`, inte `getEffectivePermissions()` — den senare bygger en route-handler-klient som försöker skriva cookies vid tokenförnyelse och hör inte hemma i en server-komponent.
- Samma `WorkOrderTimeTab` som kontoret, alltså samma klockslagskrav och samma serveruträkning av minuterna. Fältet ska inte ha en egen variant av regeln.
- Besättningens gula ruta är **ordagrant oförändrad**, bara villkorad. Den döljs för den som har fliken.
- `timeEntries` hämtas inte alls när fliken är dold — ingen extra rundtur på en telefon i fält.

## Granskningen fångade en krasch

`useMemo` för timsumman hamnade efter de tidiga returerna (`if (loading)` / `if (error)`). Första rendern hoppade över hooken, nästa gjorde det inte → React hade kastat *"Rendered more hooks than during the previous render"* på rendern efter att ordern laddats. Det hade slagit ut `/arbetsorder/[id]` för **alla** användare, inte bara för dem med fliken, eftersom hooken i sig är ovillkorlig.

Hoistad, med en varning på plats. Tredje gången den felklassen fångas av en granskning — type-check och 1163 tester är blinda för den. **ESLint är nästa pass.**

Två kommentarer som påstod att fältvyn saknar Tid-flik är också rättade; det är där repot bokför cutover-regeln.

## Verifiering

`npm run type-check` ren · `npm test` 1163 gröna · `npm run build` kompilerar. Ingen SQL. Blikk-vägen orörd — inga ändrade rader utanför kommentarer, och besättningens text är identisk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)