### PR TITLE
fix(crm): returnTo tar tillbaka till planeringen och säljtavlan

### DIFF
--- a/app/crm/arbetsorder/WorkOrderDetailClient.tsx
+++ b/app/crm/arbetsorder/WorkOrderDetailClient.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from 'react';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import Input from '../../../components/ui/Input';
 import Select from '../../../components/ui/Select';
 import Textarea from '../../../components/ui/Textarea';
@@ -10,6 +10,7 @@ import { cn } from '@/lib/shared/cn';
 import { crm, syncStatusLabel, syncStatusClass, workOrderStatusLabel, workOrderStatusClass, WORK_ORDER_STATUS_FLOW, WORK_ORDER_STATUS_OPTIONS } from '@/app/crm/lib/crmTokens';
 import { PhoneLink, EmailLink, AddressLink } from '@/app/crm/components/ContactLinks';
 import AddressAutocompleteInput from '@/app/crm/components/AddressAutocompleteInput';
+import { safeReturnTo } from '@/app/crm/lib/returnTo';
 import { resolveCrmContact } from '@/lib/domains/crm/contacts';
 import {
   buildMeasurementLines,
@@ -172,6 +173,11 @@ function roundLineBreakdown(
 
 export default function WorkOrderDetailClient({ workOrderId, fortnoxConnected, currentUserId }: { workOrderId: string; fortnoxConnected: boolean; currentUserId: string | null }) {
   const router = useRouter();
+  // Arbetsordern öppnas både från sin egen lista och från planeringskalendern. Utan det här
+  // landade planeraren i orderlistan i stället för på tavlan hen kom ifrån.
+  const searchParams = useSearchParams();
+  const backTo = safeReturnTo(searchParams.get('returnTo')) ?? '/crm/arbetsorder';
+  const backLabel = backTo.startsWith('/crm/planering') ? 'Planering' : 'Arbetsorder';
   const toast = useToast();
 
   const [workOrder, setWorkOrder] = useState<WorkOrderItem | null>(null);
@@ -492,8 +498,8 @@ export default function WorkOrderDetailClient({ workOrderId, fortnoxConnected, c
   if (error || !workOrder || !draft) {
     return (
       <div className="grid gap-4">
-        <button type="button" onClick={() => router.push('/crm/arbetsorder')} className="inline-flex w-fit items-center gap-1.5 text-sm text-slate-500 transition hover:text-slate-800">
-          <BackArrow /> Arbetsorder
+        <button type="button" onClick={() => router.push(backTo)} className="inline-flex w-fit items-center gap-1.5 text-sm text-slate-500 transition hover:text-slate-800">
+          <BackArrow /> {backLabel}
         </button>
         <div className="rounded-2xl border border-rose-200 bg-rose-50 px-5 py-4 text-sm text-rose-700">{error || 'Arbetsordern hittades inte.'}</div>
       </div>
@@ -536,8 +542,8 @@ export default function WorkOrderDetailClient({ workOrderId, fortnoxConnected, c
 
       {/* Header */}
       <div>
-        <button type="button" onClick={() => router.push('/crm/arbetsorder')} className="mb-2 inline-flex w-fit items-center gap-1.5 text-sm text-slate-500 transition hover:text-slate-800">
-          <BackArrow /> Arbetsorder
+        <button type="button" onClick={() => router.push(backTo)} className="mb-2 inline-flex w-fit items-center gap-1.5 text-sm text-slate-500 transition hover:text-slate-800">
+          <BackArrow /> {backLabel}
         </button>
         <div className="flex flex-wrap items-start justify-between gap-3">
           <div className="grid min-w-0 gap-1.5">

--- a/app/crm/arbetsorder/WorkOrderDetailClient.tsx
+++ b/app/crm/arbetsorder/WorkOrderDetailClient.tsx
@@ -10,7 +10,7 @@ import { cn } from '@/lib/shared/cn';
 import { crm, syncStatusLabel, syncStatusClass, workOrderStatusLabel, workOrderStatusClass, WORK_ORDER_STATUS_FLOW, WORK_ORDER_STATUS_OPTIONS } from '@/app/crm/lib/crmTokens';
 import { PhoneLink, EmailLink, AddressLink } from '@/app/crm/components/ContactLinks';
 import AddressAutocompleteInput from '@/app/crm/components/AddressAutocompleteInput';
-import { safeReturnTo } from '@/app/crm/lib/returnTo';
+import { safeReturnTo, withReturnTo } from '@/app/crm/lib/returnTo';
 import { resolveCrmContact } from '@/lib/domains/crm/contacts';
 import {
   buildMeasurementLines,
@@ -571,7 +571,14 @@ export default function WorkOrderDetailClient({ workOrderId, fortnoxConnected, c
               <span>{workOrder.quote_type === 'private' ? 'Privatkund' : 'Företag'}</span>
               {workOrder.customer_id ? (
                 <a
-                  href={`/crm/kunder/${workOrder.customer_id}?returnTo=${encodeURIComponent(`/crm/arbetsorder/${workOrder.id}`)}`}
+                  // Bär med varifrån ordern öppnades, annars tappas planeringen vid en sväng
+                  // förbi kundkortet: tillbaka till ordern, men ordern vet inte längre om tavlan.
+                  href={withReturnTo(
+                    `/crm/kunder/${workOrder.customer_id}`,
+                    backTo === '/crm/arbetsorder'
+                      ? `/crm/arbetsorder/${workOrder.id}`
+                      : withReturnTo(`/crm/arbetsorder/${workOrder.id}`, backTo),
+                  )}
                   className="font-medium text-emerald-700 transition hover:text-emerald-800 hover:underline"
                 >
                   Öppna kundkort →

--- a/app/crm/components/QuoteDetailPanel.tsx
+++ b/app/crm/components/QuoteDetailPanel.tsx
@@ -7,6 +7,7 @@ import { useToast } from '@/lib/Toast';
 import { documentRef } from '@/app/crm/lib/format';
 import { quoteStatusMeta } from '@/app/crm/lib/crmTokens';
 import { openFortnoxPdf } from '@/app/crm/lib/fortnoxDoc';
+import { withReturnTo } from '@/app/crm/lib/returnTo';
 import { resolveQuoteVatBreakdown, quoteAmountDisplay } from '@/lib/domains/crm/pricing';
 import { quoteCustomerName, isQuoteOverdue } from '@/app/crm/lib/quoteDisplay';
 import type { EmailableDocument } from '@/app/crm/components/useDocumentEmail';
@@ -568,7 +569,7 @@ export default function QuoteDetailPanel({
             {!offerLocked ? (
               <button
                 type="button"
-                onClick={() => { onClose(); router.push(`/crm/offerter/${quote.id}/redigera`); }}
+                onClick={() => { onClose(); router.push(withReturnTo(`/crm/offerter/${quote.id}/redigera`, returnTo)); }}
                 className="flex-1 rounded-xl py-2.5 text-sm font-semibold text-white shadow-sm transition hover:brightness-95 sm:ml-auto sm:flex-none sm:px-5"
                 style={{ backgroundColor: 'var(--crm-primary)' }}
               >

--- a/app/crm/kunder/CustomerFormClient.tsx
+++ b/app/crm/kunder/CustomerFormClient.tsx
@@ -109,8 +109,10 @@ function buildAddress(street: string, postalCode: string, city: string) {
   return { street: street || null, postal_code: postalCode || null, city: city || null };
 }
 
-// Only allow returning into the offer form (allowlist guards against open redirect).
-function safeReturnTo(returnTo: string | null): string | null {
+// Medvetet SNÄVARE än den delade `safeReturnTo` i app/crm/lib/returnTo.ts: hit kommer man bara
+// från offertformuläret, så bara den vägen tillbaka godtas. Eget namn för att skillnaden inte
+// ska förväxlas — den delade släpper igenom hela /crm/.
+function safeOfferFormReturnTo(returnTo: string | null): string | null {
   return returnTo && returnTo.startsWith('/crm/offerter/') ? returnTo : null;
 }
 
@@ -191,10 +193,17 @@ export default function CustomerFormClient({ fortnoxConnected }: Props) {
   const router = useRouter();
   const searchParams = useSearchParams();
   const toast = useToast();
-  const returnTo = safeReturnTo(searchParams.get('returnTo'));
+  const returnTo = safeOfferFormReturnTo(searchParams.get('returnTo'));
   // Where the back/cancel controls go. When we came from the offer form, return there
   // (restore_quote tells it to restore the stashed draft, without selecting a customer).
-  const cancelTo = returnTo ? `${returnTo}?restore_quote=1` : '/crm/kunder';
+  //
+  // ⚠️ Separatorn måste väljas, inte antas: offertformulärets adress bär numera sin egen
+  // `?returnTo=` när resan startade i säljtavlan. Ett hårdkodat `?` gav två frågetecken —
+  // `restore_quote` slutade räknas som parameter (utkastet återställdes inte) och hamnade
+  // i stället inuti returnTo-värdet, så tavlan aldrig återöppnade kortet.
+  const cancelTo = returnTo
+    ? `${returnTo}${returnTo.includes('?') ? '&' : '?'}restore_quote=1`
+    : '/crm/kunder';
   const [draft, setDraft] = useState<Draft>(initial);
   const [createInFortnox, setCreateInFortnox] = useState(false);
   const [saving, setSaving] = useState(false);

--- a/app/crm/lib/returnTo.ts
+++ b/app/crm/lib/returnTo.ts
@@ -1,0 +1,19 @@
+// Vart en detaljvy ska tillbaka när man kom dit från en annan yta.
+//
+// En detaljvy vet inte var man kom ifrån — arbetsordern öppnas både från sin egen lista och från
+// planeringskalendern, offertformuläret både från offertlistan och från säljtavlan. Utan ett
+// `?returnTo=` landar man alltid i listan, alltså inte där man var.
+//
+// ⚠️ Värdet kommer från URL:en och är därmed användarstyrt. Bara app-interna CRM-sökvägar godtas:
+// utan spärren blir `?returnTo=https://…` en öppen vidarebefordran som tar användaren ut ur appen
+// från en sida de litar på. `/crm/`-prefixet räcker som spärr — protokollrelativa adresser
+// (`//värd`, `/\värd`), som webbläsaren behandlar som externa, klarar inte prefixet.
+export function safeReturnTo(raw: string | null | undefined): string | null {
+  if (!raw) return null;
+  return raw.startsWith('/crm/') ? raw : null;
+}
+
+/** Lägg på `?returnTo=` (eller `&`) på en app-intern länk. */
+export function withReturnTo(href: string, returnTo: string): string {
+  return `${href}${href.includes('?') ? '&' : '?'}returnTo=${encodeURIComponent(returnTo)}`;
+}

--- a/app/crm/offerter/QuoteFormClient.tsx
+++ b/app/crm/offerter/QuoteFormClient.tsx
@@ -1383,7 +1383,13 @@ export default function QuoteFormClient({ quoteId }: { quoteId?: string }) {
         // closes the direct-URL hole the detail card's hidden "Redigera" button left open.
         if (item.work_order_id || item.work_order_number) {
           toast.info('Offerten är låst – en arbetsorder har skapats, så den kan inte längre redigeras.');
-          router.replace(backTo);
+          // Tillbaka till YTAN, utan `?quote_id=` — alltså inte in i panelen igen.
+          //
+          // Panelens låsning är lösare än formulärets: den släpper fram "Redigera" när sista
+          // Fortnox-synken misslyckats (så återsynken går att nå), medan formuläret nekar så
+          // fort det finns en arbetsorder. För en sådan offert hade återgången till panelen
+          // blivit en klickrunda utan utgång — den gamla listomdirigeringen bröt den av misstag.
+          router.replace(backTo.split('?')[0]);
           return;
         }
         setLoadedQuote(item);
@@ -2182,7 +2188,7 @@ export default function QuoteFormClient({ quoteId }: { quoteId?: string }) {
           <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
             <path d="M9 2L4 7l5 5" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round" />
           </svg>
-          Offerter
+          {backTo.startsWith('/crm/saljtavla') ? 'Säljtavlan' : 'Offerter'}
         </button>
         <h1 className={crm.pageTitle}>
           {isEditing ? (draft.project_name || 'Redigera offert') : 'Ny offert'}

--- a/app/crm/offerter/QuoteFormClient.tsx
+++ b/app/crm/offerter/QuoteFormClient.tsx
@@ -33,6 +33,7 @@ import {
   OFFER_VALIDITY_PRESETS,
   type CustomerDerivedValues,
 } from './quoteSerializers';
+import { safeReturnTo, withReturnTo } from '@/app/crm/lib/returnTo';
 import { resolveCrmContact } from '@/lib/domains/crm/contacts';
 import {
   buildMeasurementLines,
@@ -1109,6 +1110,10 @@ const DRAFT_AUTOSAVE_DEBOUNCE_MS = 800;
 export default function QuoteFormClient({ quoteId }: { quoteId?: string }) {
   const router = useRouter();
   const searchParams = useSearchParams();
+  // Offertformuläret nås både från offertlistan och från säljtavlan. Utan det här landade
+  // säljaren i listan efter att ha sparat, alltså inte på tavlan hen kom ifrån.
+  const returnToParam = safeReturnTo(searchParams.get('returnTo'));
+  const backTo = returnToParam ?? '/crm/offerter';
   const toast = useToast();
   const isEditing = Boolean(quoteId);
 
@@ -1197,7 +1202,10 @@ export default function QuoteFormClient({ quoteId }: { quoteId?: string }) {
   // Per-form storage key so a new-quote draft never collides with an edit draft.
   const draftStorageKey = quoteId ? `crm:quote-draft:edit:${quoteId}` : 'crm:quote-draft:new';
   // This offer's own URL — used as returnTo when leaving to create/edit a customer.
-  const offerSelfUrl = isEditing ? `/crm/offerter/${quoteId}/redigera` : '/crm/offerter/ny';
+  // Kundkortsresan kommer tillbaka hit, så returnTo måste följa med i adressen — annars är det
+  // borta när säljaren väl sparar, och tavlan tappas efter en sväng förbi kunden.
+  const offerSelfPath = isEditing ? `/crm/offerter/${quoteId}/redigera` : '/crm/offerter/ny';
+  const offerSelfUrl = returnToParam ? withReturnTo(offerSelfPath, returnToParam) : offerSelfPath;
 
   // Stash the draft and leave to a customer page; we return via returnTo.
   function goToCustomerPage(path: string) {
@@ -1369,13 +1377,13 @@ export default function QuoteFormClient({ quoteId }: { quoteId?: string }) {
       .then((json) => {
         if (!active) return;
         const item = json?.data?.item as QuoteItem | undefined;
-        if (!item) { toast.error('Kunde inte ladda offert'); router.push('/crm/offerter'); return; }
+        if (!item) { toast.error('Kunde inte ladda offert'); router.push(backTo); return; }
         // Locked: once a work order exists the offer is converted (and locked in Fortnox);
         // editing it would diverge the CRM quote from the created order. Bounce back — this
         // closes the direct-URL hole the detail card's hidden "Redigera" button left open.
         if (item.work_order_id || item.work_order_number) {
           toast.info('Offerten är låst – en arbetsorder har skapats, så den kan inte längre redigeras.');
-          router.replace('/crm/offerter');
+          router.replace(backTo);
           return;
         }
         setLoadedQuote(item);
@@ -1452,7 +1460,7 @@ export default function QuoteFormClient({ quoteId }: { quoteId?: string }) {
         // turn on omvänd skattskyldighet, come back" happens most.
         if (item.customer_id) hydrateSelectedCustomer(item.customer_id, { seedApplied: true });
       })
-      .catch(() => { if (active) { toast.error('Kunde inte ladda offert'); router.push('/crm/offerter'); } })
+      .catch(() => { if (active) { toast.error('Kunde inte ladda offert'); router.push(backTo); } })
       .finally(() => { if (active) setLoading(false); });
 
     return () => { active = false; };
@@ -1818,15 +1826,15 @@ export default function QuoteFormClient({ quoteId }: { quoteId?: string }) {
   function handleBack() {
     // Going back is a possible accident too. With unsaved work, show our own informative confirm
     // (the native beforeunload text isn't customisable); with nothing to keep, just leave.
-    if (isDirty) { setPendingLeaveHref('/crm/offerter'); return; }
+    if (isDirty) { setPendingLeaveHref(backTo); return; }
     clearPersistedDraft();
-    router.push('/crm/offerter');
+    router.push(backTo);
   }
 
   // Confirmed leaving with unsaved changes: flush the draft so it's recoverable, then navigate to
   // whatever destination triggered the dialog (back button or an intercepted link).
   function confirmLeave() {
-    const href = pendingLeaveHref ?? '/crm/offerter';
+    const href = pendingLeaveHref ?? backTo;
     persistDraft();
     setPendingLeaveHref(null);
     router.push(href);
@@ -1944,7 +1952,7 @@ export default function QuoteFormClient({ quoteId }: { quoteId?: string }) {
       } else {
         toast.success(isEditing ? 'Offert uppdaterad' : 'Offert skapad');
       }
-      router.push('/crm/offerter');
+      router.push(backTo);
     } catch {
       toast.error('Fel vid sparande av offert');
     } finally {

--- a/app/crm/planering/PlanningClient.tsx
+++ b/app/crm/planering/PlanningClient.tsx
@@ -6,6 +6,7 @@ import { createClientComponentClient } from '@supabase/auth-helpers-nextjs';
 import { cn } from '@/lib/shared/cn';
 import { useToast } from '@/lib/Toast';
 import { crm, workOrderStatusAccent } from '@/app/crm/lib/crmTokens';
+import { withReturnTo } from '@/app/crm/lib/returnTo';
 import type { OpsSegment, OpsTruck, SchedulableWorkOrder } from '@/lib/domains/planning/types';
 import type { AssignablePerson, CrewMember } from '@/lib/domains/planning/crew';
 import type { DayNote } from '@/lib/domains/planning/dayNotes';
@@ -457,7 +458,9 @@ export default function PlanningClient({
   // Placeholders have no work order to open; clicking one is a no-op (edit/link comes in a later slice).
   const onSegClick = useCallback(
     (seg: OpsSegment) => {
-      if (seg.work_order_id) router.push(`/crm/arbetsorder/${seg.work_order_id}`);
+      // Tillbaka till tavlan, inte till orderlistan. (Vald vecka är komponentstate och ligger
+      // inte i URL:en, så återkomsten landar på innevarande vecka.)
+      if (seg.work_order_id) router.push(withReturnTo(`/crm/arbetsorder/${seg.work_order_id}`, '/crm/planering'));
     },
     [router],
   );

--- a/app/crm/saljtavla/SaljtavlaClient.tsx
+++ b/app/crm/saljtavla/SaljtavlaClient.tsx
@@ -9,6 +9,7 @@ import DocumentNumberBadge from '@/app/crm/components/DocumentNumberBadge';
 import { documentRef, formatCurrency } from '@/app/crm/lib/format';
 import { resolveQuoteVatBreakdown, quoteAmountDisplay } from '@/lib/domains/crm/pricing';
 import { crm, quoteStatusMeta, type QuoteStatus } from '@/app/crm/lib/crmTokens';
+import { withReturnTo } from '@/app/crm/lib/returnTo';
 import { quoteCustomerName, isQuoteOverdue } from '@/app/crm/lib/quoteDisplay';
 import QuoteDetailPanel from '@/app/crm/components/QuoteDetailPanel';
 import useDocumentEmail from '@/app/crm/components/useDocumentEmail';
@@ -265,7 +266,7 @@ export default function SaljtavlaClient({ currentUserId }: { currentUserId: stri
         </div>
         <button
           type="button"
-          onClick={() => router.push('/crm/offerter/ny')}
+          onClick={() => router.push(withReturnTo('/crm/offerter/ny', '/crm/saljtavla'))}
           className={crm.primaryButton}
           style={{ backgroundColor: 'var(--crm-primary)' }}
         >

--- a/tests/crm/returnTo.test.ts
+++ b/tests/crm/returnTo.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { safeReturnTo, withReturnTo } from '@/app/crm/lib/returnTo';
+
+// `returnTo` kommer från URL:en och är alltså användarstyrt. Spärren är det enda som står mellan
+// en detaljvys tillbaka-knapp och en öppen vidarebefordran ut ur appen.
+
+describe('safeReturnTo', () => {
+  it('godtar app-interna CRM-sökvägar', () => {
+    expect(safeReturnTo('/crm/planering')).toBe('/crm/planering');
+    expect(safeReturnTo('/crm/saljtavla?quote_id=abc')).toBe('/crm/saljtavla?quote_id=abc');
+    expect(safeReturnTo('/crm/arbetsorder/123')).toBe('/crm/arbetsorder/123');
+  });
+
+  it('avvisar absoluta adresser', () => {
+    expect(safeReturnTo('https://evil.example/crm/')).toBeNull();
+    expect(safeReturnTo('http://evil.example')).toBeNull();
+  });
+
+  // Webbläsaren behandlar dessa som EXTERNA trots att de börjar med snedstreck — det är den
+  // klassiska vägen förbi en naiv "börjar med /"-kontroll.
+  it('avvisar protokollrelativa adresser', () => {
+    expect(safeReturnTo('//evil.example')).toBeNull();
+    expect(safeReturnTo('/\\evil.example')).toBeNull();
+  });
+
+  it('avvisar app-interna sökvägar utanför CRM', () => {
+    expect(safeReturnTo('/admin')).toBeNull();
+    expect(safeReturnTo('/api/crm/quotes')).toBeNull();
+    expect(safeReturnTo('/crmx/fake')).toBeNull();
+  });
+
+  it('avvisar tomt och saknat värde', () => {
+    expect(safeReturnTo(null)).toBeNull();
+    expect(safeReturnTo(undefined)).toBeNull();
+    expect(safeReturnTo('')).toBeNull();
+  });
+});
+
+describe('withReturnTo', () => {
+  it('lägger på ? när länken saknar frågesträng', () => {
+    expect(withReturnTo('/crm/arbetsorder/1', '/crm/planering'))
+      .toBe('/crm/arbetsorder/1?returnTo=%2Fcrm%2Fplanering');
+  });
+
+  it('lägger på & när länken redan har en frågesträng', () => {
+    expect(withReturnTo('/crm/offerter/1/redigera?x=1', '/crm/saljtavla'))
+      .toBe('/crm/offerter/1/redigera?x=1&returnTo=%2Fcrm%2Fsaljtavla');
+  });
+
+  // Tavlans returnTo bär sitt eget quote_id — kodas det inte tolkas det som en parameter till
+  // offertformuläret i stället, och kortet återöppnas aldrig.
+  it('kodar frågesträngen i destinationen', () => {
+    const url = withReturnTo('/crm/offerter/1/redigera', '/crm/saljtavla?quote_id=abc');
+    expect(url).toBe('/crm/offerter/1/redigera?returnTo=%2Fcrm%2Fsaljtavla%3Fquote_id%3Dabc');
+    expect(new URLSearchParams(url.split('?')[1]).get('returnTo')).toBe('/crm/saljtavla?quote_id=abc');
+  });
+
+  it('tur och retur genom safeReturnTo bevarar värdet', () => {
+    const original = '/crm/saljtavla?quote_id=abc';
+    const url = withReturnTo('/crm/offerter/1/redigera', original);
+    const parsed = new URLSearchParams(url.split('?')[1]).get('returnTo');
+    expect(safeReturnTo(parsed)).toBe(original);
+  });
+});


### PR DESCRIPTION
## Bakgrund

Två ytor öppnade en detaljvy men fick aldrig tillbaka användaren dit:

1. **Planeringskalendern → arbetsorder** landade i orderlistan. Kalendern skickade ingen `returnTo`, och arbetsordern kunde ändå inte ta emot någon — båda tillbaka-knapparna var hårdkodade till `/crm/arbetsorder`.
2. **Säljtavlan → offert** landade i offertlistan. Panelen delas av båda ytorna och bär redan en `returnTo`-prop (kundlänken använder den), men Redigera-knappen hårdkodade sin väg, och formuläret hade ingen möjlighet att ta emot ett `returnTo`. Fem hårdkodade `/crm/offerter` i formuläret: laddfel, låst-bounce, tillbaka-knapp, lämna-dialogen och efter sparning.

## Vad som ändras

Delade hjälpare i `app/crm/lib/returnTo.ts` — `safeReturnTo` (allow-list) och `withReturnTo` (lägger på `?`/`&` korrekt). Kalendern och säljtavlan skickar med varifrån man kom; arbetsordern och offertformuläret läser det och använder det för tillbaka-knapp, avbryt, lämna-dialog och navigering efter sparning. Etiketten följer destinationen ("Planering" / "Säljtavlan").

Offertformulärets **kundkortsresa bär nu `returnTo` i sin egen adress** (`offerSelfUrl`) — annars var det borta vid sparning och tavlan tappades efter en sväng förbi kundkortet.

⚠️ **Säkerhet:** `?returnTo=` är användarstyrt. Utan allow-list blir det en öppen vidarebefordran ut ur appen från en sida användaren litar på. `/crm/`-prefixet räcker som spärr — protokollrelativa adresser (`//värd`, `/\värd`), som webbläsaren behandlar som externa, klarar det inte. Täckt av tester.

## Granskningen: fem fynd, två självförvållade

`returnTo` kan nu bära en frågesträng, och det tålde inte alla anropare:

1. **Dubbla frågetecken.** `CustomerFormClient` hårdkodade `?` i sin avbryt-länk. `restore_quote` slutade räknas som parameter (utkastet återställdes inte) och hamnade i stället inuti returnTo-värdet, så tavlan aldrig återöppnade kortet. Samma fil gjorde redan rätt några rader ner. Ligger på "skapa ny kund från offertläget", som redan står som otestat.
2. **Klickrunda utan utgång.** En låst offert bouncade tillbaka *in i panelen* som erbjöd Redigera. Panelens låsning är lösare än formulärets — den släpper fram Redigera när sista Fortnox-synken misslyckats, så återsynken går att nå — medan formuläret nekar så fort det finns en arbetsorder. Den gamla listomdirigeringen bröt rundan av ren tur. Bouncar nu till ytan utan `?quote_id=`.

Övrigt: tillbaka-knappen sa "Offerter" även mot tavlan · "Öppna kundkort" på arbetsordern tappade planeringen (kedjar nu vidare) · tavlans "Ny offert" saknade `returnTo`.

`CustomerFormClient`s lokala `safeReturnTo` heter nu `safeOfferFormReturnTo` — den har medvetet snävare regel än den delade, och två funktioner med samma namn och olika kontrakt är en fälla.

## Känd begränsning (medvetet uppskjuten)

Planeringens valda vecka är komponentstate, inte URL-state, så återkomsten landar på **innevarande vecka** — inte den man tittade på. Fixen är egen och liten (lägg `weekOffset` + `view` i URL:en; `withReturnTo` kodar redan hela frågesträngen, så läget bärs med automatiskt). Görs inte här: planeringen har en egen ogranskad gren (`Fix/planning-review-findings`) och samtidiga ändringar i `PlanningClient.tsx` skulle krocka.

## Test

type-check ✅ · lint ✅ · build ✅ · **1 278 tester** ✅ (+9 för allow-listen och separatorlogiken)

**Ingen SQL, ingen migration.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)