### PR TITLE
Säljtavlan: offertmodalen öppnas på plats i stället för att skicka dig till listan

### DIFF
--- a/app/crm/components/QuoteDetailPanel.tsx
+++ b/app/crm/components/QuoteDetailPanel.tsx
@@ -1,0 +1,541 @@
+"use client";
+import { useState } from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { cn } from '@/lib/shared/cn';
+import { useToast } from '@/lib/Toast';
+import { documentRef } from '@/app/crm/lib/format';
+import { quoteStatusMeta } from '@/app/crm/lib/crmTokens';
+import { openFortnoxPdf } from '@/app/crm/lib/fortnoxDoc';
+import { resolveQuoteVatBreakdown, quoteAmountDisplay } from '@/lib/domains/crm/pricing';
+import { quoteCustomerName, isQuoteOverdue } from '@/app/crm/lib/quoteDisplay';
+import useDocumentEmail from '@/app/crm/components/useDocumentEmail';
+
+// The quote detail modal, shared by the offer list and the Säljtavla board.
+//
+// It lived inline in QuotesClient, which is why clicking a card on the board used to bounce you to
+// the list (?quote_id=…) just to open it — a detour that made the board unusable as a primary
+// workspace. The panel owns its own actions and their in-flight state; a consumer only supplies the
+// quote, tells it how to close, and receives the updated row back so its own list stays in sync.
+
+export type QuoteDetailItem = {
+  id: string;
+  status: 'draft' | 'sent' | 'follow_up' | 'won' | 'lost';
+  quote_number: string | null;
+  fortnox_offer_number: string | null;
+  fortnox_sync_status: 'not_synced' | 'pending' | 'synced' | 'failed' | null;
+  project_name: string;
+  description: string | null;
+  notes: string | null;
+  customer_id: string | null;
+  customer_name: string | null;
+  customer_snapshot: { customer_name?: string | null; company_name?: string | null; email?: string | null } | null;
+  // Passed straight back on the status PATCH; the panel never reads into it.
+  customer_source: { kind?: string | null } | null;
+  prospect_id: string | null;
+  prospect: { company_name: string } | Array<{ company_name: string }> | null;
+  quote_type: 'private' | 'business';
+  pricing_summary: { subtotal?: number; vat?: number; total?: number } | null;
+  amount: number | string;
+  currency_code: string;
+  vat_percent: number | string | null;
+  quote_date: string;
+  follow_up_date: string | null;
+  valid_until: string | null;
+  work_order_id: string | null;
+  work_order_number: string | null;
+};
+
+function formatCurrency(value: number | string, currencyCode: string) {
+  const numeric = typeof value === 'number' ? value : Number(String(value));
+  if (!Number.isFinite(numeric)) return '–';
+  return new Intl.NumberFormat('sv-SE', { style: 'currency', currency: currencyCode || 'SEK', maximumFractionDigits: 0 }).format(numeric);
+}
+
+function formatDate(value: string | null | undefined) {
+  if (!value) return '–';
+  const date = new Date(`${value}T12:00:00`);
+  if (Number.isNaN(date.getTime())) return '–';
+  return new Intl.DateTimeFormat('sv-SE', { dateStyle: 'medium' }).format(date);
+}
+
+/**
+ * Fold a server response onto the row the consumer gave us.
+ *
+ * The cast is the point of the generic: the offer list and the board type the same API rows
+ * differently (the list declares the full prospect record, the board only its company_name), so
+ * handing either of them a bare QuoteDetailItem would NARROW what they already hold. Both surfaces
+ * store rows from the same endpoint, so spreading the response over the caller's own object keeps
+ * every field it knows about and updates the ones that changed.
+ */
+function mergeQuote<T extends QuoteDetailItem>(base: T, patch: Partial<QuoteDetailItem>): T {
+  return { ...base, ...patch } as T;
+}
+
+export default function QuoteDetailPanel<T extends QuoteDetailItem>({
+  quote,
+  workOrderFortnoxNumber,
+  onClose,
+  onQuoteChanged,
+}: {
+  quote: T;
+  /** Fortnox order number for this quote's work order, if the consumer has indexed it. */
+  workOrderFortnoxNumber: string | null;
+  onClose: () => void;
+  /** The updated row after any action, so the consumer can patch its own list/board state. */
+  onQuoteChanged: (updated: T) => void;
+}) {
+  const router = useRouter();
+  const toast = useToast();
+  const documentEmail = useDocumentEmail();
+
+  const [moving, setMoving] = useState(false);
+  const [creatingWorkOrder, setCreatingWorkOrder] = useState(false);
+  const [pushingFortnox, setPushingFortnox] = useState(false);
+  const [loadingOfferPdf, setLoadingOfferPdf] = useState(false);
+  const [loadingOrderPdf, setLoadingOrderPdf] = useState(false);
+
+  // A work order locks the offer in Fortnox — unless the last sync failed, in which case the
+  // re-sync button stays available so the user can recover.
+  const offerLocked = Boolean(quote.work_order_id) && quote.fortnox_sync_status !== 'failed';
+  const display = quoteAmountDisplay(quote.quote_type, resolveQuoteVatBreakdown(quote));
+  const customerName = quoteCustomerName(quote);
+
+  async function moveQuoteToStatus(nextStatus: QuoteDetailItem['status']) {
+    if (quote.status === nextStatus) return;
+    setMoving(true);
+    try {
+      const res = await fetch(`/api/crm/quotes/${quote.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          prospect_id: quote.prospect_id,
+          customer_name: quote.customer_name,
+          quote_type: quote.quote_type,
+          customer_source: quote.customer_source,
+          customer_snapshot: quote.customer_snapshot,
+          pricing_summary: quote.pricing_summary,
+          project_name: quote.project_name,
+          description: quote.description,
+          amount: quote.amount,
+          currency_code: quote.currency_code,
+          vat_percent: quote.vat_percent,
+          valid_until: quote.valid_until,
+          status: nextStatus,
+          quote_date: quote.quote_date,
+          follow_up_date: quote.follow_up_date,
+          notes: quote.notes,
+        }),
+      });
+      const json = await res.json().catch(() => ({}));
+      if (!res.ok || !json.ok) { toast.error(json?.error || 'Kunde inte byta status'); return; }
+      const updated = json?.data?.item as QuoteDetailItem | undefined;
+      onQuoteChanged(mergeQuote(quote, updated ?? { status: nextStatus }));
+    } catch {
+      toast.error('Kunde inte byta status');
+    } finally {
+      setMoving(false);
+    }
+  }
+
+  async function createWorkOrder() {
+    if (quote.status !== 'won') { toast.error('Arbetsorder kan bara skapas från vunnen offert'); return; }
+    if (quote.work_order_id) { toast.info('Arbetsorder finns redan'); return; }
+
+    setCreatingWorkOrder(true);
+    try {
+      const res = await fetch(`/api/crm/quotes/${quote.id}/work-order`, { method: 'POST', headers: { 'Content-Type': 'application/json' } });
+      const json = await res.json().catch(() => ({}));
+      if (!res.ok || !json.ok) { toast.error(json?.error || 'Kunde inte skapa arbetsorder'); return; }
+      const updated = json?.data?.item as QuoteDetailItem | undefined;
+      if (updated) onQuoteChanged(mergeQuote(quote, updated));
+      const workOrder = json?.data?.workOrder as { id?: string; order_number?: string } | undefined;
+      if (json?.data?.fortnox_error) {
+        toast.error(`Arbetsorder skapad men Fortnox-synk misslyckades: ${json.data.fortnox_error}`);
+      } else {
+        toast.success(workOrder?.order_number ? `Arbetsorder skapad: ${workOrder.order_number}` : 'Arbetsorder skapad');
+      }
+      // Don't auto-navigate — the button flips to "Gå till arbetsorder" so the user
+      // can choose to go there when ready.
+    } catch { toast.error('Kunde inte skapa arbetsorder'); } finally { setCreatingWorkOrder(false); }
+  }
+
+  async function pushToFortnox() {
+    setPushingFortnox(true);
+    try {
+      const res = await fetch('/api/fortnox/offers', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ quote_id: quote.id }),
+      });
+      const json = await res.json().catch(() => ({}));
+      if (!res.ok || !json.ok) { toast.error(json?.error || 'Kunde inte skicka till Fortnox'); return; }
+      const offerNumber = json?.data?.fortnox_offer_number as string | undefined;
+      const wasUpdated = json?.data?.updated as boolean | undefined;
+      toast.success(
+        offerNumber
+          ? `Fortnox-offert #${offerNumber} ${wasUpdated ? 'uppdaterad' : 'skapad'}`
+          : 'Skickad till Fortnox',
+      );
+      onQuoteChanged(mergeQuote(quote, {
+        fortnox_offer_number: offerNumber ?? quote.fortnox_offer_number,
+        fortnox_sync_status: 'synced',
+      }));
+    } catch {
+      toast.error('Kunde inte skicka till Fortnox');
+    } finally {
+      setPushingFortnox(false);
+    }
+  }
+
+  // Offer PDF + email, and order-confirmation PDF + email (for the work order created
+  // from this quote). Shared fetch/popup/email logic lives in lib/fortnoxDoc.
+  async function openOfferPdf() {
+    setLoadingOfferPdf(true);
+    await openFortnoxPdf(`/api/fortnox/offers/${quote.id}/pdf`, toast.error);
+    setLoadingOfferPdf(false);
+  }
+
+  async function openOrderPdf(workOrderId: string) {
+    setLoadingOrderPdf(true);
+    await openFortnoxPdf(`/api/crm/work-orders/${workOrderId}/fortnox/pdf`, toast.error);
+    setLoadingOrderPdf(false);
+  }
+
+  return (
+    <>
+      <div
+        className="fixed inset-0 z-[2800] flex items-end justify-center bg-slate-950/50 [backdrop-filter:blur(4px)] sm:items-center sm:p-4"
+        onClick={onClose}
+      >
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-label={`Offert ${quote.project_name}`}
+          onClick={(e) => e.stopPropagation()}
+          className="flex h-[100dvh] max-h-[100dvh] w-full max-w-[600px] flex-col overflow-hidden rounded-none bg-white shadow-[0_-12px_50px_rgba(15,23,42,0.30)] sm:h-auto sm:max-h-[88vh] sm:rounded-2xl sm:shadow-[0_30px_80px_rgba(15,23,42,0.28)]"
+        >
+          {/* Sticky header */}
+          <div className="flex items-start justify-between gap-3 border-b border-slate-100 px-5 pb-4 [padding-top:calc(1rem+env(safe-area-inset-top))] sm:pt-4">
+            <div className="grid min-w-0 gap-1.5">
+              <div className="flex flex-wrap items-center gap-2">
+                <span className={cn('rounded-full border px-2.5 py-0.5 text-[11px] font-semibold', quoteStatusMeta[quote.status].className)}>
+                  {quoteStatusMeta[quote.status].label}
+                </span>
+                {quote.quote_number ? (
+                  <span className="text-[11px] font-semibold uppercase tracking-[0.14em] text-slate-400">{documentRef(quote.fortnox_offer_number, quote.quote_number)}</span>
+                ) : null}
+              </div>
+              <strong className="truncate text-lg font-bold tracking-tight text-slate-950">{quote.project_name}</strong>
+              {/* Link to the customer card when the quote is tied to a saved CRM customer; a
+                  prospect/snapshot-only quote (no customer_id) keeps a plain name. returnTo points
+                  back at the list WITH ?quote_id so the detail modal re-opens on return (same
+                  open-then-return workflow as the offer form). */}
+              {quote.customer_id ? (
+                <Link
+                  href={`/crm/kunder/${quote.customer_id}?returnTo=${encodeURIComponent(`/crm/offerter?quote_id=${quote.id}`)}`}
+                  className="m-0 inline-flex max-w-full items-center gap-1 text-sm text-slate-500 transition-colors hover:text-emerald-700"
+                >
+                  <span className="truncate underline-offset-2 hover:underline">{customerName}</span>
+                  <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden className="shrink-0">
+                    <path d="M4.5 2.5L8 6l-3.5 3.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+                  </svg>
+                </Link>
+              ) : (
+                <p className="m-0 truncate text-sm text-slate-500">{customerName}</p>
+              )}
+            </div>
+            <button
+              type="button"
+              aria-label="Stäng"
+              onClick={onClose}
+              className="!h-9 !w-9 shrink-0 !rounded-full !border !border-slate-200 !bg-white !p-0 text-slate-500 transition hover:!border-slate-300 hover:text-slate-700"
+            >
+              <svg className="mx-auto" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                <path d="M18 6L6 18M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+
+          {/* Scrollable body */}
+          <div className="grid flex-1 gap-5 overflow-y-auto px-5 py-5">
+            {/* Hero: amount + key dates */}
+            <div className="rounded-xl border border-[#e3e9df] bg-[#f6f9f3] p-4">
+              <div className="text-[11px] font-semibold uppercase tracking-[0.14em] text-slate-400">{display?.primaryLabel ?? 'Belopp'}</div>
+              <div className="mt-0.5 text-[1.75rem] font-bold leading-none tracking-tight text-slate-900 tabular-nums">
+                {formatCurrency(display?.primary ?? quote.amount, quote.currency_code)}
+              </div>
+              {display ? (
+                <div className="mt-2 flex flex-wrap gap-x-4 gap-y-0.5 text-[11px] text-slate-500">
+                  <span>Ex moms <span className="font-medium text-slate-600 tabular-nums">{formatCurrency(display.subtotal, quote.currency_code)}</span></span>
+                  <span>Moms ({display.vatPercent} %) <span className="font-medium text-slate-600 tabular-nums">{formatCurrency(display.vat, quote.currency_code)}</span></span>
+                  <span>Inkl. moms <span className="font-medium text-slate-600 tabular-nums">{formatCurrency(display.total, quote.currency_code)}</span></span>
+                </div>
+              ) : null}
+              <div className="mt-4 grid grid-cols-3 gap-3 border-t border-[#dce6d6] pt-3">
+                {([
+                  ['Offertdatum', formatDate(quote.quote_date), false],
+                  ['Följ upp', formatDate(quote.follow_up_date), isQuoteOverdue(quote)],
+                  ['Giltig till', formatDate(quote.valid_until), false],
+                ] as Array<[string, string, boolean]>).map(([lbl, val, warn]) => (
+                  <div key={lbl} className="grid gap-0.5">
+                    <span className="text-[10px] font-semibold uppercase tracking-[0.1em] text-slate-400">{lbl}</span>
+                    <span className={cn('text-sm font-medium', warn ? 'text-amber-700' : 'text-slate-700')}>{warn ? '⚠ ' : ''}{val}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            {/* Description */}
+            {quote.description ? (
+              <div className="grid gap-1.5">
+                <span className="text-[11px] font-semibold uppercase tracking-[0.14em] text-slate-400">Beskrivning</span>
+                <p className="m-0 text-sm leading-6 text-slate-700">{quote.description}</p>
+              </div>
+            ) : null}
+
+            {/* Status changer */}
+            <div className="grid gap-2">
+              <span className="text-[11px] font-semibold uppercase tracking-[0.14em] text-slate-400">Byt status</span>
+              <div className="flex flex-wrap gap-2">
+                {(Object.entries(quoteStatusMeta) as Array<[QuoteDetailItem['status'], typeof quoteStatusMeta[QuoteDetailItem['status']]]>).map(([s, meta]) => {
+                  const isCurrent = quote.status === s;
+                  return (
+                    <button
+                      key={s}
+                      type="button"
+                      disabled={moving || isCurrent}
+                      onClick={() => void moveQuoteToStatus(s)}
+                      className={cn(
+                        'inline-flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-xs font-semibold transition',
+                        isCurrent
+                          ? cn(meta.className, 'cursor-default')
+                          : 'border-slate-200 bg-white text-slate-600 hover:border-slate-300 hover:bg-slate-50 disabled:opacity-50',
+                      )}
+                    >
+                      {isCurrent ? <span className={cn('h-1.5 w-1.5 rounded-full', meta.accent)} /> : null}
+                      {meta.label}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+
+            {/* Notes */}
+            {quote.notes ? (
+              <div className="grid gap-1.5 rounded-xl border border-amber-100 bg-amber-50/60 p-3.5">
+                <span className="text-[11px] font-semibold uppercase tracking-[0.14em] text-amber-700/80">Anteckningar</span>
+                <p className="m-0 whitespace-pre-wrap text-sm leading-6 text-slate-700">{quote.notes}</p>
+              </div>
+            ) : null}
+
+            {/* Action cards */}
+            <div className="grid gap-3">
+              {/* Work order */}
+              <div className="rounded-xl border border-[#e3e9df] bg-[#f9fbf7] p-4">
+                <div className="flex flex-wrap items-start justify-between gap-3">
+                  <div className="flex min-w-0 items-start gap-3">
+                    <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-emerald-100 text-emerald-700">
+                      <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                        <rect x="5" y="4" width="14" height="17" rx="2" /><path d="M9 4V2.5h6V4M9 11h6M9 15h4" />
+                      </svg>
+                    </span>
+                    <div className="grid min-w-0 gap-0.5">
+                      <span className="text-sm font-semibold text-slate-800">Arbetsorder</span>
+                      <span className="text-xs leading-5 text-slate-500">
+                        {quote.work_order_id
+                          ? `${documentRef(workOrderFortnoxNumber, quote.work_order_number)} är skapad.`
+                          : quote.status === 'won'
+                            ? 'Klar att bli en intern arbetsorder.'
+                            : 'Sätt offerten till vunnen för att skapa.'}
+                      </span>
+                    </div>
+                  </div>
+                  <div className="flex shrink-0 gap-2">
+                    {quote.work_order_id ? (
+                      <button
+                        type="button"
+                        onClick={() => router.push(`/crm/arbetsorder/${quote.work_order_id}`)}
+                        className="rounded-lg border border-emerald-700 bg-emerald-700 px-3 py-1.5 text-sm font-semibold text-white transition hover:bg-emerald-800"
+                      >
+                        Gå till arbetsorder
+                      </button>
+                    ) : (
+                      <button
+                        type="button"
+                        onClick={() => void createWorkOrder()}
+                        disabled={quote.status !== 'won' || creatingWorkOrder}
+                        className="rounded-lg border border-emerald-700 bg-emerald-700 px-3 py-1.5 text-sm font-semibold text-white transition hover:bg-emerald-800 disabled:cursor-not-allowed disabled:border-slate-200 disabled:bg-white disabled:text-slate-400"
+                      >
+                        {creatingWorkOrder ? 'Skapar…' : 'Skapa arbetsorder'}
+                      </button>
+                    )}
+                  </div>
+                </div>
+
+                {/* Order confirmation — once a work order (Fortnox order) exists */}
+                {quote.work_order_id ? (
+                  <div className="mt-3 flex flex-wrap items-center gap-2 border-t border-[#e3e9df] pt-3">
+                    <span className="mr-auto text-xs font-medium text-slate-500">Orderbekräftelse</span>
+                    <button
+                      type="button"
+                      onClick={() => void openOrderPdf(quote.work_order_id!)}
+                      disabled={loadingOrderPdf}
+                      className="rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-sm font-semibold text-slate-700 transition hover:border-slate-300 disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                      {loadingOrderPdf ? 'Hämtar…' : 'Hämta PDF'}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => documentEmail.start({
+                        id: quote.work_order_id!,
+                        kind: 'order',
+                        ref: documentRef(workOrderFortnoxNumber, quote.work_order_number),
+                        projectName: quote.project_name,
+                        customerName,
+                        snapshotEmail: quote.customer_snapshot?.email,
+                        customerId: quote.customer_id,
+                        pdfUrl: `/api/crm/work-orders/${quote.work_order_id}/fortnox/pdf`,
+                      })}
+                      disabled={documentEmail.sendingId === quote.work_order_id}
+                      className="rounded-lg border border-indigo-600 bg-indigo-600 px-3 py-1.5 text-sm font-semibold text-white transition hover:bg-indigo-700 disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                      {documentEmail.sendingId === quote.work_order_id ? 'Mejlar…' : 'Mejla order'}
+                    </button>
+                  </div>
+                ) : null}
+              </div>
+
+              {/* Fortnox */}
+              <div className="rounded-xl border border-[#e3e9df] bg-[#f9fbf7] p-4">
+                <div className="flex flex-wrap items-start justify-between gap-3">
+                  <div className="flex min-w-0 items-start gap-3">
+                    <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-indigo-100 text-indigo-700">
+                      <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                        <path d="M12 16V4M8 8l4-4 4 4M5 20h14" />
+                      </svg>
+                    </span>
+                    <div className="grid min-w-0 gap-0.5">
+                      <div className="flex flex-wrap items-center gap-1.5">
+                        <span className="text-sm font-semibold text-slate-800">Fortnox</span>
+                        {offerLocked ? (
+                          <span className="inline-flex items-center gap-1 rounded-md border border-amber-200 bg-amber-50 px-1.5 py-0.5 text-[10px] font-semibold text-amber-700">
+                            <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                              <rect x="5" y="11" width="14" height="10" rx="2" /><path d="M8 11V7a4 4 0 018 0v4" />
+                            </svg>
+                            Låst
+                          </span>
+                        ) : null}
+                      </div>
+                      <span className="text-xs leading-5 text-slate-500">
+                        {quote.fortnox_offer_number
+                          ? `Offert #${quote.fortnox_offer_number} skapad.`
+                          : 'Skicka offerten till Fortnox.'}
+                      </span>
+                      {quote.fortnox_sync_status === 'failed' ? (
+                        <span className="text-xs font-semibold text-rose-600">Senaste synk misslyckades.</span>
+                      ) : null}
+                    </div>
+                  </div>
+                  <div className="flex shrink-0 flex-wrap items-center justify-end gap-2">
+                    {quote.fortnox_offer_number ? (
+                      <>
+                        <button
+                          type="button"
+                          onClick={() => void openOfferPdf()}
+                          disabled={loadingOfferPdf}
+                          className="rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-sm font-semibold text-slate-700 transition hover:border-slate-300 disabled:cursor-not-allowed disabled:opacity-50"
+                        >
+                          {loadingOfferPdf ? 'Hämtar…' : 'Hämta PDF'}
+                        </button>
+                        {/* Ett enda mejlsätt: eget mejlprogram. Fortnox egen offertutskick är
+                            borttaget — mottagaren gick inte att styra därifrån och används inte. */}
+                        <button
+                          type="button"
+                          onClick={() => documentEmail.start({
+                            id: quote.id,
+                            kind: 'offer',
+                            ref: documentRef(quote.fortnox_offer_number, quote.quote_number),
+                            projectName: quote.project_name,
+                            customerName,
+                            snapshotEmail: quote.customer_snapshot?.email,
+                            customerId: quote.customer_id,
+                            pdfUrl: `/api/fortnox/offers/${quote.id}/pdf`,
+                          })}
+                          disabled={documentEmail.sendingId === quote.id}
+                          title="Öppnar ditt mejlprogram – PDF:en laddas ner att bifoga."
+                          className="inline-flex items-center rounded-lg border border-indigo-600 bg-indigo-600 px-3 py-1.5 text-sm font-semibold text-white transition hover:bg-indigo-700 disabled:cursor-not-allowed disabled:opacity-50"
+                        >
+                          {documentEmail.sendingId === quote.id ? 'Mejlar…' : 'Mejla offert'}
+                        </button>
+                      </>
+                    ) : null}
+                    {/* Sync/re-sync hidden once a work order locks the offer in Fortnox
+                        (but still shown if the sync failed, so the user can recover) */}
+                    {!offerLocked ? (
+                      <button
+                        type="button"
+                        onClick={() => void pushToFortnox()}
+                        disabled={pushingFortnox || quote.fortnox_sync_status === 'pending'}
+                        className={cn(
+                          'rounded-lg border px-3 py-1.5 text-sm font-semibold transition disabled:cursor-not-allowed disabled:opacity-50',
+                          quote.fortnox_offer_number
+                            ? 'border-slate-200 bg-white text-slate-700 hover:border-slate-300'
+                            : 'border-indigo-600 bg-indigo-600 text-white hover:bg-indigo-700',
+                        )}
+                      >
+                        {pushingFortnox ? 'Skickar…' : quote.fortnox_offer_number ? 'Skicka igen' : 'Skicka'}
+                      </button>
+                    ) : null}
+                  </div>
+                </div>
+
+                {/* Locked explanation — offer can no longer be edited/re-synced */}
+                {offerLocked ? (
+                  <div className="mt-3 flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50/70 px-3 py-2.5 text-xs leading-5 text-amber-900">
+                    <svg className="mt-0.5 shrink-0" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                      <rect x="5" y="11" width="14" height="10" rx="2" /><path d="M8 11V7a4 4 0 018 0v4" />
+                    </svg>
+                    <span>
+                      Offerten är <strong>låst</strong>{quote.work_order_number ? ` – arbetsorder ${quote.work_order_number} är skapad` : ' – en arbetsorder har skapats'}, så den kan inte längre ändras eller synkas om i Fortnox. Du kan fortfarande hämta PDF:en och mejla den till kunden.
+                    </span>
+                  </div>
+                ) : null}
+              </div>
+            </div>
+          </div>
+
+          {/* Sticky footer — a locked offer (work order created) can't be edited or
+              re-synced, so the edit action is hidden and "Stäng" fills the row. */}
+          <div className="flex items-center gap-2 border-t border-slate-100 px-5 py-3 [padding-bottom:calc(0.75rem+env(safe-area-inset-bottom))] sm:[padding-bottom:0.75rem]">
+            <button
+              type="button"
+              onClick={onClose}
+              className={cn(
+                'flex-1 rounded-xl border border-slate-200 bg-white py-2.5 text-sm font-semibold text-slate-600 transition hover:border-slate-300',
+                !offerLocked && 'sm:flex-none sm:px-5',
+              )}
+            >
+              Stäng
+            </button>
+            {!offerLocked ? (
+              <button
+                type="button"
+                onClick={() => { onClose(); router.push(`/crm/offerter/${quote.id}/redigera`); }}
+                className="flex-1 rounded-xl py-2.5 text-sm font-semibold text-white shadow-sm transition hover:brightness-95 sm:ml-auto sm:flex-none sm:px-5"
+                style={{ backgroundColor: 'var(--crm-primary)' }}
+              >
+                Redigera offert
+              </button>
+            ) : null}
+          </div>
+        </div>
+      </div>
+
+      {/* Rendered as a sibling AFTER the panel, matching where it sat when this lived in
+          QuotesClient: CrmModal uses the same z-[2800], so document order decides which paints on
+          top. Nesting it inside the panel would have it fight its own container. */}
+      {documentEmail.modal}
+    </>
+  );
+}

--- a/app/crm/components/QuoteDetailPanel.tsx
+++ b/app/crm/components/QuoteDetailPanel.tsx
@@ -9,7 +9,8 @@ import { quoteStatusMeta } from '@/app/crm/lib/crmTokens';
 import { openFortnoxPdf } from '@/app/crm/lib/fortnoxDoc';
 import { resolveQuoteVatBreakdown, quoteAmountDisplay } from '@/lib/domains/crm/pricing';
 import { quoteCustomerName, isQuoteOverdue } from '@/app/crm/lib/quoteDisplay';
-import useDocumentEmail from '@/app/crm/components/useDocumentEmail';
+import type { EmailableDocument } from '@/app/crm/components/useDocumentEmail';
+import { isQuoteCardLocked } from '@/lib/domains/crm/quoteBoard';
 
 // The quote detail modal, shared by the offer list and the Säljtavla board.
 //
@@ -75,19 +76,31 @@ function mergeQuote<T extends QuoteDetailItem>(base: T, patch: Partial<QuoteDeta
 export default function QuoteDetailPanel<T extends QuoteDetailItem>({
   quote,
   workOrderFortnoxNumber,
+  returnTo,
   onClose,
   onQuoteChanged,
+  documentEmail,
 }: {
   quote: T;
   /** Fortnox order number for this quote's work order, if the consumer has indexed it. */
   workOrderFortnoxNumber: string | null;
+  /**
+   * Where the customer-card link should return to. Supplied per surface: hardcoding the offer list
+   * would have dumped a board user onto the list — reintroducing the very detour this panel removes.
+   */
+  returnTo: string;
   onClose: () => void;
   /** The updated row after any action, so the consumer can patch its own list/board state. */
   onQuoteChanged: (updated: T) => void;
+  /**
+   * Owned by the CONSUMER, not by this panel. The e-mail flow has its own dismissable progress
+   * overlay and outlives the modal it was started from — a hook living here would be torn down with
+   * the panel, silently dropping a half-finished send.
+   */
+  documentEmail: { sendingId: string | null; start: (doc: EmailableDocument) => void };
 }) {
   const router = useRouter();
   const toast = useToast();
-  const documentEmail = useDocumentEmail();
 
   const [moving, setMoving] = useState(false);
   const [creatingWorkOrder, setCreatingWorkOrder] = useState(false);
@@ -98,11 +111,25 @@ export default function QuoteDetailPanel<T extends QuoteDetailItem>({
   // A work order locks the offer in Fortnox — unless the last sync failed, in which case the
   // re-sync button stays available so the user can recover.
   const offerLocked = Boolean(quote.work_order_id) && quote.fortnox_sync_status !== 'failed';
+  // The board refuses to DRAG a won card that already has a work order (isQuoteCardLocked). Letting
+  // the same card be clicked out of 'won' in this panel would make that guard decorative — and
+  // moving it would strand the work order that was already created from it.
+  const statusLocked = isQuoteCardLocked(quote);
   const display = quoteAmountDisplay(quote.quote_type, resolveQuoteVatBreakdown(quote));
   const customerName = quoteCustomerName(quote);
 
   async function moveQuoteToStatus(nextStatus: QuoteDetailItem['status']) {
     if (quote.status === nextStatus) return;
+    // Won is a meaningful transition — confirm it, exactly as the board's drag-and-drop does. A
+    // linked prospect is converted to a customer server-side and that cannot be undone from here,
+    // so the same board offering two different safety levels for one transition would be worse than
+    // offering none.
+    if (nextStatus === 'won') {
+      const message = quote.prospect_id
+        ? 'Markera offerten som vunnen? En kopplad prospekt konverteras då till kund.'
+        : 'Markera offerten som vunnen?';
+      if (!window.confirm(message)) return;
+    }
     setMoving(true);
     try {
       const res = await fetch(`/api/crm/quotes/${quote.id}`, {
@@ -203,9 +230,8 @@ export default function QuoteDetailPanel<T extends QuoteDetailItem>({
   }
 
   return (
-    <>
-      <div
-        className="fixed inset-0 z-[2800] flex items-end justify-center bg-slate-950/50 [backdrop-filter:blur(4px)] sm:items-center sm:p-4"
+    <div
+      className="fixed inset-0 z-[2800] flex items-end justify-center bg-slate-950/50 [backdrop-filter:blur(4px)] sm:items-center sm:p-4"
         onClick={onClose}
       >
         <div
@@ -233,7 +259,7 @@ export default function QuoteDetailPanel<T extends QuoteDetailItem>({
                   open-then-return workflow as the offer form). */}
               {quote.customer_id ? (
                 <Link
-                  href={`/crm/kunder/${quote.customer_id}?returnTo=${encodeURIComponent(`/crm/offerter?quote_id=${quote.id}`)}`}
+                  href={`/crm/kunder/${quote.customer_id}?returnTo=${encodeURIComponent(returnTo)}`}
                   className="m-0 inline-flex max-w-full items-center gap-1 text-sm text-slate-500 transition-colors hover:text-emerald-700"
                 >
                   <span className="truncate underline-offset-2 hover:underline">{customerName}</span>
@@ -296,7 +322,10 @@ export default function QuoteDetailPanel<T extends QuoteDetailItem>({
 
             {/* Status changer */}
             <div className="grid gap-2">
-              <span className="text-[11px] font-semibold uppercase tracking-[0.14em] text-slate-400">Byt status</span>
+              <span className="text-[11px] font-semibold uppercase tracking-[0.14em] text-slate-400">
+                Byt status
+                {statusLocked ? <span className="ml-2 font-medium normal-case tracking-normal text-slate-400">— låst, arbetsorder är skapad</span> : null}
+              </span>
               <div className="flex flex-wrap gap-2">
                 {(Object.entries(quoteStatusMeta) as Array<[QuoteDetailItem['status'], typeof quoteStatusMeta[QuoteDetailItem['status']]]>).map(([s, meta]) => {
                   const isCurrent = quote.status === s;
@@ -304,7 +333,7 @@ export default function QuoteDetailPanel<T extends QuoteDetailItem>({
                     <button
                       key={s}
                       type="button"
-                      disabled={moving || isCurrent}
+                      disabled={moving || isCurrent || statusLocked}
                       onClick={() => void moveQuoteToStatus(s)}
                       className={cn(
                         'inline-flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-xs font-semibold transition',
@@ -530,12 +559,6 @@ export default function QuoteDetailPanel<T extends QuoteDetailItem>({
             ) : null}
           </div>
         </div>
-      </div>
-
-      {/* Rendered as a sibling AFTER the panel, matching where it sat when this lived in
-          QuotesClient: CrmModal uses the same z-[2800], so document order decides which paints on
-          top. Nesting it inside the panel would have it fight its own container. */}
-      {documentEmail.modal}
-    </>
+    </div>
   );
 }

--- a/app/crm/components/QuoteDetailPanel.tsx
+++ b/app/crm/components/QuoteDetailPanel.tsx
@@ -10,7 +10,6 @@ import { openFortnoxPdf } from '@/app/crm/lib/fortnoxDoc';
 import { resolveQuoteVatBreakdown, quoteAmountDisplay } from '@/lib/domains/crm/pricing';
 import { quoteCustomerName, isQuoteOverdue } from '@/app/crm/lib/quoteDisplay';
 import type { EmailableDocument } from '@/app/crm/components/useDocumentEmail';
-import { isQuoteCardLocked } from '@/lib/domains/crm/quoteBoard';
 
 // The quote detail modal, shared by the offer list and the Säljtavla board.
 //
@@ -61,19 +60,43 @@ function formatDate(value: string | null | undefined) {
 }
 
 /**
- * Fold a server response onto the row the consumer gave us.
+ * What an action changed, for the consumer to apply to its own row.
  *
- * The cast is the point of the generic: the offer list and the board type the same API rows
- * differently (the list declares the full prospect record, the board only its company_name), so
- * handing either of them a bare QuoteDetailItem would NARROW what they already hold. Both surfaces
- * store rows from the same endpoint, so spreading the response over the caller's own object keeps
- * every field it knows about and updates the ones that changed.
+ * ⚠️ A PATCH, deliberately — not a finished row. Merging onto the `quote` prop here would use the
+ * value captured when the button was clicked: start a slow Fortnox push, flip the status while it
+ * spins, and the push's late response would carry the OLD status back and revert the change on
+ * screen while the database holds the new one. Consumers apply this functionally against their
+ * current state instead, which is what the code this replaced did.
+ *
+ * Only scalar fields, so it spreads cleanly onto either surface's row type — the offer list and the
+ * board declare the same API rows differently (full prospect record vs. just its company_name).
  */
-function mergeQuote<T extends QuoteDetailItem>(base: T, patch: Partial<QuoteDetailItem>): T {
-  return { ...base, ...patch } as T;
+export type QuoteDetailPatch = {
+  id: string;
+  status?: QuoteDetailItem['status'];
+  work_order_id?: string | null;
+  work_order_number?: string | null;
+  converted_to_work_order_at?: string | null;
+  fortnox_offer_number?: string | null;
+  fortnox_sync_status?: QuoteDetailItem['fortnox_sync_status'];
+  fortnox_synced_at?: string | null;
+  updated_at?: string;
+};
+
+/** Narrow a full server row down to the fields a consumer needs to apply. */
+function patchFromItem(id: string, item: QuoteDetailItem | undefined, fallback: Partial<QuoteDetailPatch>): QuoteDetailPatch {
+  if (!item) return { id, ...fallback };
+  return {
+    id,
+    status: item.status,
+    work_order_id: item.work_order_id,
+    work_order_number: item.work_order_number,
+    fortnox_offer_number: item.fortnox_offer_number,
+    fortnox_sync_status: item.fortnox_sync_status,
+  };
 }
 
-export default function QuoteDetailPanel<T extends QuoteDetailItem>({
+export default function QuoteDetailPanel({
   quote,
   workOrderFortnoxNumber,
   returnTo,
@@ -81,7 +104,7 @@ export default function QuoteDetailPanel<T extends QuoteDetailItem>({
   onQuoteChanged,
   documentEmail,
 }: {
-  quote: T;
+  quote: QuoteDetailItem;
   /** Fortnox order number for this quote's work order, if the consumer has indexed it. */
   workOrderFortnoxNumber: string | null;
   /**
@@ -90,8 +113,8 @@ export default function QuoteDetailPanel<T extends QuoteDetailItem>({
    */
   returnTo: string;
   onClose: () => void;
-  /** The updated row after any action, so the consumer can patch its own list/board state. */
-  onQuoteChanged: (updated: T) => void;
+  /** What changed, for the consumer to apply against its own current state. */
+  onQuoteChanged: (patch: QuoteDetailPatch) => void;
   /**
    * Owned by the CONSUMER, not by this panel. The e-mail flow has its own dismissable progress
    * overlay and outlives the modal it was started from — a hook living here would be torn down with
@@ -111,10 +134,6 @@ export default function QuoteDetailPanel<T extends QuoteDetailItem>({
   // A work order locks the offer in Fortnox — unless the last sync failed, in which case the
   // re-sync button stays available so the user can recover.
   const offerLocked = Boolean(quote.work_order_id) && quote.fortnox_sync_status !== 'failed';
-  // The board refuses to DRAG a won card that already has a work order (isQuoteCardLocked). Letting
-  // the same card be clicked out of 'won' in this panel would make that guard decorative — and
-  // moving it would strand the work order that was already created from it.
-  const statusLocked = isQuoteCardLocked(quote);
   const display = quoteAmountDisplay(quote.quote_type, resolveQuoteVatBreakdown(quote));
   const customerName = quoteCustomerName(quote);
 
@@ -157,7 +176,7 @@ export default function QuoteDetailPanel<T extends QuoteDetailItem>({
       const json = await res.json().catch(() => ({}));
       if (!res.ok || !json.ok) { toast.error(json?.error || 'Kunde inte byta status'); return; }
       const updated = json?.data?.item as QuoteDetailItem | undefined;
-      onQuoteChanged(mergeQuote(quote, updated ?? { status: nextStatus }));
+      onQuoteChanged(patchFromItem(quote.id, updated, { status: nextStatus }));
     } catch {
       toast.error('Kunde inte byta status');
     } finally {
@@ -175,7 +194,7 @@ export default function QuoteDetailPanel<T extends QuoteDetailItem>({
       const json = await res.json().catch(() => ({}));
       if (!res.ok || !json.ok) { toast.error(json?.error || 'Kunde inte skapa arbetsorder'); return; }
       const updated = json?.data?.item as QuoteDetailItem | undefined;
-      if (updated) onQuoteChanged(mergeQuote(quote, updated));
+      onQuoteChanged(patchFromItem(quote.id, updated, {}));
       const workOrder = json?.data?.workOrder as { id?: string; order_number?: string } | undefined;
       if (json?.data?.fortnox_error) {
         toast.error(`Arbetsorder skapad men Fortnox-synk misslyckades: ${json.data.fortnox_error}`);
@@ -204,10 +223,12 @@ export default function QuoteDetailPanel<T extends QuoteDetailItem>({
           ? `Fortnox-offert #${offerNumber} ${wasUpdated ? 'uppdaterad' : 'skapad'}`
           : 'Skickad till Fortnox',
       );
-      onQuoteChanged(mergeQuote(quote, {
+      onQuoteChanged({
+        id: quote.id,
         fortnox_offer_number: offerNumber ?? quote.fortnox_offer_number,
         fortnox_sync_status: 'synced',
-      }));
+        fortnox_synced_at: new Date().toISOString(),
+      });
     } catch {
       toast.error('Kunde inte skicka till Fortnox');
     } finally {
@@ -322,10 +343,7 @@ export default function QuoteDetailPanel<T extends QuoteDetailItem>({
 
             {/* Status changer */}
             <div className="grid gap-2">
-              <span className="text-[11px] font-semibold uppercase tracking-[0.14em] text-slate-400">
-                Byt status
-                {statusLocked ? <span className="ml-2 font-medium normal-case tracking-normal text-slate-400">— låst, arbetsorder är skapad</span> : null}
-              </span>
+              <span className="text-[11px] font-semibold uppercase tracking-[0.14em] text-slate-400">Byt status</span>
               <div className="flex flex-wrap gap-2">
                 {(Object.entries(quoteStatusMeta) as Array<[QuoteDetailItem['status'], typeof quoteStatusMeta[QuoteDetailItem['status']]]>).map(([s, meta]) => {
                   const isCurrent = quote.status === s;
@@ -333,7 +351,7 @@ export default function QuoteDetailPanel<T extends QuoteDetailItem>({
                     <button
                       key={s}
                       type="button"
-                      disabled={moving || isCurrent || statusLocked}
+                      disabled={moving || isCurrent}
                       onClick={() => void moveQuoteToStatus(s)}
                       className={cn(
                         'inline-flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-xs font-semibold transition',

--- a/app/crm/kunder/CustomerDetailClient.tsx
+++ b/app/crm/kunder/CustomerDetailClient.tsx
@@ -239,13 +239,18 @@ export default function CustomerDetailClient({ customerId, fortnoxConnected }: {
     const rt = searchParams.get('returnTo');
     if (!rt) return null;
     const isOfferPath = rt === '/crm/offerter' || rt.startsWith('/crm/offerter/') || rt.startsWith('/crm/offerter?');
-    return isOfferPath || rt.startsWith('/crm/arbetsorder/') ? rt : null;
+    // The Säljtavla opens the same quote panel as the offer list, so its customer link needs the
+    // same round trip. Without it the allow-list silently drops the returnTo and the seller is
+    // dumped in the customer register instead of back on the board.
+    const isBoardPath = rt === '/crm/saljtavla' || rt.startsWith('/crm/saljtavla?');
+    return isOfferPath || isBoardPath || rt.startsWith('/crm/arbetsorder/') ? rt : null;
   })();
   // The offer FORM (/crm/offerter/ny · /[id]/redigera) re-selects this customer via
   // created_customer_id so edited details flow into the draft. The offer LIST (/crm/offerter?quote_id=,
   // opened from a quote's detail modal) just returns to reopen the modal — no customer injection.
   const isOfferFormReturn = returnTo?.startsWith('/crm/offerter/') ?? false;
-  const isOfferReturn = returnTo === '/crm/offerter' || returnTo?.startsWith('/crm/offerter/') || returnTo?.startsWith('/crm/offerter?') || false;
+  const isOfferReturn = returnTo === '/crm/offerter' || returnTo?.startsWith('/crm/offerter/') || returnTo?.startsWith('/crm/offerter?')
+    || returnTo === '/crm/saljtavla' || returnTo?.startsWith('/crm/saljtavla?') || false;
   const sep = returnTo?.includes('?') ? '&' : '?';
   const backTo = returnTo
     ? (isOfferFormReturn ? `${returnTo}${sep}created_customer_id=${customerId}` : returnTo)

--- a/app/crm/lib/quoteDisplay.ts
+++ b/app/crm/lib/quoteDisplay.ts
@@ -1,0 +1,45 @@
+// Presentation helpers shared by every surface that shows a quote: the offer list, the Säljtavla
+// board and the detail panel they both open. Pure and side-effect free, so they're unit-tested and
+// can't drift between the three places a quote is rendered.
+
+export type QuoteNameFields = {
+  customer_name: string | null;
+  customer_snapshot: { customer_name?: string | null; company_name?: string | null } | null;
+  prospect: { company_name: string } | Array<{ company_name: string }> | null;
+};
+
+/**
+ * The customer name to show for a quote.
+ *
+ * Order matters and is not arbitrary: a prospect-backed quote should read as the prospect company
+ * (that's the entity the seller is working), then the point-in-time snapshot stored on the quote,
+ * and only last the live `customer_name` column. The snapshot outranks the column so an old quote
+ * keeps showing who it was written for even if the customer has since been renamed.
+ */
+export function quoteCustomerName(item: QuoteNameFields): string {
+  const prospect = Array.isArray(item.prospect) ? item.prospect[0] : item.prospect;
+  return prospect?.company_name
+    || item.customer_snapshot?.customer_name
+    || item.customer_snapshot?.company_name
+    || item.customer_name
+    || 'Okänd kund';
+}
+
+export type QuoteOverdueFields = {
+  follow_up_date: string | null;
+  status: 'draft' | 'sent' | 'follow_up' | 'won' | 'lost';
+};
+
+/**
+ * Is the follow-up date in the past and still relevant?
+ *
+ * Won and lost quotes are never overdue — the deal is closed, so nagging about a follow-up date
+ * that was set weeks earlier is noise. `today` is injectable so the check is testable without
+ * freezing the clock; it defaults to the runtime's local calendar day, which is what a Swedish
+ * seller's browser shows.
+ */
+export function isQuoteOverdue(item: QuoteOverdueFields, today: Date = new Date()): boolean {
+  if (!item.follow_up_date || item.status === 'won' || item.status === 'lost') return false;
+  const iso = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`;
+  return item.follow_up_date < iso;
+}

--- a/app/crm/offerter/QuotesClient.tsx
+++ b/app/crm/offerter/QuotesClient.tsx
@@ -1,17 +1,16 @@
 "use client";
 import { useEffect, useMemo, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
-import Link from 'next/link';
 import Input from '../../../components/ui/Input';
 import { useToast } from '@/lib/Toast';
 import { cn } from '@/lib/shared/cn';
 import AssigneeFilter, { matchesAssignee, type AssigneeFilterValue, type AssigneeOption } from '@/app/crm/components/AssigneeFilter';
-import { openFortnoxPdf } from '@/app/crm/lib/fortnoxDoc';
 import { documentRef } from '@/app/crm/lib/format';
 import DocumentNumberBadge from '@/app/crm/components/DocumentNumberBadge';
 import { resolveQuoteVatBreakdown, quoteAmountDisplay } from '@/lib/domains/crm/pricing';
 import { quoteStatusMeta } from '@/app/crm/lib/crmTokens';
-import useDocumentEmail from '@/app/crm/components/useDocumentEmail';
+import { quoteCustomerName, isQuoteOverdue } from '@/app/crm/lib/quoteDisplay';
+import QuoteDetailPanel from '@/app/crm/components/QuoteDetailPanel';
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -76,11 +75,6 @@ function formatDate(value: string | null | undefined) {
   return new Intl.DateTimeFormat('sv-SE', { dateStyle: 'medium' }).format(date);
 }
 
-function getProspectFromQuote(item: QuoteItem) {
-  if (Array.isArray(item.prospect)) return item.prospect[0] || null;
-  return item.prospect || null;
-}
-
 function initialsOf(name: string | null | undefined) {
   if (!name) return '–';
   const parts = name.trim().split(/\s+/).filter(Boolean);
@@ -89,24 +83,10 @@ function initialsOf(name: string | null | undefined) {
   return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
 }
 
-function getQuoteCustomerName(item: QuoteItem) {
-  return getProspectFromQuote(item)?.company_name
-    || item.customer_snapshot?.customer_name
-    || item.customer_snapshot?.company_name
-    || item.customer_name
-    || 'Okänd kund';
-}
-
-function isOverdue(item: QuoteItem) {
-  if (!item.follow_up_date || item.status === 'won' || item.status === 'lost') return false;
-  const today = new Date();
-  const todayIso = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`;
-  return item.follow_up_date < todayIso;
-}
 
 function compareQuotes(a: QuoteItem, b: QuoteItem) {
-  const aOverdue = isOverdue(a);
-  const bOverdue = isOverdue(b);
+  const aOverdue = isQuoteOverdue(a);
+  const bOverdue = isQuoteOverdue(b);
   if (aOverdue !== bOverdue) return aOverdue ? -1 : 1;
   if (a.follow_up_date && b.follow_up_date && a.follow_up_date !== b.follow_up_date) {
     return a.follow_up_date.localeCompare(b.follow_up_date);
@@ -139,13 +119,7 @@ export default function QuotesClient({ currentUserId }: { currentUserId: string 
       .catch(() => { if (active) setAssignees([]); });
     return () => { active = false; };
   }, []);
-  const [movingQuoteId, setMovingQuoteId] = useState<string | null>(null);
-  const [creatingWorkOrderId, setCreatingWorkOrderId] = useState<string | null>(null);
-  const [pushingFortnoxId, setPushingFortnoxId] = useState<string | null>(null);
-  const [pdfLoadingId, setPdfLoadingId] = useState<string | null>(null);
   // Offer + order-confirmation e-mail (own mail client, with recipient resolution).
-  const documentEmail = useDocumentEmail();
-  const [orderPdfId, setOrderPdfId] = useState<string | null>(null);
   // Map of work_order_id → its Fortnox order number, so the offer list AO-chip and the
   // modal's work-order reference can lead with the Fortnox number (the quote row itself
   // doesn't carry it). Fetched once from the work-orders list (one request, no per-row
@@ -250,10 +224,8 @@ export default function QuotesClient({ currentUserId }: { currentUserId: string 
   // The offer is locked in Fortnox only once it's been converted to an order (a work
   // order exists) AND its sync didn't fail. If the sync failed we must NOT show "Låst"
   // / hide re-sync — the salesperson still needs to recover.
-  const offerLocked = Boolean(detailQuote?.work_order_id) && detailQuote?.fortnox_sync_status !== 'failed';
 
   // Amount display for the detail hero follows the same convention as the list rows.
-  const detailDisplay = detailQuote ? quoteAmountDisplay(detailQuote.quote_type, resolveQuoteVatBreakdown(detailQuote)) : null;
 
   // Load the work-orders list once and index Fortnox order numbers by work_order_id.
   useEffect(() => {
@@ -268,131 +240,6 @@ export default function QuotesClient({ currentUserId }: { currentUserId: string 
       .catch(() => { if (active) setWorkOrderFortnoxById(new Map()); });
     return () => { active = false; };
   }, []);
-
-  async function moveQuoteToStatus(quoteId: string, nextStatus: QuoteItem['status']) {
-    const currentItem = quotes.find((q) => q.id === quoteId);
-    if (!currentItem || currentItem.status === nextStatus) return;
-
-    setMovingQuoteId(quoteId);
-    const optimistic = { ...currentItem, status: nextStatus, updated_at: new Date().toISOString() };
-    setQuotes((current) => current.map((q) => (q.id === quoteId ? optimistic : q)));
-
-    try {
-      const res = await fetch(`/api/crm/quotes/${quoteId}`, {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          prospect_id: currentItem.prospect_id,
-          customer_name: currentItem.customer_name,
-          quote_type: currentItem.quote_type,
-          customer_source: currentItem.customer_source,
-          customer_snapshot: currentItem.customer_snapshot,
-          pricing_summary: currentItem.pricing_summary,
-          project_name: currentItem.project_name,
-          description: currentItem.description,
-          amount: currentItem.amount,
-          currency_code: currentItem.currency_code,
-          vat_percent: currentItem.vat_percent,
-          valid_until: currentItem.valid_until,
-          status: nextStatus,
-          quote_date: currentItem.quote_date,
-          follow_up_date: currentItem.follow_up_date,
-          notes: currentItem.notes,
-        }),
-      });
-      const json = await res.json().catch(() => ({}));
-      if (!res.ok || !json.ok) {
-        setQuotes((current) => current.map((q) => (q.id === quoteId ? currentItem : q)));
-        toast.error(json?.error || 'Kunde inte byta status');
-        return;
-      }
-      const updated = json?.data?.item as QuoteItem | undefined;
-      if (updated) setQuotes((current) => current.map((q) => (q.id === updated.id ? updated : q)));
-    } catch {
-      setQuotes((current) => current.map((q) => (q.id === quoteId ? currentItem : q)));
-      toast.error('Kunde inte byta status');
-    } finally {
-      setMovingQuoteId(null);
-    }
-  }
-
-  async function createWorkOrder(quoteId: string) {
-    const item = quotes.find((q) => q.id === quoteId);
-    if (!item || item.status !== 'won') { toast.error('Arbetsorder kan bara skapas från vunnen offert'); return; }
-    if (item.work_order_id) { toast.info('Arbetsorder finns redan'); return; }
-
-    setCreatingWorkOrderId(quoteId);
-    try {
-      const res = await fetch(`/api/crm/quotes/${quoteId}/work-order`, { method: 'POST', headers: { 'Content-Type': 'application/json' } });
-      const json = await res.json().catch(() => ({}));
-      if (!res.ok || !json.ok) { toast.error(json?.error || 'Kunde inte skapa arbetsorder'); return; }
-      const updated = json?.data?.item as QuoteItem | undefined;
-      if (updated) setQuotes((current) => current.map((q) => (q.id === updated.id ? updated : q)));
-      const workOrder = json?.data?.workOrder as { id?: string; order_number?: string } | undefined;
-      if (json?.data?.fortnox_error) {
-        toast.error(`Arbetsorder skapad men Fortnox-synk misslyckades: ${json.data.fortnox_error}`);
-      } else {
-        toast.success(workOrder?.order_number ? `Arbetsorder skapad: ${workOrder.order_number}` : 'Arbetsorder skapad');
-      }
-      // Don't auto-navigate — the button flips to "Gå till arbetsorder" so the user
-      // can choose to go there when ready.
-    } catch { toast.error('Kunde inte skapa arbetsorder'); } finally { setCreatingWorkOrderId(null); }
-  }
-
-  async function pushToFortnox(quoteId: string) {
-    setPushingFortnoxId(quoteId);
-    try {
-      const res = await fetch('/api/fortnox/offers', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ quote_id: quoteId }),
-      });
-      const json = await res.json().catch(() => ({}));
-      if (!res.ok || !json.ok) {
-        toast.error(json?.error || 'Kunde inte skicka till Fortnox');
-        return;
-      }
-      const offerNumber = json?.data?.fortnox_offer_number as string | undefined;
-      const wasUpdated = json?.data?.updated as boolean | undefined;
-      toast.success(
-        offerNumber
-          ? `Fortnox-offert #${offerNumber} ${wasUpdated ? 'uppdaterad' : 'skapad'}`
-          : 'Skickad till Fortnox',
-      );
-      // Refresh list to pick up new fortnox_offer_number and sync_status
-      setQuotes((current) =>
-        current.map((q) =>
-          q.id === quoteId
-            ? {
-                ...q,
-                fortnox_offer_number: offerNumber ?? q.fortnox_offer_number,
-                fortnox_sync_status: 'synced',
-                fortnox_synced_at: new Date().toISOString(),
-              }
-            : q,
-        ),
-      );
-    } catch {
-      toast.error('Kunde inte skicka till Fortnox');
-    } finally {
-      setPushingFortnoxId(null);
-    }
-  }
-
-  // Offer PDF + email, and order-confirmation PDF + email (for the work order created
-  // from this quote). Shared fetch/popup/email logic lives in lib/fortnoxDoc.
-  async function openOfferPdf(quoteId: string) {
-    setPdfLoadingId(quoteId);
-    await openFortnoxPdf(`/api/fortnox/offers/${quoteId}/pdf`, toast.error);
-    setPdfLoadingId(null);
-  }
-
-  async function openOrderPdf(workOrderId: string) {
-    setOrderPdfId(workOrderId);
-    await openFortnoxPdf(`/api/crm/work-orders/${workOrderId}/fortnox/pdf`, toast.error);
-    setOrderPdfId(null);
-  }
-
 
   return (
     <div className="grid grid-cols-1 gap-4">
@@ -487,7 +334,7 @@ export default function QuotesClient({ currentUserId }: { currentUserId: string 
         {!loading && visibleQuotes.length > 0 ? (
           <div className="grid gap-1">
             {sortedVisibleQuotes.map((item) => {
-              const overdue = isOverdue(item);
+              const overdue = isQuoteOverdue(item);
               const statusMeta = quoteStatusMeta[item.status];
               const sellerName = item.assigned_to ? (assigneeNameById.get(item.assigned_to) || 'Okänd') : null;
               // Private → show price incl moms; business → show ex moms (with the basis tagged).
@@ -501,7 +348,6 @@ export default function QuotesClient({ currentUserId }: { currentUserId: string 
                   className={cn(
                     'group relative flex items-stretch overflow-hidden rounded-lg border bg-white text-left shadow-[0_1px_2px_rgba(15,23,42,0.05)] transition hover:border-[#cfdcc9] hover:shadow-[0_8px_20px_-10px_rgba(20,44,27,0.30)]',
                     overdue ? 'border-amber-200' : 'border-[#e3e9df]',
-                    movingQuoteId === item.id ? 'opacity-60' : null,
                   )}
                 >
                   {/* Status accent rail */}
@@ -513,7 +359,7 @@ export default function QuotesClient({ currentUserId }: { currentUserId: string 
                       <DocumentNumberBadge label="Offert" value={documentRef(item.fortnox_offer_number, item.quote_number)} />
                       <div className="grid min-w-0 gap-0.5">
                         <strong className="truncate text-[13px] font-bold text-slate-900">{item.project_name}</strong>
-                        <span className="truncate text-[11px] text-slate-500">{getQuoteCustomerName(item)}</span>
+                        <span className="truncate text-[11px] text-slate-500">{quoteCustomerName(item)}</span>
                         <div className="flex flex-wrap items-center gap-1 pt-0.5">
                           <span className={cn('inline-flex items-center rounded-md border px-1.5 py-0.5 text-[10px] font-semibold', statusMeta.className)}>
                             {statusMeta.label}
@@ -577,336 +423,13 @@ export default function QuotesClient({ currentUserId }: { currentUserId: string 
 
       {/* ── Detail panel ── */}
       {detailPanelOpen && detailQuote ? (
-        <div
-          className="fixed inset-0 z-[2800] flex items-end justify-center bg-slate-950/50 [backdrop-filter:blur(4px)] sm:items-center sm:p-4"
-          onClick={() => setDetailPanelOpen(false)}
-        >
-          <div
-            role="dialog"
-            aria-modal="true"
-            aria-label={`Offert ${detailQuote.project_name}`}
-            onClick={(e) => e.stopPropagation()}
-            className="flex h-[100dvh] max-h-[100dvh] w-full max-w-[600px] flex-col overflow-hidden rounded-none bg-white shadow-[0_-12px_50px_rgba(15,23,42,0.30)] sm:h-auto sm:max-h-[88vh] sm:rounded-2xl sm:shadow-[0_30px_80px_rgba(15,23,42,0.28)]"
-          >
-            {/* Sticky header */}
-            <div className="flex items-start justify-between gap-3 border-b border-slate-100 px-5 pb-4 [padding-top:calc(1rem+env(safe-area-inset-top))] sm:pt-4">
-              <div className="grid min-w-0 gap-1.5">
-                <div className="flex flex-wrap items-center gap-2">
-                  <span className={cn('rounded-full border px-2.5 py-0.5 text-[11px] font-semibold', quoteStatusMeta[detailQuote.status].className)}>
-                    {quoteStatusMeta[detailQuote.status].label}
-                  </span>
-                  {detailQuote.quote_number ? (
-                    <span className="text-[11px] font-semibold uppercase tracking-[0.14em] text-slate-400">{documentRef(detailQuote.fortnox_offer_number, detailQuote.quote_number)}</span>
-                  ) : null}
-                </div>
-                <strong className="truncate text-lg font-bold tracking-tight text-slate-950">{detailQuote.project_name}</strong>
-                {/* Link to the customer card when the quote is tied to a saved CRM customer; a
-                    prospect/snapshot-only quote (no customer_id) keeps a plain name. returnTo points
-                    back at the list WITH ?quote_id so the detail modal re-opens on return (same
-                    open-then-return workflow as the offer form). */}
-                {detailQuote.customer_id ? (
-                  <Link
-                    href={`/crm/kunder/${detailQuote.customer_id}?returnTo=${encodeURIComponent(`/crm/offerter?quote_id=${detailQuote.id}`)}`}
-                    className="m-0 inline-flex max-w-full items-center gap-1 text-sm text-slate-500 transition-colors hover:text-emerald-700"
-                  >
-                    <span className="truncate underline-offset-2 hover:underline">{getQuoteCustomerName(detailQuote)}</span>
-                    <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden className="shrink-0">
-                      <path d="M4.5 2.5L8 6l-3.5 3.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
-                    </svg>
-                  </Link>
-                ) : (
-                  <p className="m-0 truncate text-sm text-slate-500">{getQuoteCustomerName(detailQuote)}</p>
-                )}
-              </div>
-              <button
-                type="button"
-                aria-label="Stäng"
-                onClick={() => setDetailPanelOpen(false)}
-                className="!h-9 !w-9 shrink-0 !rounded-full !border !border-slate-200 !bg-white !p-0 text-slate-500 transition hover:!border-slate-300 hover:text-slate-700"
-              >
-                <svg className="mx-auto" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-                  <path d="M18 6L6 18M6 6l12 12" />
-                </svg>
-              </button>
-            </div>
-
-            {/* Scrollable body */}
-            <div className="grid flex-1 gap-5 overflow-y-auto px-5 py-5">
-              {/* Hero: amount + key dates */}
-              <div className="rounded-xl border border-[#e3e9df] bg-[#f6f9f3] p-4">
-                <div className="text-[11px] font-semibold uppercase tracking-[0.14em] text-slate-400">{detailDisplay?.primaryLabel ?? 'Belopp'}</div>
-                <div className="mt-0.5 text-[1.75rem] font-bold leading-none tracking-tight text-slate-900 tabular-nums">
-                  {formatCurrency(detailDisplay?.primary ?? detailQuote.amount, detailQuote.currency_code)}
-                </div>
-                {detailDisplay ? (
-                  <div className="mt-2 flex flex-wrap gap-x-4 gap-y-0.5 text-[11px] text-slate-500">
-                    <span>Ex moms <span className="font-medium text-slate-600 tabular-nums">{formatCurrency(detailDisplay.subtotal, detailQuote.currency_code)}</span></span>
-                    <span>Moms ({detailDisplay.vatPercent} %) <span className="font-medium text-slate-600 tabular-nums">{formatCurrency(detailDisplay.vat, detailQuote.currency_code)}</span></span>
-                    <span>Inkl. moms <span className="font-medium text-slate-600 tabular-nums">{formatCurrency(detailDisplay.total, detailQuote.currency_code)}</span></span>
-                  </div>
-                ) : null}
-                <div className="mt-4 grid grid-cols-3 gap-3 border-t border-[#dce6d6] pt-3">
-                  {([
-                    ['Offertdatum', formatDate(detailQuote.quote_date), false],
-                    ['Följ upp', formatDate(detailQuote.follow_up_date), isOverdue(detailQuote)],
-                    ['Giltig till', formatDate(detailQuote.valid_until), false],
-                  ] as Array<[string, string, boolean]>).map(([lbl, val, warn]) => (
-                    <div key={lbl} className="grid gap-0.5">
-                      <span className="text-[10px] font-semibold uppercase tracking-[0.1em] text-slate-400">{lbl}</span>
-                      <span className={cn('text-sm font-medium', warn ? 'text-amber-700' : 'text-slate-700')}>{warn ? '⚠ ' : ''}{val}</span>
-                    </div>
-                  ))}
-                </div>
-              </div>
-
-              {/* Description */}
-              {detailQuote.description ? (
-                <div className="grid gap-1.5">
-                  <span className="text-[11px] font-semibold uppercase tracking-[0.14em] text-slate-400">Beskrivning</span>
-                  <p className="m-0 text-sm leading-6 text-slate-700">{detailQuote.description}</p>
-                </div>
-              ) : null}
-
-              {/* Status changer */}
-              <div className="grid gap-2">
-                <span className="text-[11px] font-semibold uppercase tracking-[0.14em] text-slate-400">Byt status</span>
-                <div className="flex flex-wrap gap-2">
-                  {(Object.entries(quoteStatusMeta) as Array<[QuoteItem['status'], typeof quoteStatusMeta[QuoteItem['status']]]>).map(([s, meta]) => {
-                    const isCurrent = detailQuote.status === s;
-                    return (
-                      <button
-                        key={s}
-                        type="button"
-                        disabled={movingQuoteId === detailQuote.id || isCurrent}
-                        onClick={() => void moveQuoteToStatus(detailQuote.id, s)}
-                        className={cn(
-                          'inline-flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-xs font-semibold transition',
-                          isCurrent
-                            ? cn(meta.className, 'cursor-default')
-                            : 'border-slate-200 bg-white text-slate-600 hover:border-slate-300 hover:bg-slate-50 disabled:opacity-50',
-                        )}
-                      >
-                        {isCurrent ? <span className={cn('h-1.5 w-1.5 rounded-full', meta.accent)} /> : null}
-                        {meta.label}
-                      </button>
-                    );
-                  })}
-                </div>
-              </div>
-
-              {/* Notes */}
-              {detailQuote.notes ? (
-                <div className="grid gap-1.5 rounded-xl border border-amber-100 bg-amber-50/60 p-3.5">
-                  <span className="text-[11px] font-semibold uppercase tracking-[0.14em] text-amber-700/80">Anteckningar</span>
-                  <p className="m-0 whitespace-pre-wrap text-sm leading-6 text-slate-700">{detailQuote.notes}</p>
-                </div>
-              ) : null}
-
-              {/* Action cards */}
-              <div className="grid gap-3">
-                {/* Work order */}
-                <div className="rounded-xl border border-[#e3e9df] bg-[#f9fbf7] p-4">
-                  <div className="flex flex-wrap items-start justify-between gap-3">
-                    <div className="flex min-w-0 items-start gap-3">
-                      <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-emerald-100 text-emerald-700">
-                        <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-                          <rect x="5" y="4" width="14" height="17" rx="2" /><path d="M9 4V2.5h6V4M9 11h6M9 15h4" />
-                        </svg>
-                      </span>
-                      <div className="grid min-w-0 gap-0.5">
-                        <span className="text-sm font-semibold text-slate-800">Arbetsorder</span>
-                        <span className="text-xs leading-5 text-slate-500">
-                          {detailQuote.work_order_id
-                            ? `${documentRef(workOrderFortnoxById.get(detailQuote.work_order_id) ?? null, detailQuote.work_order_number)} är skapad.`
-                            : detailQuote.status === 'won'
-                              ? 'Klar att bli en intern arbetsorder.'
-                              : 'Sätt offerten till vunnen för att skapa.'}
-                        </span>
-                      </div>
-                    </div>
-                    <div className="flex shrink-0 gap-2">
-                      {detailQuote.work_order_id ? (
-                        <button
-                          type="button"
-                          onClick={() => router.push(`/crm/arbetsorder/${detailQuote.work_order_id}`)}
-                          className="rounded-lg border border-emerald-700 bg-emerald-700 px-3 py-1.5 text-sm font-semibold text-white transition hover:bg-emerald-800"
-                        >
-                          Gå till arbetsorder
-                        </button>
-                      ) : (
-                        <button
-                          type="button"
-                          onClick={() => void createWorkOrder(detailQuote.id)}
-                          disabled={detailQuote.status !== 'won' || creatingWorkOrderId === detailQuote.id}
-                          className="rounded-lg border border-emerald-700 bg-emerald-700 px-3 py-1.5 text-sm font-semibold text-white transition hover:bg-emerald-800 disabled:cursor-not-allowed disabled:border-slate-200 disabled:bg-white disabled:text-slate-400"
-                        >
-                          {creatingWorkOrderId === detailQuote.id ? 'Skapar…' : 'Skapa arbetsorder'}
-                        </button>
-                      )}
-                    </div>
-                  </div>
-
-                  {/* Order confirmation — once a work order (Fortnox order) exists */}
-                  {detailQuote.work_order_id ? (
-                    <div className="mt-3 flex flex-wrap items-center gap-2 border-t border-[#e3e9df] pt-3">
-                      <span className="mr-auto text-xs font-medium text-slate-500">Orderbekräftelse</span>
-                      <button
-                        type="button"
-                        onClick={() => void openOrderPdf(detailQuote.work_order_id!)}
-                        disabled={orderPdfId === detailQuote.work_order_id}
-                        className="rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-sm font-semibold text-slate-700 transition hover:border-slate-300 disabled:cursor-not-allowed disabled:opacity-50"
-                      >
-                        {orderPdfId === detailQuote.work_order_id ? 'Hämtar…' : 'Hämta PDF'}
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => documentEmail.start({
-                          id: detailQuote.work_order_id!,
-                          kind: 'order',
-                          ref: documentRef(workOrderFortnoxById.get(detailQuote.work_order_id!) ?? null, detailQuote.work_order_number),
-                          projectName: detailQuote.project_name,
-                          customerName: getQuoteCustomerName(detailQuote),
-                          snapshotEmail: detailQuote.customer_snapshot?.email,
-                          customerId: detailQuote.customer_id,
-                          pdfUrl: `/api/crm/work-orders/${detailQuote.work_order_id}/fortnox/pdf`,
-                        })}
-                        disabled={documentEmail.sendingId === detailQuote.work_order_id}
-                        className="rounded-lg border border-indigo-600 bg-indigo-600 px-3 py-1.5 text-sm font-semibold text-white transition hover:bg-indigo-700 disabled:cursor-not-allowed disabled:opacity-50"
-                      >
-                        {documentEmail.sendingId === detailQuote.work_order_id ? 'Mejlar…' : 'Mejla order'}
-                      </button>
-                    </div>
-                  ) : null}
-                </div>
-
-                {/* Fortnox */}
-                <div className="rounded-xl border border-[#e3e9df] bg-[#f9fbf7] p-4">
-                  <div className="flex flex-wrap items-start justify-between gap-3">
-                    <div className="flex min-w-0 items-start gap-3">
-                      <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-indigo-100 text-indigo-700">
-                        <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-                          <path d="M12 16V4M8 8l4-4 4 4M5 20h14" />
-                        </svg>
-                      </span>
-                      <div className="grid min-w-0 gap-0.5">
-                        <div className="flex flex-wrap items-center gap-1.5">
-                          <span className="text-sm font-semibold text-slate-800">Fortnox</span>
-                          {offerLocked ? (
-                            <span className="inline-flex items-center gap-1 rounded-md border border-amber-200 bg-amber-50 px-1.5 py-0.5 text-[10px] font-semibold text-amber-700">
-                              <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-                                <rect x="5" y="11" width="14" height="10" rx="2" /><path d="M8 11V7a4 4 0 018 0v4" />
-                              </svg>
-                              Låst
-                            </span>
-                          ) : null}
-                        </div>
-                        <span className="text-xs leading-5 text-slate-500">
-                          {detailQuote.fortnox_offer_number
-                            ? `Offert #${detailQuote.fortnox_offer_number} skapad.`
-                            : 'Skicka offerten till Fortnox.'}
-                        </span>
-                        {detailQuote.fortnox_sync_status === 'failed' ? (
-                          <span className="text-xs font-semibold text-rose-600">Senaste synk misslyckades.</span>
-                        ) : null}
-                      </div>
-                    </div>
-                    <div className="flex shrink-0 flex-wrap items-center justify-end gap-2">
-                      {detailQuote.fortnox_offer_number ? (
-                        <>
-                          <button
-                            type="button"
-                            onClick={() => void openOfferPdf(detailQuote.id)}
-                            disabled={pdfLoadingId === detailQuote.id}
-                            className="rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-sm font-semibold text-slate-700 transition hover:border-slate-300 disabled:cursor-not-allowed disabled:opacity-50"
-                          >
-                            {pdfLoadingId === detailQuote.id ? 'Hämtar…' : 'Hämta PDF'}
-                          </button>
-                          {/* Ett enda mejlsätt: eget mejlprogram. Fortnox egen offertutskick är
-                              borttaget — mottagaren gick inte att styra därifrån och används inte. */}
-                          <button
-                            type="button"
-                            onClick={() => documentEmail.start({
-                              id: detailQuote.id,
-                              kind: 'offer',
-                              ref: documentRef(detailQuote.fortnox_offer_number, detailQuote.quote_number),
-                              projectName: detailQuote.project_name,
-                              customerName: getQuoteCustomerName(detailQuote),
-                              snapshotEmail: detailQuote.customer_snapshot?.email,
-                              customerId: detailQuote.customer_id,
-                              pdfUrl: `/api/fortnox/offers/${detailQuote.id}/pdf`,
-                            })}
-                            disabled={documentEmail.sendingId === detailQuote.id}
-                            title="Öppnar ditt mejlprogram – PDF:en laddas ner att bifoga."
-                            className="inline-flex items-center rounded-lg border border-indigo-600 bg-indigo-600 px-3 py-1.5 text-sm font-semibold text-white transition hover:bg-indigo-700 disabled:cursor-not-allowed disabled:opacity-50"
-                          >
-                            {documentEmail.sendingId === detailQuote.id ? 'Mejlar…' : 'Mejla offert'}
-                          </button>
-                        </>
-                      ) : null}
-                      {/* Sync/re-sync hidden once a work order locks the offer in Fortnox
-                          (but still shown if the sync failed, so the user can recover) */}
-                      {!offerLocked ? (
-                        <button
-                          type="button"
-                          onClick={() => void pushToFortnox(detailQuote.id)}
-                          disabled={pushingFortnoxId === detailQuote.id || detailQuote.fortnox_sync_status === 'pending'}
-                          className={cn(
-                            'rounded-lg border px-3 py-1.5 text-sm font-semibold transition disabled:cursor-not-allowed disabled:opacity-50',
-                            detailQuote.fortnox_offer_number
-                              ? 'border-slate-200 bg-white text-slate-700 hover:border-slate-300'
-                              : 'border-indigo-600 bg-indigo-600 text-white hover:bg-indigo-700',
-                          )}
-                        >
-                          {pushingFortnoxId === detailQuote.id ? 'Skickar…' : detailQuote.fortnox_offer_number ? 'Skicka igen' : 'Skicka'}
-                        </button>
-                      ) : null}
-                    </div>
-                  </div>
-
-                  {/* Locked explanation — offer can no longer be edited/re-synced */}
-                  {offerLocked ? (
-                    <div className="mt-3 flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50/70 px-3 py-2.5 text-xs leading-5 text-amber-900">
-                      <svg className="mt-0.5 shrink-0" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-                        <rect x="5" y="11" width="14" height="10" rx="2" /><path d="M8 11V7a4 4 0 018 0v4" />
-                      </svg>
-                      <span>
-                        Offerten är <strong>låst</strong>{detailQuote.work_order_number ? ` – arbetsorder ${detailQuote.work_order_number} är skapad` : ' – en arbetsorder har skapats'}, så den kan inte längre ändras eller synkas om i Fortnox. Du kan fortfarande hämta PDF:en och mejla den till kunden.
-                      </span>
-                    </div>
-                  ) : null}
-                </div>
-              </div>
-            </div>
-
-            {/* Sticky footer — a locked offer (work order created) can't be edited or
-                re-synced, so the edit action is hidden and "Stäng" fills the row. */}
-            <div className="flex items-center gap-2 border-t border-slate-100 px-5 py-3 [padding-bottom:calc(0.75rem+env(safe-area-inset-bottom))] sm:[padding-bottom:0.75rem]">
-              <button
-                type="button"
-                onClick={() => setDetailPanelOpen(false)}
-                className={cn(
-                  'flex-1 rounded-xl border border-slate-200 bg-white py-2.5 text-sm font-semibold text-slate-600 transition hover:border-slate-300',
-                  !offerLocked && 'sm:flex-none sm:px-5',
-                )}
-              >
-                Stäng
-              </button>
-              {!offerLocked ? (
-                <button
-                  type="button"
-                  onClick={() => { setDetailPanelOpen(false); router.push(`/crm/offerter/${detailQuote.id}/redigera`); }}
-                  className="flex-1 rounded-xl py-2.5 text-sm font-semibold text-white shadow-sm transition hover:brightness-95 sm:ml-auto sm:flex-none sm:px-5"
-                  style={{ backgroundColor: 'var(--crm-primary)' }}
-                >
-                  Redigera offert
-                </button>
-              ) : null}
-            </div>
-          </div>
-        </div>
+        <QuoteDetailPanel
+          quote={detailQuote}
+          workOrderFortnoxNumber={detailQuote.work_order_id ? (workOrderFortnoxById.get(detailQuote.work_order_id) ?? null) : null}
+          onClose={() => setDetailPanelOpen(false)}
+          onQuoteChanged={(updated) => setQuotes((current) => current.map((q) => (q.id === updated.id ? { ...q, ...updated } : q)))}
+        />
       ) : null}
-
-      {documentEmail.modal}
     </div>
   );
 }

--- a/app/crm/offerter/QuotesClient.tsx
+++ b/app/crm/offerter/QuotesClient.tsx
@@ -11,6 +11,7 @@ import { resolveQuoteVatBreakdown, quoteAmountDisplay } from '@/lib/domains/crm/
 import { quoteStatusMeta } from '@/app/crm/lib/crmTokens';
 import { quoteCustomerName, isQuoteOverdue } from '@/app/crm/lib/quoteDisplay';
 import QuoteDetailPanel from '@/app/crm/components/QuoteDetailPanel';
+import useDocumentEmail from '@/app/crm/components/useDocumentEmail';
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -125,6 +126,9 @@ export default function QuotesClient({ currentUserId }: { currentUserId: string 
   // doesn't carry it). Fetched once from the work-orders list (one request, no per-row
   // fetch, no DB join needed).
   const [workOrderFortnoxById, setWorkOrderFortnoxById] = useState<Map<string, string | null>>(new Map());
+  // Held here, not in the panel: the send flow has a dismissable progress overlay that must survive
+  // the modal being closed.
+  const documentEmail = useDocumentEmail();
   const [detailPanelOpen, setDetailPanelOpen] = useState(false);
   const [detailQuoteId, setDetailQuoteId] = useState<string | null>(null);
   const [hasHandledPreset, setHasHandledPreset] = useState(false);
@@ -426,10 +430,14 @@ export default function QuotesClient({ currentUserId }: { currentUserId: string 
         <QuoteDetailPanel
           quote={detailQuote}
           workOrderFortnoxNumber={detailQuote.work_order_id ? (workOrderFortnoxById.get(detailQuote.work_order_id) ?? null) : null}
+          returnTo={`/crm/offerter?quote_id=${detailQuote.id}`}
+          documentEmail={documentEmail}
           onClose={() => setDetailPanelOpen(false)}
           onQuoteChanged={(updated) => setQuotes((current) => current.map((q) => (q.id === updated.id ? { ...q, ...updated } : q)))}
         />
       ) : null}
+
+      {documentEmail.modal}
     </div>
   );
 }

--- a/app/crm/offerter/QuotesClient.tsx
+++ b/app/crm/offerter/QuotesClient.tsx
@@ -2,7 +2,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import Input from '../../../components/ui/Input';
-import { useToast } from '@/lib/Toast';
 import { cn } from '@/lib/shared/cn';
 import AssigneeFilter, { matchesAssignee, type AssigneeFilterValue, type AssigneeOption } from '@/app/crm/components/AssigneeFilter';
 import { documentRef } from '@/app/crm/lib/format';
@@ -99,7 +98,6 @@ function compareQuotes(a: QuoteItem, b: QuoteItem) {
 // ─── QuotesClient ─────────────────────────────────────────────────────────────
 
 export default function QuotesClient({ currentUserId }: { currentUserId: string | null }) {
-  const toast = useToast();
   const router = useRouter();
   const searchParams = useSearchParams();
 
@@ -433,7 +431,7 @@ export default function QuotesClient({ currentUserId }: { currentUserId: string 
           returnTo={`/crm/offerter?quote_id=${detailQuote.id}`}
           documentEmail={documentEmail}
           onClose={() => setDetailPanelOpen(false)}
-          onQuoteChanged={(updated) => setQuotes((current) => current.map((q) => (q.id === updated.id ? { ...q, ...updated } : q)))}
+          onQuoteChanged={(patch) => setQuotes((current) => current.map((q) => (q.id === patch.id ? { ...q, ...patch } : q)))}
         />
       ) : null}
 

--- a/app/crm/saljtavla/SaljtavlaClient.tsx
+++ b/app/crm/saljtavla/SaljtavlaClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useEffect, useMemo, useState } from 'react';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import Input from '../../../components/ui/Input';
 import { useToast } from '@/lib/Toast';
 import { cn } from '@/lib/shared/cn';
@@ -11,6 +11,7 @@ import { resolveQuoteVatBreakdown, quoteAmountDisplay } from '@/lib/domains/crm/
 import { crm, quoteStatusMeta, type QuoteStatus } from '@/app/crm/lib/crmTokens';
 import { quoteCustomerName, isQuoteOverdue } from '@/app/crm/lib/quoteDisplay';
 import QuoteDetailPanel from '@/app/crm/components/QuoteDetailPanel';
+import useDocumentEmail from '@/app/crm/components/useDocumentEmail';
 import {
   quoteBoardColumn,
   isQuoteCardLocked,
@@ -74,6 +75,7 @@ const COLUMN_DEF: Record<SaljtavlaColumn, { label: string; hint: string; accent:
 export default function SaljtavlaClient({ currentUserId }: { currentUserId: string | null }) {
   const toast = useToast();
   const router = useRouter();
+  const searchParams = useSearchParams();
 
   const [quotes, setQuotes] = useState<BoardQuote[]>([]);
   const [loading, setLoading] = useState(true);
@@ -94,6 +96,22 @@ export default function SaljtavlaClient({ currentUserId }: { currentUserId: stri
   // Opening a card used to navigate to the offer list just to show its modal. The panel is shared
   // now, so the board keeps you where you are.
   const [detailQuoteId, setDetailQuoteId] = useState<string | null>(null);
+  // Owned here so a send in progress survives closing the panel — see the panel's prop docs.
+  const documentEmail = useDocumentEmail();
+  const [hasHandledQuotePreset, setHasHandledQuotePreset] = useState(false);
+  const presetQuoteId = searchParams.get('quote_id') || '';
+
+  // Deep-link: reopen a card's panel when arriving with ?quote_id=, which is how the customer-card
+  // round trip gets you back here. Waits for the quote to be loaded, and runs once, so closing the
+  // panel by hand doesn't immediately re-open it.
+  useEffect(() => { setHasHandledQuotePreset(false); }, [presetQuoteId]);
+
+  useEffect(() => {
+    if (!presetQuoteId || hasHandledQuotePreset || loading) return;
+    if (!quotes.some((q) => q.id === presetQuoteId)) return;
+    setDetailQuoteId(presetQuoteId);
+    setHasHandledQuotePreset(true);
+  }, [presetQuoteId, hasHandledQuotePreset, loading, quotes]);
 
   // Load quotes (all statuses — the board groups them client-side).
   useEffect(() => {
@@ -318,10 +336,14 @@ export default function SaljtavlaClient({ currentUserId }: { currentUserId: stri
         <QuoteDetailPanel
           quote={detailQuote}
           workOrderFortnoxNumber={detailQuote.work_order_id ? (workOrderFortnoxById.get(detailQuote.work_order_id) ?? null) : null}
+          returnTo={`/crm/saljtavla?quote_id=${detailQuote.id}`}
+          documentEmail={documentEmail}
           onClose={() => setDetailQuoteId(null)}
           onQuoteChanged={(updated) => setQuotes((current) => current.map((q) => (q.id === updated.id ? updated : q)))}
         />
       ) : null}
+
+      {documentEmail.modal}
     </div>
   );
 }

--- a/app/crm/saljtavla/SaljtavlaClient.tsx
+++ b/app/crm/saljtavla/SaljtavlaClient.tsx
@@ -339,7 +339,7 @@ export default function SaljtavlaClient({ currentUserId }: { currentUserId: stri
           returnTo={`/crm/saljtavla?quote_id=${detailQuote.id}`}
           documentEmail={documentEmail}
           onClose={() => setDetailQuoteId(null)}
-          onQuoteChanged={(updated) => setQuotes((current) => current.map((q) => (q.id === updated.id ? updated : q)))}
+          onQuoteChanged={(patch) => setQuotes((current) => current.map((q) => (q.id === patch.id ? { ...q, ...patch } : q)))}
         />
       ) : null}
 

--- a/app/crm/saljtavla/SaljtavlaClient.tsx
+++ b/app/crm/saljtavla/SaljtavlaClient.tsx
@@ -9,6 +9,8 @@ import DocumentNumberBadge from '@/app/crm/components/DocumentNumberBadge';
 import { documentRef, formatCurrency } from '@/app/crm/lib/format';
 import { resolveQuoteVatBreakdown, quoteAmountDisplay } from '@/lib/domains/crm/pricing';
 import { crm, quoteStatusMeta, type QuoteStatus } from '@/app/crm/lib/crmTokens';
+import { quoteCustomerName, isQuoteOverdue } from '@/app/crm/lib/quoteDisplay';
+import QuoteDetailPanel from '@/app/crm/components/QuoteDetailPanel';
 import {
   quoteBoardColumn,
   isQuoteCardLocked,
@@ -35,7 +37,14 @@ type BoardQuote = {
   assigned_to: string | null;
   quote_type: 'private' | 'business';
   customer_name: string | null;
-  customer_snapshot: { customer_name?: string | null; company_name?: string | null } | null;
+  customer_snapshot: { customer_name?: string | null; company_name?: string | null; email?: string | null } | null;
+  // Declared because the shared detail panel reads them. They were always in the payload — the board
+  // simply didn't type them, since its cards don't show them.
+  customer_source: { kind?: string | null } | null;
+  fortnox_sync_status: 'not_synced' | 'pending' | 'synced' | 'failed' | null;
+  description: string | null;
+  notes: string | null;
+  valid_until: string | null;
   prospect: { company_name: string } | Array<{ company_name: string }> | null;
   pricing_summary: { subtotal?: number; vat?: number; total?: number } | null;
   amount: number | string;
@@ -59,24 +68,6 @@ const COLUMN_DEF: Record<SaljtavlaColumn, { label: string; hint: string; accent:
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
-function getCustomerName(item: BoardQuote) {
-  const prospect = Array.isArray(item.prospect) ? item.prospect[0] : item.prospect;
-  return prospect?.company_name
-    || item.customer_snapshot?.customer_name
-    || item.customer_snapshot?.company_name
-    || item.customer_name
-    || 'Okänd kund';
-}
-
-function todayIso() {
-  const t = new Date();
-  return `${t.getFullYear()}-${String(t.getMonth() + 1).padStart(2, '0')}-${String(t.getDate()).padStart(2, '0')}`;
-}
-
-function isOverdue(item: BoardQuote) {
-  if (!item.follow_up_date || item.status === 'won' || item.status === 'lost') return false;
-  return item.follow_up_date < todayIso();
-}
 
 // ─── SaljtavlaClient ───────────────────────────────────────────────────────────
 
@@ -100,6 +91,9 @@ export default function SaljtavlaClient({ currentUserId }: { currentUserId: stri
   // number lives on crm_work_orders. Index it once (work_order_id → fortnox number)
   // so won cards can lead with the Fortnox number the customer recognises.
   const [workOrderFortnoxById, setWorkOrderFortnoxById] = useState<Map<string, string | null>>(new Map());
+  // Opening a card used to navigate to the offer list just to show its modal. The panel is shared
+  // now, so the board keeps you where you are.
+  const [detailQuoteId, setDetailQuoteId] = useState<string | null>(null);
 
   // Load quotes (all statuses — the board groups them client-side).
   useEffect(() => {
@@ -151,6 +145,13 @@ export default function SaljtavlaClient({ currentUserId }: { currentUserId: stri
     for (const q of quotes) m.set(q.id, quoteAmountDisplay(q.quote_type, resolveQuoteVatBreakdown(q)).primary);
     return m;
   }, [quotes]);
+
+  // Resolved from the live list rather than stored, so an action inside the panel (status change,
+  // work order, Fortnox push) re-renders it from the same row the board shows.
+  const detailQuote = useMemo(
+    () => (detailQuoteId ? quotes.find((q) => q.id === detailQuoteId) ?? null : null),
+    [detailQuoteId, quotes],
+  );
 
   // Scope to the chosen "Ansvarig" filter (default = mine).
   const scopedQuotes = useMemo(
@@ -305,13 +306,22 @@ export default function SaljtavlaClient({ currentUserId }: { currentUserId: stri
                 ) : items.length === 0 ? (
                   <p className="px-1 py-6 text-center text-[11px] italic text-slate-400">{def.hint}</p>
                 ) : (
-                  items.map((item) => <BoardCard key={item.id} item={item} amount={primaryById.get(item.id) ?? 0} fortnoxOrderNumber={item.work_order_id ? (workOrderFortnoxById.get(item.work_order_id) ?? null) : null} moving={movingId === item.id} onOpen={() => router.push(`/crm/offerter?quote_id=${item.id}`)} onDragStart={() => setDraggedId(item.id)} onDragEnd={() => { setDraggedId(null); setDragOverColumn(null); }} />)
+                  items.map((item) => <BoardCard key={item.id} item={item} amount={primaryById.get(item.id) ?? 0} fortnoxOrderNumber={item.work_order_id ? (workOrderFortnoxById.get(item.work_order_id) ?? null) : null} moving={movingId === item.id} onOpen={() => setDetailQuoteId(item.id)} onDragStart={() => setDraggedId(item.id)} onDragEnd={() => { setDraggedId(null); setDragOverColumn(null); }} />)
                 )}
               </div>
             </div>
           );
         })}
       </div>
+
+      {detailQuote ? (
+        <QuoteDetailPanel
+          quote={detailQuote}
+          workOrderFortnoxNumber={detailQuote.work_order_id ? (workOrderFortnoxById.get(detailQuote.work_order_id) ?? null) : null}
+          onClose={() => setDetailQuoteId(null)}
+          onQuoteChanged={(updated) => setQuotes((current) => current.map((q) => (q.id === updated.id ? updated : q)))}
+        />
+      ) : null}
     </div>
   );
 }
@@ -337,7 +347,7 @@ function BoardCard({
 }) {
   const meta = quoteStatusMeta[item.status];
   const locked = isQuoteCardLocked(item);
-  const overdue = isOverdue(item);
+  const overdue = isQuoteOverdue(item);
 
   return (
     <div
@@ -364,7 +374,7 @@ function BoardCard({
             {item.quote_type === 'private' ? 'Privat' : 'Företag'}
           </span>
         </div>
-        <p className="mt-1 truncate text-[13px] font-bold text-slate-900">{getCustomerName(item)}</p>
+        <p className="mt-1 truncate text-[13px] font-bold text-slate-900">{quoteCustomerName(item)}</p>
         {item.project_name && <p className="truncate text-[11px] text-slate-500">{item.project_name}</p>}
         <div className="mt-1.5 flex items-center justify-between gap-2">
           <span className="text-[12px] font-semibold tabular-nums text-slate-800">{formatCurrency(amount, item.currency_code)}</span>

--- a/tests/crm/quoteDisplay.test.ts
+++ b/tests/crm/quoteDisplay.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { quoteCustomerName, isQuoteOverdue } from '@/app/crm/lib/quoteDisplay';
+
+// These helpers used to exist as identical copies in QuotesClient and SaljtavlaClient. Now that the
+// offer list, the Säljtavla board and their shared detail panel all call the same code, a change
+// here moves three surfaces at once — so the precedence order is worth pinning down.
+
+describe('quoteCustomerName', () => {
+  const base = { customer_name: null, customer_snapshot: null, prospect: null };
+
+  it('leads with the prospect company — that is the entity being worked', () => {
+    expect(quoteCustomerName({
+      ...base,
+      prospect: { company_name: 'Prospektbolaget AB' },
+      customer_snapshot: { customer_name: 'Snapshot Namn' },
+      customer_name: 'Kolumn Namn',
+    })).toBe('Prospektbolaget AB');
+  });
+
+  it('accepts the prospect as an embedded array (PostgREST returns either shape)', () => {
+    expect(quoteCustomerName({ ...base, prospect: [{ company_name: 'Array AB' }] })).toBe('Array AB');
+  });
+
+  it('prefers the snapshot over the live column, so an old quote keeps who it was written for', () => {
+    expect(quoteCustomerName({
+      ...base,
+      customer_snapshot: { customer_name: 'Vid offerttillfället' },
+      customer_name: 'Omdöpt sedan dess',
+    })).toBe('Vid offerttillfället');
+  });
+
+  it('falls back through snapshot company name, then the column', () => {
+    expect(quoteCustomerName({ ...base, customer_snapshot: { company_name: 'Bolaget AB' } })).toBe('Bolaget AB');
+    expect(quoteCustomerName({ ...base, customer_name: 'Bara kolumnen' })).toBe('Bara kolumnen');
+  });
+
+  it('never renders an empty name', () => {
+    expect(quoteCustomerName(base)).toBe('Okänd kund');
+    expect(quoteCustomerName({ ...base, prospect: [] })).toBe('Okänd kund');
+  });
+});
+
+describe('isQuoteOverdue', () => {
+  const today = new Date(2026, 7, 14); // 14 aug 2026, local calendar day
+
+  it('flags a follow-up date that has passed', () => {
+    expect(isQuoteOverdue({ follow_up_date: '2026-08-13', status: 'sent' }, today)).toBe(true);
+  });
+
+  it('does not flag today or the future', () => {
+    expect(isQuoteOverdue({ follow_up_date: '2026-08-14', status: 'sent' }, today)).toBe(false);
+    expect(isQuoteOverdue({ follow_up_date: '2026-08-15', status: 'sent' }, today)).toBe(false);
+  });
+
+  it('stays quiet on closed deals — the date is history, not a task', () => {
+    expect(isQuoteOverdue({ follow_up_date: '2026-01-01', status: 'won' }, today)).toBe(false);
+    expect(isQuoteOverdue({ follow_up_date: '2026-01-01', status: 'lost' }, today)).toBe(false);
+  });
+
+  it('needs a date at all', () => {
+    expect(isQuoteOverdue({ follow_up_date: null, status: 'follow_up' }, today)).toBe(false);
+  });
+
+  it('pads single-digit months and days, so string compare stays correct', () => {
+    // A naive `${month}` would build "2026-8-14" and compare wrong against "2026-08-13".
+    expect(isQuoteOverdue({ follow_up_date: '2026-08-13', status: 'draft' }, new Date(2026, 7, 9))).toBe(false);
+    expect(isQuoteOverdue({ follow_up_date: '2026-01-05', status: 'draft' }, new Date(2026, 0, 9))).toBe(true);
+  });
+});


### PR DESCRIPTION
Klick på ett kort i säljtavlan skickade dig till offertlistan (`?quote_id=`) bara för att modalen bodde inbäddad i `QuotesClient`. Vill man jobba från tavlan var det en omväg vid varje offert.

**Ingen SQL att köra.**

## Full paritet

Panelen ligger nu i `app/crm/components/QuoteDetailPanel.tsx` och används av båda ytorna: byt status, skapa eller gå till arbetsorder, hämta PDF och mejla för både offert och orderbekräftelse, skicka till Fortnox, samt redigera. Låsningen när en arbetsorder finns följer med oförändrad.

Ingen ny datahämtning behövdes — båda ytorna anropar redan `/api/crm/quotes` och får samma rader. Tavlan typade dem bara smalare; typen är vidgad med de fält panelen läser, som alltid funnits i svaret.

## Fynd ur granskningen som åtgärdats i grenen

- **`returnTo` var hårdkodad till offertlistan**, så kundkortsbesöket från tavlan dumpade dig i listan. Kundkortets vitlista släppte dessutom inte igenom `/crm/saljtavla` alls — returen hade tappats tyst och lämnat säljaren i kundregistret. Ytan skickar nu sin egen `returnTo`, och tavlan öppnar panelen igen på `?quote_id=`.
- **Kapplöpning kring statusuppdateringar.** Handlers slog ihop serverns svar med `quote`-propen som fångades vid klicket. Starta en långsam Fortnox-push, byt status medan den snurrar, och pushens sena svar bar tillbaka den gamla statusen och rev ändringen på skärmen medan databasen höll den nya. Callbacken skickar nu en patch som ytorna applicerar funktionellt — samma semantik som koden den ersätter.
- **Mejlflödets förloppsruta** revs när panelen stängdes; `useDocumentEmail` ägs av ytorna igen.
- **"Vunnen" saknade bekräftelsen** som tavlans dra-och-släpp har. En kopplad prospekt konverteras till kund på servern och går inte att ångra härifrån.

## Delade hjälpare

`quoteCustomerName` och `isQuoteOverdue` fanns i två identiska kopior och behövdes på ett tredje ställe. De ligger nu i `app/crm/lib/quoteDisplay.ts` med tester — precedensordningen (prospekt → snapshot → kolumn) styr tre ytor samtidigt.

## Kvar, medvetet

- **"Redigera offert" tar dig fortfarande till listan.** `QuoteFormClient` hårdkodar `/crm/offerter` vid både spara och tillbaka. Samma sorts omväg, men filen ändras kraftigt av PR #77 — tas bäst i en egen gren efteråt.
- **Tavlans dra-spärr går att kringgå via panelen.** Ett vunnet kort med arbetsorder kan inte dras till en annan kolumn men kan klickas dit i panelen. Det gällde redan innan via listan; jag låste det först men tog tillbaka det, eftersom det vore en ny begränsning som dessutom stängde sista vägen att rätta en felklickad "Vunnen".

## Validering

`npm run type-check`, `npm run lint`, `npm run build` och 1232 tester gröna (main inmergad).

🤖 Generated with [Claude Code](https://claude.com/claude-code)