### PR TITLE
feat(admin/attest): vyn byggs om för granskning, admin får rätta med revisionslogg

### DIFF
--- a/PERMISSIONS.md
+++ b/PERMISSIONS.md
@@ -84,7 +84,7 @@ caught at compile time).
 `crm.write` (write), `crm.admin`.
 
 **Time & payroll** (fas 4, seeded in `20260811_time_permissions.sql`): `time.entry.write`,
-`time.entry.read.all`, `time.approve`, `time.payroll.read`, `time.reference.manage`.
+`time.entry.read.all`, `time.approve`, `time.payroll.read`, `time.reference.manage`, `time.entry.write.all`.
 
 > Deliberately **not** `crm.*`. Time is company-wide — every employee reports it, including roles
 > with no CRM access at all. A time key inside the CRM namespace would inherit the `crm.access` /
@@ -113,7 +113,7 @@ The seed reproduces the pre-migration role behavior exactly. (Parity is asserted
 | meta `crm.write` | – | ✓ | – | ✓ |
 | meta `crm.admin` | – | – | – | ✓ |
 | `time.entry.write` | **✓** | **✓** | – | ✓ |
-| `time.entry.read.all` / `time.approve` / `time.payroll.read` / `time.reference.manage` | – | – | – | ✓ |
+| `time.entry.read.all` / `time.approve` / `time.payroll.read` / `time.reference.manage` / `time.entry.write.all` | – | – | – | ✓ |
 
 **Asymmetries to remember:** `crm.routingrule.read` excludes konsult (its RLS SELECT did too);
 `crm.aiprospect.*` is admin-only; `member` gets no CRM keys (installers reach their own work

--- a/app/admin/tid/AdminTimeApprovals.tsx
+++ b/app/admin/tid/AdminTimeApprovals.tsx
@@ -19,6 +19,11 @@ import {
   type TimePeriodStatus,
 } from '../../../lib/domains/time/approvals';
 import type { PersonPeriodSummary } from '../../../lib/domains/time/summary';
+import {
+  auditActionLabel,
+  describeAuditChange,
+  type TimeEntryAuditRow,
+} from '../../../lib/domains/time/audit';
 
 // Admin → Attest. En kalendermånad per person, och knappen som fryser den.
 //
@@ -125,9 +130,13 @@ type PersonDetail = {
   error: string | null;
   summary: PersonPeriodSummary | null;
   compensations: CompensationItem[];
+  audit: TimeEntryAuditRow[];
+  auditFailed: boolean;
 };
 
-const EMPTY_DETAIL: PersonDetail = { loading: true, error: null, summary: null, compensations: [] };
+const EMPTY_DETAIL: PersonDetail = {
+  loading: true, error: null, summary: null, compensations: [], audit: [], auditFailed: false,
+};
 
 export default function AdminTimeApprovals() {
   const [period, setPeriod] = React.useState(currentPeriod);
@@ -228,12 +237,14 @@ export default function AdminTimeApprovals() {
         error: null,
         summary: body.data as PersonPeriodSummary,
         compensations: (body.data.compensations || []) as CompensationItem[],
+        audit: (body.data.audit || []) as TimeEntryAuditRow[],
+        auditFailed: !!body.data.audit_failed,
       });
     } catch (e) {
       // Hela tillståndet skrivs om, inte bara felet: lämnas summary kvar visas föregående persons
       // dagar under felrutan. Samma fälla som redan kostat en gång i den här vyn.
       if (seq === detailSeq.current) {
-        setDetail({ loading: false, error: (e as Error).message, summary: null, compensations: [] });
+        setDetail({ loading: false, error: (e as Error).message, summary: null, compensations: [], audit: [], auditFailed: false });
       }
     }
   }, [period]);
@@ -911,6 +922,8 @@ function PersonDays({
         </div>
       ) : null}
 
+      <AuditTrail rows={detail.audit} failed={detail.auditFailed} />
+
       {detail.compensations.length > 0 ? (
         <div className="grid gap-1">
           <p className={cn(LABEL, 'm-0')}>Ersättningar</p>
@@ -1020,5 +1033,58 @@ function DayRowCells({
         </td>
       ) : null}
     </tr>
+  );
+}
+
+/**
+ * Vem som rört månaden, och vad de gjorde.
+ *
+ * Det här är andra halvan av att låta en admin rätta någon annans timmar. Utan en läsbar logg är
+ * skrivrätten bara en försäkran; med den är den granskbar. Raderna skrivs av en databastrigger som
+ * ingen väg går förbi.
+ *
+ * ⚠️ TOM LOGG BETYDER "INGEN ANNAN HAR RÖRT MÅNADEN", inte "ingenting har hänt". Triggern hoppar
+ * över personens egna sparningar med flit — annars hade varje inmatning i /tid dränkt de rader man
+ * öppnar loggen för att hitta. Därför visas sektionen bara när det finns något att visa.
+ */
+function AuditTrail({ rows, failed }: { rows: TimeEntryAuditRow[]; failed: boolean }) {
+  if (failed) {
+    return (
+      <p className="m-0 text-sm text-amber-800">
+        Ändringsloggen kunde inte läsas. Dagarna ovan är oberoende av den.
+      </p>
+    );
+  }
+  if (rows.length === 0) return null;
+
+  return (
+    <div className="grid gap-1.5">
+      <p className={cn(LABEL, 'm-0')}>Ändrat av någon annan</p>
+      <ul className="m-0 grid list-none gap-1.5 p-0">
+        {rows.map((row) => {
+          const changes = describeAuditChange(row);
+          return (
+            <li key={row.id} className="rounded-xl border border-solid border-[#e4ebe0] bg-white px-3 py-2 text-sm">
+              <div className="flex flex-wrap items-baseline gap-x-2 text-slate-700">
+                <span className="font-semibold">{auditActionLabel(row.action)}</span>
+                <span className="text-slate-500">
+                  {row.changed_by_profile?.full_name || 'okänd användare'} · {formatStamp(row.created_at)}
+                </span>
+              </div>
+              {changes.length > 0 ? (
+                <ul className="m-0 mt-1 grid list-none gap-0.5 p-0 text-slate-600">
+                  {changes.map((change) => (
+                    <li key={change.label}>
+                      {change.label}: <span className="tabular-nums">{change.from ?? '—'}</span>
+                      {change.to !== null ? <> → <span className="font-medium tabular-nums text-slate-900">{change.to}</span></> : null}
+                    </li>
+                  ))}
+                </ul>
+              ) : null}
+            </li>
+          );
+        })}
+      </ul>
+    </div>
   );
 }

--- a/app/admin/tid/AdminTimeApprovals.tsx
+++ b/app/admin/tid/AdminTimeApprovals.tsx
@@ -863,10 +863,16 @@ function PersonDays({
   if (!summary) return null;
 
   if (summary.rows.length === 0 && detail.compensations.length === 0) {
+    // ⚠️ Loggen renderas ÄVEN här. Har en admin raderat personens alla rader ser månaden tom ut, och
+    // då är raderingsraderna det enda som visar att det funnits något — att returnera tidigt hade
+    // gömt just det bevis man öppnar loggen för.
     return (
-      <p className="m-0 text-sm text-slate-500">
-        {name || 'Personen'} har inte rapporterat något den här månaden.
-      </p>
+      <div className="grid gap-3">
+        <p className="m-0 text-sm text-slate-500">
+          {name || 'Personen'} har inte rapporterat något den här månaden.
+        </p>
+        <AuditTrail rows={detail.audit} failed={detail.auditFailed} />
+      </div>
     );
   }
 
@@ -1076,7 +1082,8 @@ function AuditTrail({ rows, failed }: { rows: TimeEntryAuditRow[]; failed: boole
                   {changes.map((change) => (
                     <li key={change.label}>
                       {change.label}: <span className="tabular-nums">{change.from ?? '—'}</span>
-                      {change.to !== null ? <> → <span className="font-medium tabular-nums text-slate-900">{change.to}</span></> : null}
+                      {' → '}
+                      <span className="font-medium tabular-nums text-slate-900">{change.to ?? '—'}</span>
                     </li>
                   ))}
                 </ul>

--- a/app/admin/tid/AdminTimeApprovals.tsx
+++ b/app/admin/tid/AdminTimeApprovals.tsx
@@ -908,7 +908,7 @@ function DayRowCells({
 
   const [draftStart, setDraftStart] = React.useState(start || '');
   const [draftEnd, setDraftEnd] = React.useState(end || '');
-  const [draftBreak, setDraftBreak] = React.useState('0');
+  const [draftBreak, setDraftBreak] = React.useState(String(day.breakMinutes));
   const [draftHours, setDraftHours] = React.useState(String(minutesToHours(day.absenceMinutes)));
 
   // Rättelse kräver att raden går att peka ut. Saknas id:t är den läsbar men inte ändringsbar —
@@ -930,7 +930,7 @@ function DayRowCells({
     return (
       <tr className="border-x-0 border-b-0 border-t border-solid border-slate-200 align-top">
         <td className="whitespace-nowrap px-2 py-1.5 text-slate-700">{formatDay(day.date)}</td>
-        <td className="px-2 py-1.5" colSpan={4}>
+        <td className="px-2 py-1.5" colSpan={5}>
           <div className="flex flex-wrap items-end gap-2">
             {isAbsence ? (
               <label className="grid gap-1">
@@ -1020,8 +1020,12 @@ function DayRowCells({
               <button
                 type="button"
                 onClick={() => {
+                  // ⚠️ RASTEN MÅSTE SÅS OM. Utan den raden ligger formulärets nolla kvar och
+                  // rättelsen skickar break_minutes: 0 — servern räknar då om passet UTAN
+                  // rastavdrag och lägger till minuter på någons lön.
                   setDraftStart(start || '');
                   setDraftEnd(end || '');
+                  setDraftBreak(String(day.breakMinutes));
                   setDraftHours(String(minutesToHours(day.absenceMinutes)));
                   setEditing(true);
                 }}

--- a/app/admin/tid/AdminTimeApprovals.tsx
+++ b/app/admin/tid/AdminTimeApprovals.tsx
@@ -276,11 +276,15 @@ export default function AdminTimeApprovals() {
       if (failure) failures.push(`${row.full_name || 'Okänd'}: ${failure}`);
     }
 
+    // ⚠️ LADDA OM FÖRST, SKRIV BESKEDET SEN. `load()` nollställer felrutan som sitt första steg, så
+    // ett besked satt före anropet hann aldrig synas — och misslyckades ALLA blev det varken notis
+    // eller fel: massattesten såg ut att ha gått igenom fast ingen period rörde sig.
+    await load();
+
     const done = submitted.length - failures.length;
     if (done > 0) setNotice(`${done} av ${submitted.length} attesterade för ${periodLabel(periodStartOf(period))}.`);
     if (failures.length > 0) setError(`Gick inte att attestera ${failures.length}: ${failures.join(' · ')}`);
 
-    await load();
     setBulkBusy(false);
   }
 
@@ -345,7 +349,16 @@ export default function AdminTimeApprovals() {
           <label className="grid gap-1">
             <span className={LABEL}>Period</span>
             <span className="inline-block w-40">
-              <Input type="month" value={period} onChange={(e) => setPeriod(e.target.value || currentPeriod())} />
+              {/* Låst under massattesten. Loopen tar sekunder, och dess avslutande omladdning gäller
+                  den period den startade i: byter man månad mitt i vinner den sist startade
+                  hämtningen och målar föregående månads rader under den nya rubriken — varpå nästa
+                  "Attestera" postar fel månad på siffror som hör till en annan. */}
+              <Input
+                type="month"
+                value={period}
+                disabled={bulkBusy}
+                onChange={(e) => setPeriod(e.target.value || currentPeriod())}
+              />
             </span>
           </label>
 
@@ -480,9 +493,15 @@ export default function AdminTimeApprovals() {
           periodStart={periodStartOf(period)}
           onClose={() => setReopening(null)}
           onSubmit={async (note) => {
-            const row = reopening;
+            // Modalen stängs FÖRST när anropet lyckats. Stängdes den före anropet försvann den
+            // skrivna anledningen vid ett 409 eller ett nätverksfel — och det är hela beskedet till
+            // den anställde om vad som ska rättas, alltså det dyraste i rutan att tappa.
+            const failure = await postStatus(reopening.user_id, 'open', note);
+            if (failure) return failure;
+            setNotice(`${periodLabel(periodStartOf(period))} öppnad igen för ${reopening.full_name || 'personen'}.`);
             setReopening(null);
-            await setStatus(row, 'open', note);
+            await load();
+            return null;
           }}
         />
       ) : null}
@@ -628,10 +647,12 @@ function ReopenModal({
   row: TimeApprovalOverviewRow;
   periodStart: string;
   onClose: () => void;
-  onSubmit: (note?: string) => Promise<void>;
+  /** Felmeddelandet, eller null när det gick bra. Vid fel stannar modalen kvar med texten i behåll. */
+  onSubmit: (note?: string) => Promise<string | null>;
 }) {
   const [note, setNote] = React.useState(row.note || '');
   const [busy, setBusy] = React.useState(false);
+  const [failure, setFailure] = React.useState<string | null>(null);
 
   return (
     <CrmModal
@@ -657,7 +678,13 @@ function ReopenModal({
           </button>
           <button
             type="button"
-            onClick={async () => { setBusy(true); await onSubmit(note.trim() || undefined); }}
+            onClick={async () => {
+              setBusy(true);
+              setFailure(null);
+              const result = await onSubmit(note.trim() || undefined);
+              // Lyckades det avmonterar föräldern oss — då finns ingen state kvar att skriva till.
+              if (result) { setFailure(result); setBusy(false); }
+            }}
             disabled={busy}
             className="!py-2.5 flex-1 rounded-xl text-sm font-semibold text-white shadow-sm transition hover:brightness-95 disabled:opacity-60 sm:ml-auto sm:flex-none sm:!px-5"
             style={{ backgroundColor: 'var(--crm-primary)' }}
@@ -667,6 +694,10 @@ function ReopenModal({
         </>
       }
     >
+      {failure ? (
+        <div className="mb-3 rounded-xl border border-solid border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-700">{failure}</div>
+      ) : null}
+
       <label className="grid gap-1">
         <span className={LABEL}>Anledning (valfri)</span>
         <textarea

--- a/app/admin/tid/AdminTimeApprovals.tsx
+++ b/app/admin/tid/AdminTimeApprovals.tsx
@@ -637,7 +637,7 @@ function PersonRow({
       </div>
 
       {expanded ? (
-        <div className="border-t border-solid border-[#e4ebe0] bg-[#f9fbf7] px-4 py-3">
+        <div className="border-x-0 border-b-0 border-t border-solid border-[#e4ebe0] bg-[#f9fbf7] px-4 py-3">
           <PersonDays detail={detail} name={row.full_name} />
         </div>
       ) : null}
@@ -785,7 +785,7 @@ function PersonDays({ detail, name }: { detail: PersonDetail | null; name: strin
                 const end = formatClock(day.endTime);
                 const isAbsence = day.absenceMinutes > 0;
                 return (
-                  <tr key={`${day.date}-${index}`} className="border-t border-solid border-slate-200 align-top">
+                  <tr key={`${day.date}-${index}`} className="border-x-0 border-b-0 border-t border-solid border-slate-200 align-top">
                     <td className="whitespace-nowrap px-2 py-1.5 text-slate-700">{formatDay(day.date)}</td>
                     <td className="whitespace-nowrap px-2 py-1.5 tabular-nums text-slate-700">
                       {start && end ? (
@@ -811,7 +811,7 @@ function PersonDays({ detail, name }: { detail: PersonDetail | null; name: strin
               })}
             </tbody>
             <tfoot>
-              <tr className="border-t-2 border-solid border-slate-300 font-semibold text-slate-900">
+              <tr className="border-x-0 border-b-0 border-t-2 border-solid border-slate-300 font-semibold text-slate-900">
                 <td className="px-2 py-2" colSpan={2}>Totalt</td>
                 <td className="whitespace-nowrap px-2 py-2 text-right tabular-nums">{formatHours(summary.workMinutes)} h</td>
                 <td className="whitespace-nowrap px-2 py-2 text-right tabular-nums">

--- a/app/admin/tid/AdminTimeApprovals.tsx
+++ b/app/admin/tid/AdminTimeApprovals.tsx
@@ -332,7 +332,12 @@ export default function AdminTimeApprovals() {
   };
 
   return (
-    <div className="grid gap-4">
+    // ⚠️ Padding hör hemma HÄR, inte i skalet. AdminTabsClient renderar flikinnehållet i en
+    // `crm.card`, och den tokenen har medvetet ingen padding ("content controls its own padding")
+    // — så utan p-5 ligger rubriken och korten klistrade mot kortkanten. Systerfliken
+    // AdminTimeReference gör likadant, och de två ska se lika ut eftersom de sitter bredvid
+    // varandra i samma flikrad.
+    <div className="grid gap-4 p-5">
       <div className="grid gap-1">
         <h2 className="m-0 text-lg font-bold text-slate-900">Attest</h2>
         <p className="m-0 text-sm text-slate-600">

--- a/app/admin/tid/AdminTimeApprovals.tsx
+++ b/app/admin/tid/AdminTimeApprovals.tsx
@@ -543,7 +543,10 @@ function PersonRow({
   const absencePercent = Math.round((row.absence_minutes / scaleMinutes) * 100);
 
   return (
-    <li className="overflow-hidden rounded-2xl border border-solid border-[#e0e8dc] bg-[#f9fbf7]">
+    // Vit fyllning, inte sage. Fliken renderas i en `crm.card` som REDAN är #f9fbf7 — ett kort i
+    // samma ton på samma ton skiljs bara av en hårlinje i #e0e8dc, och då läser raderna som en enda
+    // yta. Samma grepp som tidraderna i /tid: vitt kort på sage-underlag.
+    <li className="overflow-hidden rounded-2xl border border-solid border-[#e0e8dc] bg-white">
       {/* EN rad med kolumner, inte tre band under varandra. Staplade fullbreddsblock på en yta som
           är över tusen pixlar bred ger innehåll klistrat mot ytterkanterna och luft i mitten — och
           en stapel som spänner hela bredden läser som en trasig avdelare, inte som ett mått.
@@ -634,7 +637,7 @@ function PersonRow({
       </div>
 
       {expanded ? (
-        <div className="border-t border-solid border-[#e4ebe0] bg-white px-3.5 py-3">
+        <div className="border-t border-solid border-[#e4ebe0] bg-[#f9fbf7] px-4 py-3">
           <PersonDays detail={detail} name={row.full_name} />
         </div>
       ) : null}

--- a/app/admin/tid/AdminTimeApprovals.tsx
+++ b/app/admin/tid/AdminTimeApprovals.tsx
@@ -38,8 +38,11 @@ import type { PersonPeriodSummary } from '../../../lib/domains/time/summary';
 // uppfinna en regel: systemet känner varken tjänstgöringsgrad eller schema, och en deltidare hade
 // flaggats varje månad tills flaggan slutade betyda något.
 //
-// Ändra någon annans TIMMAR går inte, med flit (se RLS i 20260811_time_entries_rls.sql). Behöver en
-// rad rättas öppnar man perioden med en anledning, och personen rättar själv. Det lämnar spår.
+// Att ändra någon annans timmar KRÄVER att perioden är öppen och nyckeln `time.entry.write.all`
+// (20260814_time_admin_corrections.sql — den filen äger numera write-policyerna, INTE
+// 20260811_time_entries_rls.sql). Låstriggern prövar radens ägare, så attesterad tid är orörbar
+// även härifrån, och varje rättelse av någon annans rad skrivs till crm_time_entry_audit av en
+// databastrigger.
 //
 // OBS preflight är av (tailwind.config.js): `border` på en <div> ritar ingen linje utan
 // `border-solid`, och <input> får `width: 100%` från globals.css.
@@ -398,9 +401,9 @@ export default function AdminTimeApprovals() {
       <div className="grid gap-1">
         <h2 className="m-0 text-lg font-bold text-slate-900">Attest</h2>
         <p className="m-0 text-sm text-slate-600">
-          Lås en kalendermånad per person. Inlämnad och attesterad tid går inte att ändra — varken av
-          den anställde eller härifrån. Behöver något rättas: öppna perioden med en anledning, så
-          rättar personen själv.
+          Lås en kalendermånad per person. Inlämnad och attesterad tid går inte att ändra — öppna
+          perioden med en anledning först, så kan den anställde rätta själv. Du kan också rätta
+          raderna härifrån när perioden är öppen; varje sådan ändring loggas med ditt namn.
         </p>
       </div>
 
@@ -497,7 +500,10 @@ export default function AdminTimeApprovals() {
             </select>
           </label>
 
-          {submitted.length > 0 ? (
+          {/* ⚠️ Bara när periodens data faktiskt är hämtad. `people` töms inte vid månadsbyte, så
+              under laddningen låg föregående månads inlämnade kvar — och knappen hade attesterat
+              DEM under den NYA perioden. */}
+          {!loading && submitted.length > 0 ? (
             confirmBulk ? (
               <span className="flex items-center gap-2 text-sm">
                 <span className="text-slate-600">Attestera {submitted.length}?</span>

--- a/app/admin/tid/AdminTimeApprovals.tsx
+++ b/app/admin/tid/AdminTimeApprovals.tsx
@@ -1,8 +1,14 @@
 "use client";
 import React from 'react';
-import Badge from '../../../components/ui/Badge';
+import CrmModal from '@/app/crm/components/CrmModal';
 import Input from '../../../components/ui/Input';
+import { cn } from '../../../lib/shared/cn';
 import { minutesToHours } from '../../../lib/domains/time/hours';
+import {
+  COMPENSATION_LABELS,
+  COMPENSATION_UNITS,
+  type CompensationItem,
+} from '../../../lib/domains/time/compensations';
 import {
   isPeriodLocked,
   periodLabel,
@@ -11,22 +17,28 @@ import {
   type TimeApprovalOverviewRow,
   type TimePeriodStatus,
 } from '../../../lib/domains/time/approvals';
-import {
-  COMPENSATION_LABELS,
-  COMPENSATION_UNITS,
-  type CompensationItem,
-} from '../../../lib/domains/time/compensations';
 import type { PersonPeriodSummary } from '../../../lib/domains/time/summary';
 
-// Admin → Attest. Fas 4.4: en kalendermånad per person, och knappen som fryser den.
+// Admin → Attest. En kalendermånad per person, och knappen som fryser den.
 //
-// Vyn visar ALLA anställda, även de som inte rapporterat en enda timme — en tom rad är precis den
-// information man öppnar attesten för. Siffrorna finns med av samma skäl: attest utan underlag är
-// bara en knapp, och den som attesterar ska kunna se att 143 timmar är rimligt innan hen trycker.
+// ⚠️ DEN HÄR VYN ÄR ERSÄTTNINGEN FÖR PILOTEN.
+//
+// Planen var att en bil skulle dubbelrapportera i /tid *utöver* Blikk under en löneperiod, så att
+// summorna kunde jämföras maskinellt innan någon lön hängde på dem. Den planen är avblåst (chefen
+// avslutar Blikk-licenserna, 2026-08-14), och i stället granskar två personer siffrorna för hand.
+//
+// Därför är vyn byggd för att LETA FEL, inte bara för att visa siffror: staplarna gör en avvikande
+// månad synlig utan att någon behöver räknas, filtren tar en rakt till dem som inte lämnat in, och
+// den som inte rapporterat något alls flaggas — en tom rad är precis den information man öppnar
+// attesten för.
+//
+// ⚠️ INGA TRÖSKLAR, INGA OMDÖMEN. Stapeln är skalad mot gruppens största månad och säger bara "den
+// här är kortare än de andra". Att sätta en gräns för hur många timmar som är "för få" vore att
+// uppfinna en regel: systemet känner varken tjänstgöringsgrad eller schema, och en deltidare hade
+// flaggats varje månad tills flaggan slutade betyda något.
 //
 // Ändra någon annans TIMMAR går inte, med flit (se RLS i 20260811_time_entries_rls.sql). Behöver en
-// rad rättas öppnar man perioden med en anledning, och personen rättar själv. Det är den enda vägen,
-// och den lämnar spår.
+// rad rättas öppnar man perioden med en anledning, och personen rättar själv. Det lämnar spår.
 //
 // OBS preflight är av (tailwind.config.js): `border` på en <div> ritar ingen linje utan
 // `border-solid`, och <input> får `width: 100%` från globals.css.
@@ -35,6 +47,27 @@ const STATUS_TONE: Record<TimePeriodStatus, string> = {
   open: 'bg-slate-100 text-slate-600',
   submitted: 'bg-amber-100 text-amber-800',
   approved: 'bg-emerald-100 text-emerald-800',
+};
+
+// Färgskenan i radens vänsterkant. Samma avläsning som CRM:ets listrader: status på en blick.
+const STATUS_RAIL: Record<TimePeriodStatus, string> = {
+  open: 'bg-slate-300',
+  submitted: 'bg-amber-400',
+  approved: 'bg-emerald-500',
+};
+
+// Fältetikett. Medvetet inte `crm.sectionTitle` — den är en avdelningsrubrik i slate-400 om 10 px,
+// runt 2,6:1 mot vitt och alltså under WCAG AA. Samma konstant och samma skäl som i /tid.
+const LABEL = 'text-[11px] font-bold uppercase tracking-[0.12em] text-slate-600';
+
+type Filter = 'all' | 'awaiting' | 'not_submitted' | 'empty';
+type Sort = 'name' | 'hours_asc' | 'hours_desc';
+
+const FILTER_LABELS: Record<Filter, string> = {
+  all: 'Alla',
+  awaiting: 'Väntar på attest',
+  not_submitted: 'Ej inlämnade',
+  empty: 'Inget rapporterat',
 };
 
 function formatHours(minutes: number): string {
@@ -51,14 +84,7 @@ function formatStamp(value: string | null): string {
   return Number.isNaN(date.getTime()) ? '' : new Intl.DateTimeFormat('sv-SE', { dateStyle: 'short' }).format(date);
 }
 
-/** Innevarande månad som 'ÅÅÅÅ-MM'. Lokala getters, inte toISOString: den senare är UTC. */
-function currentPeriod(): string {
-  const now = new Date();
-  return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
-}
-
-/** '2026-08-14' → 'fre 14 aug'. Fälten plockas ur strängen och formateras i UTC, så ingen
- *  tidszon kan flytta datumet en dag — samma skäl som periodStartOf räknar på strängar. */
+/** '2026-08-14' → 'fre 14 aug'. UTC-formatering, så ingen tidszon flyttar dagen. */
 function formatDay(iso: string): string {
   const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(iso);
   if (!match) return iso;
@@ -69,6 +95,25 @@ function formatDay(iso: string): string {
 /** Postgres `time` serialiseras som 'HH:MM:SS'. Sekunderna är alltid noll här och bara brus. */
 function formatClock(value: string | null): string | null {
   return value ? value.slice(0, 5) : null;
+}
+
+/**
+ * Innevarande månad som 'ÅÅÅÅ-MM', i svensk tid.
+ *
+ * Zonen pinnas för att sidan server-renderas innan den hydreras och servern går på UTC: lokala
+ * getters ger olika månad på server och klient den första i månaden mellan 00:00 och 02:00, vilket
+ * är ett hydreringsfel på precis den yta där periodval betyder något. Samma fälla som PR #69.
+ */
+const STOCKHOLM_MONTH = new Intl.DateTimeFormat('sv-SE', {
+  timeZone: 'Europe/Stockholm',
+  year: 'numeric',
+  month: '2-digit',
+});
+
+function currentPeriod(): string {
+  const parts = STOCKHOLM_MONTH.formatToParts(new Date());
+  const value = (type: string) => parts.find((part) => part.type === type)?.value ?? '';
+  return `${value('year')}-${value('month')}`;
 }
 
 type PersonDetail = {
@@ -87,6 +132,12 @@ export default function AdminTimeApprovals() {
   const [error, setError] = React.useState<string | null>(null);
   const [notice, setNotice] = React.useState<string | null>(null);
   const [busyId, setBusyId] = React.useState<string | null>(null);
+  const [filter, setFilter] = React.useState<Filter>('all');
+  const [sort, setSort] = React.useState<Sort>('name');
+  const [confirmBulk, setConfirmBulk] = React.useState(false);
+  const [bulkBusy, setBulkBusy] = React.useState(false);
+  const [reopening, setReopening] = React.useState<TimeApprovalOverviewRow | null>(null);
+
   // En person i taget öppen. Fler samtidiga hade betytt fler tillstånd att hålla i takt med
   // perioden, och dagvyn läses en person åt gången ändå.
   const [expandedId, setExpandedId] = React.useState<string | null>(null);
@@ -110,7 +161,7 @@ export default function AdminTimeApprovals() {
     } catch (e) {
       if (seq === loadSeq.current) {
         setError((e as Error).message);
-        // Töm tabellen. Står föregående månads rader kvar under felrutan attesterar "Attestera"
+        // Töm listan. Står föregående månads rader kvar under felrutan attesterar "Attestera"
         // den NYA perioden utifrån den GAMLA månadens siffror — och setStatus rensar felrutan
         // först, så det sista som varnade försvinner i samma klick.
         setPeople([]);
@@ -129,6 +180,7 @@ export default function AdminTimeApprovals() {
     detailSeq.current++;
     setExpandedId(null);
     setDetail(null);
+    setConfirmBulk(false);
   }, [period]);
 
   const loadDetail = React.useCallback(async (userId: string) => {
@@ -168,38 +220,68 @@ export default function AdminTimeApprovals() {
     void loadDetail(userId);
   }
 
-  async function setStatus(row: TimeApprovalOverviewRow, status: TimePeriodStatus, note?: string) {
-    setBusyId(row.user_id);
-    setError(null);
-    setNotice(null);
+  /** En statusövergång. Returnerar felmeddelandet, eller null när det gick bra. */
+  const postStatus = React.useCallback(async (userId: string, status: TimePeriodStatus, note?: string) => {
     try {
       const res = await fetch('/api/time/approvals', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'same-origin',
-        body: JSON.stringify({ period, status, user_id: row.user_id, note: note ?? null }),
+        body: JSON.stringify({ period, status, user_id: userId, note: note ?? null }),
       });
       const body = await res.json().catch(() => null);
-      if (!res.ok || !body?.ok) throw new Error(body?.error || `Fel (${res.status})`);
+      if (!res.ok || !body?.ok) return body?.error || `Fel (${res.status})`;
+      return null;
+    } catch (e) {
+      return (e as Error).message;
+    }
+  }, [period]);
+
+  async function setStatus(row: TimeApprovalOverviewRow, status: TimePeriodStatus, note?: string) {
+    setBusyId(row.user_id);
+    setError(null);
+    setNotice(null);
+    const failure = await postStatus(row.user_id, status, note);
+    if (failure) setError(failure);
+    else {
       setNotice(
         status === 'approved'
           ? `${row.full_name || 'Personen'} attesterad för ${periodLabel(periodStartOf(period))}.`
           : `${periodLabel(periodStartOf(period))} öppnad igen för ${row.full_name || 'personen'}.`,
       );
       await load();
-    } catch (e) {
-      setError((e as Error).message);
-    } finally {
-      setBusyId(null);
     }
+    setBusyId(null);
   }
 
-  function reopen(row: TimeApprovalOverviewRow) {
-    // Anledningen är inte byråkrati: den syns för den anställde i /tid och är hela beskedet om vad
-    // som ska rättas. Tom sträng skickas som null — ingen anledning är bättre än "".
-    const note = window.prompt(`Varför öppnas ${periodLabel(periodStartOf(period))} igen för ${row.full_name || 'personen'}?`, row.note || '');
-    if (note === null) return;
-    void setStatus(row, 'open', note.trim() || undefined);
+  const submitted = React.useMemo(() => people.filter((row) => row.status === 'submitted'), [people]);
+
+  /**
+   * Attestera alla inlämnade i ett svep.
+   *
+   * Sekventiellt och inte parallellt: RPC:n tar ett advisory lock per person och period, och en
+   * skur av samtidiga anrop hade bara köat på databassidan utan att gå fortare. Viktigare är att
+   * ett DELVIS misslyckande måste gå att läsa — därför räknas felen och rapporteras rakt ut i
+   * stället för att ett rött meddelande får det att se ut som att ingenting gick igenom.
+   */
+  async function approveAllSubmitted() {
+    setConfirmBulk(false);
+    setBulkBusy(true);
+    setError(null);
+    setNotice(null);
+
+    const failures: string[] = [];
+    for (const row of submitted) {
+      const failure = await postStatus(row.user_id, 'approved');
+      if (failure) failures.push(`${row.full_name || 'Okänd'}: ${failure}`);
+    }
+
+    const done = submitted.length - failures.length;
+    if (done > 0) setNotice(`${done} av ${submitted.length} attesterade för ${periodLabel(periodStartOf(period))}.`);
+    if (failures.length > 0) setError(`Gick inte att attestera ${failures.length}: ${failures.join(' · ')}`);
+
+    await load();
+    setBulkBusy(false);
   }
 
   const totals = React.useMemo(() => {
@@ -211,10 +293,39 @@ export default function AdminTimeApprovals() {
         submitted: acc.submitted + (row.status === 'submitted' ? 1 : 0),
         approved: acc.approved + (row.status === 'approved' ? 1 : 0),
         open: acc.open + (row.status === 'open' ? 1 : 0),
+        empty: acc.empty + (row.entry_count === 0 ? 1 : 0),
       }),
-      { work: 0, absence: 0, compensation: 0, submitted: 0, approved: 0, open: 0 },
+      { work: 0, absence: 0, compensation: 0, submitted: 0, approved: 0, open: 0, empty: 0 },
     );
   }, [people]);
+
+  // Skalan för staplarna: gruppens största månad, arbete och frånvaro tillsammans. Ingen tröskel,
+  // ingen norm — bara en gemensam linjal, så att en kort stapel syns utan att någon döms.
+  const scaleMinutes = React.useMemo(
+    () => Math.max(1, ...people.map((row) => row.work_minutes + row.absence_minutes)),
+    [people],
+  );
+
+  const visible = React.useMemo(() => {
+    const matches = people.filter((row) => {
+      if (filter === 'awaiting') return row.status === 'submitted';
+      if (filter === 'not_submitted') return row.status === 'open';
+      if (filter === 'empty') return row.entry_count === 0;
+      return true;
+    });
+    const sorted = [...matches];
+    if (sort === 'hours_asc') sorted.sort((a, b) => a.work_minutes - b.work_minutes);
+    else if (sort === 'hours_desc') sorted.sort((a, b) => b.work_minutes - a.work_minutes);
+    else sorted.sort((a, b) => (a.full_name || '').localeCompare(b.full_name || '', 'sv'));
+    return sorted;
+  }, [people, filter, sort]);
+
+  const filterCount: Record<Filter, number> = {
+    all: people.length,
+    awaiting: totals.submitted,
+    not_submitted: totals.open,
+    empty: totals.empty,
+  };
 
   return (
     <div className="grid gap-4">
@@ -227,22 +338,39 @@ export default function AdminTimeApprovals() {
         </p>
       </div>
 
-      <div className="flex flex-wrap items-end gap-3">
-        <label className="grid gap-1">
-          <span className="text-xs font-semibold text-slate-600">Period</span>
-          <span className="inline-block w-40">
-            <Input type="month" value={period} onChange={(e) => setPeriod(e.target.value || currentPeriod())} />
-          </span>
-        </label>
-        <div className="flex flex-wrap gap-2 pb-1">
-          <Badge>{totals.open} öppna</Badge>
-          <Badge variant="accent">{totals.submitted} inlämnade</Badge>
-          <Badge>{totals.approved} attesterade</Badge>
-          <Badge>Totalt {formatHours(totals.work)} h</Badge>
-          {totals.absence > 0 ? <Badge>Frånvaro {formatHours(totals.absence)} h</Badge> : null}
-          {totals.compensation > 0 ? <Badge>Ersättningar {formatAmount(totals.compensation)} kr</Badge> : null}
+      {/* Periodhuvud. Två frågor, åtskilda med flit: hur långt har jag kommit (framstegen) och hur
+          stora är summorna (underlaget). Förut låg båda som sex likadana badges i rad. */}
+      <section className="grid gap-3 rounded-2xl border border-solid border-[#e0e8dc] bg-[#f9fbf7] p-3.5">
+        <div className="flex flex-wrap items-end justify-between gap-3">
+          <label className="grid gap-1">
+            <span className={LABEL}>Period</span>
+            <span className="inline-block w-40">
+              <Input type="month" value={period} onChange={(e) => setPeriod(e.target.value || currentPeriod())} />
+            </span>
+          </label>
+
+          <div className="grid gap-1 text-right">
+            <span className={LABEL}>Attesterade</span>
+            <span className="text-lg font-bold tabular-nums text-slate-900">
+              {totals.approved} <span className="text-sm font-semibold text-slate-500">av {people.length}</span>
+            </span>
+          </div>
         </div>
-      </div>
+
+        {people.length > 0 ? (
+          <div className="flex h-2 gap-0.5 overflow-hidden rounded-full">
+            {people.map((row) => (
+              <span key={row.user_id} className={cn('flex-1', STATUS_RAIL[row.status])} aria-hidden />
+            ))}
+          </div>
+        ) : null}
+
+        <div className="flex flex-wrap gap-x-4 gap-y-1 text-sm text-slate-600">
+          <span>Arbetat <strong className="tabular-nums text-slate-900">{formatHours(totals.work)} h</strong></span>
+          {totals.absence > 0 ? <span>Frånvaro <strong className="tabular-nums text-amber-800">{formatHours(totals.absence)} h</strong></span> : null}
+          {totals.compensation > 0 ? <span>Ersättningar <strong className="tabular-nums text-slate-900">{formatAmount(totals.compensation)} kr</strong></span> : null}
+        </div>
+      </section>
 
       {error ? (
         <div className="rounded-xl border border-solid border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700">{error}</div>
@@ -251,111 +379,307 @@ export default function AdminTimeApprovals() {
         <div className="rounded-xl border border-solid border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-800">{notice}</div>
       ) : null}
 
+      {/* Filtren är granskningens arbetsredskap: de tar en rakt till dem som inte lämnat in eller
+          inte rapporterat något. Ett filter utan träffar visas ändå, med sin nolla — att listan är
+          tom är svaret man letade efter. */}
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex flex-wrap gap-1.5">
+          {(Object.keys(FILTER_LABELS) as Filter[]).map((key) => (
+            <button
+              key={key}
+              type="button"
+              onClick={() => setFilter(key)}
+              aria-pressed={filter === key}
+              className={cn(
+                '!px-3 !py-1.5 rounded-full border border-solid text-sm font-semibold transition',
+                filter === key
+                  ? 'border-transparent bg-slate-900 text-white'
+                  : 'border-[#dbe4d6] bg-white text-slate-600 hover:border-slate-400',
+                key === 'empty' && filterCount.empty > 0 && filter !== key ? 'text-amber-800' : '',
+              )}
+            >
+              {FILTER_LABELS[key]} <span className="tabular-nums opacity-70">{filterCount[key]}</span>
+            </button>
+          ))}
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2">
+          <label className="flex items-center gap-2 text-sm text-slate-600">
+            <span className={LABEL}>Sortera</span>
+            <select
+              value={sort}
+              onChange={(e) => setSort(e.target.value as Sort)}
+              className="rounded-lg border border-solid border-[#dbe4d6] bg-white px-2.5 py-1.5 text-sm"
+            >
+              <option value="name">Namn</option>
+              <option value="hours_asc">Timmar, lägst först</option>
+              <option value="hours_desc">Timmar, högst först</option>
+            </select>
+          </label>
+
+          {submitted.length > 0 ? (
+            confirmBulk ? (
+              <span className="flex items-center gap-2 text-sm">
+                <span className="text-slate-600">Attestera {submitted.length}?</span>
+                <button
+                  type="button"
+                  onClick={() => void approveAllSubmitted()}
+                  className="!px-3 !py-1.5 rounded-lg border border-solid border-emerald-300 bg-emerald-50 text-sm font-semibold text-emerald-800"
+                >
+                  Ja, attestera
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setConfirmBulk(false)}
+                  className="!px-2 !py-1.5 rounded-lg text-sm font-semibold text-slate-500"
+                >
+                  Avbryt
+                </button>
+              </span>
+            ) : (
+              <button
+                type="button"
+                onClick={() => setConfirmBulk(true)}
+                disabled={bulkBusy}
+                className="!px-3 !py-1.5 rounded-lg border border-solid border-emerald-300 bg-emerald-50 text-sm font-semibold text-emerald-800 transition hover:border-emerald-400 disabled:opacity-60"
+              >
+                {bulkBusy ? 'Attesterar…' : `Attestera alla inlämnade (${submitted.length})`}
+              </button>
+            )
+          ) : null}
+        </div>
+      </div>
+
       {loading ? (
         <p className="m-0 text-sm text-slate-400">Laddar…</p>
       ) : people.length === 0 ? (
         <p className="m-0 text-sm text-slate-500">Inga anställda att visa.</p>
+      ) : visible.length === 0 ? (
+        <p className="m-0 text-sm text-slate-500">Ingen matchar “{FILTER_LABELS[filter]}” i {periodLabel(periodStartOf(period))}.</p>
       ) : (
-        <div className="overflow-x-auto">
-          <table className="w-full min-w-[900px] border-collapse text-sm">
-            <thead>
-              <tr className="border-b border-solid border-slate-200 text-left text-[11px] font-extrabold uppercase tracking-wide text-slate-500">
-                <th className="px-3 py-2">Person</th>
-                <th className="px-3 py-2">Status</th>
-                <th className="px-3 py-2 text-right">Arbetat</th>
-                <th className="px-3 py-2 text-right">Frånvaro</th>
-                <th className="px-3 py-2 text-right">Rader</th>
-                <th className="px-3 py-2 text-right">Ersättningar</th>
-                <th className="px-3 py-2" />
-              </tr>
-            </thead>
-            <tbody>
-              {people.map((row) => {
-                const locked = isPeriodLocked(row.status);
-                const isExpanded = expandedId === row.user_id;
-                return (
-                  <React.Fragment key={row.user_id}>
-                  <tr className="border-b border-solid border-slate-100 align-top">
-                    <td className="px-3 py-2">
-                      {/* Ikonknapp: globals.css ger varje <button> padding och centrering utan att
-                          ligga i ett lager, så Tailwind måste gå före med `!`. */}
-                      <button
-                        type="button"
-                        onClick={() => toggleDetail(row.user_id)}
-                        aria-expanded={isExpanded}
-                        className="!inline-flex !items-start !justify-start !p-0 !text-left"
-                      >
-                        <span aria-hidden className={`mt-0.5 text-slate-400 transition-transform ${isExpanded ? 'rotate-90' : ''}`}>›</span>
-                        <span>
-                          <span className="block font-medium text-slate-900 underline-offset-2 hover:underline">
-                            {row.full_name || '(namn saknas)'}
-                          </span>
-                          <span className="block text-xs text-slate-400">{row.role}</span>
-                        </span>
-                      </button>
-                    </td>
-                    <td className="px-3 py-2">
-                      <span className={`inline-block rounded-lg px-2 py-1 text-xs font-semibold ${STATUS_TONE[row.status]}`}>
-                        {TIME_PERIOD_STATUS_LABELS[row.status]}
-                      </span>
-                      <div className="mt-1 text-xs text-slate-500">
-                        {row.status === 'submitted' && row.submitted_at ? `Inlämnad ${formatStamp(row.submitted_at)}` : null}
-                        {row.status === 'approved' && row.approved_at
-                          ? `Attesterad ${formatStamp(row.approved_at)}${row.approved_by_name ? ` av ${row.approved_by_name}` : ''}`
-                          : null}
-                        {row.status === 'open' && row.note ? `Öppnad igen: ${row.note}` : null}
-                      </div>
-                    </td>
-                    <td className="px-3 py-2 text-right font-medium">{formatHours(row.work_minutes)} h</td>
-                    <td className="px-3 py-2 text-right text-slate-600">
-                      {row.absence_minutes > 0 ? `${formatHours(row.absence_minutes)} h` : '—'}
-                    </td>
-                    {/* Noll rader på en person som ska ha rapporterat är det attesten finns för att
-                        upptäcka — därför en egen kolumn och inte bara timmarna. */}
-                    <td className={`px-3 py-2 text-right ${row.entry_count === 0 ? 'text-amber-700' : 'text-slate-500'}`}>
-                      {row.entry_count}
-                    </td>
-                    <td className="px-3 py-2 text-right text-slate-600">
-                      {row.compensation_count > 0 ? `${formatAmount(row.compensation_amount)} kr` : '—'}
-                    </td>
-                    <td className="px-3 py-2 text-right whitespace-nowrap">
-                      {row.status !== 'approved' ? (
-                        <button
-                          type="button"
-                          onClick={() => void setStatus(row, 'approved')}
-                          disabled={busyId === row.user_id}
-                          className="rounded-lg border border-solid border-emerald-300 bg-emerald-50 px-3 py-1.5 text-sm font-semibold text-emerald-800 transition hover:border-emerald-400 disabled:opacity-60"
-                        >
-                          Attestera
-                        </button>
-                      ) : null}
-                      {locked ? (
-                        <button
-                          type="button"
-                          onClick={() => reopen(row)}
-                          disabled={busyId === row.user_id}
-                          className="ml-2 rounded-lg border border-solid border-slate-300 bg-white px-3 py-1.5 text-sm font-semibold text-slate-700 transition hover:border-slate-400 disabled:opacity-60"
-                        >
-                          Öppna igen
-                        </button>
-                      ) : null}
-                    </td>
-                  </tr>
-                  {isExpanded ? (
-                    <tr className="border-b border-solid border-slate-100">
-                      <td colSpan={7} className="bg-slate-50 px-3 py-3">
-                        <PersonDays detail={detail} name={row.full_name} />
-                      </td>
-                    </tr>
-                  ) : null}
-                  </React.Fragment>
-                );
-              })}
-            </tbody>
-          </table>
-        </div>
+        <ul className="m-0 grid list-none gap-2 p-0">
+          {visible.map((row) => (
+            <PersonRow
+              key={row.user_id}
+              row={row}
+              scaleMinutes={scaleMinutes}
+              expanded={expandedId === row.user_id}
+              detail={expandedId === row.user_id ? detail : null}
+              busy={busyId === row.user_id || bulkBusy}
+              onToggle={() => toggleDetail(row.user_id)}
+              onApprove={() => void setStatus(row, 'approved')}
+              onReopen={() => setReopening(row)}
+            />
+          ))}
+        </ul>
       )}
+
+      {reopening ? (
+        <ReopenModal
+          row={reopening}
+          periodStart={periodStartOf(period)}
+          onClose={() => setReopening(null)}
+          onSubmit={async (note) => {
+            const row = reopening;
+            setReopening(null);
+            await setStatus(row, 'open', note);
+          }}
+        />
+      ) : null}
     </div>
+  );
+}
+
+/**
+ * En person i listan.
+ *
+ * Stapeln är radens signatur: alla skalas mot gruppens största månad, så en kort stapel syns direkt
+ * utan att någon behöver jämföra tal. Frånvaron ligger som ett eget segment efter arbetstiden —
+ * en månad med mycket frånvaro har kort arbetsstapel av ett skäl man ska kunna se, inte gissa.
+ */
+function PersonRow({
+  row, scaleMinutes, expanded, detail, busy, onToggle, onApprove, onReopen,
+}: {
+  row: TimeApprovalOverviewRow;
+  scaleMinutes: number;
+  expanded: boolean;
+  detail: PersonDetail | null;
+  busy: boolean;
+  onToggle: () => void;
+  onApprove: () => void;
+  onReopen: () => void;
+}) {
+  const locked = isPeriodLocked(row.status);
+  const workPercent = Math.round((row.work_minutes / scaleMinutes) * 100);
+  const absencePercent = Math.round((row.absence_minutes / scaleMinutes) * 100);
+
+  return (
+    <li className="overflow-hidden rounded-2xl border border-solid border-[#e0e8dc] bg-[#f9fbf7]">
+      <div className="flex">
+        <span className={cn('w-1 shrink-0', STATUS_RAIL[row.status])} aria-hidden />
+
+        <div className="min-w-0 flex-1 grid gap-2 px-3.5 py-3">
+          <div className="flex flex-wrap items-start justify-between gap-x-3 gap-y-1">
+            <button
+              type="button"
+              onClick={onToggle}
+              aria-expanded={expanded}
+              className="!inline-flex !items-baseline !justify-start !gap-2 !p-0 !text-left min-w-0"
+            >
+              <span aria-hidden className={cn('text-slate-400 transition-transform', expanded ? 'rotate-90' : '')}>›</span>
+              <span className="min-w-0">
+                <span className="block truncate font-semibold text-slate-900 underline-offset-2 hover:underline">
+                  {row.full_name || '(namn saknas)'}
+                </span>
+                <span className="block text-xs text-slate-400">{row.role}</span>
+              </span>
+            </button>
+
+            <div className="flex flex-wrap items-center gap-2">
+              {/* Noll rader på en person som ska ha rapporterat är det attesten finns för att
+                  upptäcka — därför en egen flagga och inte bara en siffra i en kolumn. */}
+              {row.entry_count === 0 ? (
+                <span className="whitespace-nowrap rounded-full border border-solid border-amber-200 bg-amber-50 px-2.5 py-0.5 text-[11px] font-semibold text-amber-800">
+                  Inget rapporterat
+                </span>
+              ) : null}
+              <span className={cn('whitespace-nowrap rounded-full px-2.5 py-0.5 text-[11px] font-semibold', STATUS_TONE[row.status])}>
+                {TIME_PERIOD_STATUS_LABELS[row.status]}
+              </span>
+            </div>
+          </div>
+
+          <div className="grid gap-1">
+            <div className="flex h-1.5 overflow-hidden rounded-full bg-[#e8eee4]">
+              <span className="bg-[#4a7a58]" style={{ width: `${workPercent}%` }} aria-hidden />
+              <span className="bg-amber-400" style={{ width: `${absencePercent}%` }} aria-hidden />
+            </div>
+            <div className="flex flex-wrap items-baseline gap-x-3 gap-y-0.5 text-sm">
+              <strong className="tabular-nums text-slate-900">{formatHours(row.work_minutes)} h</strong>
+              {row.absence_minutes > 0 ? (
+                <span className="tabular-nums text-amber-800">{formatHours(row.absence_minutes)} h frånvaro</span>
+              ) : null}
+              <span className="text-slate-500">
+                <span className="tabular-nums">{row.entry_count}</span> {row.entry_count === 1 ? 'rad' : 'rader'}
+              </span>
+              {row.compensation_count > 0 ? (
+                <span className="text-slate-500"><span className="tabular-nums">{formatAmount(row.compensation_amount)}</span> kr i ersättning</span>
+              ) : null}
+            </div>
+          </div>
+
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <span className="text-xs text-slate-500">
+              {row.status === 'submitted' && row.submitted_at ? `Inlämnad ${formatStamp(row.submitted_at)}` : null}
+              {row.status === 'approved' && row.approved_at
+                ? `Attesterad ${formatStamp(row.approved_at)}${row.approved_by_name ? ` av ${row.approved_by_name}` : ''}`
+                : null}
+              {row.status === 'open' && row.note ? `Öppnad igen: ${row.note}` : null}
+            </span>
+
+            <span className="flex flex-wrap gap-2">
+              {row.status !== 'approved' ? (
+                <button
+                  type="button"
+                  onClick={onApprove}
+                  disabled={busy}
+                  className="!px-3 !py-1.5 rounded-lg border border-solid border-emerald-300 bg-emerald-50 text-sm font-semibold text-emerald-800 transition hover:border-emerald-400 disabled:opacity-60"
+                >
+                  Attestera
+                </button>
+              ) : null}
+              {locked ? (
+                <button
+                  type="button"
+                  onClick={onReopen}
+                  disabled={busy}
+                  className="!px-3 !py-1.5 rounded-lg border border-solid border-[#dbe4d6] bg-white text-sm font-semibold text-slate-700 transition hover:border-slate-400 disabled:opacity-60"
+                >
+                  Öppna igen
+                </button>
+              ) : null}
+            </span>
+          </div>
+        </div>
+      </div>
+
+      {expanded ? (
+        <div className="border-t border-solid border-[#e4ebe0] bg-white px-3.5 py-3">
+          <PersonDays detail={detail} name={row.full_name} />
+        </div>
+      ) : null}
+    </li>
+  );
+}
+
+/**
+ * Återöppning med en anledning.
+ *
+ * Ett riktigt fält, inte window.prompt: texten går rakt till den anställde i /tid och är hela
+ * beskedet om vad som ska rättas. En rå webbläsardialog gav ingen plats att skriva mer än en rad,
+ * ingen formatering och inget sätt att se vad som stod där sist.
+ *
+ * Anledningen är fortfarande VALFRI. Tom text skickas som null — ingen anledning är bättre än en
+ * tom sträng, och att tvinga fram en mening hade gjort "." till standardsvaret.
+ */
+function ReopenModal({
+  row, periodStart, onClose, onSubmit,
+}: {
+  row: TimeApprovalOverviewRow;
+  periodStart: string;
+  onClose: () => void;
+  onSubmit: (note?: string) => Promise<void>;
+}) {
+  const [note, setNote] = React.useState(row.note || '');
+  const [busy, setBusy] = React.useState(false);
+
+  return (
+    <CrmModal
+      onClose={onClose}
+      ariaLabel="Öppna perioden igen"
+      maxWidth="sm:max-w-[460px]"
+      header={
+        <>
+          <h2 className="text-lg font-bold text-slate-900">Öppna {periodLabel(periodStart)} igen</h2>
+          <p className="m-0 mt-0.5 text-sm text-slate-500">
+            {row.full_name || 'Personen'} kan då rätta sin tid själv och lämna in på nytt.
+          </p>
+        </>
+      }
+      footer={
+        <>
+          <button
+            type="button"
+            onClick={onClose}
+            className="!py-2.5 flex-1 rounded-xl border border-solid border-[#dbe4d6] bg-white text-sm font-semibold text-slate-600 transition hover:border-slate-400 sm:flex-none sm:!px-5"
+          >
+            Avbryt
+          </button>
+          <button
+            type="button"
+            onClick={async () => { setBusy(true); await onSubmit(note.trim() || undefined); }}
+            disabled={busy}
+            className="!py-2.5 flex-1 rounded-xl text-sm font-semibold text-white shadow-sm transition hover:brightness-95 disabled:opacity-60 sm:ml-auto sm:flex-none sm:!px-5"
+            style={{ backgroundColor: 'var(--crm-primary)' }}
+          >
+            {busy ? 'Öppnar…' : 'Öppna igen'}
+          </button>
+        </>
+      }
+    >
+      <label className="grid gap-1">
+        <span className={LABEL}>Anledning (valfri)</span>
+        <textarea
+          value={note}
+          onChange={(e) => setNote(e.target.value)}
+          rows={3}
+          autoFocus
+          className="w-full rounded-xl border border-solid border-[#dbe4d6] bg-white px-3 py-2 text-sm text-slate-900"
+          placeholder="T.ex. Onsdag 12/8 saknar klockslag — fyll i och lämna in igen."
+        />
+        <span className="text-xs text-slate-500">Syns för {row.full_name || 'personen'} i Tidrapport.</span>
+      </label>
+    </CrmModal>
   );
 }
 
@@ -363,17 +687,16 @@ export default function AdminTimeApprovals() {
  * En persons månad, dag för dag.
  *
  * Lönepersonens enda uttryckliga krav (William 2026-08-14): hon vill se **starttid, sluttid och
- * total arbetad tid** när hon kontrollerar någons arbetstider. Aggregatet i tabellen ovanför går
- * inte att kontrollera — det ÄR summan av det man vill titta på.
+ * total arbetad tid** när hon kontrollerar någons arbetstider. Aggregatet i raden ovanför går inte
+ * att kontrollera — det ÄR summan av det man vill titta på.
  *
  * Kolumnerna följer byråns underlag (se TIME_AND_PAYROLL.md): datum, klockslag, arbetade timmar,
  * frånvarotimmar med orsak, anteckning. "Orsak / jobb" bär dessutom arbetsordern, vilket byrån inte
  * bett om — det är för kontorets egen granskning, som sedan piloten blåstes av är den enda
  * kontrollen som finns.
  *
- * Rader utan klockslag flaggas i stället för att visa ett tankstreck: de är kvar från kontorets
- * Tid-flik och ska bort innan klockslagen blir obligatoriska. En tom ruta hade sett ut som en
- * detalj; "saknas" är en uppgift.
+ * Rader utan klockslag flaggas i stället för att visa ett tankstreck: en tom ruta hade sett ut som
+ * en detalj, "saknas" är en uppgift.
  */
 function PersonDays({ detail, name }: { detail: PersonDetail | null; name: string | null }) {
   if (!detail || detail.loading) return <p className="m-0 text-sm text-slate-400">Laddar dagar…</p>;
@@ -400,9 +723,9 @@ function PersonDays({ detail, name }: { detail: PersonDetail | null; name: strin
     <div className="grid gap-3">
       {summary.rows.length > 0 ? (
         <div className="overflow-x-auto">
-          <table className="w-full min-w-[640px] border-collapse text-sm">
+          <table className="w-full min-w-[560px] border-collapse text-sm">
             <thead>
-              <tr className="text-left text-[11px] font-extrabold uppercase tracking-wide text-slate-500">
+              <tr className="text-left text-[11px] font-bold uppercase tracking-[0.12em] text-slate-600">
                 <th className="px-2 py-1.5">Datum</th>
                 <th className="px-2 py-1.5">Klockslag</th>
                 <th className="px-2 py-1.5 text-right">Arbetat</th>
@@ -469,7 +792,7 @@ function PersonDays({ detail, name }: { detail: PersonDetail | null; name: strin
 
       {detail.compensations.length > 0 ? (
         <div className="grid gap-1">
-          <p className="m-0 text-[11px] font-extrabold uppercase tracking-wide text-slate-500">Ersättningar</p>
+          <p className={cn(LABEL, 'm-0')}>Ersättningar</p>
           <ul className="m-0 grid list-none gap-1 p-0 text-sm text-slate-700">
             {detail.compensations.map((item) => {
               const unit = COMPENSATION_UNITS[item.kind];

--- a/app/admin/tid/AdminTimeApprovals.tsx
+++ b/app/admin/tid/AdminTimeApprovals.tsx
@@ -129,7 +129,13 @@ const EMPTY_DETAIL: PersonDetail = { loading: true, error: null, summary: null, 
 export default function AdminTimeApprovals() {
   const [period, setPeriod] = React.useState(currentPeriod);
   const [people, setPeople] = React.useState<TimeApprovalOverviewRow[]>([]);
-  const [loading, setLoading] = React.useState(true);
+  // Skelettet härleds ur VILKEN PERIOD som faktiskt är hämtad, det sätts inte för hand.
+  //
+  // Förut satte varje load() `loading = true`, även omladdningen efter en rättelse. Då byttes hela
+  // listan mot "Laddar…", sidan blev kort, och webbläsaren tappade scrollpositionen — man kastades
+  // till toppen efter varje sparning. Datan måste hämtas om (timmar, radantal och gruppens
+  // stapelskala kommer ur RPC:n), men vyn behöver inte rivas ner för det.
+  const [loadedPeriod, setLoadedPeriod] = React.useState<string | null>(null);
   const [error, setError] = React.useState<string | null>(null);
   const [notice, setNotice] = React.useState<string | null>(null);
   const [busyId, setBusyId] = React.useState<string | null>(null);
@@ -165,7 +171,6 @@ export default function AdminTimeApprovals() {
 
   const load = React.useCallback(async () => {
     const seq = ++loadSeq.current;
-    setLoading(true);
     setError(null);
     try {
       const res = await fetch(`/api/admin/time/approvals?period=${period}`, { cache: 'no-store', credentials: 'same-origin' });
@@ -182,9 +187,12 @@ export default function AdminTimeApprovals() {
         setPeople([]);
       }
     } finally {
-      if (seq === loadSeq.current) setLoading(false);
+      // Även efter ett fel: felrutan förklarar vad som hände, ett evigt skelett gör det inte.
+      if (seq === loadSeq.current) setLoadedPeriod(period);
     }
   }, [period]);
+
+  const loading = loadedPeriod !== period;
 
   React.useEffect(() => { void load(); }, [load]);
 
@@ -198,9 +206,12 @@ export default function AdminTimeApprovals() {
     setConfirmBulk(false);
   }, [period]);
 
-  const loadDetail = React.useCallback(async (userId: string) => {
+  const loadDetail = React.useCallback(async (userId: string, opts?: { keepVisible?: boolean }) => {
     const seq = ++detailSeq.current;
-    setDetail(EMPTY_DETAIL);
+    // `keepVisible` vid omladdning efter en rättelse: raderna byts ut när svaret kommer i stället
+    // för att ersättas av "Laddar dagar…" och tillbaka igen. En rad som blinkar bort och kommer
+    // åter flyttar allt under sig — och blicken med.
+    if (!opts?.keepVisible) setDetail(EMPTY_DETAIL);
     try {
       const res = await fetch(`/api/admin/time/entries?period=${period}&user_id=${userId}`, {
         cache: 'no-store',
@@ -247,7 +258,7 @@ export default function AdminTimeApprovals() {
       // och ett meddelande bakom den är ett meddelande ingen ser.
       if (!res.ok || !body?.ok) return body?.error || `Fel (${res.status})`;
       setNotice(patch ? 'Tidraden rättad.' : 'Tidraden borttagen.');
-      if (expandedId) await loadDetail(expandedId);
+      if (expandedId) await loadDetail(expandedId, { keepVisible: true });
       await load();
       return null;
     } catch {

--- a/app/admin/tid/AdminTimeApprovals.tsx
+++ b/app/admin/tid/AdminTimeApprovals.tsx
@@ -21,6 +21,7 @@ import {
 import type { PersonPeriodSummary } from '../../../lib/domains/time/summary';
 import {
   auditActionLabel,
+  auditWorkDate,
   describeAuditChange,
   type TimeEntryAuditRow,
 } from '../../../lib/domains/time/audit';
@@ -1069,14 +1070,20 @@ function AuditTrail({ rows, failed }: { rows: TimeEntryAuditRow[]; failed: boole
       <ul className="m-0 grid list-none gap-1.5 p-0">
         {rows.map((row) => {
           const changes = describeAuditChange(row);
+          // Dagen först: utan den går raden inte att koppla till något i tabellen ovanför.
+          const day = auditWorkDate(row);
           return (
             <li key={row.id} className="rounded-xl border border-solid border-[#e4ebe0] bg-white px-3 py-2 text-sm">
               <div className="flex flex-wrap items-baseline gap-x-2 text-slate-700">
-                <span className="font-semibold">{auditActionLabel(row.action)}</span>
+                <span className="font-semibold">{day ? formatDay(day) : 'Okänd dag'}</span>
+                <span>{auditActionLabel(row.action).toLowerCase()}</span>
                 <span className="text-slate-500">
                   {row.changed_by_profile?.full_name || 'okänd användare'} · {formatStamp(row.created_at)}
                 </span>
               </div>
+              {changes.length === 0 && row.action === 'update' ? (
+                <p className="m-0 mt-1 text-slate-500">Inga värden ändrades.</p>
+              ) : null}
               {changes.length > 0 ? (
                 <ul className="m-0 mt-1 grid list-none gap-0.5 p-0 text-slate-600">
                   {changes.map((change) => (

--- a/app/admin/tid/AdminTimeApprovals.tsx
+++ b/app/admin/tid/AdminTimeApprovals.tsx
@@ -1,6 +1,7 @@
 "use client";
 import React from 'react';
 import CrmModal from '@/app/crm/components/CrmModal';
+import AdminTimeCorrectionModal, { type CorrectionReference } from './AdminTimeCorrectionModal';
 import Input from '../../../components/ui/Input';
 import { cn } from '../../../lib/shared/cn';
 import { minutesToHours } from '../../../lib/domains/time/hours';
@@ -137,6 +138,20 @@ export default function AdminTimeApprovals() {
   const [confirmBulk, setConfirmBulk] = React.useState(false);
   const [bulkBusy, setBulkBusy] = React.useState(false);
   const [reopening, setReopening] = React.useState<TimeApprovalOverviewRow | null>(null);
+  const [correcting, setCorrecting] = React.useState<PersonPeriodSummary['rows'][number] | null>(null);
+  // Referenslistorna behövs bara när en rättelse öppnas, men hämtas en gång: de ändras sällan och
+  // ett anrop per modalöppning hade gjort knappen trög utan att ge något.
+  const [reference, setReference] = React.useState<CorrectionReference>({ time_code: [], internal_project: [], absence_type: [] });
+
+  React.useEffect(() => {
+    let active = true;
+    (async () => {
+      const res = await fetch('/api/time/reference', { cache: 'no-store', credentials: 'same-origin' });
+      const body = await res.json().catch(() => null);
+      if (active && res.ok && body?.ok) setReference(body.data);
+    })();
+    return () => { active = false; };
+  }, []);
 
   // En person i taget öppen. Fler samtidiga hade betytt fler tillstånd att hålla i takt med
   // perioden, och dagvyn läses en person åt gången ändå.
@@ -218,7 +233,7 @@ export default function AdminTimeApprovals() {
    *
    * Både dagvyn och personens summor ändras av en rättelse, så båda laddas om.
    */
-  const correctEntry = React.useCallback(async (entryId: string, patch: Record<string, unknown> | null) => {
+  const correctEntry = React.useCallback(async (entryId: string, patch: Record<string, unknown> | null): Promise<string | null> => {
     setError(null);
     setNotice(null);
     try {
@@ -228,14 +243,15 @@ export default function AdminTimeApprovals() {
         ...(patch ? { headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(patch) } : {}),
       });
       const body = await res.json().catch(() => null);
-      if (!res.ok || !body?.ok) { setError(body?.error || `Fel (${res.status})`); return false; }
+      // Felet RETURNERAS i stället för att bara skrivas i sidans felruta: rättelsen sker i en modal,
+      // och ett meddelande bakom den är ett meddelande ingen ser.
+      if (!res.ok || !body?.ok) return body?.error || `Fel (${res.status})`;
       setNotice(patch ? 'Tidraden rättad.' : 'Tidraden borttagen.');
       if (expandedId) await loadDetail(expandedId);
       await load();
-      return true;
+      return null;
     } catch {
-      setError('Kunde inte spara ändringen — kontrollera uppkopplingen');
-      return false;
+      return 'Kunde inte spara ändringen — kontrollera uppkopplingen';
     }
   }, [expandedId, loadDetail, load]);
 
@@ -522,11 +538,30 @@ export default function AdminTimeApprovals() {
               onToggle={() => toggleDetail(row.user_id)}
               onApprove={() => void setStatus(row, 'approved')}
               onReopen={() => setReopening(row)}
-              onCorrect={correctEntry}
+              onEdit={setCorrecting}
+              onDelete={async (entryId) => {
+                const failure = await correctEntry(entryId, null);
+                if (failure) setError(failure);
+                return !failure;
+              }}
             />
           ))}
         </ul>
       )}
+
+      {correcting ? (
+        <AdminTimeCorrectionModal
+          day={correcting}
+          reference={reference}
+          onClose={() => setCorrecting(null)}
+          onSave={async (patch) => {
+            const failure = await correctEntry(correcting.entryId!, patch);
+            if (failure) return failure;
+            setCorrecting(null);
+            return null;
+          }}
+        />
+      ) : null}
 
       {reopening ? (
         <ReopenModal
@@ -558,7 +593,7 @@ export default function AdminTimeApprovals() {
  * en månad med mycket frånvaro har kort arbetsstapel av ett skäl man ska kunna se, inte gissa.
  */
 function PersonRow({
-  row, scaleMinutes, expanded, detail, busy, onToggle, onApprove, onReopen, onCorrect,
+  row, scaleMinutes, expanded, detail, busy, onToggle, onApprove, onReopen, onEdit, onDelete,
 }: {
   row: TimeApprovalOverviewRow;
   scaleMinutes: number;
@@ -568,7 +603,8 @@ function PersonRow({
   onToggle: () => void;
   onApprove: () => void;
   onReopen: () => void;
-  onCorrect: (entryId: string, patch: Record<string, unknown> | null) => Promise<boolean>;
+  onEdit: (day: PersonPeriodSummary['rows'][number]) => void;
+  onDelete: (entryId: string) => Promise<boolean>;
 }) {
   const locked = isPeriodLocked(row.status);
   const workPercent = Math.round((row.work_minutes / scaleMinutes) * 100);
@@ -672,7 +708,7 @@ function PersonRow({
         <div className="border-x-0 border-b-0 border-t border-solid border-[#e4ebe0] bg-[#f9fbf7] px-4 py-3">
           {/* Rättelse bara i en öppen period. Är månaden inlämnad eller attesterad avvisar databasen
               ändringen ändå — knappen döljs för att slippa be någon trycka på något som inte går. */}
-          <PersonDays detail={detail} name={row.full_name} canCorrect={!locked} onCorrect={onCorrect} />
+          <PersonDays detail={detail} name={row.full_name} canCorrect={!locked} onEdit={onEdit} onDelete={onDelete} />
         </div>
       ) : null}
     </li>
@@ -778,12 +814,13 @@ function ReopenModal({
  * en detalj, "saknas" är en uppgift.
  */
 function PersonDays({
-  detail, name, canCorrect, onCorrect,
+  detail, name, canCorrect, onEdit, onDelete,
 }: {
   detail: PersonDetail | null;
   name: string | null;
   canCorrect: boolean;
-  onCorrect: (entryId: string, patch: Record<string, unknown> | null) => Promise<boolean>;
+  onEdit: (day: PersonPeriodSummary['rows'][number]) => void;
+  onDelete: (entryId: string) => Promise<boolean>;
 }) {
   if (!detail || detail.loading) return <p className="m-0 text-sm text-slate-400">Laddar dagar…</p>;
   if (detail.error) {
@@ -827,7 +864,8 @@ function PersonDays({
                   key={day.entryId || `${day.date}-${index}`}
                   day={day}
                   canCorrect={canCorrect}
-                  onCorrect={onCorrect}
+                  onEdit={onEdit}
+                  onDelete={onDelete}
                 />
               ))}
             </tbody>
@@ -892,13 +930,13 @@ function PersonDays({
  * Frånvaro har inga klockslag — byrån vill ha den i timmar — så den får ett timfält i stället.
  */
 function DayRowCells({
-  day, canCorrect, onCorrect,
+  day, canCorrect, onEdit, onDelete,
 }: {
   day: PersonPeriodSummary['rows'][number];
   canCorrect: boolean;
-  onCorrect: (entryId: string, patch: Record<string, unknown> | null) => Promise<boolean>;
+  onEdit: (day: PersonPeriodSummary['rows'][number]) => void;
+  onDelete: (entryId: string) => Promise<boolean>;
 }) {
-  const [editing, setEditing] = React.useState(false);
   const [confirmDelete, setConfirmDelete] = React.useState(false);
   const [busy, setBusy] = React.useState(false);
 
@@ -906,77 +944,10 @@ function DayRowCells({
   const end = formatClock(day.endTime);
   const isAbsence = day.absenceMinutes > 0;
 
-  const [draftStart, setDraftStart] = React.useState(start || '');
-  const [draftEnd, setDraftEnd] = React.useState(end || '');
-  const [draftBreak, setDraftBreak] = React.useState(String(day.breakMinutes));
-  const [draftHours, setDraftHours] = React.useState(String(minutesToHours(day.absenceMinutes)));
 
   // Rättelse kräver att raden går att peka ut. Saknas id:t är den läsbar men inte ändringsbar —
   // hellre ingen knapp än en som svarar 404.
   const editable = canCorrect && !!day.entryId;
-
-  async function save() {
-    if (!day.entryId) return;
-    setBusy(true);
-    const patch = isAbsence
-      ? { hours: Number(draftHours.replace(',', '.')) }
-      : { start_time: draftStart, end_time: draftEnd, break_minutes: Number(draftBreak) || 0 };
-    const okDone = await onCorrect(day.entryId, patch);
-    setBusy(false);
-    if (okDone) setEditing(false);
-  }
-
-  if (editing) {
-    return (
-      <tr className="border-x-0 border-b-0 border-t border-solid border-slate-200 align-top">
-        <td className="whitespace-nowrap px-2 py-1.5 text-slate-700">{formatDay(day.date)}</td>
-        <td className="px-2 py-1.5" colSpan={5}>
-          <div className="flex flex-wrap items-end gap-2">
-            {isAbsence ? (
-              <label className="grid gap-1">
-                <span className={LABEL}>Frånvarotimmar</span>
-                <span className="inline-block w-24">
-                  <Input inputMode="decimal" value={draftHours} onChange={(e) => setDraftHours(e.target.value)} />
-                </span>
-              </label>
-            ) : (
-              <>
-                <label className="grid gap-1">
-                  <span className={LABEL}>Start</span>
-                  <span className="inline-block w-28"><Input type="time" value={draftStart} onChange={(e) => setDraftStart(e.target.value)} /></span>
-                </label>
-                <label className="grid gap-1">
-                  <span className={LABEL}>Slut</span>
-                  <span className="inline-block w-28"><Input type="time" value={draftEnd} onChange={(e) => setDraftEnd(e.target.value)} /></span>
-                </label>
-                <label className="grid gap-1">
-                  <span className={LABEL}>Rast (min)</span>
-                  <span className="inline-block w-20"><Input inputMode="numeric" value={draftBreak} onChange={(e) => setDraftBreak(e.target.value)} /></span>
-                </label>
-              </>
-            )}
-          </div>
-        </td>
-        <td className="whitespace-nowrap px-2 py-1.5 text-right">
-          <button
-            type="button"
-            onClick={() => void save()}
-            disabled={busy}
-            className="!px-3 !py-1.5 rounded-lg border border-solid border-emerald-300 bg-emerald-50 text-sm font-semibold text-emerald-800 disabled:opacity-60"
-          >
-            {busy ? 'Sparar…' : 'Spara'}
-          </button>
-          <button
-            type="button"
-            onClick={() => setEditing(false)}
-            className="!px-2 !py-1.5 ml-1 rounded-lg text-sm font-semibold text-slate-500"
-          >
-            Avbryt
-          </button>
-        </td>
-      </tr>
-    );
-  }
 
   return (
     <tr className="border-x-0 border-b-0 border-t border-solid border-slate-200 align-top">
@@ -1007,7 +978,7 @@ function DayRowCells({
               <span className="text-slate-500">Ta bort?</span>
               <button
                 type="button"
-                onClick={async () => { setBusy(true); await onCorrect(day.entryId!, null); setBusy(false); setConfirmDelete(false); }}
+                onClick={async () => { setBusy(true); await onDelete(day.entryId!); setBusy(false); setConfirmDelete(false); }}
                 disabled={busy}
                 className="!p-0 font-semibold text-rose-600 disabled:opacity-50"
               >
@@ -1019,16 +990,7 @@ function DayRowCells({
             <span className="flex items-center justify-end gap-3 text-sm">
               <button
                 type="button"
-                onClick={() => {
-                  // ⚠️ RASTEN MÅSTE SÅS OM. Utan den raden ligger formulärets nolla kvar och
-                  // rättelsen skickar break_minutes: 0 — servern räknar då om passet UTAN
-                  // rastavdrag och lägger till minuter på någons lön.
-                  setDraftStart(start || '');
-                  setDraftEnd(end || '');
-                  setDraftBreak(String(day.breakMinutes));
-                  setDraftHours(String(minutesToHours(day.absenceMinutes)));
-                  setEditing(true);
-                }}
+                onClick={() => onEdit(day)}
                 className="!p-0 font-medium text-slate-600 underline underline-offset-2"
               >
                 Rätta

--- a/app/admin/tid/AdminTimeApprovals.tsx
+++ b/app/admin/tid/AdminTimeApprovals.tsx
@@ -344,44 +344,49 @@ export default function AdminTimeApprovals() {
 
       {/* Periodhuvud. Två frågor, åtskilda med flit: hur långt har jag kommit (framstegen) och hur
           stora är summorna (underlaget). Förut låg båda som sex likadana badges i rad. */}
-      <section className="grid gap-3 rounded-2xl border border-solid border-[#e0e8dc] bg-[#f9fbf7] p-3.5">
-        <div className="flex flex-wrap items-end justify-between gap-3">
-          <label className="grid gap-1">
-            <span className={LABEL}>Period</span>
-            <span className="inline-block w-40">
-              {/* Låst under massattesten. Loopen tar sekunder, och dess avslutande omladdning gäller
-                  den period den startade i: byter man månad mitt i vinner den sist startade
-                  hämtningen och målar föregående månads rader under den nya rubriken — varpå nästa
-                  "Attestera" postar fel månad på siffror som hör till en annan. */}
-              <Input
-                type="month"
-                value={period}
-                disabled={bulkBusy}
-                onChange={(e) => setPeriod(e.target.value || currentPeriod())}
-              />
-            </span>
-          </label>
-
-          <div className="grid gap-1 text-right">
-            <span className={LABEL}>Attesterade</span>
-            <span className="text-lg font-bold tabular-nums text-slate-900">
-              {totals.approved} <span className="text-sm font-semibold text-slate-500">av {people.length}</span>
-            </span>
-          </div>
-        </div>
+      {/* En rad, tre kolumner — inte tre fullbreddsblock under varandra. På en 1200 px-yta blir
+          staplade block bara innehåll som klistras mot ytterkanterna med luft i mitten. */}
+      <section className="flex flex-wrap items-end gap-x-6 gap-y-3 rounded-2xl border border-solid border-[#e0e8dc] bg-[#f9fbf7] p-3.5">
+        <label className="grid gap-1">
+          <span className={LABEL}>Period</span>
+          <span className="inline-block w-40">
+            {/* Låst under massattesten. Loopen tar sekunder, och dess avslutande omladdning gäller
+                den period den startade i: byter man månad mitt i vinner den sist startade
+                hämtningen och målar föregående månads rader under den nya rubriken — varpå nästa
+                "Attestera" postar fel månad på siffror som hör till en annan. */}
+            <Input
+              type="month"
+              value={period}
+              disabled={bulkBusy}
+              onChange={(e) => setPeriod(e.target.value || currentPeriod())}
+            />
+          </span>
+        </label>
 
         {people.length > 0 ? (
-          <div className="flex h-2 gap-0.5 overflow-hidden rounded-full">
-            {people.map((row) => (
-              <span key={row.user_id} className={cn('flex-1', STATUS_RAIL[row.status])} aria-hidden />
-            ))}
+          <div className="grid min-w-[220px] max-w-[420px] flex-1 gap-1">
+            <span className={LABEL}>Attesterade</span>
+            <span className="flex items-center gap-3">
+              <span className="whitespace-nowrap text-lg font-bold leading-none tabular-nums text-slate-900">
+                {totals.approved} <span className="text-sm font-semibold text-slate-500">av {people.length}</span>
+              </span>
+              {/* Ett segment per person, färgat av status: månadens form på en blick. */}
+              <span className="flex h-2 flex-1 gap-0.5 overflow-hidden rounded-full">
+                {people.map((row) => (
+                  <span key={row.user_id} className={cn('flex-1', STATUS_RAIL[row.status])} aria-hidden />
+                ))}
+              </span>
+            </span>
           </div>
         ) : null}
 
-        <div className="flex flex-wrap gap-x-4 gap-y-1 text-sm text-slate-600">
-          <span>Arbetat <strong className="tabular-nums text-slate-900">{formatHours(totals.work)} h</strong></span>
-          {totals.absence > 0 ? <span>Frånvaro <strong className="tabular-nums text-amber-800">{formatHours(totals.absence)} h</strong></span> : null}
-          {totals.compensation > 0 ? <span>Ersättningar <strong className="tabular-nums text-slate-900">{formatAmount(totals.compensation)} kr</strong></span> : null}
+        <div className="grid gap-1">
+          <span className={LABEL}>Underlag</span>
+          <span className="flex flex-wrap gap-x-4 gap-y-1 text-sm leading-none text-slate-600">
+            <span>Arbetat <strong className="tabular-nums text-slate-900">{formatHours(totals.work)} h</strong></span>
+            {totals.absence > 0 ? <span>Frånvaro <strong className="tabular-nums text-amber-800">{formatHours(totals.absence)} h</strong></span> : null}
+            {totals.compensation > 0 ? <span>Ersättningar <strong className="tabular-nums text-slate-900">{formatAmount(totals.compensation)} kr</strong></span> : null}
+          </span>
         </div>
       </section>
 
@@ -534,90 +539,91 @@ function PersonRow({
 
   return (
     <li className="overflow-hidden rounded-2xl border border-solid border-[#e0e8dc] bg-[#f9fbf7]">
+      {/* EN rad med kolumner, inte tre band under varandra. Staplade fullbreddsblock på en yta som
+          är över tusen pixlar bred ger innehåll klistrat mot ytterkanterna och luft i mitten — och
+          en stapel som spänner hela bredden läser som en trasig avdelare, inte som ett mått.
+          Kolumnerna radbryts i stället på smala skärmar. */}
       <div className="flex">
         <span className={cn('w-1 shrink-0', STATUS_RAIL[row.status])} aria-hidden />
 
-        <div className="min-w-0 flex-1 grid gap-2 px-3.5 py-3">
-          <div className="flex flex-wrap items-start justify-between gap-x-3 gap-y-1">
-            <button
-              type="button"
-              onClick={onToggle}
-              aria-expanded={expanded}
-              className="!inline-flex !items-baseline !justify-start !gap-2 !p-0 !text-left min-w-0"
-            >
-              <span aria-hidden className={cn('text-slate-400 transition-transform', expanded ? 'rotate-90' : '')}>›</span>
-              <span className="min-w-0">
-                <span className="block truncate font-semibold text-slate-900 underline-offset-2 hover:underline">
-                  {row.full_name || '(namn saknas)'}
-                </span>
-                <span className="block text-xs text-slate-400">{row.role}</span>
+        <div className="min-w-0 flex-1 flex flex-wrap items-center gap-x-5 gap-y-2 px-4 py-2.5">
+          {/* Namn + den lilla historiken. Roll och tidsstämpel på samma rad sparar ett band. */}
+          <button
+            type="button"
+            onClick={onToggle}
+            aria-expanded={expanded}
+            className="!inline-flex !items-baseline !justify-start !gap-2 !p-0 !text-left min-w-[180px] flex-1"
+          >
+            <span aria-hidden className={cn('shrink-0 text-slate-400 transition-transform', expanded ? 'rotate-90' : '')}>›</span>
+            <span className="min-w-0">
+              <span className="block truncate font-semibold text-slate-900 underline-offset-2 hover:underline">
+                {row.full_name || '(namn saknas)'}
               </span>
-            </button>
-
-            <div className="flex flex-wrap items-center gap-2">
-              {/* Noll rader på en person som ska ha rapporterat är det attesten finns för att
-                  upptäcka — därför en egen flagga och inte bara en siffra i en kolumn. */}
-              {row.entry_count === 0 ? (
-                <span className="whitespace-nowrap rounded-full border border-solid border-amber-200 bg-amber-50 px-2.5 py-0.5 text-[11px] font-semibold text-amber-800">
-                  Inget rapporterat
-                </span>
-              ) : null}
-              <span className={cn('whitespace-nowrap rounded-full px-2.5 py-0.5 text-[11px] font-semibold', STATUS_TONE[row.status])}>
-                {TIME_PERIOD_STATUS_LABELS[row.status]}
+              <span className="block truncate text-xs text-slate-400">
+                {row.role}
+                {row.status === 'submitted' && row.submitted_at ? ` · Inlämnad ${formatStamp(row.submitted_at)}` : null}
+                {row.status === 'approved' && row.approved_at
+                  ? ` · Attesterad ${formatStamp(row.approved_at)}${row.approved_by_name ? ` av ${row.approved_by_name}` : ''}`
+                  : null}
+                {row.status === 'open' && row.note ? ` · Öppnad igen: ${row.note}` : null}
               </span>
-            </div>
-          </div>
+            </span>
+          </button>
 
-          <div className="grid gap-1">
-            <div className="flex h-1.5 overflow-hidden rounded-full bg-[#e8eee4]">
+          {/* Måttet: stapeln är avgränsad och står bredvid talet den mäter, inte över hela raden. */}
+          <div className="flex min-w-[210px] flex-1 items-center gap-3">
+            <span className="flex h-1.5 w-24 shrink-0 overflow-hidden rounded-full bg-[#e8eee4]">
               <span className="bg-[#4a7a58]" style={{ width: `${workPercent}%` }} aria-hidden />
               <span className="bg-amber-400" style={{ width: `${absencePercent}%` }} aria-hidden />
-            </div>
-            <div className="flex flex-wrap items-baseline gap-x-3 gap-y-0.5 text-sm">
+            </span>
+            <span className="flex flex-wrap items-baseline gap-x-2.5 gap-y-0.5 text-sm">
               <strong className="tabular-nums text-slate-900">{formatHours(row.work_minutes)} h</strong>
               {row.absence_minutes > 0 ? (
-                <span className="tabular-nums text-amber-800">{formatHours(row.absence_minutes)} h frånvaro</span>
+                <span className="whitespace-nowrap tabular-nums text-amber-800">{formatHours(row.absence_minutes)} h frånvaro</span>
               ) : null}
-              <span className="text-slate-500">
+              <span className="whitespace-nowrap text-slate-500">
                 <span className="tabular-nums">{row.entry_count}</span> {row.entry_count === 1 ? 'rad' : 'rader'}
               </span>
               {row.compensation_count > 0 ? (
-                <span className="text-slate-500"><span className="tabular-nums">{formatAmount(row.compensation_amount)}</span> kr i ersättning</span>
+                <span className="whitespace-nowrap text-slate-500"><span className="tabular-nums">{formatAmount(row.compensation_amount)}</span> kr</span>
               ) : null}
-            </div>
+            </span>
           </div>
 
-          <div className="flex flex-wrap items-center justify-between gap-2">
-            <span className="text-xs text-slate-500">
-              {row.status === 'submitted' && row.submitted_at ? `Inlämnad ${formatStamp(row.submitted_at)}` : null}
-              {row.status === 'approved' && row.approved_at
-                ? `Attesterad ${formatStamp(row.approved_at)}${row.approved_by_name ? ` av ${row.approved_by_name}` : ''}`
-                : null}
-              {row.status === 'open' && row.note ? `Öppnad igen: ${row.note}` : null}
+          <div className="flex shrink-0 items-center gap-2">
+            {/* Noll rader på en person som ska ha rapporterat är det attesten finns för att
+                upptäcka — därför en egen flagga och inte bara en siffra i en kolumn. */}
+            {row.entry_count === 0 ? (
+              <span className="whitespace-nowrap rounded-full border border-solid border-amber-200 bg-amber-50 px-2.5 py-0.5 text-[11px] font-semibold text-amber-800">
+                Inget rapporterat
+              </span>
+            ) : null}
+            <span className={cn('whitespace-nowrap rounded-full px-2.5 py-0.5 text-[11px] font-semibold', STATUS_TONE[row.status])}>
+              {TIME_PERIOD_STATUS_LABELS[row.status]}
             </span>
+          </div>
 
-            <span className="flex flex-wrap gap-2">
-              {row.status !== 'approved' ? (
-                <button
-                  type="button"
-                  onClick={onApprove}
-                  disabled={busy}
-                  className="!px-3 !py-1.5 rounded-lg border border-solid border-emerald-300 bg-emerald-50 text-sm font-semibold text-emerald-800 transition hover:border-emerald-400 disabled:opacity-60"
-                >
-                  Attestera
-                </button>
-              ) : null}
-              {locked ? (
-                <button
-                  type="button"
-                  onClick={onReopen}
-                  disabled={busy}
-                  className="!px-3 !py-1.5 rounded-lg border border-solid border-[#dbe4d6] bg-white text-sm font-semibold text-slate-700 transition hover:border-slate-400 disabled:opacity-60"
-                >
-                  Öppna igen
-                </button>
-              ) : null}
-            </span>
+          <div className="flex shrink-0 gap-2">
+            {row.status !== 'approved' ? (
+              <button
+                type="button"
+                onClick={onApprove}
+                disabled={busy}
+                className="!px-3 !py-1.5 rounded-lg border border-solid border-emerald-300 bg-emerald-50 text-sm font-semibold text-emerald-800 transition hover:border-emerald-400 disabled:opacity-60"
+              >
+                Attestera
+              </button>
+            ) : null}
+            {locked ? (
+              <button
+                type="button"
+                onClick={onReopen}
+                disabled={busy}
+                className="!px-3 !py-1.5 rounded-lg border border-solid border-[#dbe4d6] bg-white text-sm font-semibold text-slate-700 transition hover:border-slate-400 disabled:opacity-60"
+              >
+                Öppna igen
+              </button>
+            ) : null}
           </div>
         </div>
       </div>

--- a/app/admin/tid/AdminTimeApprovals.tsx
+++ b/app/admin/tid/AdminTimeApprovals.tsx
@@ -209,6 +209,36 @@ export default function AdminTimeApprovals() {
     }
   }, [period]);
 
+  /**
+   * Rätta eller ta bort någon annans tidrad.
+   *
+   * Går bara i en ÖPPEN period — låstriggern prövar radens ägare, så en attesterad månad avvisas av
+   * databasen även om knappen skulle råka visas. Varje ändring loggas av en databastrigger, inte
+   * härifrån: en väg som glömmer logga ska inte kunna finnas.
+   *
+   * Både dagvyn och personens summor ändras av en rättelse, så båda laddas om.
+   */
+  const correctEntry = React.useCallback(async (entryId: string, patch: Record<string, unknown> | null) => {
+    setError(null);
+    setNotice(null);
+    try {
+      const res = await fetch(`/api/admin/time/entries/${entryId}`, {
+        method: patch ? 'PATCH' : 'DELETE',
+        credentials: 'same-origin',
+        ...(patch ? { headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(patch) } : {}),
+      });
+      const body = await res.json().catch(() => null);
+      if (!res.ok || !body?.ok) { setError(body?.error || `Fel (${res.status})`); return false; }
+      setNotice(patch ? 'Tidraden rättad.' : 'Tidraden borttagen.');
+      if (expandedId) await loadDetail(expandedId);
+      await load();
+      return true;
+    } catch {
+      setError('Kunde inte spara ändringen — kontrollera uppkopplingen');
+      return false;
+    }
+  }, [expandedId, loadDetail, load]);
+
   function toggleDetail(userId: string) {
     if (expandedId === userId) {
       detailSeq.current++;
@@ -492,6 +522,7 @@ export default function AdminTimeApprovals() {
               onToggle={() => toggleDetail(row.user_id)}
               onApprove={() => void setStatus(row, 'approved')}
               onReopen={() => setReopening(row)}
+              onCorrect={correctEntry}
             />
           ))}
         </ul>
@@ -527,7 +558,7 @@ export default function AdminTimeApprovals() {
  * en månad med mycket frånvaro har kort arbetsstapel av ett skäl man ska kunna se, inte gissa.
  */
 function PersonRow({
-  row, scaleMinutes, expanded, detail, busy, onToggle, onApprove, onReopen,
+  row, scaleMinutes, expanded, detail, busy, onToggle, onApprove, onReopen, onCorrect,
 }: {
   row: TimeApprovalOverviewRow;
   scaleMinutes: number;
@@ -537,6 +568,7 @@ function PersonRow({
   onToggle: () => void;
   onApprove: () => void;
   onReopen: () => void;
+  onCorrect: (entryId: string, patch: Record<string, unknown> | null) => Promise<boolean>;
 }) {
   const locked = isPeriodLocked(row.status);
   const workPercent = Math.round((row.work_minutes / scaleMinutes) * 100);
@@ -638,7 +670,9 @@ function PersonRow({
 
       {expanded ? (
         <div className="border-x-0 border-b-0 border-t border-solid border-[#e4ebe0] bg-[#f9fbf7] px-4 py-3">
-          <PersonDays detail={detail} name={row.full_name} />
+          {/* Rättelse bara i en öppen period. Är månaden inlämnad eller attesterad avvisar databasen
+              ändringen ändå — knappen döljs för att slippa be någon trycka på något som inte går. */}
+          <PersonDays detail={detail} name={row.full_name} canCorrect={!locked} onCorrect={onCorrect} />
         </div>
       ) : null}
     </li>
@@ -743,7 +777,14 @@ function ReopenModal({
  * Rader utan klockslag flaggas i stället för att visa ett tankstreck: en tom ruta hade sett ut som
  * en detalj, "saknas" är en uppgift.
  */
-function PersonDays({ detail, name }: { detail: PersonDetail | null; name: string | null }) {
+function PersonDays({
+  detail, name, canCorrect, onCorrect,
+}: {
+  detail: PersonDetail | null;
+  name: string | null;
+  canCorrect: boolean;
+  onCorrect: (entryId: string, patch: Record<string, unknown> | null) => Promise<boolean>;
+}) {
   if (!detail || detail.loading) return <p className="m-0 text-sm text-slate-400">Laddar dagar…</p>;
   if (detail.error) {
     return (
@@ -777,38 +818,18 @@ function PersonDays({ detail, name }: { detail: PersonDetail | null; name: strin
                 <th className="px-2 py-1.5 text-right">Frånvaro</th>
                 <th className="px-2 py-1.5">Orsak / jobb</th>
                 <th className="px-2 py-1.5">Anteckning</th>
+                {canCorrect ? <th className="px-2 py-1.5" /> : null}
               </tr>
             </thead>
             <tbody>
-              {summary.rows.map((day, index) => {
-                const start = formatClock(day.startTime);
-                const end = formatClock(day.endTime);
-                const isAbsence = day.absenceMinutes > 0;
-                return (
-                  <tr key={`${day.date}-${index}`} className="border-x-0 border-b-0 border-t border-solid border-slate-200 align-top">
-                    <td className="whitespace-nowrap px-2 py-1.5 text-slate-700">{formatDay(day.date)}</td>
-                    <td className="whitespace-nowrap px-2 py-1.5 tabular-nums text-slate-700">
-                      {start && end ? (
-                        `${start}–${end}`
-                      ) : isAbsence ? (
-                        <span className="text-slate-400">—</span>
-                      ) : (
-                        <span className="font-semibold text-amber-700">saknas</span>
-                      )}
-                    </td>
-                    <td className="whitespace-nowrap px-2 py-1.5 text-right tabular-nums text-slate-900">
-                      {day.workMinutes > 0 ? `${formatHours(day.workMinutes)} h` : '—'}
-                    </td>
-                    <td className="whitespace-nowrap px-2 py-1.5 text-right tabular-nums text-slate-600">
-                      {day.absenceMinutes > 0 ? `${formatHours(day.absenceMinutes)} h` : '—'}
-                    </td>
-                    <td className="px-2 py-1.5 text-slate-600">
-                      {day.absenceReasons.length > 0 ? day.absenceReasons.join(', ') : day.label || '—'}
-                    </td>
-                    <td className="px-2 py-1.5 text-slate-500">{day.note || ''}</td>
-                  </tr>
-                );
-              })}
+              {summary.rows.map((day, index) => (
+                <DayRowCells
+                  key={day.entryId || `${day.date}-${index}`}
+                  day={day}
+                  canCorrect={canCorrect}
+                  onCorrect={onCorrect}
+                />
+              ))}
             </tbody>
             <tfoot>
               <tr className="border-x-0 border-b-0 border-t-2 border-solid border-slate-300 font-semibold text-slate-900">
@@ -817,7 +838,7 @@ function PersonDays({ detail, name }: { detail: PersonDetail | null; name: strin
                 <td className="whitespace-nowrap px-2 py-2 text-right tabular-nums">
                   {summary.absenceMinutes > 0 ? `${formatHours(summary.absenceMinutes)} h` : '—'}
                 </td>
-                <td colSpan={2} />
+                <td colSpan={canCorrect ? 3 : 2} />
               </tr>
             </tfoot>
           </table>
@@ -857,5 +878,164 @@ function PersonDays({ detail, name }: { detail: PersonDetail | null; name: strin
         </div>
       ) : null}
     </div>
+  );
+}
+
+/**
+ * En dag i underlaget — och, i en öppen period, raden man rättar.
+ *
+ * Rättelsen ändrar BARA klockslag, rast och frånvarotimmar. Vilket jobb raden hör till, vilken dag
+ * den ligger på och om den är arbete eller frånvaro kommer alltid från raden själv (mergeCorrection
+ * i lib/domains/time/entries.ts). Skillnaden är avsiktlig: att laga ett felskrivet klockslag är en
+ * sak, att skriva om någons löneunderlag en annan.
+ *
+ * Frånvaro har inga klockslag — byrån vill ha den i timmar — så den får ett timfält i stället.
+ */
+function DayRowCells({
+  day, canCorrect, onCorrect,
+}: {
+  day: PersonPeriodSummary['rows'][number];
+  canCorrect: boolean;
+  onCorrect: (entryId: string, patch: Record<string, unknown> | null) => Promise<boolean>;
+}) {
+  const [editing, setEditing] = React.useState(false);
+  const [confirmDelete, setConfirmDelete] = React.useState(false);
+  const [busy, setBusy] = React.useState(false);
+
+  const start = formatClock(day.startTime);
+  const end = formatClock(day.endTime);
+  const isAbsence = day.absenceMinutes > 0;
+
+  const [draftStart, setDraftStart] = React.useState(start || '');
+  const [draftEnd, setDraftEnd] = React.useState(end || '');
+  const [draftBreak, setDraftBreak] = React.useState('0');
+  const [draftHours, setDraftHours] = React.useState(String(minutesToHours(day.absenceMinutes)));
+
+  // Rättelse kräver att raden går att peka ut. Saknas id:t är den läsbar men inte ändringsbar —
+  // hellre ingen knapp än en som svarar 404.
+  const editable = canCorrect && !!day.entryId;
+
+  async function save() {
+    if (!day.entryId) return;
+    setBusy(true);
+    const patch = isAbsence
+      ? { hours: Number(draftHours.replace(',', '.')) }
+      : { start_time: draftStart, end_time: draftEnd, break_minutes: Number(draftBreak) || 0 };
+    const okDone = await onCorrect(day.entryId, patch);
+    setBusy(false);
+    if (okDone) setEditing(false);
+  }
+
+  if (editing) {
+    return (
+      <tr className="border-x-0 border-b-0 border-t border-solid border-slate-200 align-top">
+        <td className="whitespace-nowrap px-2 py-1.5 text-slate-700">{formatDay(day.date)}</td>
+        <td className="px-2 py-1.5" colSpan={4}>
+          <div className="flex flex-wrap items-end gap-2">
+            {isAbsence ? (
+              <label className="grid gap-1">
+                <span className={LABEL}>Frånvarotimmar</span>
+                <span className="inline-block w-24">
+                  <Input inputMode="decimal" value={draftHours} onChange={(e) => setDraftHours(e.target.value)} />
+                </span>
+              </label>
+            ) : (
+              <>
+                <label className="grid gap-1">
+                  <span className={LABEL}>Start</span>
+                  <span className="inline-block w-28"><Input type="time" value={draftStart} onChange={(e) => setDraftStart(e.target.value)} /></span>
+                </label>
+                <label className="grid gap-1">
+                  <span className={LABEL}>Slut</span>
+                  <span className="inline-block w-28"><Input type="time" value={draftEnd} onChange={(e) => setDraftEnd(e.target.value)} /></span>
+                </label>
+                <label className="grid gap-1">
+                  <span className={LABEL}>Rast (min)</span>
+                  <span className="inline-block w-20"><Input inputMode="numeric" value={draftBreak} onChange={(e) => setDraftBreak(e.target.value)} /></span>
+                </label>
+              </>
+            )}
+          </div>
+        </td>
+        <td className="whitespace-nowrap px-2 py-1.5 text-right">
+          <button
+            type="button"
+            onClick={() => void save()}
+            disabled={busy}
+            className="!px-3 !py-1.5 rounded-lg border border-solid border-emerald-300 bg-emerald-50 text-sm font-semibold text-emerald-800 disabled:opacity-60"
+          >
+            {busy ? 'Sparar…' : 'Spara'}
+          </button>
+          <button
+            type="button"
+            onClick={() => setEditing(false)}
+            className="!px-2 !py-1.5 ml-1 rounded-lg text-sm font-semibold text-slate-500"
+          >
+            Avbryt
+          </button>
+        </td>
+      </tr>
+    );
+  }
+
+  return (
+    <tr className="border-x-0 border-b-0 border-t border-solid border-slate-200 align-top">
+      <td className="whitespace-nowrap px-2 py-1.5 text-slate-700">{formatDay(day.date)}</td>
+      <td className="whitespace-nowrap px-2 py-1.5 tabular-nums text-slate-700">
+        {start && end ? (
+          `${start}–${end}`
+        ) : isAbsence ? (
+          <span className="text-slate-400">—</span>
+        ) : (
+          <span className="font-semibold text-amber-700">saknas</span>
+        )}
+      </td>
+      <td className="whitespace-nowrap px-2 py-1.5 text-right tabular-nums text-slate-900">
+        {day.workMinutes > 0 ? `${formatHours(day.workMinutes)} h` : '—'}
+      </td>
+      <td className="whitespace-nowrap px-2 py-1.5 text-right tabular-nums text-slate-600">
+        {day.absenceMinutes > 0 ? `${formatHours(day.absenceMinutes)} h` : '—'}
+      </td>
+      <td className="px-2 py-1.5 text-slate-600">
+        {day.absenceReasons.length > 0 ? day.absenceReasons.join(', ') : day.label || '—'}
+      </td>
+      <td className="px-2 py-1.5 text-slate-500">{day.note || ''}</td>
+      {canCorrect ? (
+        <td className="whitespace-nowrap px-2 py-1.5 text-right">
+          {!editable ? null : confirmDelete ? (
+            <span className="flex items-center justify-end gap-2 text-sm">
+              <span className="text-slate-500">Ta bort?</span>
+              <button
+                type="button"
+                onClick={async () => { setBusy(true); await onCorrect(day.entryId!, null); setBusy(false); setConfirmDelete(false); }}
+                disabled={busy}
+                className="!p-0 font-semibold text-rose-600 disabled:opacity-50"
+              >
+                Ja
+              </button>
+              <button type="button" onClick={() => setConfirmDelete(false)} className="!p-0 text-slate-400">Nej</button>
+            </span>
+          ) : (
+            <span className="flex items-center justify-end gap-3 text-sm">
+              <button
+                type="button"
+                onClick={() => {
+                  setDraftStart(start || '');
+                  setDraftEnd(end || '');
+                  setDraftHours(String(minutesToHours(day.absenceMinutes)));
+                  setEditing(true);
+                }}
+                className="!p-0 font-medium text-slate-600 underline underline-offset-2"
+              >
+                Rätta
+              </button>
+              <button type="button" onClick={() => setConfirmDelete(true)} className="!p-0 font-medium text-slate-400 hover:text-rose-600">
+                Ta bort
+              </button>
+            </span>
+          )}
+        </td>
+      ) : null}
+    </tr>
   );
 }

--- a/app/admin/tid/AdminTimeCorrectionModal.tsx
+++ b/app/admin/tid/AdminTimeCorrectionModal.tsx
@@ -59,14 +59,15 @@ export default function AdminTimeCorrectionModal({
   /** Returnerar felmeddelandet, eller null när det gick bra. */
   onSave: (patch: Record<string, unknown>) => Promise<string | null>;
 }) {
-  const isAbsenceRow = day.absenceMinutes > 0;
-
-  const [kind, setKind] = React.useState<Kind>(isAbsenceRow ? 'absence' : 'work_order');
+  // Sorten kommer från RADEN, inte ur siffrorna: en internrad har arbetade minuter precis som en
+  // arbetsorderrad, så en gissning öppnade den som "Arbetsorder" och tappade sedan valt jobb tyst.
+  const [kind, setKind] = React.useState<Kind>(day.kind);
   const [date, setDate] = React.useState(day.date);
   const [start, setStart] = React.useState((day.startTime || '').slice(0, 5));
   const [end, setEnd] = React.useState((day.endTime || '').slice(0, 5));
   const [breakMinutes, setBreakMinutes] = React.useState(String(day.breakMinutes));
   const [absenceHours, setAbsenceHours] = React.useState(String(minutesToHours(day.absenceMinutes) || 8));
+  const isAbsenceRow = day.kind === 'absence';
   const [workOrderId, setWorkOrderId] = React.useState('');
   const [internalId, setInternalId] = React.useState('');
   const [absenceId, setAbsenceId] = React.useState('');
@@ -85,7 +86,9 @@ export default function AdminTimeCorrectionModal({
   React.useEffect(() => {
     if (kind !== 'work_order') return;
     const term = query.trim();
-    if (term.length < 2) { setHits([]); return; }
+    // setSearching(false) också här: utan den satt "Söker…" kvar för alltid när man backade ned
+    // under två tecken, eftersom den grenen aldrig nådde finally.
+    if (term.length < 2) { setHits([]); setSearching(false); return; }
     const seq = ++searchSeq.current;
     setSearching(true);
     // Fördröjning så en sökning inte skickas per tangenttryck.
@@ -115,7 +118,7 @@ export default function AdminTimeCorrectionModal({
   // Målet behöver bara väljas när man BYTER det. Rör man inte väljaren ärver raden sitt nuvarande
   // mål av servern, så en ren klockslagsrättelse ska inte kräva att man letar upp jobbet igen.
   const targetChanged = kind === 'work_order' ? !!workOrderId : kind === 'internal' ? !!internalId : !!absenceId;
-  const kindChanged = kind !== (isAbsenceRow ? 'absence' : 'work_order');
+  const kindChanged = kind !== day.kind;
   const needsTarget = kindChanged && !targetChanged;
 
   async function save() {

--- a/app/admin/tid/AdminTimeCorrectionModal.tsx
+++ b/app/admin/tid/AdminTimeCorrectionModal.tsx
@@ -1,0 +1,304 @@
+"use client";
+import React from 'react';
+import CrmModal from '@/app/crm/components/CrmModal';
+import Input from '../../../components/ui/Input';
+import { cn } from '../../../lib/shared/cn';
+import { minutesToHours, workedMinutes } from '../../../lib/domains/time/hours';
+import type { TimeReferenceItem } from '../../../lib/domains/time/reference';
+import type { PersonPeriodSummary } from '../../../lib/domains/time/summary';
+
+// Adminrättelse av en tidrad, i en modal.
+//
+// ⚠️ MODAL OCH INTE INLINE I TABELLEN, av två skäl. Det första är att `globals.css` sätter
+// `label { display: block; width: 100% }` utan lager, så fälten staplades på höjden i tabellcellen
+// hur mycket flex man än la på — samma familj som knapparnas padding. Det andra väger tyngre: att
+// byta arbetsorder kräver en sökbar väljare, och den får inte plats i en tabellrad.
+//
+// ⚠️ VAD SOM GÅR ATT RÄTTA: allt utom vem tiden tillhör. Ägaren läses ur databasen i routen och
+// finns inte ens i schemat — att rätta ett fel är en sak, att flytta någons timmar till en annan
+// persons löneunderlag en annan.
+//
+// Varje ändring loggas av en databastrigger, och perioden måste vara öppen: låstriggern prövar
+// radens ägare, så attesterad tid går inte att röra ens härifrån.
+
+type Kind = 'work_order' | 'internal' | 'absence';
+
+export type CorrectionReference = {
+  time_code: TimeReferenceItem[];
+  internal_project: TimeReferenceItem[];
+  absence_type: TimeReferenceItem[];
+};
+
+type WorkOrderHit = { id: string; order_number: string | null; fortnox_order_number: string | null; project_name: string | null; client_name: string | null };
+
+const KINDS: Array<{ key: Kind; label: string }> = [
+  { key: 'work_order', label: 'Arbetsorder' },
+  { key: 'internal', label: 'Intern' },
+  { key: 'absence', label: 'Frånvaro' },
+];
+
+const FIELD = 'w-full rounded-xl border border-solid border-[#dbe4d6] bg-white px-3 py-2 text-sm text-slate-900';
+const LABEL = 'text-[11px] font-bold uppercase tracking-[0.12em] text-slate-600';
+
+function formatHours(minutes: number): string {
+  return minutesToHours(minutes).toFixed(2).replace('.', ',');
+}
+
+/** Fortnox-numret leder, det interna är reserven — husets konvention (documentRef). */
+function orderLabel(order: WorkOrderHit): string {
+  const ref = order.fortnox_order_number ? `#${order.fortnox_order_number}` : order.order_number;
+  return [ref, order.project_name || order.client_name].filter(Boolean).join(' · ') || 'Arbetsorder';
+}
+
+export default function AdminTimeCorrectionModal({
+  day, reference, onClose, onSave,
+}: {
+  day: PersonPeriodSummary['rows'][number];
+  reference: CorrectionReference;
+  onClose: () => void;
+  /** Returnerar felmeddelandet, eller null när det gick bra. */
+  onSave: (patch: Record<string, unknown>) => Promise<string | null>;
+}) {
+  const isAbsenceRow = day.absenceMinutes > 0;
+
+  const [kind, setKind] = React.useState<Kind>(isAbsenceRow ? 'absence' : 'work_order');
+  const [date, setDate] = React.useState(day.date);
+  const [start, setStart] = React.useState((day.startTime || '').slice(0, 5));
+  const [end, setEnd] = React.useState((day.endTime || '').slice(0, 5));
+  const [breakMinutes, setBreakMinutes] = React.useState(String(day.breakMinutes));
+  const [absenceHours, setAbsenceHours] = React.useState(String(minutesToHours(day.absenceMinutes) || 8));
+  const [workOrderId, setWorkOrderId] = React.useState('');
+  const [internalId, setInternalId] = React.useState('');
+  const [absenceId, setAbsenceId] = React.useState('');
+  const [busy, setBusy] = React.useState(false);
+  const [failure, setFailure] = React.useState<string | null>(null);
+
+  // Arbetsordersökning. Admin får söka i HELA registret, inte bara i personens schemalagda jobb:
+  // rättelsen finns för att raden hamnat på fel order, och den rätta ordern är per definition en
+  // personen inte var bokad på. (get_my_crm_jobs är dessutom självskopad — den hade gett adminens
+  // egna jobb, vilket är fel lista i varje tänkbart fall.)
+  const [query, setQuery] = React.useState('');
+  const [hits, setHits] = React.useState<WorkOrderHit[]>([]);
+  const [searching, setSearching] = React.useState(false);
+  const searchSeq = React.useRef(0);
+
+  React.useEffect(() => {
+    if (kind !== 'work_order') return;
+    const term = query.trim();
+    if (term.length < 2) { setHits([]); return; }
+    const seq = ++searchSeq.current;
+    setSearching(true);
+    // Fördröjning så en sökning inte skickas per tangenttryck.
+    const timer = setTimeout(async () => {
+      try {
+        const res = await fetch(`/api/crm/work-orders?q=${encodeURIComponent(term)}&limit=8`, {
+          cache: 'no-store', credentials: 'same-origin',
+        });
+        const body = await res.json().catch(() => null);
+        if (seq !== searchSeq.current) return;
+        setHits(res.ok && body?.ok ? (body.data.items || []) : []);
+      } finally {
+        if (seq === searchSeq.current) setSearching(false);
+      }
+    }, 250);
+    return () => clearTimeout(timer);
+  }, [kind, query]);
+
+  const previewMinutes = React.useMemo(() => {
+    if (kind === 'absence') {
+      const hours = Number(String(absenceHours).replace(',', '.'));
+      return Number.isFinite(hours) ? Math.round(hours * 60) : 0;
+    }
+    return workedMinutes({ workDate: date, startTime: start || null, endTime: end || null, breakMinutes: Number(breakMinutes) || 0 });
+  }, [kind, absenceHours, date, start, end, breakMinutes]);
+
+  // Målet behöver bara väljas när man BYTER det. Rör man inte väljaren ärver raden sitt nuvarande
+  // mål av servern, så en ren klockslagsrättelse ska inte kräva att man letar upp jobbet igen.
+  const targetChanged = kind === 'work_order' ? !!workOrderId : kind === 'internal' ? !!internalId : !!absenceId;
+  const kindChanged = kind !== (isAbsenceRow ? 'absence' : 'work_order');
+  const needsTarget = kindChanged && !targetChanged;
+
+  async function save() {
+    setBusy(true);
+    setFailure(null);
+    const patch: Record<string, unknown> = { work_date: date };
+    if (kindChanged) patch.kind = kind;
+    if (kind === 'work_order' && workOrderId) patch.work_order_id = workOrderId;
+    if (kind === 'internal' && internalId) patch.internal_project_id = internalId;
+    if (kind === 'absence' && absenceId) patch.absence_type_id = absenceId;
+    if (kind === 'absence') {
+      patch.hours = Number(String(absenceHours).replace(',', '.'));
+    } else {
+      patch.start_time = start;
+      patch.end_time = end;
+      patch.break_minutes = Number(breakMinutes) || 0;
+    }
+    const result = await onSave(patch);
+    // Lyckades det avmonterar föräldern oss — då finns ingen state kvar att skriva till.
+    if (result) { setFailure(result); setBusy(false); }
+  }
+
+  return (
+    <CrmModal
+      onClose={onClose}
+      ariaLabel="Rätta tidrad"
+      maxWidth="sm:max-w-[520px]"
+      header={
+        <>
+          <h2 className="text-lg font-bold text-slate-900">Rätta tidrad</h2>
+          <p className="m-0 mt-0.5 text-sm text-slate-500">
+            Ändringen loggas med ditt namn. Den anställde ser den i sin tidrapport.
+          </p>
+        </>
+      }
+      footer={
+        <>
+          <button
+            type="button"
+            onClick={onClose}
+            className="!py-2.5 flex-1 rounded-xl border border-solid border-[#dbe4d6] bg-white text-sm font-semibold text-slate-600 transition hover:border-slate-400 sm:flex-none sm:!px-5"
+          >
+            Avbryt
+          </button>
+          <button
+            type="button"
+            onClick={() => void save()}
+            disabled={busy || previewMinutes <= 0 || needsTarget}
+            className="!py-2.5 flex-1 rounded-xl text-sm font-semibold text-white shadow-sm transition hover:brightness-95 disabled:cursor-not-allowed disabled:opacity-60 sm:ml-auto sm:flex-none sm:!px-5"
+            style={{ backgroundColor: 'var(--crm-primary)' }}
+          >
+            {busy ? 'Sparar…' : 'Spara rättelse'}
+          </button>
+        </>
+      }
+    >
+      <div className="grid gap-4">
+        {failure ? (
+          <div className="rounded-xl border border-solid border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-700">{failure}</div>
+        ) : null}
+
+        <div className="flex gap-1 rounded-xl bg-[#eef3ea] p-1">
+          {KINDS.map((option) => (
+            <button
+              key={option.key}
+              type="button"
+              onClick={() => setKind(option.key)}
+              aria-pressed={kind === option.key}
+              className={cn(
+                '!px-2 !py-2 flex-1 rounded-lg text-sm font-semibold transition',
+                kind === option.key ? 'bg-white text-slate-900 shadow-sm' : 'text-slate-500',
+              )}
+            >
+              {option.label}
+            </button>
+          ))}
+        </div>
+
+        {/* ⚠️ `!w-auto` på varje label: globals.css ger <label> `width: 100%` utan att ligga i ett
+            lager, så utan den staplas fälten på höjden oavsett grid eller flex. */}
+        <label className="!w-auto grid gap-1">
+          <span className={LABEL}>Datum</span>
+          <Input type="date" value={date} onChange={(e) => setDate(e.target.value)} />
+        </label>
+
+        {kind === 'work_order' ? (
+          <div className="grid gap-1.5">
+            <span className={LABEL}>Arbetsorder</span>
+            <p className="m-0 text-xs text-slate-500">
+              {day.label ? <>Nu: <strong className="font-semibold text-slate-700">{day.label}</strong>. </> : null}
+              Sök bara om raden ska flyttas till ett annat jobb.
+            </p>
+            <Input value={query} onChange={(e) => setQuery(e.target.value)} placeholder="Sök ordernummer eller kund…" />
+            {searching ? <span className="text-sm text-slate-400">Söker…</span> : null}
+            {hits.length > 0 ? (
+              <div className="grid gap-1.5">
+                {hits.map((order) => (
+                  <button
+                    key={order.id}
+                    type="button"
+                    onClick={() => setWorkOrderId(order.id)}
+                    aria-pressed={workOrderId === order.id}
+                    className={cn(
+                      '!px-3 !py-2.5 !justify-start !text-left w-full rounded-xl border border-solid text-sm transition',
+                      workOrderId === order.id
+                        ? 'border-transparent text-white shadow-sm'
+                        : 'border-[#dbe4d6] bg-white text-slate-700 hover:border-slate-400',
+                    )}
+                    style={workOrderId === order.id ? { backgroundColor: 'var(--crm-primary)' } : undefined}
+                  >
+                    {orderLabel(order)}
+                  </button>
+                ))}
+              </div>
+            ) : null}
+          </div>
+        ) : kind === 'internal' ? (
+          <label className="!w-auto grid gap-1">
+            <span className={LABEL}>Internprojekt</span>
+            <select value={internalId} onChange={(e) => setInternalId(e.target.value)} className={FIELD}>
+              <option value="">{kindChanged ? 'Välj…' : 'Oförändrat'}</option>
+              {reference.internal_project.map((item) => (
+                <option key={item.id} value={item.id}>{item.name}</option>
+              ))}
+            </select>
+          </label>
+        ) : (
+          <label className="!w-auto grid gap-1">
+            <span className={LABEL}>Frånvaroorsak</span>
+            <select value={absenceId} onChange={(e) => setAbsenceId(e.target.value)} className={FIELD}>
+              <option value="">{kindChanged ? 'Välj…' : 'Oförändrad'}</option>
+              {reference.absence_type.map((item) => (
+                <option key={item.id} value={item.id}>{item.name}</option>
+              ))}
+            </select>
+          </label>
+        )}
+
+        {kind === 'absence' ? (
+          <label className="!w-auto grid gap-1">
+            <span className={LABEL}>Antal timmar</span>
+            <Input inputMode="decimal" value={absenceHours} onChange={(e) => setAbsenceHours(e.target.value)} />
+          </label>
+        ) : (
+          <div className="grid gap-3 rounded-2xl border border-solid border-[#e0e8dc] bg-[#f6f9f4] p-3">
+            <div className="grid grid-cols-2 gap-2">
+              <label className="!w-auto grid gap-1">
+                <span className={LABEL}>Start</span>
+                <Input type="time" value={start} onChange={(e) => setStart(e.target.value)} />
+              </label>
+              <label className="!w-auto grid gap-1">
+                <span className={LABEL}>Slut</span>
+                <Input type="time" value={end} onChange={(e) => setEnd(e.target.value)} />
+              </label>
+            </div>
+            <div className="flex items-end justify-between gap-3">
+              <label className="!w-auto grid gap-1">
+                <span className={LABEL}>Rast (min)</span>
+                <span className="block w-24">
+                  <Input inputMode="numeric" value={breakMinutes} onChange={(e) => setBreakMinutes(e.target.value)} />
+                </span>
+              </label>
+              <div className="shrink-0 text-right">
+                <div className={cn(LABEL, 'whitespace-nowrap')}>Arbetad tid</div>
+                <div className={cn('whitespace-nowrap text-xl font-bold tabular-nums leading-tight', previewMinutes > 0 ? 'text-slate-900' : 'text-slate-300')}>
+                  {formatHours(previewMinutes)} h
+                </div>
+              </div>
+            </div>
+            {!start || !end ? (
+              <p className="m-0 text-sm text-slate-500">Fyll i start- och sluttid.</p>
+            ) : previewMinutes <= 0 ? (
+              <p className="m-0 text-sm text-rose-600">Rasten är längre än passet.</p>
+            ) : null}
+          </div>
+        )}
+
+        {needsTarget ? (
+          <p className="m-0 text-sm text-amber-800">
+            Sorten är ändrad — välj {kind === 'work_order' ? 'en arbetsorder' : kind === 'internal' ? 'ett internprojekt' : 'en frånvaroorsak'} innan du sparar.
+          </p>
+        ) : null}
+      </div>
+    </CrmModal>
+  );
+}

--- a/app/admin/tid/AdminTimeCorrectionModal.tsx
+++ b/app/admin/tid/AdminTimeCorrectionModal.tsx
@@ -40,6 +40,21 @@ const KINDS: Array<{ key: Kind; label: string }> = [
 const FIELD = 'w-full rounded-xl border border-solid border-[#dbe4d6] bg-white px-3 py-2 text-sm text-slate-900';
 const LABEL = 'text-[11px] font-bold uppercase tracking-[0.12em] text-slate-600';
 
+/**
+ * Rast i minuter, eller null när fältet inte går att tolka.
+ *
+ * ⚠️ ALDRIG `Number(x) || 0`. "30 min", "0,5" och ett klistrat blanksteg blir alla NaN, och `|| 0`
+ * gör då rastavdraget till noll — 07:00–16:00 skrivs som 540 minuter i stället för 510, alltså
+ * trettio minuter tillagda på någon annans lön. Exakt samma fälla som redan kostade en gång på
+ * dagradens sida; här kom den tillbaka via inmatningen.
+ */
+function parseBreak(value: string): number | null {
+  const trimmed = value.trim().replace(',', '.');
+  if (trimmed === '') return 0;
+  const parsed = Number(trimmed);
+  return Number.isFinite(parsed) && parsed >= 0 && Number.isInteger(parsed) ? parsed : null;
+}
+
 function formatHours(minutes: number): string {
   return minutesToHours(minutes).toFixed(2).replace('.', ',');
 }
@@ -66,8 +81,12 @@ export default function AdminTimeCorrectionModal({
   const [start, setStart] = React.useState((day.startTime || '').slice(0, 5));
   const [end, setEnd] = React.useState((day.endTime || '').slice(0, 5));
   const [breakMinutes, setBreakMinutes] = React.useState(String(day.breakMinutes));
-  const [absenceHours, setAbsenceHours] = React.useState(String(minutesToHours(day.absenceMinutes) || 8));
-  const isAbsenceRow = day.kind === 'absence';
+  // ⚠️ Radens EGNA minuter som utgångsvärde, inte 8. `|| 8` slog till på varje arbetsrad som görs
+  // om till frånvaro (absenceMinutes är noll där per konstruktion) och föreslog då åtta timmar för
+  // ett fyratimmarspass — dubbelt mot sanningen, på löneunderlaget.
+  const [absenceHours, setAbsenceHours] = React.useState(
+    String(minutesToHours(day.absenceMinutes || day.workMinutes) || ''),
+  );
   const [workOrderId, setWorkOrderId] = React.useState('');
   const [internalId, setInternalId] = React.useState('');
   const [absenceId, setAbsenceId] = React.useState('');
@@ -80,6 +99,10 @@ export default function AdminTimeCorrectionModal({
   // egna jobb, vilket är fel lista i varje tänkbart fall.)
   const [query, setQuery] = React.useState('');
   const [hits, setHits] = React.useState<WorkOrderHit[]>([]);
+  // ⚠️ Valet måste synas ÄVEN när träfflistan är borta. Förut kunde man klicka en träff för att
+  // läsa den, tömma sökrutan så listan försvann, och spara — varpå raden tyst flyttades till det
+  // jobbet. Den enda markören satt på träffknappen, som just hade avmonterats.
+  const [chosen, setChosen] = React.useState<WorkOrderHit | null>(null);
   const [searching, setSearching] = React.useState(false);
   const searchSeq = React.useRef(0);
 
@@ -100,6 +123,10 @@ export default function AdminTimeCorrectionModal({
         const body = await res.json().catch(() => null);
         if (seq !== searchSeq.current) return;
         setHits(res.ok && body?.ok ? (body.data.items || []) : []);
+      } catch {
+        // Utan den här grenen låg FÖRRA sökningens träffar kvar under den NYA termen, och ett klick
+        // flyttade raden till en order man inte sökt efter.
+        if (seq === searchSeq.current) setHits([]);
       } finally {
         if (seq === searchSeq.current) setSearching(false);
       }
@@ -107,13 +134,22 @@ export default function AdminTimeCorrectionModal({
     return () => clearTimeout(timer);
   }, [kind, query]);
 
+  const parsedBreak = parseBreak(breakMinutes);
+  const absenceValue = Number(String(absenceHours).replace(',', '.'));
+
   const previewMinutes = React.useMemo(() => {
     if (kind === 'absence') {
-      const hours = Number(String(absenceHours).replace(',', '.'));
-      return Number.isFinite(hours) ? Math.round(hours * 60) : 0;
+      return Number.isFinite(absenceValue) && absenceValue > 0 ? Math.round(absenceValue * 60) : 0;
     }
-    return workedMinutes({ workDate: date, startTime: start || null, endTime: end || null, breakMinutes: Number(breakMinutes) || 0 });
-  }, [kind, absenceHours, date, start, end, breakMinutes]);
+    if (parsedBreak === null) return 0;
+    return workedMinutes({ workDate: date, startTime: start || null, endTime: end || null, breakMinutes: parsedBreak });
+  }, [kind, absenceValue, date, start, end, parsedBreak]);
+
+  // ⚠️ `grossMinutes` läser `end <= start` som ett pass över midnatt, så identiska klockslag ger
+  // exakt 1440 minuter — och serverns guard är `> 1440`, alltså exklusiv. Ett dubbelklistrat
+  // klockslag hade skrivit ett DYGN på någon annans månad, med "24,00 h" i förhandsvisningen som
+  // enda signal. Ett pass måste sluta på en annan tid än det börjar.
+  const sameClock = kind !== 'absence' && !!start && start === end;
 
   // Målet behöver bara väljas när man BYTER det. Rör man inte väljaren ärver raden sitt nuvarande
   // mål av servern, så en ren klockslagsrättelse ska inte kräva att man letar upp jobbet igen.
@@ -134,7 +170,7 @@ export default function AdminTimeCorrectionModal({
     } else {
       patch.start_time = start;
       patch.end_time = end;
-      patch.break_minutes = Number(breakMinutes) || 0;
+      patch.break_minutes = parsedBreak ?? 0;
     }
     const result = await onSave(patch);
     // Lyckades det avmonterar föräldern oss — då finns ingen state kvar att skriva till.
@@ -150,7 +186,7 @@ export default function AdminTimeCorrectionModal({
         <>
           <h2 className="text-lg font-bold text-slate-900">Rätta tidrad</h2>
           <p className="m-0 mt-0.5 text-sm text-slate-500">
-            Ändringen loggas med ditt namn. Den anställde ser den i sin tidrapport.
+            Ändringen loggas med ditt namn, datum och radens värde före och efter.
           </p>
         </>
       }
@@ -166,7 +202,7 @@ export default function AdminTimeCorrectionModal({
           <button
             type="button"
             onClick={() => void save()}
-            disabled={busy || previewMinutes <= 0 || needsTarget}
+            disabled={busy || previewMinutes <= 0 || needsTarget || sameClock || !date}
             className="!py-2.5 flex-1 rounded-xl text-sm font-semibold text-white shadow-sm transition hover:brightness-95 disabled:cursor-not-allowed disabled:opacity-60 sm:ml-auto sm:flex-none sm:!px-5"
             style={{ backgroundColor: 'var(--crm-primary)' }}
           >
@@ -211,6 +247,18 @@ export default function AdminTimeCorrectionModal({
               {day.label ? <>Nu: <strong className="font-semibold text-slate-700">{day.label}</strong>. </> : null}
               Sök bara om raden ska flyttas till ett annat jobb.
             </p>
+            {chosen ? (
+              <div className="flex flex-wrap items-center justify-between gap-2 rounded-xl border border-solid border-emerald-200 bg-emerald-50 px-3 py-2 text-sm">
+                <span className="font-semibold text-emerald-900">Flyttas till {orderLabel(chosen)}</span>
+                <button
+                  type="button"
+                  onClick={() => { setWorkOrderId(''); setChosen(null); }}
+                  className="!p-0 text-sm font-semibold text-emerald-800 underline underline-offset-2"
+                >
+                  Ångra
+                </button>
+              </div>
+            ) : null}
             <Input value={query} onChange={(e) => setQuery(e.target.value)} placeholder="Sök ordernummer eller kund…" />
             {searching ? <span className="text-sm text-slate-400">Söker…</span> : null}
             {hits.length > 0 ? (
@@ -219,7 +267,7 @@ export default function AdminTimeCorrectionModal({
                   <button
                     key={order.id}
                     type="button"
-                    onClick={() => setWorkOrderId(order.id)}
+                    onClick={() => { setWorkOrderId(order.id); setChosen(order); }}
                     aria-pressed={workOrderId === order.id}
                     className={cn(
                       '!px-3 !py-2.5 !justify-start !text-left w-full rounded-xl border border-solid text-sm transition',
@@ -290,6 +338,10 @@ export default function AdminTimeCorrectionModal({
             </div>
             {!start || !end ? (
               <p className="m-0 text-sm text-slate-500">Fyll i start- och sluttid.</p>
+            ) : sameClock ? (
+              <p className="m-0 text-sm text-rose-600">Start och slut är samma klockslag.</p>
+            ) : parsedBreak === null ? (
+              <p className="m-0 text-sm text-rose-600">Rasten måste vara ett helt antal minuter.</p>
             ) : previewMinutes <= 0 ? (
               <p className="m-0 text-sm text-rose-600">Rasten är längre än passet.</p>
             ) : null}

--- a/app/admin/tid/AdminTimeReference.tsx
+++ b/app/admin/tid/AdminTimeReference.tsx
@@ -181,7 +181,7 @@ export default function AdminTimeReference() {
             <div className="overflow-x-auto rounded-xl border border-solid border-slate-200 bg-white">
               <table className="w-full min-w-[720px] border-collapse text-sm">
                 <thead>
-                  <tr className="border-b border-solid border-slate-200 text-left text-[11px] font-extrabold uppercase tracking-wide text-slate-500">
+                  <tr className="border-x-0 border-t-0 border-b border-solid border-slate-200 text-left text-[11px] font-extrabold uppercase tracking-wide text-slate-500">
                     <th className="px-3 py-2">Namn</th>
                     <th className="px-3 py-2">Kod</th>
                     <th className="px-3 py-2">Lönesort</th>
@@ -201,7 +201,7 @@ export default function AdminTimeReference() {
                   {items.map((item) => {
                     const busy = busyKey === `${section.kind}:${item.id}`;
                     return (
-                      <tr key={item.id} className={'border-b border-solid border-slate-100 ' + (item.is_active ? '' : 'text-slate-400')}>
+                      <tr key={item.id} className={'border-x-0 border-t-0 border-b border-solid border-slate-100 ' + (item.is_active ? '' : 'text-slate-400')}>
                         <td className="px-3 py-2 font-medium">
                           {item.name}
                           {item.blikk_id ? <span className="ml-2 text-xs text-slate-400">Blikk #{item.blikk_id}</span> : null}

--- a/app/api/admin/time/entries/[id]/route.ts
+++ b/app/api/admin/time/entries/[id]/route.ts
@@ -1,0 +1,124 @@
+import { cookies } from 'next/headers';
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
+import { explainWriteMiss, periodLockError } from '@/lib/domains/time/approvals';
+import {
+  adminDeleteTimeEntry,
+  adminUpdateTimeEntry,
+  buildTimeEntryRow,
+  getTimeEntryForCorrection,
+  mergeCorrection,
+} from '@/lib/domains/time/entries';
+import {
+  correctTimeEntrySchema,
+  invalidUuidParam,
+  ok,
+  requirePermission,
+  routeError,
+  validationError,
+} from '@/app/api/time/_lib';
+
+// Adminrättelse av EN ANNAN PERSONS tidrad.
+//
+// Regeln var länge att ingen ändrar någon annans timmar — policyerna är `user_id = auth.uid()`, och
+// vägen att rätta har varit att öppna perioden så personen rättar själv. Den regeln hade ett hål:
+// en anställd som är sjukskriven, har slutat eller inte svarar när lönen ska köras. Då gick
+// månaden inte att rätta alls, och med Blikk borta är det här enda systemet.
+//
+// ⚠️ ATTESTERAD TID ÄNDRAS INTE, inte ens härifrån. Låstriggern prövar RADENS ÄGARE, så en admin
+// måste öppna personens period först — vilket kräver en anledning som sparas på attestraden och
+// visas för den anställde i /tid. Rättelsen lämnar alltså spår i båda ändarna: varför perioden
+// öppnades, och exakt vad som ändrades.
+//
+// ⚠️ REVISIONSLOGGEN SKRIVS AV EN DATABASTRIGGER, inte här. Det är avsiktligt: en serverväg som
+// glömmer logga, eller en UPDATE körd direkt i SQL-editorn, ska inte kunna gå förbi den.
+// Se supabase/sql/20260814_time_admin_corrections.sql.
+
+type RouteContext = { params: { id: string } };
+
+export async function PATCH(req: Request, context: RouteContext) {
+  try {
+    const gate = await requirePermission('time.entry.write.all');
+    // Uppdelad i två steg i stället för husets `return gate.response`: Next's genererade routetyp
+    // tillåter inte `null` i returen, och den ena grenen kan inte smalna av den andra åt oss.
+    if (gate.response) return gate.response;
+    if (!gate.currentUser) return routeError(401, 'unauthorized', 'Unauthorized');
+    // Husets hjälpare returnerar null när id:t ÄR giltigt — den ska prövas, inte returneras rakt av.
+    const badId = invalidUuidParam(context.params.id);
+    if (badId) return badId;
+
+    const parsed = correctTimeEntrySchema.safeParse(await req.json().catch(() => null));
+    if (!parsed.success) return validationError(parsed.error);
+
+    const supabase = createRouteHandlerClient({ cookies });
+
+    // Ägaren läses ur DATABASEN, aldrig ur anropet. Kom user_id från klienten kunde en rättelse
+    // flytta någons timmar till en annan persons löneunderlag med en handskriven request.
+    const existing = await getTimeEntryForCorrection(supabase, context.params.id);
+    if (existing.error) return routeError(500, 'time_entry_lookup_failed', existing.error.message);
+    if (!existing.data) return routeError(404, 'time_entry_not_found', 'Tidraden hittades inte');
+    const current = existing.data as Parameters<typeof mergeCorrection>[0] & { user_id: string };
+
+    const built = buildTimeEntryRow(mergeCorrection(current, parsed.data), current.user_id);
+    if (built.error || !built.row) return routeError(400, 'time_entry_invalid', built.error || 'Ogiltig tidrad');
+
+    const { data, error } = await adminUpdateTimeEntry(supabase, context.params.id, built.row);
+    if (error) {
+      const locked = periodLockError(error);
+      if (locked) return routeError(locked.status, locked.code, locked.message);
+      return routeError(500, 'time_entry_update_failed', error.message);
+    }
+    // Noll rader betyder nästan alltid att periodlåset i policyns USING filtrerade bort raden —
+    // en UPDATE som inte passerar USING ger noll rader UTAN fel. explainWriteMiss läser raden på
+    // nytt (SELECT-policyn bär inget lås) och svarar med skillnaden mellan inlämnad och attesterad.
+    if (!data) {
+      const miss = await explainWriteMiss(supabase, {
+        table: 'crm_time_entries', dateColumn: 'work_date', id: context.params.id, userId: current.user_id,
+      });
+      if (miss.locked) return routeError(409, 'time_period_locked', miss.message);
+      return routeError(404, 'time_entry_not_found', 'Tidraden hittades inte');
+    }
+
+    return ok({ item: data });
+  } catch (e: any) {
+    return routeError(500, 'admin_time_entry_update_unexpected', e?.message || 'Kunde inte rätta tidraden');
+  }
+}
+
+export async function DELETE(_req: Request, context: RouteContext) {
+  try {
+    const gate = await requirePermission('time.entry.write.all');
+    // Uppdelad i två steg i stället för husets `return gate.response`: Next's genererade routetyp
+    // tillåter inte `null` i returen, och den ena grenen kan inte smalna av den andra åt oss.
+    if (gate.response) return gate.response;
+    if (!gate.currentUser) return routeError(401, 'unauthorized', 'Unauthorized');
+    // Husets hjälpare returnerar null när id:t ÄR giltigt — den ska prövas, inte returneras rakt av.
+    const badId = invalidUuidParam(context.params.id);
+    if (badId) return badId;
+
+    const supabase = createRouteHandlerClient({ cookies });
+
+    // Ägaren behövs innan raderingen: efteråt finns ingen rad att förklara ett låst svar med.
+    const existing = await getTimeEntryForCorrection(supabase, context.params.id);
+    if (existing.error) return routeError(500, 'time_entry_lookup_failed', existing.error.message);
+    if (!existing.data) return routeError(404, 'time_entry_not_found', 'Tidraden hittades inte');
+    const ownerId = (existing.data as { user_id: string }).user_id;
+
+    const { data, error } = await adminDeleteTimeEntry(supabase, context.params.id);
+    if (error) {
+      const locked = periodLockError(error);
+      if (locked) return routeError(locked.status, locked.code, locked.message);
+      return routeError(500, 'time_entry_delete_failed', error.message);
+    }
+    if (!data) {
+      const miss = await explainWriteMiss(supabase, {
+        table: 'crm_time_entries', dateColumn: 'work_date', id: context.params.id, userId: ownerId,
+      });
+      if (miss.locked) return routeError(409, 'time_period_locked', miss.message);
+      return routeError(404, 'time_entry_not_found', 'Tidraden hittades inte');
+    }
+
+    return ok({ id: context.params.id });
+  } catch (e: any) {
+    return routeError(500, 'admin_time_entry_delete_unexpected', e?.message || 'Kunde inte ta bort tidraden');
+  }
+}

--- a/app/api/admin/time/entries/route.ts
+++ b/app/api/admin/time/entries/route.ts
@@ -2,6 +2,7 @@ import { cookies } from 'next/headers';
 import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
 import { periodRange, periodStartOf } from '@/lib/domains/time/approvals';
 import { listCompensations } from '@/lib/domains/time/compensations';
+import { auditInRange, listTimeEntryAudit, type TimeEntryAuditRow } from '@/lib/domains/time/audit';
 import { listTimeEntries, toSummarizableEntry, type TimeEntryRow } from '@/lib/domains/time/entries';
 import { summarizePerson } from '@/lib/domains/time/summary';
 import { ok, personPeriodQuerySchema, requirePermission, routeError, validationError } from '@/app/api/time/_lib';
@@ -46,12 +47,20 @@ export async function GET(req: Request) {
 
     // Sessionsklient, inte getSupabaseAdmin(): read.all-grenen i RLS är redan svaret på "får den
     // här personen se andras tid", och service-role hade öppnat hela databasen för att slippa den.
-    const [entries, compensations] = await Promise.all([
+    const [entries, compensations, audit] = await Promise.all([
       listTimeEntries(supabase, range, { userId }),
       listCompensations(supabase, range, { userId }),
+      // Loggen följer med samma hämtning: den hör till granskningen av månaden, och en egen
+      // rundtur per utfälld person hade gjort dagvyn segare utan att ge något.
+      listTimeEntryAudit(supabase, { userId }),
     ]);
     if (entries.error) return routeError(500, 'time_entries_failed', entries.error.message);
     if (compensations.error) return routeError(500, 'time_compensations_failed', compensations.error.message);
+    // Loggen är TILLÄGGSINFORMATION. Fallerar den ska dagarna ändå visas — att vägra rita månaden
+    // för att revisionsraderna inte gick att läsa vore att göra granskningen omöjlig av fel skäl.
+    const auditRows = audit.error
+      ? []
+      : ((audit.data ?? []) as unknown as TimeEntryAuditRow[]).filter((row) => auditInRange(row, range));
 
     const summary = summarizePerson(
       ((entries.data ?? []) as unknown as TimeEntryRow[]).map(toSummarizableEntry),
@@ -64,6 +73,8 @@ export async function GET(req: Request) {
       user_id: userId,
       ...summary,
       compensations: compensations.data ?? [],
+      audit: auditRows,
+      audit_failed: !!audit.error,
     });
   } catch (e: any) {
     return routeError(500, 'admin_time_entries_unexpected', e?.message || 'Kunde inte hämta personens tid');

--- a/app/api/time/_lib.ts
+++ b/app/api/time/_lib.ts
@@ -66,14 +66,21 @@ export const createTimeEntrySchema = z.object({
   note: optionalText.optional().default(null),
 });
 
-// Adminrättelse: BARA klockslagen, rasten, frånvarotimmarna och anteckningen. Allt utelämnat ärvs
-// från raden som redan finns (se mergeCorrection i lib/domains/time/entries.ts).
+// Adminrättelse. Allt är valfritt — det som utelämnas ärvs från raden som redan finns
+// (mergeCorrection i lib/domains/time/entries.ts).
 //
-// ⚠️ Varken `kind`, `work_date` eller måltavlan finns här, och det är avsiktligt. En rättelse ska
-// kunna laga ett felskrivet klockslag — inte flytta någons timmar till ett annat jobb eller göra om
-// arbetstid till frånvaro. Det är skillnaden mellan att rätta ett fel och att skriva om ett
-// löneunderlag, och den skillnaden ska synas i schemat.
+// ⚠️ `user_id` finns INTE med, och ska aldrig göra det. Att rätta ett fel är en sak; att flytta
+// någons timmar till en annan persons löneunderlag är en annan. Routen läser ägaren ur databasen.
+//
+// Allt annat går att rätta, inklusive vilket jobb raden hör till: att ha rapporterat på fel
+// arbetsorder är precis den sortens misstag rättelsen finns för.
 export const correctTimeEntrySchema = z.object({
+  kind: z.enum(['work_order', 'internal', 'absence']).optional(),
+  work_date: isoDateSchema.optional(),
+  work_order_id: z.string().uuid().nullable().optional(),
+  internal_project_id: z.string().uuid().nullable().optional(),
+  absence_type_id: z.string().uuid().nullable().optional(),
+  time_code_id: z.string().uuid().nullable().optional(),
   start_time: clockSchema.nullable().optional(),
   end_time: clockSchema.nullable().optional(),
   break_minutes: z.coerce.number().int().min(0).max(1439).optional(),

--- a/app/api/time/_lib.ts
+++ b/app/api/time/_lib.ts
@@ -66,6 +66,21 @@ export const createTimeEntrySchema = z.object({
   note: optionalText.optional().default(null),
 });
 
+// Adminrättelse: BARA klockslagen, rasten, frånvarotimmarna och anteckningen. Allt utelämnat ärvs
+// från raden som redan finns (se mergeCorrection i lib/domains/time/entries.ts).
+//
+// ⚠️ Varken `kind`, `work_date` eller måltavlan finns här, och det är avsiktligt. En rättelse ska
+// kunna laga ett felskrivet klockslag — inte flytta någons timmar till ett annat jobb eller göra om
+// arbetstid till frånvaro. Det är skillnaden mellan att rätta ett fel och att skriva om ett
+// löneunderlag, och den skillnaden ska synas i schemat.
+export const correctTimeEntrySchema = z.object({
+  start_time: clockSchema.nullable().optional(),
+  end_time: clockSchema.nullable().optional(),
+  break_minutes: z.coerce.number().int().min(0).max(1439).optional(),
+  hours: z.coerce.number().min(0).max(24).nullable().optional(),
+  note: optionalText.optional(),
+});
+
 // ── Attest ───────────────────────────────────────────────────────────────────
 
 // Perioden anges som månad ('2026-08') och aldrig som ett fritt datumintervall: attesten ÄR en

--- a/app/api/time/audit/route.ts
+++ b/app/api/time/audit/route.ts
@@ -1,0 +1,40 @@
+import { cookies } from 'next/headers';
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
+import { auditInRange, listTimeEntryAudit, type TimeEntryAuditRow } from '@/lib/domains/time/audit';
+import { ok, rangeQuerySchema, requireSignedInUser, routeError, validationError } from '@/app/api/time/_lib';
+
+// GET /api/time/audit?from&to — "har någon annan rört min tid?"
+//
+// Den anställdes egen insyn i revisionsloggen. Att en admin kan rätta någons timmar är försvarbart
+// bara om den det gäller kan se att det hänt — annars är loggen en försäkring för kontoret och inte
+// för den vars lön det handlar om.
+//
+// INGEN userId-parameter, av samma skäl som /api/time/entries: den här ytan är "min egen tid", och
+// att se andras går genom time.entry.read.all och adminytan. RLS på crm_time_entry_audit gör samma
+// avgränsning en gång till.
+//
+// Loggen innehåller bara ändringar som NÅGON ANNAN gjort — triggern hoppar över egna sparningar med
+// flit. Ett tomt svar betyder alltså "ingen har rört din tid".
+export async function GET(req: Request) {
+  try {
+    const user = await requireSignedInUser();
+    if (user.response || !user.currentUser) return user.response;
+
+    const url = new URL(req.url);
+    const parsed = rangeQuerySchema.safeParse({
+      from: url.searchParams.get('from'),
+      to: url.searchParams.get('to'),
+    });
+    if (!parsed.success) return validationError(parsed.error);
+
+    const supabase = createRouteHandlerClient({ cookies });
+    const { data, error } = await listTimeEntryAudit(supabase, { userId: user.currentUser.id });
+    if (error) return routeError(500, 'time_audit_failed', error.message);
+
+    // Intervallet gäller radens ARBETSDATUM, som bor i jsonb — se listTimeEntryAudit.
+    const items = ((data ?? []) as unknown as TimeEntryAuditRow[]).filter((row) => auditInRange(row, parsed.data));
+    return ok({ items });
+  } catch (e: any) {
+    return routeError(500, 'time_audit_unexpected', e?.message || 'Kunde inte hämta ändringsloggen');
+  }
+}

--- a/app/crm/components/CrmModal.tsx
+++ b/app/crm/components/CrmModal.tsx
@@ -58,7 +58,7 @@ export default function CrmModal({
         )}
       >
         {/* Sticky header */}
-        <div className="flex items-start justify-between gap-3 border-b border-solid border-[#e4ebe0] px-5 pb-4 [padding-top:calc(1rem+env(safe-area-inset-top))] sm:pt-4">
+        <div className="flex items-start justify-between gap-3 border-x-0 border-t-0 border-b border-solid border-[#e4ebe0] px-5 pb-4 [padding-top:calc(1rem+env(safe-area-inset-top))] sm:pt-4">
           <div className="min-w-0 flex-1">{header}</div>
           <button
             type="button"
@@ -77,7 +77,7 @@ export default function CrmModal({
 
         {/* Sticky footer */}
         {footer ? (
-          <div className="flex items-center gap-2 border-t border-solid border-[#e4ebe0] px-5 py-3 [padding-bottom:calc(0.75rem+env(safe-area-inset-bottom))] sm:[padding-bottom:0.75rem]">
+          <div className="flex items-center gap-2 border-x-0 border-b-0 border-t border-solid border-[#e4ebe0] px-5 py-3 [padding-bottom:calc(0.75rem+env(safe-area-inset-bottom))] sm:[padding-bottom:0.75rem]">
             {footer}
           </div>
         ) : null}

--- a/app/tid/TidClient.tsx
+++ b/app/tid/TidClient.tsx
@@ -10,7 +10,7 @@ import { parseDecimal } from '@/lib/shared/number';
 import { addDays, buildWeekDays, fmtISO, isoWeek, startOfWeek, type WeekDay } from '@/app/crm/planering/planningDates';
 import { COMPENSATION_KINDS, COMPENSATION_LABELS, COMPENSATION_UNITS, summarizeCompensations, type CompensationItem, type CompensationKind } from '@/lib/domains/time/compensations';
 import { isPeriodLocked, periodLabel, TIME_PERIOD_STATUS_LABELS, type TimeApprovalRow, type TimePeriodStatus } from '@/lib/domains/time/approvals';
-import { auditActionLabel, describeAuditChange, type TimeEntryAuditRow } from '@/lib/domains/time/audit';
+import { auditActionLabel, auditWorkDate, describeAuditChange, type TimeEntryAuditRow } from '@/lib/domains/time/audit';
 import TimeEntryModal, { type EditableEntry, type ReferenceData } from './TimeEntryModal';
 
 // Tidrapporten, CRM-versionen. Ligger på /tid bredvid gamla /tidrapport (som fortsätter mot Blikk)
@@ -972,15 +972,24 @@ function AuditNotice({ rows }: { rows: TimeEntryAuditRow[] }) {
       <ul className="m-0 grid list-none gap-1.5 p-0 text-sm text-amber-900">
         {rows.map((row) => {
           const changes = describeAuditChange(row);
+          // ⚠️ DAGEN MÅSTE STÅ MED. Utan den säger rutan att någon rört din tid men inte vilken rad,
+          // och då går den inte att kontrollera — vilket är hela poängen med att visa den.
+          const day = auditWorkDate(row);
           return (
             <li key={row.id}>
-              <span className="font-medium">{auditActionLabel(row.action)}</span>
-              {' — '}
+              <span className="font-medium">
+                {day ? longDayLabel(day) : 'Okänd dag'} — {auditActionLabel(row.action).toLowerCase()}
+              </span>
+              {' av '}
               {row.changed_by_profile?.full_name || 'okänd användare'}, {formatStamp(row.created_at)}
               {changes.length > 0 ? (
                 <span className="block text-amber-800">
                   {changes.map((change) => `${change.label}: ${change.from ?? '—'} → ${change.to ?? '—'}`).join(' · ')}
                 </span>
+              ) : row.action === 'update' ? (
+                // En uppdatering som inte ändrade något värde. Säg det — en tom rad läser som att
+                // detaljerna saknas, inte som att det inte fanns några.
+                <span className="block text-amber-800">Inga värden ändrades.</span>
               ) : null}
             </li>
           );

--- a/app/tid/TidClient.tsx
+++ b/app/tid/TidClient.tsx
@@ -10,6 +10,7 @@ import { parseDecimal } from '@/lib/shared/number';
 import { addDays, buildWeekDays, fmtISO, isoWeek, startOfWeek, type WeekDay } from '@/app/crm/planering/planningDates';
 import { COMPENSATION_KINDS, COMPENSATION_LABELS, COMPENSATION_UNITS, summarizeCompensations, type CompensationItem, type CompensationKind } from '@/lib/domains/time/compensations';
 import { isPeriodLocked, periodLabel, TIME_PERIOD_STATUS_LABELS, type TimeApprovalRow, type TimePeriodStatus } from '@/lib/domains/time/approvals';
+import { auditActionLabel, describeAuditChange, type TimeEntryAuditRow } from '@/lib/domains/time/audit';
 import TimeEntryModal, { type EditableEntry, type ReferenceData } from './TimeEntryModal';
 
 // Tidrapporten, CRM-versionen. Ligger på /tid bredvid gamla /tidrapport (som fortsätter mot Blikk)
@@ -177,6 +178,7 @@ export default function TidClient() {
 
   const [entries, setEntries] = React.useState<EntryRow[]>([]);
   const [compensations, setCompensations] = React.useState<CompensationItem[]>([]);
+  const [audit, setAudit] = React.useState<TimeEntryAuditRow[]>([]);
   const [approval, setApproval] = React.useState<TimeApprovalRow | null>(null);
   const [approvalStatus, setApprovalStatus] = React.useState<TimePeriodStatus>('open');
   const [reference, setReference] = React.useState<ReferenceData>({ time_code: [], internal_project: [], absence_type: [] });
@@ -203,17 +205,21 @@ export default function TidClient() {
     const seq = ++loadSeq.current;
     setError(null);
     try {
-      const [entriesRes, compsRes, refRes, approvalRes] = await Promise.all([
+      const [entriesRes, compsRes, refRes, approvalRes, auditRes] = await Promise.all([
         fetch(`/api/time/entries?from=${fetchRange.from}&to=${fetchRange.to}`, { cache: 'no-store' }),
         fetch(`/api/time/compensations?from=${fetchRange.monthStart}&to=${fetchRange.monthEnd}`, { cache: 'no-store' }),
         fetch('/api/time/reference', { cache: 'no-store' }),
         fetch(`/api/time/approvals?period=${fetchRange.period}`, { cache: 'no-store' }),
+        // "Har någon annan rört min tid?" Loggen innehåller BARA andras ändringar — triggern hoppar
+        // över egna sparningar — så en tom lista är ett rakt svar och inte ett tomt.
+        fetch(`/api/time/audit?from=${fetchRange.monthStart}&to=${fetchRange.monthEnd}`, { cache: 'no-store' }),
       ]);
-      const [entriesJson, compsJson, refJson, approvalJson] = await Promise.all([
+      const [entriesJson, compsJson, refJson, approvalJson, auditJson] = await Promise.all([
         entriesRes.json().catch(() => ({})),
         compsRes.json().catch(() => ({})),
         refRes.json().catch(() => ({})),
         approvalRes.json().catch(() => ({})),
+        auditRes.json().catch(() => ({})),
       ]);
       if (seq !== loadSeq.current) return;
 
@@ -231,6 +237,8 @@ export default function TidClient() {
       if (!entriesRes.ok || !entriesJson.ok) throw new Error(entriesJson?.error || 'Kunde inte hämta tidrader');
       setEntries(entriesJson.data.items || []);
       if (compsRes.ok && compsJson.ok) setCompensations(compsJson.data.items || []);
+      // Tilläggsinformation: fallerar den ska veckan ändå ritas.
+      setAudit(auditRes.ok && auditJson.ok ? (auditJson.data.items || []) : []);
       if (refRes.ok && refJson.ok) setReference(refJson.data);
     } catch (e) {
       if (seq === loadSeq.current) {
@@ -454,6 +462,8 @@ export default function TidClient() {
         onChanged={load}
         onError={setError}
       />
+
+      <AuditNotice rows={audit} />
 
       <CompensationSection
         items={compensations}
@@ -933,6 +943,48 @@ function CompensationSection({
           )}
         </>
       ) : null}
+    </section>
+  );
+}
+
+/**
+ * "Någon annan har ändrat i din tid."
+ *
+ * Att kontoret kan rätta en tidrad är försvarbart bara om den vars lön det gäller kan se att det
+ * hänt. Utan den här rutan är revisionsloggen en försäkring för kontoret och inte för den anställde
+ * — och då är den inte värd namnet.
+ *
+ * Visas bara när det finns något: loggen innehåller enbart ANDRAS ändringar (triggern hoppar över
+ * egna sparningar med flit), så en tom lista betyder att ingen rört månaden.
+ */
+function AuditNotice({ rows }: { rows: TimeEntryAuditRow[] }) {
+  if (rows.length === 0) return null;
+
+  return (
+    <section className="grid gap-2 rounded-2xl border border-solid border-amber-200 bg-amber-50 px-3.5 py-3">
+      <p className="m-0 text-sm font-semibold text-amber-900">
+        {rows.length === 1 ? 'En rad' : `${rows.length} rader`} i din tid har ändrats av någon annan
+      </p>
+      <ul className="m-0 grid list-none gap-1.5 p-0 text-sm text-amber-900">
+        {rows.map((row) => {
+          const changes = describeAuditChange(row);
+          return (
+            <li key={row.id}>
+              <span className="font-medium">{auditActionLabel(row.action)}</span>
+              {' — '}
+              {row.changed_by_profile?.full_name || 'okänd användare'}, {formatStamp(row.created_at)}
+              {changes.length > 0 ? (
+                <span className="block text-amber-800">
+                  {changes.map((change) => `${change.label}: ${change.from ?? '—'}${change.to !== null ? ` → ${change.to}` : ''}`).join(' · ')}
+                </span>
+              ) : null}
+            </li>
+          );
+        })}
+      </ul>
+      <p className="m-0 text-xs text-amber-800">
+        Stämmer det inte? Säg till innan du lämnar in månaden.
+      </p>
     </section>
   );
 }

--- a/app/tid/TidClient.tsx
+++ b/app/tid/TidClient.tsx
@@ -212,7 +212,7 @@ export default function TidClient() {
         fetch(`/api/time/approvals?period=${fetchRange.period}`, { cache: 'no-store' }),
         // "Har någon annan rört min tid?" Loggen innehåller BARA andras ändringar — triggern hoppar
         // över egna sparningar — så en tom lista är ett rakt svar och inte ett tomt.
-        fetch(`/api/time/audit?from=${fetchRange.monthStart}&to=${fetchRange.monthEnd}`, { cache: 'no-store' }),
+        fetch(`/api/time/audit?from=${fetchRange.from}&to=${fetchRange.to}`, { cache: 'no-store' }),
       ]);
       const [entriesJson, compsJson, refJson, approvalJson, auditJson] = await Promise.all([
         entriesRes.json().catch(() => ({})),
@@ -960,10 +960,14 @@ function CompensationSection({
 function AuditNotice({ rows }: { rows: TimeEntryAuditRow[] }) {
   if (rows.length === 0) return null;
 
+  // Antal RADER, inte antal händelser: tre rättelser av samma rad är en rad som ändrats tre gånger,
+  // inte tre ändrade rader.
+  const touched = new Set(rows.map((row) => row.entry_id)).size;
+
   return (
     <section className="grid gap-2 rounded-2xl border border-solid border-amber-200 bg-amber-50 px-3.5 py-3">
       <p className="m-0 text-sm font-semibold text-amber-900">
-        {rows.length === 1 ? 'En rad' : `${rows.length} rader`} i din tid har ändrats av någon annan
+        {touched === 1 ? 'En rad' : `${touched} rader`} i din tid har ändrats av någon annan
       </p>
       <ul className="m-0 grid list-none gap-1.5 p-0 text-sm text-amber-900">
         {rows.map((row) => {
@@ -975,7 +979,7 @@ function AuditNotice({ rows }: { rows: TimeEntryAuditRow[] }) {
               {row.changed_by_profile?.full_name || 'okänd användare'}, {formatStamp(row.created_at)}
               {changes.length > 0 ? (
                 <span className="block text-amber-800">
-                  {changes.map((change) => `${change.label}: ${change.from ?? '—'}${change.to !== null ? ` → ${change.to}` : ''}`).join(' · ')}
+                  {changes.map((change) => `${change.label}: ${change.from ?? '—'} → ${change.to ?? '—'}`).join(' · ')}
                 </span>
               ) : null}
             </li>

--- a/components/ui/Badge.tsx
+++ b/components/ui/Badge.tsx
@@ -2,7 +2,11 @@ import * as React from 'react';
 import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/lib/shared/cn';
 
-export const badgeVariants = cva('inline-flex items-center rounded-full border px-2 py-1 text-xs font-bold', {
+// ⚠️ `border-solid` är inte dekoration. Preflight är av (tailwind.config.js), och en <span> har
+// ingen kant från webbläsarens standardmall — så `border` ensamt sätter bredd och färg men lämnar
+// border-style på `none`, och ramen ritas ALDRIG. Formulärfält ser bortkomna ut på samma sätt men
+// klarar sig, eftersom <input> ärver en kantstil från UA-mallen. En <span> gör det inte.
+export const badgeVariants = cva('inline-flex items-center rounded-full border border-solid px-2 py-1 text-xs font-bold', {
   variants: {
     variant: {
       neutral: 'border-slate-200 bg-slate-50 text-slate-600',

--- a/lib/auth/permissions.ts
+++ b/lib/auth/permissions.ts
@@ -43,6 +43,10 @@ export const PERMISSION_KEYS = [
   // Note these are NOT crm.* keys: time is company-wide (every employee reports), not a CRM surface.
   'time.entry.write', 'time.entry.read.all',
   'time.approve', 'time.payroll.read', 'time.reference.manage',
+  // Rätta ANDRAS tidrader i en öppen period. Egen nyckel och inte `time.approve`: att attestera är
+  // att godkänna det någon annan skrivit, att rätta är att skriva i deras ställe. Varje ändring
+  // loggas av en databastrigger (20260814_time_admin_corrections.sql).
+  'time.entry.write.all',
   // Coarse meta keys backing the legacy requireCrmUser/Writer/Admin guards 1:1
   'crm.access', 'crm.write', 'crm.admin',
 ] as const;

--- a/lib/domains/crm/work-orders.ts
+++ b/lib/domains/crm/work-orders.ts
@@ -438,12 +438,19 @@ function applyWorkOrderListFilters<Q extends {
   or: (f: string) => Q; eq: (c: string, v: string) => Q; in: (c: string, v: string[]) => Q;
 }>(query: Q, options: WorkOrderListFilters): Q {
   if (options.search) {
+    // ⚠️ KOMMATECKEN OCH PARENTESER MÅSTE BORT. PostgREST läser `or=(...)` som en villkorslista
+    // separerad med komma, så ett kundnamn som "Ekbergs Bygg, AB" delar uttrycket mitt itu och hela
+    // frågan svarar 400 — vilket väljaren visar som "inga träffar" och orderlistan som ett fel. En
+    // term som `x,status.eq.invoiced` hade dessutom smugit in en egen gren i filtret.
+    const term = options.search.replace(/[,()]/g, ' ').trim();
+    if (!term) return query;
+
     // ⚠️ `fortnox_order_number` är med sedan 2026-08-14. Den saknades, vilket betydde att numret
     // appen VISAR överallt (documentRef leder med Fortnox-numret) var det enda man inte kunde söka
     // på — man fick leta upp ordern på kundnamn för att hitta ett nummer man redan hade framför
-    // sig. Söktermen städas av anroparen; samma interpolering som de övriga termerna.
+    // sig.
     query = query.or(
-      `order_number.ilike.%${options.search}%,fortnox_order_number.ilike.%${options.search}%,project_name.ilike.%${options.search}%,client_name.ilike.%${options.search}%,notes.ilike.%${options.search}%`,
+      `order_number.ilike.%${term}%,fortnox_order_number.ilike.%${term}%,project_name.ilike.%${term}%,client_name.ilike.%${term}%,notes.ilike.%${term}%`,
     );
   }
   const statuses = options.filter ? BOARD_FILTER_STATUSES[options.filter] : null;

--- a/lib/domains/crm/work-orders.ts
+++ b/lib/domains/crm/work-orders.ts
@@ -438,8 +438,12 @@ function applyWorkOrderListFilters<Q extends {
   or: (f: string) => Q; eq: (c: string, v: string) => Q; in: (c: string, v: string[]) => Q;
 }>(query: Q, options: WorkOrderListFilters): Q {
   if (options.search) {
+    // ⚠️ `fortnox_order_number` är med sedan 2026-08-14. Den saknades, vilket betydde att numret
+    // appen VISAR överallt (documentRef leder med Fortnox-numret) var det enda man inte kunde söka
+    // på — man fick leta upp ordern på kundnamn för att hitta ett nummer man redan hade framför
+    // sig. Söktermen städas av anroparen; samma interpolering som de övriga termerna.
     query = query.or(
-      `order_number.ilike.%${options.search}%,project_name.ilike.%${options.search}%,client_name.ilike.%${options.search}%,notes.ilike.%${options.search}%`,
+      `order_number.ilike.%${options.search}%,fortnox_order_number.ilike.%${options.search}%,project_name.ilike.%${options.search}%,client_name.ilike.%${options.search}%,notes.ilike.%${options.search}%`,
     );
   }
   const statuses = options.filter ? BOARD_FILTER_STATUSES[options.filter] : null;

--- a/lib/domains/time/audit.ts
+++ b/lib/domains/time/audit.ts
@@ -17,7 +17,8 @@ export type TimeEntryAuditRow = {
   id: string;
   entry_id: string;
   user_id: string;
-  changed_by: string;
+  /** Null = okänd aktör (servicenyckel eller SQL-editor). */
+  changed_by: string | null;
   action: 'insert' | 'update' | 'delete';
   before_data: Record<string, unknown> | null;
   after_data: Record<string, unknown> | null;
@@ -47,7 +48,11 @@ export async function listTimeEntryAudit(
     .from('crm_time_entry_audit')
     .select(timeEntryAuditSelect)
     .order('created_at', { ascending: false })
-    .limit(opts.limit ?? 200);
+    // Rundligt tilltaget: loggen innehåller bara ANDRAS ändringar, som per konstruktion är
+    // undantag. Filtreringen på arbetsdatum sker i JS (värdet bor i jsonb), så en för snäv gräns
+    // hade tyst svarat "ingen har rört månaden" om en äldre månad — därför hellre en gräns ingen
+    // realistisk mängd rättelser når.
+    .limit(opts.limit ?? 1000);
 
   // Utan userId begränsar RLS till den egna tiden, om man inte har time.entry.read.all.
   if (opts.userId) query = query.eq('user_id', opts.userId);
@@ -69,6 +74,13 @@ export function auditInRange(row: TimeEntryAuditRow, range: { from: string; to: 
 
 // ── Vad som faktiskt ändrades ────────────────────────────────────────────────
 
+/**
+ * En ändrad uppgift. `null` betyder ALLTID "tomt" — aldrig "vet ej".
+ *
+ * ⚠️ Överlasta inte `to` med en sentinel. En tidigare version skrev jobbytet som `to: null` och
+ * lät vyn hoppa över pilen, vilket gjorde att en TÖMD anteckning ritades som bara sitt gamla värde
+ * — "Anteckning: Fel" läste som det som står där nu, tvärtom mot vad som hänt.
+ */
 export type AuditChange = { label: string; from: string | null; to: string | null };
 
 const CLOCK_FIELDS = ['start_time', 'end_time'] as const;
@@ -123,7 +135,7 @@ export function describeAuditChange(row: Pick<TimeEntryAuditRow, 'action' | 'bef
   // Målbytet redovisas som ett faktum, inte som två uuid:n.
   const targets = ['work_order_id', 'internal_project_id', 'absence_type_id'] as const;
   if (targets.some((field) => before[field] !== after[field])) {
-    changes.push({ label: 'Jobb eller orsak', from: 'ändrat', to: null });
+    changes.push({ label: 'Jobb eller orsak', from: null, to: 'ändrat' });
   }
 
   return changes;

--- a/lib/domains/time/audit.ts
+++ b/lib/domains/time/audit.ts
@@ -1,0 +1,136 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { minutesToHours } from './hours';
+
+// Revisionsloggen för tidrader — läsningen.
+//
+// Skrivningen sköts av en databastrigger (20260814_time_admin_corrections.sql) och kan inte
+// kringgås. Det här är den andra halvan: en logg ingen läser är inte en logg, den är en förklaring
+// man tänkte ge.
+//
+// ⚠️ BARA ÄNDRINGAR AV NÅGON ANNANS TID FINNS HÄR. Triggern hoppar över egna ändringar med flit —
+// varje sparning i /tid hade annars dränkt de rader man faktiskt vill hitta. En tom logg betyder
+// alltså "ingen annan har rört din tid", inte "ingenting har hänt".
+//
+// Vem som får läsa avgörs av RLS: den vars tid det gäller, och den som har time.entry.read.all.
+
+export type TimeEntryAuditRow = {
+  id: string;
+  entry_id: string;
+  user_id: string;
+  changed_by: string;
+  action: 'insert' | 'update' | 'delete';
+  before_data: Record<string, unknown> | null;
+  after_data: Record<string, unknown> | null;
+  created_at: string;
+  changed_by_profile?: { full_name: string | null } | null;
+};
+
+export const timeEntryAuditSelect =
+  'id, entry_id, user_id, changed_by, action, before_data, after_data, created_at, changed_by_profile:profiles!changed_by(full_name)';
+
+/**
+ * Loggrader för ett datumintervall.
+ *
+ * Intervallet gäller RADENS arbetsdatum, inte när ändringen gjordes: frågan man ställer är "har
+ * någon rört augusti?", inte "vad hände i augusti". En rättelse i september av en augustidag hör
+ * till augusti.
+ *
+ * Datumet läses ur `before_data` för en radering och ur `after_data` annars — en raderad rad har
+ * inget efteråt, och en ny inget innan. Filtreringen sker i JS eftersom värdet bor i jsonb och ett
+ * uttrycksfilter mot PostgREST hade varit svårare att läsa än den här kommentaren.
+ */
+export async function listTimeEntryAudit(
+  supabase: SupabaseClient,
+  opts: { userId?: string; limit?: number } = {},
+) {
+  let query = supabase
+    .from('crm_time_entry_audit')
+    .select(timeEntryAuditSelect)
+    .order('created_at', { ascending: false })
+    .limit(opts.limit ?? 200);
+
+  // Utan userId begränsar RLS till den egna tiden, om man inte har time.entry.read.all.
+  if (opts.userId) query = query.eq('user_id', opts.userId);
+
+  return query;
+}
+
+/** Radens arbetsdatum, oavsett om den skapades, ändrades eller togs bort. */
+export function auditWorkDate(row: Pick<TimeEntryAuditRow, 'before_data' | 'after_data'>): string | null {
+  const source = row.after_data ?? row.before_data;
+  const value = source?.work_date;
+  return typeof value === 'string' ? value : null;
+}
+
+export function auditInRange(row: TimeEntryAuditRow, range: { from: string; to: string }): boolean {
+  const date = auditWorkDate(row);
+  return !!date && date >= range.from && date <= range.to;
+}
+
+// ── Vad som faktiskt ändrades ────────────────────────────────────────────────
+
+export type AuditChange = { label: string; from: string | null; to: string | null };
+
+const CLOCK_FIELDS = ['start_time', 'end_time'] as const;
+
+function clock(value: unknown): string | null {
+  return typeof value === 'string' ? value.slice(0, 5) : null;
+}
+
+function hours(value: unknown): string | null {
+  const minutes = typeof value === 'number' ? value : null;
+  return minutes == null ? null : `${minutesToHours(minutes).toFixed(2).replace('.', ',')} h`;
+}
+
+function text(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() !== '' ? value : null;
+}
+
+const KIND_LABELS: Record<string, string> = {
+  work_order: 'Arbetsorder',
+  internal: 'Intern tid',
+  absence: 'Frånvaro',
+};
+
+/**
+ * Skillnaden mellan före och efter, i klartext.
+ *
+ * ⚠️ MÅL-ID:N ÖVERSÄTTS INTE TILL NAMN. Loggen sparar radens uuid:n, och att slå upp dem här hade
+ * krävt en join per rad mot fyra tabeller — varav några kan ha hunnit ändras sedan dess, vilket
+ * gjort loggen till en beskrivning av NUET i stället för av vad som hände. Ett byte redovisas
+ * därför som ett byte, utan att låtsas namnge det. Klockslag, minuter, datum och anteckning är
+ * däremot självförklarande och visas som de är.
+ */
+export function describeAuditChange(row: Pick<TimeEntryAuditRow, 'action' | 'before_data' | 'after_data'>): AuditChange[] {
+  if (row.action !== 'update') return [];
+  const before = row.before_data ?? {};
+  const after = row.after_data ?? {};
+  const changes: AuditChange[] = [];
+
+  const push = (label: string, from: string | null, to: string | null) => {
+    if (from !== to) changes.push({ label, from, to });
+  };
+
+  for (const field of CLOCK_FIELDS) {
+    push(field === 'start_time' ? 'Starttid' : 'Sluttid', clock(before[field]), clock(after[field]));
+  }
+  push('Rast', text(String(before.break_minutes ?? '')), text(String(after.break_minutes ?? '')));
+  push('Arbetad tid', hours(before.minutes_worked), hours(after.minutes_worked));
+  push('Datum', text(before.work_date), text(after.work_date));
+  push('Sort', KIND_LABELS[String(before.kind)] ?? null, KIND_LABELS[String(after.kind)] ?? null);
+  push('Anteckning', text(before.note), text(after.note));
+
+  // Målbytet redovisas som ett faktum, inte som två uuid:n.
+  const targets = ['work_order_id', 'internal_project_id', 'absence_type_id'] as const;
+  if (targets.some((field) => before[field] !== after[field])) {
+    changes.push({ label: 'Jobb eller orsak', from: 'ändrat', to: null });
+  }
+
+  return changes;
+}
+
+export function auditActionLabel(action: TimeEntryAuditRow['action']): string {
+  if (action === 'delete') return 'Raden togs bort';
+  if (action === 'insert') return 'Raden lades till';
+  return 'Raden ändrades';
+}

--- a/lib/domains/time/entries.ts
+++ b/lib/domains/time/entries.ts
@@ -257,8 +257,26 @@ export async function getTimeEntryForCorrection(supabase: SupabaseClient, id: st
     .maybeSingle();
 }
 
-/** Fälten en admin får rätta. Allt annat ärvs från raden. */
+/**
+ * Fälten en admin får rätta. Allt som utelämnas ärvs från raden.
+ *
+ * ⚠️ `user_id` finns INTE här, och kommer aldrig att göra det. Att rätta ett fel är en sak; att
+ * flytta någons timmar till en annan persons löneunderlag är en annan, och den ska inte gå att
+ * göra av misstag eller med en handskriven request.
+ *
+ * Allt annat ÄR rättbart — inklusive `kind`, datum och vilket jobb raden hör till. Det var
+ * ursprungligen låst av mig, men William 2026-08-14: "kan ju varit så att dom råkat rapportera på
+ * fel projekt eller liknande". Att rapportera på fel arbetsorder är precis den sortens misstag
+ * rättelsen finns för, och en rättelse som inte kan laga det hade skickat folk till att radera och
+ * skriva om raden i stället — vilket ger sämre spår, inte bättre.
+ */
 export type TimeEntryCorrection = {
+  kind?: TimeEntryKind;
+  work_date?: string;
+  work_order_id?: string | null;
+  internal_project_id?: string | null;
+  absence_type_id?: string | null;
+  time_code_id?: string | null;
   start_time?: string | null;
   end_time?: string | null;
   break_minutes?: number;
@@ -267,7 +285,13 @@ export type TimeEntryCorrection = {
   note?: string | null;
 };
 
-/** Befintlig rad + rättelse → indata till buildTimeEntryRow. Ren, så sammanslagningen går att testa. */
+/**
+ * Befintlig rad + rättelse → indata till buildTimeEntryRow. Ren, så sammanslagningen går att testa.
+ *
+ * Byts `kind` nollställer buildTimeEntryRow de mål som inte hör till den nya sorten, och kräver att
+ * det nya målet finns — en halvfärdig ändring blir alltså ett läsbart fel i stället för en rad som
+ * påstår sig vara arbetsordertid utan arbetsorder.
+ */
 export function mergeCorrection(
   existing: {
     kind: TimeEntryKind;
@@ -286,13 +310,12 @@ export function mergeCorrection(
 ): TimeEntryInput {
   const pick = <T,>(next: T | undefined, current: T): T => (next === undefined ? current : next);
   return {
-    // Aldrig från anropet: diskriminatorn, datumet och måltavlan hör till raden.
-    kind: existing.kind,
-    work_date: existing.work_date,
-    work_order_id: existing.work_order_id,
-    internal_project_id: existing.internal_project_id,
-    absence_type_id: existing.absence_type_id,
-    time_code_id: existing.time_code_id,
+    kind: pick(patch.kind, existing.kind),
+    work_date: pick(patch.work_date, existing.work_date),
+    work_order_id: pick(patch.work_order_id, existing.work_order_id),
+    internal_project_id: pick(patch.internal_project_id, existing.internal_project_id),
+    absence_type_id: pick(patch.absence_type_id, existing.absence_type_id),
+    time_code_id: pick(patch.time_code_id, existing.time_code_id),
     start_time: pick(patch.start_time, existing.start_time),
     end_time: pick(patch.end_time, existing.end_time),
     break_minutes: pick(patch.break_minutes, existing.break_minutes ?? 0),

--- a/lib/domains/time/entries.ts
+++ b/lib/domains/time/entries.ts
@@ -252,7 +252,7 @@ export async function updateTimeEntry(
 export async function getTimeEntryForCorrection(supabase: SupabaseClient, id: string) {
   return supabase
     .from('crm_time_entries')
-    .select('id, user_id, kind, work_date, work_order_id, internal_project_id, absence_type_id, start_time, end_time, break_minutes, minutes_worked, time_code_id, note')
+    .select('id, user_id, kind, work_date, work_order_id, internal_project_id, absence_type_id, start_time, end_time, break_minutes, minutes_worked, hours, time_code_id, note')
     .eq('id', id)
     .maybeSingle();
 }
@@ -303,6 +303,8 @@ export function mergeCorrection(
     end_time: string | null;
     break_minutes: number | null;
     minutes_worked: number | null;
+    /** Fallbacken för de gamla kontorsraderna, där minutes_worked är NULL men hours satt. */
+    hours: number | null;
     time_code_id: string | null;
     note: string | null;
   },
@@ -319,8 +321,16 @@ export function mergeCorrection(
     start_time: pick(patch.start_time, existing.start_time),
     end_time: pick(patch.end_time, existing.end_time),
     break_minutes: pick(patch.break_minutes, existing.break_minutes ?? 0),
-    // Frånvaro anges i timmar. Utelämnas de behålls radens nuvarande minuttal, omräknat.
-    hours: pick(patch.hours, existing.minutes_worked != null ? existing.minutes_worked / 60 : null),
+    // Frånvaro anges i timmar. Utelämnas de behålls radens nuvarande värde.
+    //
+    // ⚠️ `hours` är fallbacken och måste vara med. På de gamla kontorsraderna är minutes_worked NULL
+    // men hours satt; utan fallbacken blev timtalet null, buildTimeEntryRow krävde klockslag som
+    // raden aldrig haft, och admin fick hitta på tider — varpå triggern skrev om radens hours till
+    // något helt annat. En rättelse av ARBETSORDERN hade då tyst ändrat lönetimmarna.
+    hours: pick(
+      patch.hours,
+      existing.minutes_worked != null ? existing.minutes_worked / 60 : existing.hours,
+    ),
     note: pick(patch.note, existing.note),
   };
 }

--- a/lib/domains/time/entries.ts
+++ b/lib/domains/time/entries.ts
@@ -154,12 +154,21 @@ export function buildTimeEntryRow(input: TimeEntryInput, userId: string): BuiltT
  */
 export function toSummarizableEntry(row: TimeEntryRow): SummarizableEntry {
   const workOrder = row.work_order;
-  // Ordernumret först: det är vad kontoret känner igen ett jobb på. Projekt- eller kundnamn läggs
-  // till när det finns, så en rad går att placera utan att slå upp ordern.
+
+  // ⚠️ FORTNOX-NUMRET LEDER, det interna är reserven — och `#` sätts bara på Fortnox-numret.
+  //
+  // Samma regel som `documentRef` i app/crm/lib/format.ts, som är husets konvention på varje annan
+  // CRM-yta. Skälet är praktiskt: kunder, fakturor, offerter och ordrar visar alla Fortnox-numret,
+  // så ett internt AO-nummer i attesten är ett nummer ingen som granskar känner igen. Regeln
+  // upprepas här i stället för att importeras: en domänmodul ska inte hänga på en UI-hjälpare.
+  //
+  // Projekt- eller kundnamnet läggs till när det finns, så en rad går att placera utan att slå upp
+  // ordern.
+  const orderRef = workOrder?.fortnox_order_number
+    ? `#${workOrder.fortnox_order_number}`
+    : workOrder?.order_number || null;
   const workOrderLabel = workOrder
-    ? [workOrder.order_number || workOrder.fortnox_order_number, workOrder.project_name || workOrder.client_name]
-        .filter(Boolean)
-        .join(' · ') || null
+    ? [orderRef, workOrder.project_name || workOrder.client_name].filter(Boolean).join(' · ') || null
     : null;
 
   return {

--- a/lib/domains/time/entries.ts
+++ b/lib/domains/time/entries.ts
@@ -172,6 +172,7 @@ export function toSummarizableEntry(row: TimeEntryRow): SummarizableEntry {
     : null;
 
   return {
+    id: row.id,
     workDate: row.work_date,
     startTime: row.start_time,
     endTime: row.end_time,
@@ -227,6 +228,98 @@ export async function updateTimeEntry(
     .eq('id', id)
     .eq('user_id', userId)
     .select(timeEntrySelect)
+    .maybeSingle();
+}
+
+// ── Adminrättelser ───────────────────────────────────────────────────────────
+// Funktionerna nedan är INTE ägarskopade, och det är hela poängen: en admin rättar någon annans
+// rad. Säkerhetsgränsen är RLS (`time.entry.write.all` i 20260814_time_admin_corrections.sql), och
+// varje ändring loggas av en databastrigger — inte av koden här, så en serverväg som glömmer logga
+// inte kan finnas.
+//
+// Periodlåset gäller oförändrat och prövas mot RADENS ÄGARE. Admin måste alltså öppna personens
+// period först; attesterad tid går inte att röra ens härifrån.
+
+/**
+ * Raden som den ser ut nu — underlaget för en rättelse.
+ *
+ * Hela raden och inte bara ägaren: en rättelse SLÅS IHOP med det som redan står. `kind` och
+ * måltavlan (arbetsorder, internprojekt, frånvaroorsak) kommer alltid härifrån och aldrig från
+ * anropet, så en rättelse kan ändra klockslagen men aldrig flytta timmarna till ett annat jobb
+ * eller göra om arbetstid till frånvaro. Det är inte en begränsning som råkade bli så — det är
+ * skillnaden mellan att rätta ett fel och att skriva om någons löneunderlag.
+ */
+export async function getTimeEntryForCorrection(supabase: SupabaseClient, id: string) {
+  return supabase
+    .from('crm_time_entries')
+    .select('id, user_id, kind, work_date, work_order_id, internal_project_id, absence_type_id, start_time, end_time, break_minutes, minutes_worked, time_code_id, note')
+    .eq('id', id)
+    .maybeSingle();
+}
+
+/** Fälten en admin får rätta. Allt annat ärvs från raden. */
+export type TimeEntryCorrection = {
+  start_time?: string | null;
+  end_time?: string | null;
+  break_minutes?: number;
+  /** Bara för frånvaro, som anges i timmar. */
+  hours?: number | null;
+  note?: string | null;
+};
+
+/** Befintlig rad + rättelse → indata till buildTimeEntryRow. Ren, så sammanslagningen går att testa. */
+export function mergeCorrection(
+  existing: {
+    kind: TimeEntryKind;
+    work_date: string;
+    work_order_id: string | null;
+    internal_project_id: string | null;
+    absence_type_id: string | null;
+    start_time: string | null;
+    end_time: string | null;
+    break_minutes: number | null;
+    minutes_worked: number | null;
+    time_code_id: string | null;
+    note: string | null;
+  },
+  patch: TimeEntryCorrection,
+): TimeEntryInput {
+  const pick = <T,>(next: T | undefined, current: T): T => (next === undefined ? current : next);
+  return {
+    // Aldrig från anropet: diskriminatorn, datumet och måltavlan hör till raden.
+    kind: existing.kind,
+    work_date: existing.work_date,
+    work_order_id: existing.work_order_id,
+    internal_project_id: existing.internal_project_id,
+    absence_type_id: existing.absence_type_id,
+    time_code_id: existing.time_code_id,
+    start_time: pick(patch.start_time, existing.start_time),
+    end_time: pick(patch.end_time, existing.end_time),
+    break_minutes: pick(patch.break_minutes, existing.break_minutes ?? 0),
+    // Frånvaro anges i timmar. Utelämnas de behålls radens nuvarande minuttal, omräknat.
+    hours: pick(patch.hours, existing.minutes_worked != null ? existing.minutes_worked / 60 : null),
+    note: pick(patch.note, existing.note),
+  };
+}
+
+export async function adminUpdateTimeEntry(supabase: SupabaseClient, id: string, row: Record<string, unknown>) {
+  // `user_id` skalas bort. Att rätta en rad är en sak, att flytta den till en annan persons
+  // löneunderlag en helt annan — och den andra ska inte gå att göra av misstag.
+  const { user_id: _ignored, ...patch } = row;
+  return supabase
+    .from('crm_time_entries')
+    .update(patch)
+    .eq('id', id)
+    .select(timeEntrySelect)
+    .maybeSingle();
+}
+
+export async function adminDeleteTimeEntry(supabase: SupabaseClient, id: string) {
+  return supabase
+    .from('crm_time_entries')
+    .delete()
+    .eq('id', id)
+    .select('id')
     .maybeSingle();
 }
 

--- a/lib/domains/time/summary.ts
+++ b/lib/domains/time/summary.ts
@@ -47,6 +47,15 @@ export type DayRow = {
   /** Tidraden bakom dagraden, när den är känd — annars går raden inte att rätta. */
   entryId: string | null;
   /**
+   * Radens sort.
+   *
+   * ⚠️ Går inte att härleda ur siffrorna. En internrad har arbetade minuter precis som en
+   * arbetsorderrad, så en rättelse som gissade sorten ur `absenceMinutes` öppnade internraden som
+   * "Arbetsorder" — och ett valt jobb föll då tyst bort i sammanslagningen medan UI:t sa att raden
+   * var rättad.
+   */
+  kind: TimeEntryKind;
+  /**
    * Rastavdraget i minuter.
    *
    * ⚠️ Måste följa med. Den som RÄTTAR raden skickar tillbaka rasten tillsammans med klockslagen,
@@ -75,6 +84,7 @@ export function buildDayRows(entries: SummarizableEntry[]): DayRow[] {
         note: entry.note ?? null,
         label: isAbsence ? null : entry.label ?? null,
         entryId: entry.id ?? null,
+        kind: entry.kind,
         breakMinutes: isAbsence ? 0 : entry.breakMinutes ?? 0,
       };
     });

--- a/lib/domains/time/summary.ts
+++ b/lib/domains/time/summary.ts
@@ -46,6 +46,15 @@ export type DayRow = {
   label: string | null;
   /** Tidraden bakom dagraden, när den är känd — annars går raden inte att rätta. */
   entryId: string | null;
+  /**
+   * Rastavdraget i minuter.
+   *
+   * ⚠️ Måste följa med. Den som RÄTTAR raden skickar tillbaka rasten tillsammans med klockslagen,
+   * och servern räknar om minuterna ur alla tre. Saknas den här defaultar formuläret till noll och
+   * en rättad 07:00–16:00 med halvtimmes rast går från 510 till 540 minuter — trettio minuter
+   * tillagda på någons lön, tyst, vid varje rättelse.
+   */
+  breakMinutes: number;
 };
 
 // En rad per tidrad, inte per dag: byrån vill se klockslagen, och två pass samma dag har två par.
@@ -66,6 +75,7 @@ export function buildDayRows(entries: SummarizableEntry[]): DayRow[] {
         note: entry.note ?? null,
         label: isAbsence ? null : entry.label ?? null,
         entryId: entry.id ?? null,
+        breakMinutes: isAbsence ? 0 : entry.breakMinutes ?? 0,
       };
     });
 }

--- a/lib/domains/time/summary.ts
+++ b/lib/domains/time/summary.ts
@@ -15,6 +15,8 @@ export type TimeEntryKind = 'work_order' | 'internal' | 'absence';
 export type SummarizableEntry = ShiftInput & {
   kind: TimeEntryKind;
   userId: string;
+  /** Tidradens id. Underlaget är en LÄSVY, men attesten måste kunna peka ut raden som ska rättas. */
+  id?: string;
   /** Frånvaroorsakens namn (crm_absence_types.name) — hamnar i underlagets frånvarokolumn. */
   absenceReason?: string | null;
   /** Byråns lönesort, från referensraden. */
@@ -42,6 +44,8 @@ export type DayRow = {
   note: string | null;
   /** Arbetsordern eller internprojektet raden hör till. Null på frånvaro. */
   label: string | null;
+  /** Tidraden bakom dagraden, när den är känd — annars går raden inte att rätta. */
+  entryId: string | null;
 };
 
 // En rad per tidrad, inte per dag: byrån vill se klockslagen, och två pass samma dag har två par.
@@ -61,6 +65,7 @@ export function buildDayRows(entries: SummarizableEntry[]): DayRow[] {
         absenceReasons: isAbsence && entry.absenceReason ? [entry.absenceReason] : [],
         note: entry.note ?? null,
         label: isAbsence ? null : entry.label ?? null,
+        entryId: entry.id ?? null,
       };
     });
 }

--- a/supabase/sql/20260812_time_approvals.sql
+++ b/supabase/sql/20260812_time_approvals.sql
@@ -30,6 +30,13 @@
 -- 20260811_time_entries_reshape.sql + _rls.sql och 20260811_time_compensations.sql.
 -- Den här filen ÄGER numera write-policyerna på BÅDA de tabellerna — se SUPERSEDED-noterna i
 -- respektive fil. Kör den SIST av tid-filerna, och kör om den om någon av dem körts om.
+--
+-- ⚠️⚠️ DELVIS SUPERSEDED av supabase/sql/20260814_time_admin_corrections.sql (2026-08-14).
+-- Den filen äger numera `crm_time_entries_update_own` och `_delete_own` — den lägger till
+-- admin-grenen (`time.entry.write.all`) som gör det möjligt att rätta någon annans rad i en öppen
+-- period. `create policy` har inget `or replace`, så KÖRS DEN HÄR FILEN EFTERÅT försvinner
+-- admin-grenen TYST: rättelserna träffar noll rader utan fel, och routen svarar "Tidraden hittades
+-- inte" om en rad som syns i listan. Kör alltså 20260814 SIST av tid-filerna, inte den här.
 -- Idempotent (kör den två gånger i SQL-editorn innan du litar på den).
 
 -- ── 1. Tabellen ──────────────────────────────────────────────────────────────

--- a/supabase/sql/20260814_time_admin_corrections.sql
+++ b/supabase/sql/20260814_time_admin_corrections.sql
@@ -47,7 +47,11 @@ create table if not exists public.crm_time_entry_audit (
   -- Vems tid det gällde, och vem som ändrade. Båda behövs: "admin ändrade" utan att veta vems
   -- lön det rörde är oanvändbart, och tvärtom likaså.
   user_id       uuid not null,
-  changed_by    uuid not null,
+  -- NULL = okänd aktör (servicenyckel eller SQL-editor, där auth.uid() är null). Nullbar OCH med
+  -- främmande nyckel, inte ett noll-uuid: dels för att en sentinel som inte finns i profiles gör
+  -- FK:n omöjlig, dels för att PostgREST kräver en FK för att kunna bädda in namnet — utan den
+  -- svarar hela läsningen PGRST200 och loggen går inte att visa alls.
+  changed_by    uuid references public.profiles(id) on delete set null,
   action        text not null check (action in ('update','delete','insert')),
   -- Hela raden före och efter, som jsonb. Inte kolumn för kolumn: tabellen växer med tiden, och en
   -- logg som tappar ett fält när schemat ändras är sämre än ingen logg alls.
@@ -63,6 +67,23 @@ create table if not exists public.crm_time_entry_audit (
   -- ett värde som triggern ser utan att hela ändringen görs i EN databasfunktion.)
   created_at    timestamptz not null default now()
 );
+
+-- Migrering för den som redan kört en tidigare version av den här filen: kolumnen skapades då
+-- `not null` utan FK, och `create table if not exists` rör inte en tabell som finns.
+do $$
+begin
+  alter table public.crm_time_entry_audit alter column changed_by drop not null;
+exception when others then null;
+end $$;
+
+update public.crm_time_entry_audit
+   set changed_by = null
+ where changed_by = '00000000-0000-0000-0000-000000000000'::uuid;
+
+alter table public.crm_time_entry_audit drop constraint if exists crm_time_entry_audit_changed_by_fkey;
+alter table public.crm_time_entry_audit
+  add constraint crm_time_entry_audit_changed_by_fkey
+  foreign key (changed_by) references public.profiles(id) on delete set null;
 
 create index if not exists crm_time_entry_audit_entry_idx on public.crm_time_entry_audit (entry_id, created_at desc);
 create index if not exists crm_time_entry_audit_user_idx  on public.crm_time_entry_audit (user_id, created_at desc);
@@ -160,8 +181,9 @@ begin
   values (
     v_entry,
     v_owner,
-    -- changed_by är not null: en okänd aktör bokförs som nollan i stället för att raden faller bort.
-    coalesce(v_actor, '00000000-0000-0000-0000-000000000000'::uuid),
+    -- NULL när aktören är okänd (servicenyckel, SQL-editor). Loggen ska bära det som ett faktum,
+    -- inte som ett påhittat uuid som ingen profil matchar.
+    v_actor,
     lower(tg_op),
     v_before,
     v_after

--- a/supabase/sql/20260814_time_admin_corrections.sql
+++ b/supabase/sql/20260814_time_admin_corrections.sql
@@ -17,8 +17,10 @@
 -- som medvetet ligger på två ställen (trigger + policy), hade blivit dekoration. Att öppna perioden
 -- kräver en anledning som syns för den anställde, så rättelsen lämnar spår i BÅDA ändarna.
 --
--- ADDITIV: nya nycklar, ny tabell, nya policygrenar. Inget befintligt villkor tas bort, så den kan
--- köras före eller efter koden. (Före koden ger bara en nyckel ingen ännu använder.)
+-- ⚠️ KÖRS FÖRE KODEN. Additiv i schemat, men INTE i beteende: getEffectivePermissions failar closed,
+-- så en route som vaktar på en nyckel databasen inte känner till nekar alla. Och utan policygrenen
+-- nedan träffar adminens UPDATE noll rader UTAN fel, vilket routen svarar 404 på — om en rad som
+-- syns i listan. PERMISSIONS.md: "The same rule applies to every later key ... each SQL-first".
 
 
 -- ── 1. Nyckeln ───────────────────────────────────────────────────────────────
@@ -68,9 +70,12 @@ create index if not exists crm_time_entry_audit_user_idx  on public.crm_time_ent
 -- Loggen är läsbar för den som får se andras tid, och för den vars tid det gäller — den anställde
 -- ska kunna se att någon rört hens rader. INGA insert/update/delete-policyer: raderna skrivs bara
 -- av triggern nedan, som är security definer. En logg som går att redigera är inte en logg.
+-- `force` och inte bara `enable`: utan den går tabellägaren förbi RLS, och revoke gäller inte
+-- service_role. En logg som en serverväg kan tömma är ingen logg.
 alter table public.crm_time_entry_audit enable row level security;
+alter table public.crm_time_entry_audit force row level security;
 grant select on public.crm_time_entry_audit to authenticated;
-revoke insert, update, delete on public.crm_time_entry_audit from authenticated;
+revoke insert, update, delete on public.crm_time_entry_audit from authenticated, anon;
 
 drop policy if exists crm_time_entry_audit_select on public.crm_time_entry_audit;
 create policy crm_time_entry_audit_select on public.crm_time_entry_audit
@@ -78,7 +83,34 @@ create policy crm_time_entry_audit_select on public.crm_time_entry_audit
   using (user_id = auth.uid() or public.has_permission('time.entry.read.all'));
 
 
--- ── 3. Triggern som loggar ───────────────────────────────────────────────────
+-- ── 3. Ägarlåset ─────────────────────────────────────────────────────────────
+-- ⚠️ EN TIDRAD FÅR ALDRIG BYTA ÄGARE. Att rätta ett fel är en sak; att flytta någons timmar till en
+-- annan persons löneunderlag en helt annan.
+--
+-- Fram till nu höll RLS det: WITH CHECK krävde `user_id = auth.uid()`, så en PATCH som ändrade
+-- ägaren avvisades oavsett vilken väg den kom. Admin-grenen nedan släpper det villkoret för den som
+-- har time.entry.write.all — och WITH CHECK KAN INTE SE OLD, så den kan omöjligt jämföra gammal och
+-- ny ägare. Utan den här triggern vore appens fältstrippning enda skyddet, och den gäller inte en
+-- request som går direkt mot PostgREST med användarens egen session.
+create or replace function public.enforce_time_entry_owner()
+returns trigger
+language plpgsql
+as $$
+begin
+  if new.user_id is distinct from old.user_id then
+    raise exception 'En tidrad kan inte byta ägare';
+  end if;
+  return new;
+end;
+$$;
+
+drop trigger if exists enforce_time_entry_owner on public.crm_time_entries;
+create trigger enforce_time_entry_owner
+  before update on public.crm_time_entries
+  for each row execute function public.enforce_time_entry_owner();
+
+
+-- ── 4. Triggern som loggar ───────────────────────────────────────────────────
 -- security definer: loggen ska skrivas även om den som ändrar inte har rätt att skriva i
 -- audit-tabellen — vilket ingen har, med flit.
 create or replace function public.log_time_entry_change()
@@ -108,7 +140,11 @@ begin
   elsif tg_op = 'INSERT' then
     v_owner := new.user_id; v_entry := new.id; v_before := null;             v_after := to_jsonb(new);
   else
-    v_owner := new.user_id; v_entry := new.id; v_before := to_jsonb(old);    v_after := to_jsonb(new);
+    -- ⚠️ ÄGAREN TAS UR OLD PÅ EN UPPDATERING. Tog vi den ur NEW skulle en ägarflytt bokföras under
+    -- den som TOG timmarna, och om den som flyttade dem tog dem till sig själv blev actor = owner
+    -- och hoppet nedan skrev ingen rad alls — spårlöst, alltså precis tvärtemot vad loggen finns
+    -- för. Ägarlåset ovan gör flytten omöjlig, men loggen ska inte förlita sig på en annan trigger.
+    v_owner := old.user_id; v_entry := old.id; v_before := to_jsonb(old);    v_after := to_jsonb(new);
   end if;
 
   -- Egna ändringar loggas inte. Den normala vägen i /tid ska inte fylla loggen med brus; det är
@@ -145,7 +181,7 @@ create trigger log_time_entry_change
   for each row execute function public.log_time_entry_change();
 
 
--- ── 4. Policygrenarna ────────────────────────────────────────────────────────
+-- ── 5. Policygrenarna ────────────────────────────────────────────────────────
 -- ⚠️ DE HÄR ERSÄTTER policyerna med samma namn i 20260812_time_approvals.sql. Kör den filen INNAN
 -- den här, aldrig efter — annars försvinner admin-grenen tyst, precis som periodlåset gjorde när
 -- 20260811-filerna kördes om. `create policy` har inget `or replace`.

--- a/supabase/sql/20260814_time_admin_corrections.sql
+++ b/supabase/sql/20260814_time_admin_corrections.sql
@@ -88,30 +88,52 @@ security definer
 set search_path = public
 as $$
 declare
-  v_actor uuid := auth.uid();
-  v_owner uuid := coalesce(new.user_id, old.user_id);
+  v_actor  uuid := auth.uid();
+  v_owner  uuid;
+  v_entry  uuid;
+  v_before jsonb;
+  v_after  jsonb;
 begin
+  -- ⚠️ EN GREN PER OPERATION, aldrig `coalesce(new.x, old.x)`.
+  --
+  -- I plpgsql är NEW OALLOKERAD i en delete-trigger och OLD i en insert-trigger, och att läsa ett
+  -- fält ur en oallokerad record är ett fel — inte null. coalesce hjälper inte, den evaluerar båda
+  -- argumenten. En sådan funktion hade fått VARJE insert och VARJE delete på crm_time_entries att
+  -- misslyckas, alltså all tidrapportering och inte bara adminrättelserna.
+  --
+  -- enforce_time_period_lock i 20260812_time_approvals.sql undviker samma sak med flit; dess
+  -- kommentar om "två grenar i stället för ett CASE" är samma fälla.
+  if tg_op = 'DELETE' then
+    v_owner := old.user_id; v_entry := old.id; v_before := to_jsonb(old); v_after := null;
+  elsif tg_op = 'INSERT' then
+    v_owner := new.user_id; v_entry := new.id; v_before := null;             v_after := to_jsonb(new);
+  else
+    v_owner := new.user_id; v_entry := new.id; v_before := to_jsonb(old);    v_after := to_jsonb(new);
+  end if;
+
   -- Egna ändringar loggas inte. Den normala vägen i /tid ska inte fylla loggen med brus; det är
   -- ändringar av NÅGON ANNANS tid som behöver kunna spåras.
   --
   -- v_actor är null när ändringen kommer från en servicenyckel eller ett SQL-editor-anrop. Då
   -- loggas den — en ändring utan känd användare är precis det man vill hitta i efterhand.
   if v_actor is not null and v_actor = v_owner then
-    return coalesce(new, old);
+    return null;
   end if;
 
   insert into public.crm_time_entry_audit (entry_id, user_id, changed_by, action, before_data, after_data)
   values (
-    coalesce(new.id, old.id),
+    v_entry,
     v_owner,
     -- changed_by är not null: en okänd aktör bokförs som nollan i stället för att raden faller bort.
     coalesce(v_actor, '00000000-0000-0000-0000-000000000000'::uuid),
     lower(tg_op),
-    case when tg_op in ('UPDATE','DELETE') then to_jsonb(old) end,
-    case when tg_op in ('UPDATE','INSERT') then to_jsonb(new) end
+    v_before,
+    v_after
   );
 
-  return coalesce(new, old);
+  -- AFTER-triggerns returvärde ignoreras, så null är rätt svar — och slipper röra record-variabler
+  -- en gång till.
+  return null;
 end;
 $$;
 

--- a/supabase/sql/20260814_time_admin_corrections.sql
+++ b/supabase/sql/20260814_time_admin_corrections.sql
@@ -1,0 +1,181 @@
+-- Admin får rätta andras tidrader — med revisionslogg (fas 4.8)
+--
+-- William 2026-08-14: admin ska kunna rätta när något blivit fel. Fram tills nu har regeln varit
+-- att INGEN ändrar någon annans timmar: policyerna är `user_id = auth.uid()` rakt av, och vägen att
+-- rätta har varit att öppna perioden så personen rättar själv.
+--
+-- Den regeln hade ett hål ingen adresserat: **en anställd som är sjukskriven, har slutat eller
+-- helt enkelt inte svarar när lönen ska köras.** Då gick månaden inte att rätta alls. Med Blikk
+-- borta är det här enda systemet, så hålet var inte längre teoretiskt.
+--
+-- ⚠️ LOGGEN ÄR INTE VALFRI. Utan den byter vi "kan inte rätta" mot "någon annans lön ändrades och
+-- ingen kan säga av vem". Därför skrivs revisionsraden av en TRIGGER och inte av appen: en
+-- serverväg som glömmer logga, eller en direkt UPDATE i SQL-editorn, ska inte kunna kringgå den.
+--
+-- ⚠️ ATTESTERAD TID ÄNDRAS INTE. Låset står kvar oförändrat: admin måste öppna perioden först,
+-- rätta, och attestera igen. Kunde attesterad tid ändras vore attesten meningslös — och periodlåset,
+-- som medvetet ligger på två ställen (trigger + policy), hade blivit dekoration. Att öppna perioden
+-- kräver en anledning som syns för den anställde, så rättelsen lämnar spår i BÅDA ändarna.
+--
+-- ADDITIV: nya nycklar, ny tabell, nya policygrenar. Inget befintligt villkor tas bort, så den kan
+-- köras före eller efter koden. (Före koden ger bara en nyckel ingen ännu använder.)
+
+
+-- ── 1. Nyckeln ───────────────────────────────────────────────────────────────
+-- Egen nyckel och inte `time.approve`: att få attestera är att godkänna det någon annan skrivit,
+-- att få rätta är att skriva i deras ställe. Två olika befogenheter, och den ena ska gå att ge utan
+-- den andra — en arbetsledare kan tänkas attestera utan att någonsin få ändra siffrorna.
+--
+-- Speglar lib/auth/permissions.ts PERMISSION_KEYS (antalstestet vaktar pariteten: 44 → 45).
+insert into public.permissions (key, description) values
+  ('time.entry.write.all', 'Tid: rätta andras tidrader i en öppen period')
+on conflict (key) do nothing;
+
+insert into public.role_permissions (role, permission_key) values
+  ('admin','time.entry.write.all')
+on conflict do nothing;
+
+
+-- ── 2. Revisionsloggen ───────────────────────────────────────────────────────
+-- En rad per ändring som INTE gjordes av raden ägare. Egna ändringar loggas inte: de är den
+-- normala vägen, och att logga varje sparning i /tid hade dränkt de rader man faktiskt vill hitta.
+create table if not exists public.crm_time_entry_audit (
+  id            uuid primary key default gen_random_uuid(),
+  entry_id      uuid not null,
+  -- Vems tid det gällde, och vem som ändrade. Båda behövs: "admin ändrade" utan att veta vems
+  -- lön det rörde är oanvändbart, och tvärtom likaså.
+  user_id       uuid not null,
+  changed_by    uuid not null,
+  action        text not null check (action in ('update','delete','insert')),
+  -- Hela raden före och efter, som jsonb. Inte kolumn för kolumn: tabellen växer med tiden, och en
+  -- logg som tappar ett fält när schemat ändras är sämre än ingen logg alls.
+  before_data   jsonb,
+  after_data    jsonb,
+  -- ⚠️ INGEN `reason`-kolumn, och det är avsiktligt. Motiveringen finns redan ett steg tidigare:
+  -- för att en admin ska KUNNA rätta måste perioden vara öppen, och att öppna den kräver en
+  -- anledning som sparas på attestraden och visas för den anställde i /tid. Att be om samma
+  -- förklaring en gång till per rad hade gett "." som standardsvar.
+  --
+  -- (En kolumn här skulle dessutom vara svår att fylla: `set_config(..., true)` är
+  -- transaktionslokal och PostgREST kör varje anrop i sin egen transaktion, så appen kan inte sätta
+  -- ett värde som triggern ser utan att hela ändringen görs i EN databasfunktion.)
+  created_at    timestamptz not null default now()
+);
+
+create index if not exists crm_time_entry_audit_entry_idx on public.crm_time_entry_audit (entry_id, created_at desc);
+create index if not exists crm_time_entry_audit_user_idx  on public.crm_time_entry_audit (user_id, created_at desc);
+
+-- Loggen är läsbar för den som får se andras tid, och för den vars tid det gäller — den anställde
+-- ska kunna se att någon rört hens rader. INGA insert/update/delete-policyer: raderna skrivs bara
+-- av triggern nedan, som är security definer. En logg som går att redigera är inte en logg.
+alter table public.crm_time_entry_audit enable row level security;
+grant select on public.crm_time_entry_audit to authenticated;
+revoke insert, update, delete on public.crm_time_entry_audit from authenticated;
+
+drop policy if exists crm_time_entry_audit_select on public.crm_time_entry_audit;
+create policy crm_time_entry_audit_select on public.crm_time_entry_audit
+  for select to authenticated
+  using (user_id = auth.uid() or public.has_permission('time.entry.read.all'));
+
+
+-- ── 3. Triggern som loggar ───────────────────────────────────────────────────
+-- security definer: loggen ska skrivas även om den som ändrar inte har rätt att skriva i
+-- audit-tabellen — vilket ingen har, med flit.
+create or replace function public.log_time_entry_change()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_actor uuid := auth.uid();
+  v_owner uuid := coalesce(new.user_id, old.user_id);
+begin
+  -- Egna ändringar loggas inte. Den normala vägen i /tid ska inte fylla loggen med brus; det är
+  -- ändringar av NÅGON ANNANS tid som behöver kunna spåras.
+  --
+  -- v_actor är null när ändringen kommer från en servicenyckel eller ett SQL-editor-anrop. Då
+  -- loggas den — en ändring utan känd användare är precis det man vill hitta i efterhand.
+  if v_actor is not null and v_actor = v_owner then
+    return coalesce(new, old);
+  end if;
+
+  insert into public.crm_time_entry_audit (entry_id, user_id, changed_by, action, before_data, after_data)
+  values (
+    coalesce(new.id, old.id),
+    v_owner,
+    -- changed_by är not null: en okänd aktör bokförs som nollan i stället för att raden faller bort.
+    coalesce(v_actor, '00000000-0000-0000-0000-000000000000'::uuid),
+    lower(tg_op),
+    case when tg_op in ('UPDATE','DELETE') then to_jsonb(old) end,
+    case when tg_op in ('UPDATE','INSERT') then to_jsonb(new) end
+  );
+
+  return coalesce(new, old);
+end;
+$$;
+
+-- AFTER: loggen ska spegla vad som FAKTISKT hände. En BEFORE-trigger hade skrivit en revisionsrad
+-- även för en ändring som sedan avvisades av en CHECK eller av låstriggern.
+drop trigger if exists log_time_entry_change on public.crm_time_entries;
+create trigger log_time_entry_change
+  after insert or update or delete on public.crm_time_entries
+  for each row execute function public.log_time_entry_change();
+
+
+-- ── 4. Policygrenarna ────────────────────────────────────────────────────────
+-- ⚠️ DE HÄR ERSÄTTER policyerna med samma namn i 20260812_time_approvals.sql. Kör den filen INNAN
+-- den här, aldrig efter — annars försvinner admin-grenen tyst, precis som periodlåset gjorde när
+-- 20260811-filerna kördes om. `create policy` har inget `or replace`.
+--
+-- Låsvillkoret står KVAR i båda grenarna och prövas mot RADENS ÄGARE, inte mot den som ändrar:
+-- perioden som fryser är den anställdes, och en admin som rättar måste öppna just den. Det är hela
+-- skälet till att attesterad tid förblir orörbar.
+drop policy if exists crm_time_entries_update_own on public.crm_time_entries;
+create policy crm_time_entries_update_own on public.crm_time_entries
+  for update to authenticated
+  using (
+    (user_id = auth.uid() or public.has_permission('time.entry.write.all'))
+    and not public.is_time_locked(user_id, work_date)
+  )
+  with check (
+    (user_id = auth.uid() or public.has_permission('time.entry.write.all'))
+    and not public.is_time_locked(user_id, work_date)
+    and (
+      work_order_id is null
+      or exists (
+        select 1 from public.crm_work_orders w
+        where w.id = crm_time_entries.work_order_id and w.assigned_to = auth.uid()
+      )
+      or public.is_user_on_work_order(auth.uid(), work_order_id)
+      or public.has_permission('crm.workorder.read')
+    )
+  );
+
+drop policy if exists crm_time_entries_delete_own on public.crm_time_entries;
+create policy crm_time_entries_delete_own on public.crm_time_entries
+  for delete to authenticated
+  using (
+    (user_id = auth.uid() or public.has_permission('time.entry.write.all'))
+    and not public.is_time_locked(user_id, work_date)
+  );
+
+-- INSERT lämnas ORÖRD: `user_id = auth.uid()` står kvar. Att admin ska kunna lägga till en rad åt
+-- någon annan är ett större steg — det är inte att rätta ett fel utan att skapa underlag från
+-- ingenting — och det har William inte bett om. Rättningen täcker det efterfrågade fallet.
+
+
+-- ── Verifiering ──────────────────────────────────────────────────────────────
+--   select key from public.permissions where key = 'time.entry.write.all';
+--
+--   select policyname, cmd, qual from pg_policies
+--   where schemaname='public' and tablename='crm_time_entries' and cmd in ('UPDATE','DELETE');
+--   -- båda ska nämna time.entry.write.all OCH is_time_locked(user_id, work_date)
+--
+--   select tgname from pg_trigger where tgrelid = 'public.crm_time_entries'::regclass;
+--   -- ska innehålla BÅDE enforce_time_period_lock OCH log_time_entry_change
+--
+-- Att loggen biter (kör som admin, på någon ANNANS rad i en öppen period):
+--   update public.crm_time_entries set note = note where id = '<uuid>';
+--   select action, changed_by, created_at from public.crm_time_entry_audit
+--    where entry_id = '<uuid>' order by created_at desc limit 1;

--- a/tests/auth/permissions.test.ts
+++ b/tests/auth/permissions.test.ts
@@ -20,7 +20,7 @@ describe('PERMISSION_KEYS catalog', () => {
   // Mirrors the SQL `permissions` catalog in 20260608_permissions_model.sql. If you add a key
   // there, add it here too (and to the seed + parity assert) — this guards the count.
   it('has the expected count and no duplicates', () => {
-    expect(PERMISSION_KEYS.length).toBe(44);
+    expect(PERMISSION_KEYS.length).toBe(45);
     expect(new Set(PERMISSION_KEYS).size).toBe(PERMISSION_KEYS.length);
   });
 
@@ -61,7 +61,7 @@ describe('PERMISSION_KEYS catalog', () => {
   // the CRM meta guards (crm.access/crm.write) and quietly lock installers out of their own hours.
   it('keeps the time keys outside the crm.* namespace', () => {
     const timeKeys = PERMISSION_KEYS.filter((key) => key.startsWith('time.'));
-    expect(timeKeys.length).toBe(5);
+    expect(timeKeys.length).toBe(6);
     for (const key of timeKeys) expect(key.startsWith('crm.')).toBe(false);
   });
 });

--- a/tests/time/adminEntries.route.test.ts
+++ b/tests/time/adminEntries.route.test.ts
@@ -153,6 +153,17 @@ describe('GET /api/admin/time/entries — underlaget', () => {
     expect(json.data.rows[0].label).toBe('AO-20260729-42E7C4 · Villa Ek');
   });
 
+  // Regression: mapparen ledde med det INTERNA numret, så attesten visade ett AO-nummer medan
+  // /tid visade Fortnox-numret för samma rad. Fortnox-numret är det enda någon känner igen.
+  it('visar Fortnox-numret när det finns, inte det interna', async () => {
+    mockEntries.mockResolvedValue({
+      data: [{ ...shiftRow, work_order: { ...shiftRow.work_order, fortnox_order_number: '10241' } }],
+      error: null,
+    } as any);
+    const json = await (await GET(req(URL_OK))).json();
+    expect(json.data.rows[0].label).toBe('#10241 · Villa Ek');
+  });
+
   it('håller frånvaro utanför arbetstiden och namnger orsaken', async () => {
     mockEntries.mockResolvedValue({
       data: [

--- a/tests/time/adminEntries.route.test.ts
+++ b/tests/time/adminEntries.route.test.ts
@@ -21,6 +21,12 @@ vi.mock('@/lib/domains/time/entries', async (importOriginal) => {
   return { ...actual, listTimeEntries: vi.fn() };
 });
 
+// Loggen hämtas i samma svar som dagarna sedan 2026-08-14.
+vi.mock('@/lib/domains/time/audit', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/domains/time/audit')>();
+  return { ...actual, listTimeEntryAudit: vi.fn() };
+});
+
 vi.mock('@/lib/domains/time/compensations', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/lib/domains/time/compensations')>();
   return { ...actual, listCompensations: vi.fn() };
@@ -33,12 +39,14 @@ import { getCurrentUser } from '@/lib/auth/route';
 import { getEffectivePermissions } from '@/lib/auth/permissions';
 import { listTimeEntries } from '@/lib/domains/time/entries';
 import { listCompensations } from '@/lib/domains/time/compensations';
+import { listTimeEntryAudit } from '@/lib/domains/time/audit';
 
 const { GET } = await import('@/app/api/admin/time/entries/route');
 
 const mockUser = vi.mocked(getCurrentUser);
 const mockEntries = vi.mocked(listTimeEntries);
 const mockCompensations = vi.mocked(listCompensations);
+const mockAudit = vi.mocked(listTimeEntryAudit);
 
 const ANNA = '44444444-4444-4444-8444-444444444444';
 
@@ -71,6 +79,7 @@ beforeEach(() => {
     effectivePermissionsForRole((await vi.mocked(getCurrentUser)())?.role));
   mockEntries.mockResolvedValue({ data: [], error: null } as any);
   mockCompensations.mockResolvedValue({ data: [], error: null } as any);
+  mockAudit.mockResolvedValue({ data: [], error: null } as any);
 });
 
 describe('GET /api/admin/time/entries — åtkomst', () => {
@@ -227,6 +236,19 @@ describe('GET /api/admin/time/entries — underlaget', () => {
     const json = await (await GET(req(URL_OK))).json();
     expect(json.data.rows[0].workMinutes).toBe(450);
     expect(json.data.workMinutes).toBe(450);
+  });
+
+  // Loggen är tilläggsinformation. Fallerar den ska dagarna ändå visas — att vägra rita månaden för
+  // att revisionsraderna inte gick att läsa vore att göra granskningen omöjlig av fel skäl.
+  it('visar dagarna även när ändringsloggen fallerar', async () => {
+    mockEntries.mockResolvedValue({ data: [shiftRow], error: null } as any);
+    mockAudit.mockResolvedValue({ data: null, error: { message: 'permission denied' } } as any);
+    const res = await GET(req(URL_OK));
+    const json = await res.json();
+    expect(res.status).toBe(200);
+    expect(json.data.rows).toHaveLength(1);
+    expect(json.data.audit).toEqual([]);
+    expect(json.data.audit_failed).toBe(true);
   });
 
   it('svarar 500 med databasens meddelande när läsningen fallerar', async () => {

--- a/tests/time/adminEntryEdit.route.test.ts
+++ b/tests/time/adminEntryEdit.route.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { adminUser, memberUser, konsultUser, salesUser, effectivePermissionsForRole } from '../crm/helpers/supabase';
+
+// PATCH/DELETE /api/admin/time/entries/[id] — adminrättelse av EN ANNAN PERSONS tidrad.
+//
+// Den här ytan skriver i någon annans löneunderlag, så gränserna prövas hårdare än vanligt: vem som
+// kommer in, att ägaren aldrig kan komma från anropet, att servern räknar om minuterna, och att ett
+// periodlås blir 409 med en förklaring i stället för "hittades inte".
+
+vi.mock('@/lib/auth/route', () => ({ getCurrentUser: vi.fn() }));
+
+vi.mock('@/lib/auth/permissions', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/auth/permissions')>();
+  return { ...actual, getEffectivePermissions: vi.fn() };
+});
+
+// buildTimeEntryRow körs på riktigt — det är den regel routen finns för att tillämpa.
+vi.mock('@/lib/domains/time/entries', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/domains/time/entries')>();
+  return { ...actual, getTimeEntryForCorrection: vi.fn(), adminUpdateTimeEntry: vi.fn(), adminDeleteTimeEntry: vi.fn() };
+});
+
+vi.mock('@/lib/domains/time/approvals', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/domains/time/approvals')>();
+  return { ...actual, explainWriteMiss: vi.fn() };
+});
+
+vi.mock('@supabase/auth-helpers-nextjs', () => ({ createRouteHandlerClient: vi.fn(() => ({})) }));
+vi.mock('next/headers', () => ({ cookies: vi.fn() }));
+
+import { getCurrentUser } from '@/lib/auth/route';
+import { getEffectivePermissions } from '@/lib/auth/permissions';
+import { getTimeEntryForCorrection, adminUpdateTimeEntry, adminDeleteTimeEntry } from '@/lib/domains/time/entries';
+import { explainWriteMiss } from '@/lib/domains/time/approvals';
+
+const { PATCH, DELETE } = await import('@/app/api/admin/time/entries/[id]/route');
+
+const mockUser = vi.mocked(getCurrentUser);
+const mockOwner = vi.mocked(getTimeEntryForCorrection);
+const mockUpdate = vi.mocked(adminUpdateTimeEntry);
+const mockDelete = vi.mocked(adminDeleteTimeEntry);
+const mockExplain = vi.mocked(explainWriteMiss);
+
+const ENTRY_ID = '77777777-7777-4777-8777-777777777777';
+const OWNER_ID = '88888888-8888-4888-8888-888888888888';
+const WORK_ORDER_ID = '99999999-9999-4999-8999-999999999999';
+
+const ctx = { params: { id: ENTRY_ID } };
+
+// Byråns exempel: 08–18 med en timmes rast är nio timmar, inte tio.
+const SHIFT = {
+  kind: 'work_order',
+  work_date: '2026-08-14',
+  work_order_id: WORK_ORDER_ID,
+  start_time: '08:00',
+  end_time: '18:00',
+  break_minutes: 60,
+};
+
+function jsonReq(payload: unknown) {
+  return new Request(`http://localhost/api/admin/time/entries/${ENTRY_ID}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+}
+
+function plainReq() {
+  return new Request(`http://localhost/api/admin/time/entries/${ENTRY_ID}`, { method: 'DELETE' });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getEffectivePermissions).mockImplementation(async () =>
+    effectivePermissionsForRole((await vi.mocked(getCurrentUser)())?.role));
+  mockUser.mockResolvedValue(adminUser);
+  mockOwner.mockResolvedValue({
+    data: {
+      id: ENTRY_ID, user_id: OWNER_ID, kind: 'work_order', work_date: '2026-08-14',
+      work_order_id: WORK_ORDER_ID, internal_project_id: null, absence_type_id: null,
+      start_time: '07:00:00', end_time: '16:00:00', break_minutes: 30, minutes_worked: 510,
+      time_code_id: null, note: null,
+    },
+    error: null,
+  } as any);
+  mockUpdate.mockResolvedValue({ data: { id: ENTRY_ID }, error: null } as any);
+  mockDelete.mockResolvedValue({ data: { id: ENTRY_ID }, error: null } as any);
+  mockExplain.mockResolvedValue({ locked: false });
+});
+
+describe('adminrättelse — åtkomst', () => {
+  it('kräver inloggning', async () => {
+    mockUser.mockResolvedValue(null);
+    expect((await PATCH(jsonReq(SHIFT), ctx))!.status).toBe(401);
+    expect((await DELETE(plainReq(), ctx))!.status).toBe(401);
+  });
+
+  // Egen nyckel och inte time.approve: att attestera är att godkänna det någon annan skrivit, att
+  // rätta är att skriva i deras ställe. Ingen utom admin har den i seeden.
+  it('kräver time.entry.write.all — member, sales och konsult nekas', async () => {
+    for (const user of [memberUser, salesUser, konsultUser]) {
+      mockUser.mockResolvedValue(user);
+      expect((await PATCH(jsonReq(SHIFT), ctx))!.status).toBe(403);
+      expect((await DELETE(plainReq(), ctx))!.status).toBe(403);
+    }
+    expect(mockUpdate).not.toHaveBeenCalled();
+    expect(mockDelete).not.toHaveBeenCalled();
+  });
+
+  it('avvisar ett id som inte är ett uuid', async () => {
+    const bad = { params: { id: 'inte-ett-uuid' } };
+    expect((await PATCH(jsonReq(SHIFT), bad))!.status).toBe(400);
+    expect(mockOwner).not.toHaveBeenCalled();
+  });
+});
+
+describe('adminrättelse — ägaren', () => {
+  // Det farligaste misstaget den här routen kan göra: låta anroparen bestämma vems löneunderlag
+  // raden hamnar i. Ägaren läses ur databasen, och user_id i kroppen ignoreras.
+  it('läser ägaren ur databasen och bygger raden på DEN, inte på anropets user_id', async () => {
+    await PATCH(jsonReq({ ...SHIFT, user_id: 'någon-annan' }), ctx);
+    const row = mockUpdate.mock.calls[0][2] as Record<string, unknown>;
+    expect(row.user_id).toBe(OWNER_ID);
+  });
+
+  it('svarar 404 när raden inte finns', async () => {
+    mockOwner.mockResolvedValue({ data: null, error: null } as any);
+    expect((await PATCH(jsonReq(SHIFT), ctx))!.status).toBe(404);
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+});
+
+describe('adminrättelse — regeln', () => {
+  it('räknar om minuterna på servern och lämnar hours till triggern', async () => {
+    await PATCH(jsonReq(SHIFT), ctx);
+    const row = mockUpdate.mock.calls[0][2] as Record<string, unknown>;
+    expect(row.minutes_worked).toBe(540);
+    expect(row).not.toHaveProperty('hours');
+  });
+
+  it('avvisar en rad utan klockslag — kravet gäller även en rättelse', async () => {
+    const res = (await PATCH(jsonReq({ ...SHIFT, start_time: null, end_time: null }), ctx))!;
+    expect(res.status).toBe(400);
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+});
+
+describe('adminrättelse — periodlåset', () => {
+  // Attesterad tid ändras inte, inte ens av en admin: låstriggern prövar RADENS ÄGARE. Svaret ska
+  // säga varför och vad man gör åt det, inte "hittades inte" om en rad som syns i listan.
+  it('översätter triggerns P0001 till 409', async () => {
+    mockUpdate.mockResolvedValue({ data: null, error: { code: 'P0001', message: 'augusti 2026 är attesterad' } } as any);
+    const res = (await PATCH(jsonReq(SHIFT), ctx))!;
+    expect(res.status).toBe(409);
+  });
+
+  it('förklarar noll träffar med periodens status i stället för 404', async () => {
+    mockUpdate.mockResolvedValue({ data: null, error: null } as any);
+    mockExplain.mockResolvedValue({ locked: true, message: 'augusti 2026 är attesterad och kan inte ändras.' });
+    const res = (await PATCH(jsonReq(SHIFT), ctx))!;
+    expect(res.status).toBe(409);
+    expect((await res.json()).error).toContain('attesterad');
+  });
+
+  it('frågar om ÄGARENS period, inte adminens', async () => {
+    mockUpdate.mockResolvedValue({ data: null, error: null } as any);
+    await PATCH(jsonReq(SHIFT), ctx);
+    expect(mockExplain).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ userId: OWNER_ID }));
+  });
+
+  it('gäller lika hårt vid radering', async () => {
+    mockDelete.mockResolvedValue({ data: null, error: null } as any);
+    mockExplain.mockResolvedValue({ locked: true, message: 'augusti 2026 är inlämnad.' });
+    expect((await DELETE(plainReq(), ctx))!.status).toBe(409);
+  });
+});
+
+describe('adminrättelse — radering', () => {
+  it('läser ägaren FÖRE raderingen — efteråt finns ingen rad att förklara med', async () => {
+    await DELETE(plainReq(), ctx);
+    expect(mockOwner).toHaveBeenCalled();
+    expect(mockDelete).toHaveBeenCalledWith(expect.anything(), ENTRY_ID);
+  });
+
+  it('svarar 200 med radens id när den togs bort', async () => {
+    const res = (await DELETE(plainReq(), ctx))!;
+    expect(res.status).toBe(200);
+    expect((await res.json()).data.id).toBe(ENTRY_ID);
+  });
+});

--- a/tests/time/audit.test.ts
+++ b/tests/time/audit.test.ts
@@ -58,7 +58,7 @@ describe('describeAuditChange', () => {
   // eftersom ordern kan ha ändrats sedan dess. Bytet redovisas som ett faktum.
   it('redovisar ett jobbyte utan att låtsas namnge det', () => {
     const changes = describeAuditChange(row({ after_data: { ...base, work_order_id: 'wo-2' } }));
-    expect(changes).toEqual([{ label: 'Jobb eller orsak', from: 'ändrat', to: null }]);
+    expect(changes).toEqual([{ label: 'Jobb eller orsak', from: null, to: 'ändrat' }]);
   });
 
   it('namnger sorten på svenska när den bytts', () => {
@@ -70,6 +70,9 @@ describe('describeAuditChange', () => {
     });
   });
 
+  // ⚠️ `null` betyder ALLTID tomt, aldrig "vet ej". Delade jobbytet plats med den betydelsen
+  // ritades en TÖMD anteckning som bara sitt gamla värde — "Anteckning: Fel" läste som det som
+  // står där nu, tvärtom mot vad som hänt.
   it('visar en tillagd och en borttagen anteckning', () => {
     expect(describeAuditChange(row({ after_data: { ...base, note: 'Rättat efter samtal' } }))[0])
       .toEqual({ label: 'Anteckning', from: null, to: 'Rättat efter samtal' });

--- a/tests/time/audit.test.ts
+++ b/tests/time/audit.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest';
+import {
+  auditActionLabel,
+  auditInRange,
+  auditWorkDate,
+  describeAuditChange,
+  type TimeEntryAuditRow,
+} from '@/lib/domains/time/audit';
+
+// Revisionsloggens läsning. Skrivningen sköts av en databastrigger som ingen väg går förbi; det som
+// prövas här är att före/efter blir begripligt — en logg man inte kan läsa är inte en logg.
+
+const base = {
+  kind: 'work_order',
+  work_date: '2026-08-14',
+  work_order_id: 'wo-1',
+  internal_project_id: null,
+  absence_type_id: null,
+  start_time: '07:00:00',
+  end_time: '16:00:00',
+  break_minutes: 30,
+  minutes_worked: 510,
+  note: null,
+};
+
+const row = (over: Partial<TimeEntryAuditRow> = {}): TimeEntryAuditRow => ({
+  id: 'a1',
+  entry_id: 'e1',
+  user_id: 'anna',
+  changed_by: 'admin',
+  action: 'update',
+  before_data: { ...base },
+  after_data: { ...base },
+  created_at: '2026-08-15T09:00:00Z',
+  ...over,
+});
+
+describe('describeAuditChange', () => {
+  it('visar klockslag som ändrats, och bara dem', () => {
+    const changes = describeAuditChange(row({ after_data: { ...base, end_time: '17:00:00', minutes_worked: 570 } }));
+    expect(changes.map((change) => change.label)).toEqual(['Sluttid', 'Arbetad tid']);
+    expect(changes[0]).toEqual({ label: 'Sluttid', from: '16:00', to: '17:00' });
+    expect(changes[1]).toEqual({ label: 'Arbetad tid', from: '8,50 h', to: '9,50 h' });
+  });
+
+  it('säger ingenting när ingenting ändrats', () => {
+    expect(describeAuditChange(row())).toEqual([]);
+  });
+
+  // En radering har inget efteråt och en ny rad inget innan — där är själva handlingen svaret,
+  // och en fältdiff hade bara listat hela raden som "ändrad".
+  it('beskriver inte fält för radering och tillägg', () => {
+    expect(describeAuditChange(row({ action: 'delete', after_data: null }))).toEqual([]);
+    expect(describeAuditChange(row({ action: 'insert', before_data: null }))).toEqual([]);
+  });
+
+  // ⚠️ Mål-id:n översätts INTE till namn: uppslaget hade beskrivit nuet i stället för vad som hände,
+  // eftersom ordern kan ha ändrats sedan dess. Bytet redovisas som ett faktum.
+  it('redovisar ett jobbyte utan att låtsas namnge det', () => {
+    const changes = describeAuditChange(row({ after_data: { ...base, work_order_id: 'wo-2' } }));
+    expect(changes).toEqual([{ label: 'Jobb eller orsak', from: 'ändrat', to: null }]);
+  });
+
+  it('namnger sorten på svenska när den bytts', () => {
+    const changes = describeAuditChange(row({
+      after_data: { ...base, kind: 'absence', work_order_id: null, absence_type_id: 'vab' },
+    }));
+    expect(changes.find((change) => change.label === 'Sort')).toEqual({
+      label: 'Sort', from: 'Arbetsorder', to: 'Frånvaro',
+    });
+  });
+
+  it('visar en tillagd och en borttagen anteckning', () => {
+    expect(describeAuditChange(row({ after_data: { ...base, note: 'Rättat efter samtal' } }))[0])
+      .toEqual({ label: 'Anteckning', from: null, to: 'Rättat efter samtal' });
+    expect(describeAuditChange(row({ before_data: { ...base, note: 'Fel' }, after_data: { ...base } }))[0])
+      .toEqual({ label: 'Anteckning', from: 'Fel', to: null });
+  });
+});
+
+describe('auditWorkDate och auditInRange', () => {
+  // Intervallet gäller radens ARBETSDATUM, inte när ändringen gjordes: frågan är "har någon rört
+  // augusti?", inte "vad hände i augusti". En rättelse i september av en augustidag hör till augusti.
+  it('läser datumet ur efteråt, och ur innan när raden togs bort', () => {
+    expect(auditWorkDate(row())).toBe('2026-08-14');
+    expect(auditWorkDate(row({ action: 'delete', after_data: null }))).toBe('2026-08-14');
+  });
+
+  it('placerar en rättelse gjord i september på augustidagen den gäller', () => {
+    const september = row({ created_at: '2026-09-02T08:00:00Z' });
+    expect(auditInRange(september, { from: '2026-08-01', to: '2026-08-31' })).toBe(true);
+    expect(auditInRange(september, { from: '2026-09-01', to: '2026-09-30' })).toBe(false);
+  });
+
+  it('utesluter en rad utan läsbart datum i stället för att gissa', () => {
+    expect(auditInRange(row({ before_data: null, after_data: null }), { from: '2026-08-01', to: '2026-08-31' })).toBe(false);
+  });
+});
+
+describe('auditActionLabel', () => {
+  it('säger vad som hände på svenska', () => {
+    expect(auditActionLabel('update')).toBe('Raden ändrades');
+    expect(auditActionLabel('delete')).toBe('Raden togs bort');
+    expect(auditActionLabel('insert')).toBe('Raden lades till');
+  });
+});

--- a/tests/time/entries.test.ts
+++ b/tests/time/entries.test.ts
@@ -234,3 +234,57 @@ describe('toSummarizableEntry', () => {
     expect(absence.payrollCode).toBe('LÖN300');
   });
 });
+
+// ---------------------------------------------------------------------------
+// mergeCorrection — adminrättelsens gräns
+// ---------------------------------------------------------------------------
+// En rättelse ska kunna laga ett felskrivet klockslag, aldrig flytta någons timmar till ett annat
+// jobb eller göra om arbetstid till frånvaro. Gränsen bor här, inte i UI:t.
+
+import { mergeCorrection } from '@/lib/domains/time/entries';
+
+const current = {
+  kind: 'work_order' as const,
+  work_date: '2026-08-14',
+  work_order_id: 'wo-1',
+  internal_project_id: null,
+  absence_type_id: null,
+  start_time: '07:00:00',
+  end_time: '16:00:00',
+  break_minutes: 30,
+  minutes_worked: 510,
+  time_code_id: 'tc-1',
+  note: 'Vindsbjälklag',
+};
+
+describe('mergeCorrection', () => {
+  it('tar klockslagen ur rättelsen och resten ur raden', () => {
+    const merged = mergeCorrection(current, { start_time: '08:00', end_time: '17:00' });
+    expect(merged.start_time).toBe('08:00');
+    expect(merged.end_time).toBe('17:00');
+    expect(merged.break_minutes).toBe(30);
+    expect(merged.note).toBe('Vindsbjälklag');
+  });
+
+  // Det farligaste en rättelse kan göra är att tyst byta vems eller vilket jobb timmarna hör till.
+  it('behåller kind, datum och måltavla oavsett vad som skickas in', () => {
+    const merged = mergeCorrection(current, {
+      ...({ kind: 'absence', work_date: '2026-01-01', work_order_id: 'wo-2' } as any),
+      start_time: '08:00',
+    });
+    expect(merged.kind).toBe('work_order');
+    expect(merged.work_date).toBe('2026-08-14');
+    expect(merged.work_order_id).toBe('wo-1');
+  });
+
+  it('skiljer utelämnat från null — en tömd anteckning ska gå att spara', () => {
+    expect(mergeCorrection(current, {}).note).toBe('Vindsbjälklag');
+    expect(mergeCorrection(current, { note: null }).note).toBeNull();
+  });
+
+  it('räknar om frånvarons timmar ur minuterna när de inte skickas med', () => {
+    const absence = { ...current, kind: 'absence' as const, work_order_id: null, absence_type_id: 'vab', minutes_worked: 240 };
+    expect(mergeCorrection(absence, {}).hours).toBe(4);
+    expect(mergeCorrection(absence, { hours: 8 }).hours).toBe(8);
+  });
+});

--- a/tests/time/entries.test.ts
+++ b/tests/time/entries.test.ts
@@ -266,15 +266,28 @@ describe('mergeCorrection', () => {
     expect(merged.note).toBe('Vindsbjälklag');
   });
 
-  // Det farligaste en rättelse kan göra är att tyst byta vems eller vilket jobb timmarna hör till.
-  it('behåller kind, datum och måltavla oavsett vad som skickas in', () => {
-    const merged = mergeCorrection(current, {
-      ...({ kind: 'absence', work_date: '2026-01-01', work_order_id: 'wo-2' } as any),
-      start_time: '08:00',
-    });
-    expect(merged.kind).toBe('work_order');
-    expect(merged.work_date).toBe('2026-08-14');
+  // Att ha rapporterat på fel arbetsorder är precis den sortens misstag rättelsen finns för
+  // (William 2026-08-14), så målet SKA gå att flytta.
+  it('flyttar raden till ett annat jobb när det efterfrågas', () => {
+    const merged = mergeCorrection(current, { work_order_id: 'wo-2' });
+    expect(merged.work_order_id).toBe('wo-2');
+    expect(merged.start_time).toBe('07:00:00');
+  });
+
+  it('byter sort och tar det nya målet med sig', () => {
+    const merged = mergeCorrection(current, { kind: 'internal', internal_project_id: 'ip-1' });
+    expect(merged.kind).toBe('internal');
+    expect(merged.internal_project_id).toBe('ip-1');
+    // buildTimeEntryRow nollar målen som inte hör till den nya sorten — mergeCorrection bär bara
+    // vidare, den städar inte.
     expect(merged.work_order_id).toBe('wo-1');
+  });
+
+  // Det enda som ALDRIG går att flytta. `user_id` finns inte ens i typen, så en rättelse kan inte
+  // hamna i någon annans löneunderlag — och routen läser ägaren ur databasen, aldrig ur anropet.
+  it('har ingen väg att byta ägare', () => {
+    const merged = mergeCorrection(current, { ...({ user_id: 'någon-annan' } as any) });
+    expect(merged).not.toHaveProperty('user_id');
   });
 
   it('skiljer utelämnat från null — en tömd anteckning ska gå att spara', () => {

--- a/tests/time/entries.test.ts
+++ b/tests/time/entries.test.ts
@@ -201,18 +201,20 @@ describe('toSummarizableEntry', () => {
     expect(mapped.minutesWorked).toBe(455);
   });
 
-  it('namnger arbetsordern med ordernummer och projekt', () => {
+  // Fortnox-numret leder, precis som documentRef gör på varje annan CRM-yta: det interna
+  // AO-numret är ingen utanför systemet känner igen, allra minst den som granskar lönen.
+  it('namnger arbetsordern med FORTNOX-numret och projektet', () => {
     const mapped = toSummarizableEntry(row({
       work_order: { id: 'wo1', order_number: 'AO-1', fortnox_order_number: '12', project_name: 'Villa Ek', client_name: 'Ekbergs' },
     }));
-    expect(mapped.label).toBe('AO-1 · Villa Ek');
+    expect(mapped.label).toBe('#12 · Villa Ek');
   });
 
-  it('faller tillbaka på Fortnox-numret och kundnamnet när CRM-fälten saknas', () => {
+  it('faller tillbaka på det interna numret först när Fortnox-numret saknas — och utan brädgård', () => {
     const mapped = toSummarizableEntry(row({
-      work_order: { id: 'wo1', order_number: null, fortnox_order_number: '12', project_name: null, client_name: 'Ekbergs' },
+      work_order: { id: 'wo1', order_number: 'AO-1', fortnox_order_number: null, project_name: null, client_name: 'Ekbergs' },
     }));
-    expect(mapped.label).toBe('12 · Ekbergs');
+    expect(mapped.label).toBe('AO-1 · Ekbergs');
   });
 
   it('använder internprojektets namn på interntid', () => {

--- a/tests/time/entries.test.ts
+++ b/tests/time/entries.test.ts
@@ -253,6 +253,7 @@ const current = {
   end_time: '16:00:00',
   break_minutes: 30,
   minutes_worked: 510,
+  hours: 8.5,
   time_code_id: 'tc-1',
   note: 'Vindsbjälklag',
 };
@@ -299,5 +300,13 @@ describe('mergeCorrection', () => {
     const absence = { ...current, kind: 'absence' as const, work_order_id: null, absence_type_id: 'vab', minutes_worked: 240 };
     expect(mergeCorrection(absence, {}).hours).toBe(4);
     expect(mergeCorrection(absence, { hours: 8 }).hours).toBe(8);
+  });
+
+  // Regression: de gamla kontorsraderna har minutes_worked NULL men hours satt. Utan fallbacken
+  // blev timtalet null, buildTimeEntryRow krävde klockslag raden aldrig haft, och den admin som
+  // bara ville flytta raden till rätt jobb tvingades hitta på tider — som sedan skrev om lönetimmarna.
+  it('faller tillbaka på hours när minutes_worked är null', () => {
+    const legacy = { ...current, minutes_worked: null, hours: 6.5, start_time: null, end_time: null };
+    expect(mergeCorrection(legacy, {}).hours).toBe(6.5);
   });
 });

--- a/tests/time/summary.test.ts
+++ b/tests/time/summary.test.ts
@@ -173,10 +173,12 @@ describe('buildDayRows — rasten', () => {
 // "Arbetsorder" — och ett valt jobb föll då tyst bort medan UI:t sa att raden var rättad.
 describe('buildDayRows — sorten', () => {
   it('bär radens kind, som inte går att härleda ur minuterna', () => {
+    // Egna datum: buildDayRows sorterar på datum och starttid, och en frånvarorad utan klockslag
+    // hamnar annars först — ordningen är inte poängen här, sorten är.
     const rows = buildDayRows([
-      entry({ kind: 'work_order' }),
-      entry({ kind: 'internal' }),
-      entry({ kind: 'absence', startTime: null, endTime: null, minutesWorked: 240 }),
+      entry({ kind: 'work_order', workDate: '2026-08-11' }),
+      entry({ kind: 'internal', workDate: '2026-08-12' }),
+      entry({ kind: 'absence', workDate: '2026-08-13', startTime: null, endTime: null, minutesWorked: 240 }),
     ]);
     expect(rows.map((row) => row.kind)).toEqual(['work_order', 'internal', 'absence']);
   });

--- a/tests/time/summary.test.ts
+++ b/tests/time/summary.test.ts
@@ -167,3 +167,17 @@ describe('buildDayRows — rasten', () => {
     expect(rows[0].absenceMinutes).toBe(240);
   });
 });
+
+// Regression: sorten måste följa med dagraden. En internrad har arbetade minuter precis som en
+// arbetsorderrad, så en rättelse som gissade sorten ur siffrorna öppnade internraden som
+// "Arbetsorder" — och ett valt jobb föll då tyst bort medan UI:t sa att raden var rättad.
+describe('buildDayRows — sorten', () => {
+  it('bär radens kind, som inte går att härleda ur minuterna', () => {
+    const rows = buildDayRows([
+      entry({ kind: 'work_order' }),
+      entry({ kind: 'internal' }),
+      entry({ kind: 'absence', startTime: null, endTime: null, minutesWorked: 240 }),
+    ]);
+    expect(rows.map((row) => row.kind)).toEqual(['work_order', 'internal', 'absence']);
+  });
+});

--- a/tests/time/summary.test.ts
+++ b/tests/time/summary.test.ts
@@ -146,3 +146,24 @@ describe('buildDayRows — vad tiden lades på', () => {
     expect(rows[0].absenceReasons).toEqual(['VAB']);
   });
 });
+
+// Regression, och den dyraste sorten: rastavdraget måste följa med dagraden.
+//
+// Attestens rättelse skickar tillbaka rasten tillsammans med klockslagen, och servern räknar om
+// minuterna ur alla tre. Tappas den här defaultar formuläret till noll, och en rättad 07:00–16:00
+// med halvtimmes rast går från 510 till 540 minuter — trettio minuter tillagda på någons lön, tyst.
+describe('buildDayRows — rasten', () => {
+  it('bär rastavdraget vidare på arbetad tid', () => {
+    const rows = buildDayRows([entry({ startTime: '07:00', endTime: '16:00', breakMinutes: 30 })]);
+    expect(rows[0].breakMinutes).toBe(30);
+    expect(rows[0].workMinutes).toBe(510);
+  });
+
+  it('nollar rasten på frånvaro — den anges i timmar och har inget pass att dra från', () => {
+    const rows = buildDayRows([
+      entry({ kind: 'absence', startTime: null, endTime: null, minutesWorked: 240, breakMinutes: 30 }),
+    ]);
+    expect(rows[0].breakMinutes).toBe(0);
+    expect(rows[0].absenceMinutes).toBe(240);
+  });
+});


### PR DESCRIPTION
Attesten är **ersättningen för piloten**. Planen var att en bil skulle dubbelrapportera i `/tid` utöver Blikk så att summorna kunde jämföras maskinellt innan någon lön hängde på dem. Den planen är avblåst — i stället granskar två personer siffrorna för hand, här. Då ska vyn hjälpa dem hitta det som är fel.

## Vyn

**Stapeln är radens signatur.** Varje person får en stapel skalad mot gruppens största månad, med frånvaron som eget segment. En kort stapel syns direkt, utan att någon jämför tal.

⚠️ **Inga trösklar, inga omdömen.** Att sätta en gräns för hur få timmar som är "för få" vore att uppfinna en regel: systemet känner varken tjänstgöringsgrad eller schema, och en deltidare hade flaggats varje månad tills flaggan slutade betyda något. Enda flaggan är den faktiska — noll rapporterade rader.

- Sex likadana badges → två åtskilda frågor: hur långt har jag kommit, och hur stora är summorna
- **Filter som arbetsredskap**: Alla / Väntar på attest / Ej inlämnade / Inget rapporterat, plus sortering på timmar
- **"Attestera alla inlämnade"** med tvåstegsbekräftelse
- `window.prompt` borta — återöppningsanledningen går rakt till den anställde och förtjänar ett fält
- Tabellen på 900 px ersatt av CRM:ets listrad-mönster

## Admin får rätta andras tidrader

Regeln var att ingen ändrar någon annans timmar. Den hade ett hål ingen adresserat: **en anställd som är sjukskriven, har slutat eller inte svarar när lönen ska köras.** Då gick månaden inte att rätta alls, och med Blikk borta är det här enda systemet.

Tre spärrar står kvar:

1. **Attesterad tid ändras inte**, inte ens av admin. Låstriggern prövar radens ägare, så en rättelse kräver att personens period är öppen — vilket kräver en anledning som visas för den anställde.
2. **En tidrad kan aldrig byta ägare.** Egen `BEFORE UPDATE`-trigger; WITH CHECK kan inte se OLD, så RLS ensamt räcker inte.
3. **Loggen skrivs av en databastrigger**, inte av appen. En serverväg som glömmer logga, eller en `UPDATE` i SQL-editorn, går inte förbi den. Tabellen har `force row level security` och inga skrivpolicyer.

## Revisionsloggen har läsare — åt båda hållen

Admin ser den under personens dagar. **Den anställde ser den i `/tid`**: *"En rad i din tid har ändrats av någon annan"*, med dag, vad, av vem och när.

Det andra hållet är inte en finess. Att kontoret kan rätta någons timmar är försvarbart bara om den vars lön det gäller kan se att det hänt — annars är loggen en försäkring för kontoret, inte för den anställde.

⚠️ Loggen innehåller **bara andras ändringar**; triggern hoppar över egna sparningar med flit. En tom logg betyder "ingen har rört din tid", och därför visas sektionen inte alls när den är tom.

⚠️ **Mål-id:n översätts inte till namn.** Ett uppslag hade beskrivit *nuet* i stället för vad som hände — ordern kan ha ändrats sedan dess.

## ⚠️ SQL — körs FÖRE koden

`supabase/sql/20260814_time_admin_corrections.sql`. `getEffectivePermissions` failar closed, så en route som vaktar på en nyckel databasen inte känner till nekar alla.

**Filen är nu SIST av tid-filerna.** Den återskapar `crm_time_entries_update_own`/`_delete_own`; `create policy` har inget `or replace`, så körs `20260812` efteråt försvinner admin-grenen tyst. SUPERSEDED-not tillagd där.

## Vad granskningarna kostade

Fem omgångar, varav en på max över hela diffen med tio vinklar. Ingen av dessa fångades av type-check, lint eller 1198 tester:

- **Triggern hade slagit ut ALL tidrapportering.** `coalesce(new.x, old.x)` — i plpgsql är NEW oallokerad i en delete-trigger och OLD i en insert-trigger, och coalesce evaluerar båda. Varje insert och delete hade misslyckats. Hann bli live; upptäckt och rättad.
- **Ägarlåset var borta.** Min egen admin-gren tog bort den enda databasgarantin mot ägarbyte.
- **Loggen gick inte att läsa alls** — PostgREST-embedden kräver en FK som tabellen saknade.
- **Tre vägar som tyst lade till timmar**: `Number(rast) || 0`, `|| 8` som frånvarodefault, och `start == end` som ger 1440 minuter mot en guard som är `> 1440`.
- Massattesten kunde misslyckas helt tyst, och kunde attestera föregående månads personer under den nya perioden.
- Söktermen bröt PostgREST-filtret på ett kommatecken — vilket väljaren visade som "inga träffar".

Plus: `Badge` ritade aldrig sin ram, fantom-kanter på 3 px från `border-solid` utan bredd, attestfliken saknade padding helt, och sidans text påstod fortfarande att ingen kan ändra någon annans timmar.

## Verifiering

`npm run lint` · `npm run type-check` · `npm test` 1198 gröna (84 filer) · `npm run build`. Blikk-vägen orörd — enda träffarna är kommentarer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)