### PR TITLE
feat(crm): privatkund får en primär kontaktperson vid skapandet

### DIFF
--- a/app/crm/arbetsorder/WorkOrderDetailClient.tsx
+++ b/app/crm/arbetsorder/WorkOrderDetailClient.tsx
@@ -10,6 +10,7 @@ import { cn } from '@/lib/shared/cn';
 import { crm, syncStatusLabel, syncStatusClass, workOrderStatusLabel, workOrderStatusClass, WORK_ORDER_STATUS_FLOW, WORK_ORDER_STATUS_OPTIONS } from '@/app/crm/lib/crmTokens';
 import { PhoneLink, EmailLink, AddressLink } from '@/app/crm/components/ContactLinks';
 import AddressAutocompleteInput from '@/app/crm/components/AddressAutocompleteInput';
+import { resolveCrmContact } from '@/lib/domains/crm/contacts';
 import { lineItemQuantity } from '@/lib/domains/crm/lineItems';
 import { lineItemEffectiveUnitPrice } from '@/lib/domains/crm/pricing';
 import { inferMaterialFromArticle, sacksFor } from '@/lib/domains/crm/materials';
@@ -200,15 +201,23 @@ export default function WorkOrderDetailClient({ workOrderId, fortnoxConnected, c
 
   // The linked customer's contacts, for the "change responsible contact" picker (in case the
   // contact changed between offer→order). Empty for standalone orders with no linked customer.
+  // The card's own channels come along too: a contact row without phone/e-mail (a private
+  // customer's auto-created row carries only the name) must fall back to them on pick.
   const [customerContacts, setCustomerContacts] = useState<Array<{ id: string; name: string; role: string | null; phone: string | null; email: string | null; is_primary: boolean }>>([]);
+  const [customerCard, setCustomerCard] = useState<{ email: string | null; phone: string | null; mobile: string | null } | null>(null);
   useEffect(() => {
     const cid = workOrder?.customer_id;
-    if (!cid) { setCustomerContacts([]); return; }
+    if (!cid) { setCustomerContacts([]); setCustomerCard(null); return; }
     let active = true;
     fetch(`/api/crm/customers/${cid}`, { cache: 'no-store' })
       .then((r) => r.json().catch(() => ({})))
-      .then((json) => { if (active) setCustomerContacts(json?.ok && Array.isArray(json.data?.item?.contacts) ? json.data.item.contacts : []); })
-      .catch(() => { if (active) setCustomerContacts([]); });
+      .then((json) => {
+        if (!active) return;
+        const item = json?.ok ? json.data?.item : null;
+        setCustomerContacts(Array.isArray(item?.contacts) ? item.contacts : []);
+        setCustomerCard(item ? { email: item.email ?? null, phone: item.phone ?? null, mobile: item.mobile ?? null } : null);
+      })
+      .catch(() => { if (active) { setCustomerContacts([]); setCustomerCard(null); } });
     return () => { active = false; };
   }, [workOrder?.customer_id]);
 
@@ -766,7 +775,12 @@ export default function WorkOrderDetailClient({ workOrderId, fortnoxConnected, c
                     value={customerContacts.find((c) => c.name === draft.contact_name)?.id ?? ''}
                     onChange={(e) => {
                       const c = customerContacts.find((x) => x.id === e.target.value);
-                      if (c) setDraft((d) => (d ? { ...d, contact_name: c.name, contact_phone: c.phone || '', contact_email: c.email || '' } : d));
+                      if (!c) return;
+                      // Delad regel, fält för fält: kontaktraden vinner där den har ett värde,
+                      // kortet fyller luckorna. Råa c.phone/c.email tömde fälten när raden
+                      // saknade dem (privatkundens automatiska kontakt bär bara namnet).
+                      const resolved = resolveCrmContact({ ...customerCard, contacts: customerContacts }, c);
+                      setDraft((d) => (d ? { ...d, contact_name: resolved.name, contact_phone: resolved.phone, contact_email: resolved.email } : d));
                     }}
                   >
                     <option value="">Skriv manuellt…</option>

--- a/app/crm/offerter/QuoteFormClient.tsx
+++ b/app/crm/offerter/QuoteFormClient.tsx
@@ -2347,7 +2347,12 @@ export default function QuoteFormClient({ quoteId }: { quoteId?: string }) {
                   value={selectedCustomer.contacts.find((c) => c.name === draft.contact_name)?.id ?? ''}
                   onChange={(e) => {
                     const c = selectedCustomer.contacts.find((x) => x.id === e.target.value);
-                    if (c) setDraft((d) => ({ ...d, contact_name: c.name, phone: c.phone || '', email: c.email || '' }));
+                    if (!c) return;
+                    // Fält för fält mot kundkortet (delad regel) — en kontaktrad utan telefon
+                    // eller e-post ska ärva kortets, inte tömma fälten. Privatkundens
+                    // automatiska rad bär bara namnet, så råa c.phone/c.email raderade numret.
+                    const resolved = resolveCrmContact(selectedCustomer, c);
+                    setDraft((d) => ({ ...d, contact_name: resolved.name, phone: resolved.phone, email: resolved.email }));
                   }}
                 >
                   <option value="">Skriv manuellt…</option>

--- a/lib/domains/crm/contacts.ts
+++ b/lib/domains/crm/contacts.ts
@@ -8,15 +8,22 @@
 //                                            has no contact-person entity, it only carries the
 //                                            chosen person's NAME as the YourReference string.
 //
-// The trouble was never the split — it was that no write path fills both halves (the customer
-// form writes only the card, the prospect form writes only a contact row) and every read site
-// then guessed its own precedence. Three different orders across eight call sites meant the
-// same customer could get the offer, the order confirmation and the Fortnox e-mail at three
+// The trouble was never the split — it was that no write path filled both halves (the customer
+// form wrote only the card, the prospect form only a contact row) and every read site then
+// guessed its own precedence. Three different orders across eight call sites meant the same
+// customer could get the offer, the order confirmation and the Fortnox e-mail at three
 // different addresses.
 //
 // One rule, everywhere: a named contact person wins when one exists, otherwise the card.
 // Resolved FIELD BY FIELD, so a contact with a name but no e-mail still falls back to the
 // card's address instead of resolving to nothing.
+//
+// The field-by-field part is now load-bearing, not just defensive: a PRIVATE customer gets an
+// automatic primary contact row carrying ONLY the person's name (createCrmCustomer), precisely
+// so "Er referens" fills itself while telephone and e-mail keep coming from the card. Copying
+// the channels into that row would freeze an address that is later corrected on the card.
+// Anything reading a contact row directly must go through here — two pickers that read
+// `contact.phone` raw would otherwise blank a number the card had already supplied.
 //
 // Deliberately pure and dependency-free so both server domain code and client components can
 // import it (same as `pricing.ts`).

--- a/lib/domains/crm/customers.ts
+++ b/lib/domains/crm/customers.ts
@@ -361,7 +361,28 @@ export async function saveCrmCustomerCreditReport(
   return supabase.from('crm_customers').update(input).eq('id', id).select(crmCustomerSelect).single();
 }
 
+// Bara EN primärkontakt per kund. `is_primary` är en vanlig boolean utan unikt index eller
+// trigger (20260602_crm_customers.sql), så invarianten måste hållas här — annars kan en kund
+// få två primärrader, och `primaryCrmContact` gör `.find(c => c.is_primary)` över en OORDNAD
+// PostgREST-embed: vilken som vinner blir godtyckligt, och den kontakt säljaren medvetet
+// pekade ut kan tyst ignoreras.
+//
+// Blev akut i och med att privatkunder nu får en automatisk primärrad vid skapandet: utan
+// degraderingen förlorar den kontaktperson säljaren lägger till EFTERÅT mot den automatiska.
+// Tidigare fanns ingen rad alls, så säljarens val vann alltid.
+//
+// Degradera FÖRE skrivningen, annars nollas den nya raden av sin egen städning. Två anrop
+// utan transaktion: slår skrivningen fel efteråt står kunden utan primär, och
+// `primaryCrmContact` faller tillbaka på `contacts[0]` — den kan alltså fortfarande nå en
+// kontakt. Alternativet vore ett partiellt unikt index, men det kräver en migrering.
+async function demoteOtherPrimaryContacts(supabase: SupabaseClient, customerId: string, exceptId?: string) {
+  let query = supabase.from('crm_customer_contacts').update({ is_primary: false }).eq('customer_id', customerId);
+  if (exceptId) query = query.neq('id', exceptId);
+  await query;
+}
+
 export async function createCrmCustomerContact(supabase: SupabaseClient, input: CreateCrmCustomerContactInput) {
+  if (input.is_primary) await demoteOtherPrimaryContacts(supabase, input.customer_id);
   return supabase.from('crm_customer_contacts').insert(input).select('id, name, role, phone, email, is_primary').single();
 }
 
@@ -370,6 +391,15 @@ export async function updateCrmCustomerContact(
   id: string,
   input: UpdateCrmCustomerContactInput
 ) {
+  // Kontaktraden bär kundens id, så vi måste läsa den innan vi kan degradera syskonen.
+  if (input.is_primary) {
+    const { data: existing } = await supabase
+      .from('crm_customer_contacts')
+      .select('customer_id')
+      .eq('id', id)
+      .maybeSingle();
+    if (existing?.customer_id) await demoteOtherPrimaryContacts(supabase, existing.customer_id as string, id);
+  }
   return supabase
     .from('crm_customer_contacts')
     .update(input)

--- a/lib/domains/crm/customers.ts
+++ b/lib/domains/crm/customers.ts
@@ -296,8 +296,54 @@ export async function getCrmCustomer(supabase: SupabaseClient, id: string) {
   return supabase.from('crm_customers').select(crmCustomerSelect).eq('id', id).single();
 }
 
+// Privatkundens kontaktperson: personen ÄR kunden, så namnet står redan på kortet.
+// Returnerar null för företag — där heter kontaktpersonen nästan aldrig samma sak som
+// bolaget, så ett härlett namn vore fel — och för en privatkund utan ifyllt namn.
+export function privateCustomerContactName(input: {
+  customer_type: CrmCustomerType;
+  first_name?: string | null;
+  last_name?: string | null;
+}): string | null {
+  if (input.customer_type !== 'private') return null;
+  const name = [input.first_name, input.last_name]
+    .map((part) => part?.trim() || '')
+    .filter(Boolean)
+    .join(' ');
+  return name || null;
+}
+
+// Skapar kunden och — för privatkunder — en primär kontaktperson med BARA namnet.
+//
+// Varför raden behövs: utan den returnerar `resolveCrmContact` tom sträng som namn, och
+// offertens "Er referens" (obligatorisk, går till Fortnox YourReference) står tom trots att
+// kontaktpersonen bevisligen är kunden själv. Prospektformuläret fyller redan i sin halva
+// (se createCrmProspect) — det här stänger luckan från kundhållet.
+//
+// Varför BARA namnet: `resolveCrmContact` löser fält för fält och låter kontaktraden vinna
+// över kortet. Kopierades telefon och e-post hit skulle en adress som rättas på kortet i
+// efterhand tyst förbli oanvänd på offerter och mejl. Med enbart namnet fylls "Er referens"
+// i av sig själv medan kortet förblir enda källan för telefon och e-post.
+//
+// Raden lever sitt eget liv efter skapandet — den speglar inte ett senare namnbyte på kortet.
+// Den syns i kundkortets kontaktlista och rättas där.
 export async function createCrmCustomer(supabase: SupabaseClient, input: CreateCrmCustomerInput) {
-  return supabase.from('crm_customers').insert(input).select(crmCustomerSelect).single();
+  const created = await supabase.from('crm_customers').insert(input).select(crmCustomerSelect).single();
+  if (created.error || !created.data) return created;
+
+  const contactName = privateCustomerContactName(input);
+  if (!contactName) return created;
+
+  const customerId = created.data.id as string;
+  const { error: contactError } = await supabase
+    .from('crm_customer_contacts')
+    .insert({ customer_id: customerId, name: contactName, is_primary: true });
+  // Icke-kritiskt: kunden är skapad. Utan kontaktraden faller allt tillbaka på kortet,
+  // precis som det gjorde före den här ändringen — bättre än att fela hela skapandet.
+  if (contactError) return created;
+
+  // Hämta om så svaret bär med sig den nya kontakten (samma mönster som createCrmProspect).
+  const refetched = await supabase.from('crm_customers').select(crmCustomerSelect).eq('id', customerId).single();
+  return refetched.error || !refetched.data ? created : refetched;
 }
 
 export async function updateCrmCustomer(supabase: SupabaseClient, id: string, input: UpdateCrmCustomerInput) {

--- a/tests/crm/customers.domain.test.ts
+++ b/tests/crm/customers.domain.test.ts
@@ -8,6 +8,8 @@ import {
   convertProspectToCustomer,
   getCrmCustomerDisplayName,
   privateCustomerContactName,
+  createCrmCustomerContact,
+  updateCrmCustomerContact,
 } from '@/lib/domains/crm/customers';
 import { resolveCrmContact } from '@/lib/domains/crm/contacts';
 
@@ -205,6 +207,56 @@ describe('createCrmCustomer', () => {
     });
 
     expect(sb.from).not.toHaveBeenCalledWith('crm_customer_contacts');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Primärkontakt-invarianten: bara EN per kund.
+//
+// `is_primary` saknar unikt index och trigger i databasen, och primaryCrmContact gör
+// .find() över en oordnad embed. Två primärrader = godtyckligt utfall, och kontakten
+// säljaren pekade ut kan tyst förlora mot privatkundens automatiska rad.
+// ---------------------------------------------------------------------------
+
+describe('createCrmCustomerContact', () => {
+  it('degraderar tidigare primärkontakter innan en ny primär skrivs', async () => {
+    const sb = makeSupabaseMock({ data: { id: 'ct-2' }, error: null });
+
+    await createCrmCustomerContact(sb as any, { customer_id: 'c1', name: 'Erik', is_primary: true });
+
+    expect(sb._query.update).toHaveBeenCalledWith({ is_primary: false });
+    expect(sb._query.eq).toHaveBeenCalledWith('customer_id', 'c1');
+    // Degraderingen måste ske FÖRE insert, annars städar den nya raden bort sig själv.
+    const updateOrder = (sb._query.update as any).mock.invocationCallOrder[0];
+    const insertOrder = (sb._query.insert as any).mock.invocationCallOrder[0];
+    expect(updateOrder).toBeLessThan(insertOrder);
+  });
+
+  it('rör inga andra rader när kontakten inte är primär', async () => {
+    const sb = makeSupabaseMock({ data: { id: 'ct-2' }, error: null });
+
+    await createCrmCustomerContact(sb as any, { customer_id: 'c1', name: 'Erik', is_primary: false });
+
+    expect(sb._query.update).not.toHaveBeenCalled();
+  });
+});
+
+describe('updateCrmCustomerContact', () => {
+  it('degraderar syskonen men inte raden som görs primär', async () => {
+    const sb = makeSupabaseMock({ data: { customer_id: 'c1' }, error: null });
+
+    await updateCrmCustomerContact(sb as any, 'ct-2', { is_primary: true });
+
+    expect(sb._query.update).toHaveBeenCalledWith({ is_primary: false });
+    expect(sb._query.neq).toHaveBeenCalledWith('id', 'ct-2');
+  });
+
+  it('degraderar ingen när is_primary inte sätts', async () => {
+    const sb = makeSupabaseMock({ data: { id: 'ct-2' }, error: null });
+
+    await updateCrmCustomerContact(sb as any, 'ct-2', { phone: '070-1' });
+
+    expect(sb._query.neq).not.toHaveBeenCalled();
   });
 });
 

--- a/tests/crm/customers.domain.test.ts
+++ b/tests/crm/customers.domain.test.ts
@@ -7,7 +7,9 @@ import {
   updateCrmCustomer,
   convertProspectToCustomer,
   getCrmCustomerDisplayName,
+  privateCustomerContactName,
 } from '@/lib/domains/crm/customers';
+import { resolveCrmContact } from '@/lib/domains/crm/contacts';
 
 beforeEach(() => vi.clearAllMocks());
 
@@ -157,6 +159,116 @@ describe('createCrmCustomer', () => {
     const result = await createCrmCustomer(sb as any, validInput);
 
     expect((result as any).error).toBeTruthy();
+  });
+
+  it('skapar INGEN kontaktperson för företagskund', async () => {
+    const sb = makeSupabaseMock({ data: { id: 'new-1', ...validInput }, error: null });
+
+    await createCrmCustomer(sb as any, validInput);
+
+    expect(sb.from).not.toHaveBeenCalledWith('crm_customer_contacts');
+  });
+
+  it('skapar en primär kontaktperson med BARA namnet för privatkund', async () => {
+    const privateInput = {
+      customer_type: 'private' as const,
+      first_name: 'Anna',
+      last_name: 'Svensson',
+      phone: '070-123 45 67',
+      email: 'anna@example.se',
+      assigned_to: 'user-1',
+      created_by: 'user-1',
+    };
+    const sb = makeSupabaseMock({ data: { id: 'new-1', ...privateInput }, error: null });
+
+    await createCrmCustomer(sb as any, privateInput);
+
+    expect(sb.from).toHaveBeenCalledWith('crm_customer_contacts');
+    // Telefon och e-post lämnas MED FLIT utanför raden: kontakten vinner över kortet i
+    // resolveCrmContact, så en kopia här skulle frysa en adress som senare rättas på kortet.
+    expect(sb._query.insert).toHaveBeenCalledWith({
+      customer_id: 'new-1',
+      name: 'Anna Svensson',
+      is_primary: true,
+    });
+  });
+
+  it('skapar ingen kontaktperson för privatkund utan namn', async () => {
+    const sb = makeSupabaseMock({ data: { id: 'new-1' }, error: null });
+
+    await createCrmCustomer(sb as any, {
+      customer_type: 'private',
+      first_name: null,
+      last_name: null,
+      assigned_to: 'user-1',
+      created_by: 'user-1',
+    });
+
+    expect(sb.from).not.toHaveBeenCalledWith('crm_customer_contacts');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// privateCustomerContactName — ren funktion
+// ---------------------------------------------------------------------------
+
+describe('privateCustomerContactName', () => {
+  it('sätter ihop för- och efternamn för privatkund', () => {
+    expect(
+      privateCustomerContactName({ customer_type: 'private', first_name: 'Anna', last_name: 'Svensson' })
+    ).toBe('Anna Svensson');
+  });
+
+  it('klarar att bara ett av namnen är ifyllt', () => {
+    expect(privateCustomerContactName({ customer_type: 'private', first_name: 'Anna', last_name: null })).toBe('Anna');
+    expect(privateCustomerContactName({ customer_type: 'private', first_name: '  ', last_name: 'Svensson' })).toBe('Svensson');
+  });
+
+  it('returnerar null för företag — kontaktpersonen heter inte samma sak som bolaget', () => {
+    expect(
+      privateCustomerContactName({ customer_type: 'business', first_name: 'Anna', last_name: 'Svensson' })
+    ).toBeNull();
+  });
+
+  it('returnerar null när privatkunden saknar namn', () => {
+    expect(privateCustomerContactName({ customer_type: 'private', first_name: '', last_name: '   ' })).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Namn-bara-kontakten mot den delade resolveCrmContact-regeln.
+//
+// Hela poängen med att bara skriva namnet är att telefon och e-post ska fortsätta komma
+// från kundkortet. Går den fältvisa fallbacken sönder får ordern en kontaktperson utan
+// nummer — och installatören står utan sätt att nå kunden.
+// ---------------------------------------------------------------------------
+
+describe('privatkundens automatiska kontakt + resolveCrmContact', () => {
+  const card = {
+    email: 'anna@example.se',
+    phone: '070-123 45 67',
+    mobile: null,
+    contacts: [{ name: 'Anna Svensson', phone: null, email: null, is_primary: true }],
+  };
+
+  it('ger namnet från kontakten och telefon/e-post från kortet', () => {
+    expect(resolveCrmContact(card)).toEqual({
+      name: 'Anna Svensson',
+      email: 'anna@example.se',
+      phone: '070-123 45 67',
+    });
+  });
+
+  it('faller vidare till mobil när kortet saknar fast telefon', () => {
+    expect(resolveCrmContact({ ...card, phone: null, mobile: '070-999 88 77' }).phone).toBe('070-999 88 77');
+  });
+
+  it('ger samma resultat när raden väljs uttryckligen i en väljare (preferContact)', () => {
+    expect(resolveCrmContact(card, card.contacts[0])).toEqual({
+      name: 'Anna Svensson',
+      email: 'anna@example.se',
+      phone: '070-123 45 67',
+    });
   });
 });
 


### PR DESCRIPTION
## Bakgrund

En privatperson **är** sin egen kontaktperson, men kundformuläret skrev bara kundkortet — aldrig en rad i `crm_customer_contacts`. Följden:

- `resolveCrmContact` gav **tomt namn**, så offertens obligatoriska **"Er referens"** (som blir Fortnox `YourReference`) stod tom trots att namnet redan fanns på kortet. Säljaren fick skriva det för hand.
- Kontaktväljaren i offert och arbetsorder syntes aldrig för privatkunder — den kräver `contacts.length > 0`.

Det är exakt luckan som beskrivs i huvudkommentaren till `lib/domains/crm/contacts.ts`: *"no write path fills both halves"*. Prospektformuläret fyller redan sin halva (`createCrmProspect`); det här stänger luckan från kundhållet.

## Vad som ändras

**1. Kontaktraden skapas** — `createCrmCustomer` skapar en primär kontaktperson med `Förnamn Efternamn` när `customer_type = 'private'`. Företag lämnas orörda: där heter kontaktpersonen nästan aldrig samma sak som bolaget. Ny ren hjälpare `privateCustomerContactName` gör beslutet testbart. Misslyckas kontakt-insertet returneras kunden ändå — allt faller då tillbaka på kortet precis som förut, hellre än att fela hela kundskapandet.

Ligger i domänlagret, så **både kundformuläret och offertens "Skapa ny kund"** täcks (båda går via `POST /api/crm/customers`). Fortnox-massimporten går en annan väg och är orörd.

**2. Bara namnet — med flit.** `resolveCrmContact` löser fält för fält och låter kontaktraden **vinna** över kortet. Kopierades telefon och e-post in i raden skulle en adress som rättas på kortet i efterhand tyst förbli oanvänd på offerter och mejl — samma felklass som `contacts.ts` skrevs för att döda. Nu fylls "Er referens" i av sig själv medan kortet förblir enda källan för telefon och e-post.

**3. Följdfix: två väljare hade nollat telefonnumret.** `QuoteFormClient` och `WorkOrderDetailClient` läste kontaktraden rått (`c.phone || ''`). Så fort privatkundens namn-bara-rad dök upp i rullistan hade ett val där **raderat** ett nummer som kortet redan fyllt i — tyst, mitt i en offert. Båda går nu via `resolveCrmContact` med `preferContact`.

**4. Granskningsfynd: invarianten om EN primärkontakt.** `is_primary` saknar unikt index och trigger, och inget skrivflöde degraderade en tidigare primär. Ofarligt så länge privatkunder saknade rader — men med den automatiska raden kunde en kontakt säljaren lägger till *efteråt* och kryssar i som primär **tyst förlora**, eftersom `primaryCrmContact` gör `.find()` över en oordnad PostgREST-embed. `createCrmCustomerContact` och `updateCrmCustomerContact` degraderar nu syskonen före skrivningen.

## Medvetna avgränsningar

- **Namnet speglar inte kortet i efterhand.** Rättas för- eller efternamnet senare står kontaktraden kvar som den var. Enklaste varianten valdes med flit — raden syns i kundkortets kontaktlista och kan rättas där. Vi tar en djupare lösning om behovet visar sig.
- **Ingen SQL.** Ett partiellt unikt index på `is_primary` vore stramare än degraderingen i domänlagret, men kräver en migrering. Båda vägarna in går genom domänlagret.

## Test

type-check ✅ · lint ✅ · build ✅ · **1 246 tester** ✅ (85 filer, +15 nya)

De nya testerna täcker: raden skapas för privat men inte för företag eller namnlös kund · payloaden är namn-bara · `resolveCrmContact` ger kortets telefon/mobil/e-post för en namn-bara-rad, både som primärkontakt och som uttryckligt val i en väljare · degraderingen sker före insert (annars städar den nya raden bort sig själv).

**Ingen migration att köra.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)