### PR TITLE
Filer på arbetsordern — ritningar och bilder för fältet

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,27 @@ Notes:
 - Read access: all authenticated users.
 - Write access (create folders, upload/delete): admins only.
 
+Work order files (ritningar, förberedelser, foto före/efter)
+
+Setup:
+
+- Run migration: `supabase/sql/20260815_crm_work_order_files.sql` in the Supabase SQL editor. **Run
+  it before deploying the code** — the upload URL is minted before the row is written, so without
+  the table a user pays for an upload that then fails to save.
+- No new bucket. Files live under the prefix `Arbetsorder/<work_order_id>/` in the existing private
+  bucket. `SUPABASE_WORK_ORDER_FILES_BUCKET` overrides it (fallback: `SUPABASE_BUCKET`, default:
+  `pdfs`) — set it only if these files must be split off later.
+
+Notes:
+
+- The browser uploads **straight to Storage** with a signed upload URL; bytes never pass through a
+  route handler, so a 20 MB drawing is not a problem. The server mints the URL, then re-reads the
+  object's real size and mime type before writing the row.
+- Read access: office (`crm.workorder.read`), the uploader, and crew scheduled on the job
+  (`is_user_on_work_order`). Crew never see files marked internal.
+- Write access: office (`crm.workorder.write`) and crew on the job. `konsult` is read-only.
+- Delete: your own uploads always; office deletes anything on the order.
+
 Auth
 
 - A simple email magic link sign-in is available at `/auth/sign-in`.

--- a/app/api/crm/work-orders/[id]/files/[fileId]/route.ts
+++ b/app/api/crm/work-orders/[id]/files/[fileId]/route.ts
@@ -1,0 +1,104 @@
+import { NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
+import { deleteCrmWorkOrderFile, getCrmWorkOrderFile } from '@/lib/domains/crm/work-orders';
+import { removeWorkOrderFileObject, signWorkOrderFileUrl } from '@/lib/domains/crm/workOrderFiles/storage';
+import type { WorkOrderFileRow } from '@/lib/domains/crm/workOrderFiles/types';
+import { can, getEffectivePermissions } from '@/lib/auth/permissions';
+import { getSupabaseAdmin } from '@/lib/supabase/server';
+import { invalidUuidParam, ok, requireSignedInUser, routeError } from '../../../_lib';
+
+// nodejs: signering och städning sker med service-role-nyckeln.
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+type RouteContext = {
+  params: {
+    id: string;
+    fileId: string;
+  };
+};
+
+// Öppna eller ladda ner en enskild fil.
+//
+// `?redirect=1` ger en 302 till den signerade URL:en i stället för JSON. Det är formen som duger
+// som href — länken går aldrig ut, för den gatas om vid varje klick — och den som PDF-iframen och
+// "Öppna i ny flik" använder. Listan använder den INTE för miniatyrer: det hade blivit ett
+// funktionsanrop per bild och rendering.
+//
+// `?download=1` sätter Content-Disposition: attachment via den signerade URL:en.
+export async function GET(req: Request, context: RouteContext) {
+  try {
+    const currentUser = await requireSignedInUser();
+    if (currentUser.response) return currentUser.response;
+
+    // Utan detta blir en trasig id ett 500 med ett rått Postgres-meddelande i svaret.
+    const badId = invalidUuidParam(context.params.id) || invalidUuidParam(context.params.fileId);
+    if (badId) return badId;
+
+    const { searchParams } = new URL(req.url);
+    const wantsRedirect = searchParams.get('redirect') === '1';
+    const wantsDownload = searchParams.get('download') === '1';
+
+    // Läses med SESSIONSKLIENTEN: RLS avgör om den här användaren över huvud taget får se raden.
+    // Först därefter signerar vi med service-role.
+    const supabase = createRouteHandlerClient({ cookies });
+    const { data, error } = await getCrmWorkOrderFile(supabase, context.params.fileId, context.params.id);
+
+    if (error) return routeError(500, 'crm_work_order_file_read_failed', error.message);
+    if (!data) return routeError(404, 'crm_work_order_file_not_found', 'Filen hittades inte.');
+
+    const row = data as unknown as WorkOrderFileRow;
+    const url = await signWorkOrderFileUrl(
+      getSupabaseAdmin(),
+      row.storage_bucket,
+      row.storage_path,
+      wantsDownload ? row.file_name : undefined,
+    );
+    if (!url) return routeError(500, 'crm_work_order_file_sign_failed', 'Kunde inte skapa en länk till filen.');
+
+    if (wantsRedirect) return NextResponse.redirect(url, { status: 302 });
+
+    return ok({ url });
+  } catch (e: any) {
+    return routeError(500, 'crm_work_order_file_unexpected', e?.message || 'Failed to read work order file');
+  }
+}
+
+// Kontoret raderar allt på ordern; alla andra bara sina egna uppladdningar.
+//
+// Kontorets undantag uttrycks som att ägarfiltret UTELÄMNAS, inte som en assert — 0 rader blir 404,
+// precis som på kommentarerna. En installatör som försöker radera kontorets ritning får alltså
+// samma svar som om filen inte fanns, vilket är rätt: hen har inget med den att göra.
+export async function DELETE(_req: Request, context: RouteContext) {
+  try {
+    const currentUser = await requireSignedInUser();
+    if (currentUser.response || !currentUser.currentUser) return currentUser.response;
+
+    const badId = invalidUuidParam(context.params.id) || invalidUuidParam(context.params.fileId);
+    if (badId) return badId;
+
+    const perms = await getEffectivePermissions();
+    const ownerId = can(perms, 'crm.workorder.write') ? null : currentUser.currentUser.id;
+
+    const supabase = createRouteHandlerClient({ cookies });
+    const { data, error } = await deleteCrmWorkOrderFile(
+      supabase,
+      context.params.fileId,
+      context.params.id,
+      ownerId,
+    );
+
+    if (error) return routeError(500, 'crm_work_order_file_delete_failed', error.message);
+    if (!data) return routeError(404, 'crm_work_order_file_not_found', 'Filen hittades inte.');
+
+    // Raden är borta. Objektet städas best-effort — misslyckas det ligger byte kvar utan rad, och
+    // det är osynligt skräp snarare än ett trasigt kort i listan.
+    const row = data as unknown as { id: string; storage_bucket: string; storage_path: string };
+    await removeWorkOrderFileObject(getSupabaseAdmin(), row.storage_bucket, row.storage_path);
+
+    return ok({ id: row.id });
+  } catch (e: any) {
+    return routeError(500, 'crm_work_order_file_unexpected', e?.message || 'Failed to delete work order file');
+  }
+}

--- a/app/api/crm/work-orders/[id]/files/route.ts
+++ b/app/api/crm/work-orders/[id]/files/route.ts
@@ -1,0 +1,211 @@
+import { cookies } from 'next/headers';
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
+import {
+  createCrmWorkOrderFile,
+  findCrmWorkOrderFileByPath,
+  isUserOnWorkOrder,
+  listCrmWorkOrderFiles,
+} from '@/lib/domains/crm/work-orders';
+import {
+  getWorkOrderFileBucket,
+  isWorkOrderFilePath,
+  readWorkOrderFileInfo,
+  removeWorkOrderFileObject,
+  signWorkOrderFileUrls,
+} from '@/lib/domains/crm/workOrderFiles/storage';
+import { isPreviewableImage, validateWorkOrderFile } from '@/lib/domains/crm/workOrderFiles/validation';
+import { mapWorkOrderFileRow } from '@/lib/domains/crm/workOrderFiles/mappers';
+import type { WorkOrderFileRow } from '@/lib/domains/crm/workOrderFiles/types';
+import { can, getEffectivePermissions } from '@/lib/auth/permissions';
+import { getSupabaseAdmin } from '@/lib/supabase/server';
+import {
+  createWorkOrderFileSchema,
+  invalidUuidParam,
+  ok,
+  requireSignedInUser,
+  routeError,
+  validationError,
+} from '../../_lib';
+
+// nodejs: signering och städning sker med service-role-nyckeln.
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+type RouteContext = {
+  params: {
+    id: string;
+  };
+};
+
+export async function GET(_req: Request, context: RouteContext) {
+  try {
+    const currentUser = await requireSignedInUser();
+    if (currentUser.response || !currentUser.currentUser) return currentUser.response;
+
+    const badId = invalidUuidParam(context.params.id);
+    if (badId) return badId;
+
+    const supabase = createRouteHandlerClient({ cookies });
+    const { data, error } = await listCrmWorkOrderFiles(supabase, context.params.id);
+
+    if (error) {
+      return routeError(500, 'crm_work_order_files_list_failed', error.message);
+    }
+
+    const rows = (data || []) as unknown as WorkOrderFileRow[];
+
+    // Bara bilder signeras — de är de enda som renderas som miniatyr. PDF:er får null och öppnas
+    // via /files/<id>?redirect=1 vid klick, så vi inte signerar det som ändå inte visas.
+    //
+    // EN batch-signering (createSignedUrls) i stället för N enskilda: en telefon i fält ska inte
+    // betala tio rundturer för att rita en lista. Support-modulens has_screenshot-lösning duger
+    // inte här — där finns högst en bild i en detaljvy, här är miniatyrerna hela poängen.
+    // Grupperat PER BUCKET, inte "ta bucketen från första raden": bucketnamnet sparas per rad
+    // just för att en framtida bucketflytt inte ska göra gamla rader olästbara, och en signering
+    // som antar en enda bucket hade tyst tappat miniatyren på allt som låg kvar i den gamla.
+    // I normalfallet är det en bucket och därmed ett anrop.
+    const previewable = rows.filter((row) => isPreviewableImage(row.content_type));
+    const admin = getSupabaseAdmin();
+    const byBucket = new Map<string, string[]>();
+    for (const row of previewable) {
+      const bucket = row.storage_bucket || getWorkOrderFileBucket();
+      byBucket.set(bucket, [...(byBucket.get(bucket) || []), row.storage_path]);
+    }
+    if (byBucket.size === 0) byBucket.set(getWorkOrderFileBucket(), []);
+
+    const urls = new Map<string, string>();
+    for (const [bucket, paths] of byBucket) {
+      const signed = await signWorkOrderFileUrls(admin, bucket, paths);
+      for (const [path, url] of signed) urls.set(path, url);
+    }
+
+    const perms = await getEffectivePermissions();
+    const isOfficeWriter = can(perms, 'crm.workorder.write');
+
+    // Kan den här användaren ladda upp? Kontoret alltid; besättningen på sitt eget jobb. Frågan
+    // ställs till samma funktion som RLS-policyn kallar, så knappen och databasen är överens.
+    // Klienten kan inte svara på det själv — därför följer flaggorna med listan.
+    let canUpload = isOfficeWriter;
+    if (!canUpload) {
+      const { data: onJob } = await isUserOnWorkOrder(supabase, currentUser.currentUser.id, context.params.id);
+      canUpload = onJob === true;
+    }
+
+    return ok({
+      items: rows.map((row) => mapWorkOrderFileRow(row, urls.get(row.storage_path) ?? null)),
+      can_upload: canUpload,
+      // Bara kontoret får dölja en fil för besättningen.
+      can_mark_internal: isOfficeWriter,
+      can_delete_any: isOfficeWriter,
+    });
+  } catch (e: any) {
+    return routeError(500, 'crm_work_order_files_unexpected', e?.message || 'Failed to list work order files');
+  }
+}
+
+// Steg 3 av tre: klienten har laddat upp och rapporterar var filen hamnade.
+//
+// ALLT I KROPPEN ÄR ETT PÅSTÅENDE. Upload-token binder bara sökvägen — inte storlek, inte
+// mimetype — så den här routen är den enda försvarslinjen mot en klient som påstod 2 MB och
+// laddade upp 40. Tre kontroller bär det:
+//   1. sökvägen måste ligga under Arbetsorder/<denna order>/<den här användaren>/ — annars kan en
+//      klient koppla ett Support/-objekt ELLER en kollegas fil till sin egen order,
+//   2. sökvägen får inte redan vara registrerad (409) — se nedan om varför det är en säkerhets-
+//      kontroll och inte en dubblettstädning,
+//   3. storlek och mimetype läses ur LAGRINGEN, inte ur kroppen.
+//
+// ⚠️ UPPSTÄDNINGEN ÄR DESTRUKTIV och får bara röra ett objekt som den här användaren själv just
+// laddat upp. Sökvägen till en bild går att läsa ut ur den signerade URL:en listan skickar
+// (`/object/sign/<bucket>/<path>?token=…`), så vad som helst i listan kan spelas tillbaka hit.
+// Kontroll 1 och 2 är det som gör städningen ofarlig — ta inte bort någon av dem.
+export async function POST(req: Request, context: RouteContext) {
+  const bucket = getWorkOrderFileBucket();
+  let uploadedPath: string | null = null;
+
+  try {
+    const currentUser = await requireSignedInUser();
+    if (currentUser.response || !currentUser.currentUser) return currentUser.response;
+
+    const badId = invalidUuidParam(context.params.id);
+    if (badId) return badId;
+
+    const parsedBody = createWorkOrderFileSchema.safeParse(await req.json().catch(() => null));
+    if (!parsedBody.success) return validationError(parsedBody.error);
+
+    const { storage_path: storagePath, file_name: fileName, category } = parsedBody.data;
+
+    if (!isWorkOrderFilePath(storagePath, context.params.id, currentUser.currentUser.id)) {
+      return routeError(400, 'crm_work_order_file_path_invalid', 'Filen hör inte till den här arbetsordern.');
+    }
+
+    const supabase = createRouteHandlerClient({ cookies });
+
+    // Redan registrerad? Då är objektet någon annans (eller vårt eget, redan sparat) och får inte
+    // röras. Svara innan `uploadedPath` sätts, så ingen felgren kan städa bort det.
+    const { data: existing } = await findCrmWorkOrderFileByPath(supabase, storagePath);
+    if (existing) {
+      return routeError(409, 'crm_work_order_file_already_registered', 'Filen är redan sparad på arbetsordern.');
+    }
+
+    uploadedPath = storagePath;
+
+    const admin = getSupabaseAdmin();
+    const info = await readWorkOrderFileInfo(admin, bucket, storagePath);
+    if (!info) {
+      return routeError(400, 'crm_work_order_file_missing_object', 'Uppladdningen kom aldrig fram. Försök igen.');
+    }
+
+    const fileError = validateWorkOrderFile({ size: info.size, type: info.contentType || '', name: fileName });
+    if (fileError) {
+      // Filen ligger redan i lagringen och är inte tillåten — städa bort den direkt.
+      await removeWorkOrderFileObject(admin, bucket, storagePath);
+      uploadedPath = null;
+      return routeError(400, 'crm_work_order_file_invalid', fileError);
+    }
+
+    // Interna filer är ett kontorsbegrepp. En installatör ska inte kunna lägga upp något
+    // besättningen inte ser — RLS gör om samma kontroll, det här är bara det snälla svaret.
+    const perms = await getEffectivePermissions();
+    const isInternal = can(perms, 'crm.workorder.write') ? parsedBody.data.is_internal : false;
+
+    const { data, error } = await createCrmWorkOrderFile(supabase, {
+      work_order_id: context.params.id,
+      category,
+      is_internal: isInternal,
+      file_name: fileName,
+      storage_bucket: bucket,
+      storage_path: storagePath,
+      content_type: info.contentType,
+      size_bytes: info.size,
+      created_by: currentUser.currentUser.id,
+      // profiles är self-read-only, så namnet snapshottas här och läses aldrig via en join.
+      created_by_name: currentUser.currentUser.name || 'Okänd',
+    });
+
+    if (error || !data) {
+      // 23505 = unikt index på storage_path. Då vann någon annan kapplöpningen om samma sökväg och
+      // objektet tillhör DERAS rad — städa inte, det vore att radera en fil som just sparats.
+      // Förkontrollen ovan fångar normalfallet; det här är racet mellan den och insert:en.
+      const isDuplicate = (error as { code?: string } | null)?.code === '23505';
+      if (!isDuplicate) await removeWorkOrderFileObject(admin, bucket, storagePath);
+      uploadedPath = null;
+      if (isDuplicate) {
+        return routeError(409, 'crm_work_order_file_already_registered', 'Filen är redan sparad på arbetsordern.');
+      }
+      return routeError(500, 'crm_work_order_file_create_failed', error?.message || 'Kunde inte spara filen.');
+    }
+
+    uploadedPath = null;
+    const row = data as unknown as WorkOrderFileRow;
+    const url = isPreviewableImage(row.content_type)
+      ? (await signWorkOrderFileUrls(admin, bucket, [row.storage_path])).get(row.storage_path) ?? null
+      : null;
+
+    return ok({ item: mapWorkOrderFileRow(row, url) }, 201);
+  } catch (e: any) {
+    // Samma städning som ovan — ett kvarglömt objekt utan rad är skräp ingen kan nå, men det ska
+    // inte bli kvar bara för att felet kom från oväntat håll.
+    if (uploadedPath) await removeWorkOrderFileObject(getSupabaseAdmin(), bucket, uploadedPath);
+    return routeError(500, 'crm_work_order_file_unexpected', e?.message || 'Failed to create work order file');
+  }
+}

--- a/app/api/crm/work-orders/[id]/files/upload-url/route.ts
+++ b/app/api/crm/work-orders/[id]/files/upload-url/route.ts
@@ -1,0 +1,96 @@
+import { cookies } from 'next/headers';
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
+import { isUserOnWorkOrder } from '@/lib/domains/crm/work-orders';
+import {
+  buildWorkOrderFilePath,
+  createWorkOrderFileUploadUrl,
+  getWorkOrderFileBucket,
+} from '@/lib/domains/crm/workOrderFiles/storage';
+import { validateWorkOrderFile } from '@/lib/domains/crm/workOrderFiles/validation';
+import { can, getEffectivePermissions } from '@/lib/auth/permissions';
+import { getSupabaseAdmin } from '@/lib/supabase/server';
+import {
+  invalidUuidParam,
+  ok,
+  requireSignedInUser,
+  routeError,
+  validationError,
+  workOrderFileUploadUrlSchema,
+} from '../../../_lib';
+
+// nodejs: myntandet sker med service-role-nyckeln.
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+type RouteContext = {
+  params: {
+    id: string;
+  };
+};
+
+// Steg 1 av tre i uppladdningen. Här skapas INGEN databasrad — bara en engångs-URL som klienten
+// laddar upp till. En avbruten uppladdning lämnar därför aldrig en rad som pekar på ingenting;
+// den lämnar på sin höjd ett oåtkomligt objekt (privat bucket, inga storage-policyer).
+//
+// Grinden är requireSignedInUser() och inte requireCrmUser(): installatören har inga CRM-nycklar
+// alls, precis som på kommentarerna och tidraderna. Skrivrätten avgörs i stället av samma två
+// villkor som INSERT-policyn i 20260815_crm_work_order_files.sql — ord för ord, så routens svar
+// blir identiskt med databasens i stället för ungefärligt.
+export async function POST(req: Request, context: RouteContext) {
+  try {
+    const currentUser = await requireSignedInUser();
+    if (currentUser.response || !currentUser.currentUser) return currentUser.response;
+
+    // Utan den här skulle en trasig id mynta en signerad URL under Arbetsorder/<skräp>/ — ett
+    // objekt ingen arbetsorder någonsin kan nå, men som ligger kvar i bucketen.
+    const badId = invalidUuidParam(context.params.id);
+    if (badId) return badId;
+
+    const parsedBody = workOrderFileUploadUrlSchema.safeParse(await req.json().catch(() => null));
+    if (!parsedBody.success) return validationError(parsedBody.error);
+
+    // Avvisa det uppenbart felaktiga innan vi kostar på oss en storage-runda. Påståendena är inte
+    // att lita på — steg 2 läser filens faktiska storlek och typ ur lagringen — men en fil som
+    // redan på pappret är 40 MB ska stoppas här, innan användaren laddat upp den.
+    const claimError = validateWorkOrderFile({
+      size: parsedBody.data.size_bytes,
+      type: parsedBody.data.content_type,
+      name: parsedBody.data.file_name,
+    });
+    if (claimError) return routeError(400, 'crm_work_order_file_invalid', claimError);
+
+    const supabase = createRouteHandlerClient({ cookies });
+    const perms = await getEffectivePermissions();
+
+    let allowed = can(perms, 'crm.workorder.write');
+    if (!allowed) {
+      // Besättningsfrågan kan bara databasen svara på. Samma SECURITY DEFINER-funktion som
+      // policyn kallar — inte en rollkoll, som hade gett fel svar för den som har en
+      // per-användar-grant.
+      const { data: onJob } = await isUserOnWorkOrder(supabase, currentUser.currentUser.id, context.params.id);
+      allowed = onJob === true;
+    }
+    if (!allowed) {
+      return routeError(403, 'crm_work_order_file_forbidden', 'Du kan inte ladda upp filer på den här arbetsordern.');
+    }
+
+    const bucket = getWorkOrderFileBucket();
+    // Uppladdarens id ligger i sökvägen — se buildWorkOrderFilePath. Det är spärren som gör att en
+    // läsbehörig användare inte kan spela tillbaka någon annans filsökväg till bekräftelsesteget.
+    const path = buildWorkOrderFilePath(
+      context.params.id,
+      currentUser.currentUser.id,
+      parsedBody.data.file_name,
+      crypto.randomUUID(),
+    );
+
+    const { signedUrl, token, error } = await createWorkOrderFileUploadUrl(getSupabaseAdmin(), bucket, path);
+    if (error || !signedUrl || !token) {
+      return routeError(500, 'crm_work_order_file_upload_url_failed', error?.message || 'Kunde inte skapa uppladdningslänk.');
+    }
+
+    return ok({ bucket, path, token, signed_url: signedUrl });
+  } catch (e: any) {
+    return routeError(500, 'crm_work_order_file_upload_url_unexpected', e?.message || 'Failed to create upload url');
+  }
+}

--- a/app/api/crm/work-orders/_lib.ts
+++ b/app/api/crm/work-orders/_lib.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { quoteLineItemSchema } from '../quotes/_lib';
+import { WORK_ORDER_FILE_CATEGORIES } from '@/lib/domains/crm/workOrderFiles/types';
 export { ok, routeError, validationError, invalidUuidParam, isNoRowsError, requireCrmUser, requireCrmWriter, requirePermission, requireSignedInUser, pickProvidedFields } from '../_shared';
 
 // Reuses the quote line-item schema so work order article edits validate identically.
@@ -58,6 +59,40 @@ export const createWorkOrderTimeEntrySchema = z.object({
   end_time: clockSchema,
   break_minutes: z.coerce.number().int().min(0).max(1439).optional().default(0),
   note: z.preprocess((value) => normalizeOptionalText(value), z.string().nullable()).optional().default(null),
+});
+
+// ── Filer på ordern ─────────────────────────────────────────────────────────
+//
+// Uppladdningen sker i två steg: klienten ber om en signerad URL, laddar upp direkt till lagringen,
+// och bekräftar sedan. Byten passerar aldrig en route handler — en ritning på 20 MB är vanlig och
+// ska inte behöva rymmas i en request-kropp.
+//
+// Steg 1: klienten talar om vad den TÄNKER ladda upp. Allt här är påståenden — de duger för att
+// avvisa uppenbart fel tidigt (innan vi ens myntar en URL), men servern litar aldrig på dem: i
+// steg 2 läses filens faktiska storlek och mimetype ur lagringen.
+export const workOrderFileUploadUrlSchema = z.object({
+  file_name: z.string().trim().min(1, 'Filnamn krävs').max(255, 'Filnamnet är för långt'),
+  content_type: z.string().trim().max(255).optional().default(''),
+  size_bytes: z.coerce.number().int().min(0, 'Ogiltig filstorlek'),
+});
+
+// Steg 2: bekräfta att uppladdningen gick igenom och skapa raden.
+// `storage_path` valideras mot ordern i routen (isWorkOrderFilePath) — en klient som hittar på en
+// sökväg får inte kunna koppla ett Support/- eller Documents/-objekt till sin arbetsorder.
+export const createWorkOrderFileSchema = z.object({
+  storage_path: z.string().trim().min(1, 'Sökväg krävs'),
+  file_name: z.string().trim().min(1, 'Filnamn krävs').max(255, 'Filnamnet är för långt'),
+  category: z.enum(WORK_ORDER_FILE_CATEGORIES).default('other'),
+  // Nekas för den som saknar crm.workorder.write — routen tvingar false, och RLS gör om samma
+  // kontroll så en handskriven POST inte kan gömma en fil för besättningen.
+  //
+  // INTE z.coerce.boolean(): den gör Boolean(värde), och `Boolean("false") === true`. Strängen
+  // "false" hade alltså DOLT filen för besättningen — raka motsatsen till vad avsändaren bad om,
+  // och tyst. Bara ett riktigt booleskt värde eller de två strängarna räknas.
+  is_internal: z
+    .union([z.boolean(), z.enum(['true', 'false']).transform((value) => value === 'true')])
+    .optional()
+    .default(false),
 });
 
 export const createWorkOrderCommentSchema = z.object({

--- a/app/arbetsorder/WorkOrderInstallerClient.tsx
+++ b/app/arbetsorder/WorkOrderInstallerClient.tsx
@@ -62,7 +62,11 @@ export default function WorkOrderInstallerClient({
   // Ritningar och bilder. Samma hook och samma flikkomponent som kontorsvyn; RLS avgör vad
   // besättningen får se (interna filer filtreras bort i databasen) och routen svarar med om den
   // här personen får ladda upp.
-  const files = useWorkOrderFiles(workOrderId);
+  //
+  // Hämtas först när fliken öppnats — samma skäl som `includeTimeEntries` ovan: en telefon i fält
+  // ska inte betala en rundtur, plus signering av varje bild på servern, för en lista som ingenting
+  // renderar.
+  const files = useWorkOrderFiles(workOrderId, { enabled: activeTab === 'files' });
 
   // ⚠️ ALLA HOOKS MÅSTE LIGGA FÖRE DE TIDIGA RETURERNA NEDAN (`if (loading)`, `if (error)`).
   // Den här summan används först längst ner, men får inte deklareras där: första rendern går ut

--- a/app/arbetsorder/WorkOrderInstallerClient.tsx
+++ b/app/arbetsorder/WorkOrderInstallerClient.tsx
@@ -8,7 +8,9 @@ import { PhoneLink, EmailLink, AddressLink } from '@/app/crm/components/ContactL
 import WorkOrderCommentsTab from '@/app/crm/arbetsorder/WorkOrderCommentsTab';
 import WorkOrderArticlesTab, { type ArticleLineItem } from '@/app/crm/arbetsorder/WorkOrderArticlesTab';
 import WorkOrderTimeTab from '@/app/crm/arbetsorder/WorkOrderTimeTab';
+import WorkOrderFilesTab from '@/app/crm/arbetsorder/WorkOrderFilesTab';
 import { useWorkOrderActivity } from '@/app/crm/arbetsorder/useWorkOrderActivity';
+import { useWorkOrderFiles } from '@/app/crm/arbetsorder/useWorkOrderFiles';
 import { useCustomerContact } from '@/app/crm/arbetsorder/useCustomerContact';
 import { formatDate, joinAddress, documentRef } from '@/app/crm/lib/format';
 
@@ -35,7 +37,7 @@ type InstallerWorkOrder = {
   status: WorkOrderStatus;
 };
 
-type InstallerTab = 'info' | 'articles' | 'time';
+type InstallerTab = 'info' | 'articles' | 'files' | 'time';
 
 export default function WorkOrderInstallerClient({
   workOrderId,
@@ -56,6 +58,11 @@ export default function WorkOrderInstallerClient({
 
   // Utan Tid-fliken finns ingen konsument för tidraderna — hämta dem inte då.
   const activity = useWorkOrderActivity(workOrderId, { includeTimeEntries: canReportTime });
+
+  // Ritningar och bilder. Samma hook och samma flikkomponent som kontorsvyn; RLS avgör vad
+  // besättningen får se (interna filer filtreras bort i databasen) och routen svarar med om den
+  // här personen får ladda upp.
+  const files = useWorkOrderFiles(workOrderId);
 
   // ⚠️ ALLA HOOKS MÅSTE LIGGA FÖRE DE TIDIGA RETURERNA NEDAN (`if (loading)`, `if (error)`).
   // Den här summan används först längst ner, men får inte deklareras där: första rendern går ut
@@ -124,8 +131,12 @@ export default function WorkOrderInstallerClient({
   // Villkoret är alltså ett testfönster (William 2026-08-14: "jag måste ändå kunna testa"), inte en
   // behörighetsmodell. Vid cutovern tas `canReportTime` bort härifrån och ur page.tsx, och den gula
   // rutan nedan med den.
+  //
+  // Filer-fliken är däremot ALLTID med. Den är hela skälet till att besättningen öppnar ordern
+  // kvällen före — ritningen och förberedelserna ligger där — och den har ingen motsvarighet till
+  // Blikk-problemet ovan.
   const tabs: Array<[InstallerTab, string]> = [
-    ['info', 'Info'], ['articles', 'Artiklar'],
+    ['info', 'Info'], ['articles', 'Artiklar'], ['files', 'Filer'],
     ...(canReportTime ? [['time', 'Tid'] as [InstallerTab, string]] : []),
   ];
 
@@ -234,6 +245,23 @@ export default function WorkOrderInstallerClient({
           fortnoxConnected={false}
           canEdit={false}
           onSave={async () => false}
+        />
+      ) : null}
+
+      {/* Filer — samma komponent som kontorets flik. Interna filer har redan filtrerats bort av
+          RLS innan de nådde hit, och `canUpload` kommer från routen (besättning på jobbet). */}
+      {activeTab === 'files' ? (
+        <WorkOrderFilesTab
+          workOrderId={workOrderId}
+          files={files.files}
+          loading={files.loading}
+          currentUserId={currentUserId}
+          canUpload={files.canUpload}
+          canMarkInternal={files.canMarkInternal}
+          canDeleteAny={files.canDeleteAny}
+          uploadProgress={files.uploadProgress}
+          onUpload={files.uploadFiles}
+          onDelete={files.deleteFile}
         />
       ) : null}
 

--- a/app/crm/arbetsorder/WorkOrderDetailClient.tsx
+++ b/app/crm/arbetsorder/WorkOrderDetailClient.tsx
@@ -251,7 +251,9 @@ export default function WorkOrderDetailClient({ workOrderId, fortnoxConnected, c
   } = useWorkOrderActivity(workOrderId);
 
   // Ritningar och bilder på jobbet. Egen hook — fältvyn monterar samma flik med samma hook.
-  const workOrderFiles = useWorkOrderFiles(workOrderId);
+  // Hämtas först när fliken öppnats: listsvaret signerar en URL per bild på servern, och en order
+  // öppnas ofta för Ekonomi eller Artiklar utan att Filer någonsin visas.
+  const workOrderFiles = useWorkOrderFiles(workOrderId, { enabled: activeTab === 'files' });
 
   // Load work order
   useEffect(() => {

--- a/app/crm/arbetsorder/WorkOrderDetailClient.tsx
+++ b/app/crm/arbetsorder/WorkOrderDetailClient.tsx
@@ -24,8 +24,10 @@ import { parseDecimal } from '@/lib/shared/number';
 import WorkOrderTimeTab from './WorkOrderTimeTab';
 import WorkOrderCommentsTab from './WorkOrderCommentsTab';
 import WorkOrderArticlesTab, { type ArticleLineItem } from './WorkOrderArticlesTab';
+import WorkOrderFilesTab from './WorkOrderFilesTab';
 import WorkOrderPartialInvoiceModal, { type PartialInvoiceLine } from './WorkOrderPartialInvoiceModal';
 import { useWorkOrderActivity } from './useWorkOrderActivity';
+import { useWorkOrderFiles } from './useWorkOrderFiles';
 import { useCustomerContact } from './useCustomerContact';
 import { formatDate, formatDateTime, formatCurrency, joinAddress, isWorkOrderOverdue, documentRef } from '@/app/crm/lib/format';
 import { openFortnoxPdf } from '@/app/crm/lib/fortnoxDoc';
@@ -34,7 +36,7 @@ import useDocumentEmail from '@/app/crm/components/useDocumentEmail';
 // ─── Types ──────────────────────────────────────────────────────────────────
 
 type WorkOrderStatus = 'draft' | 'scheduled' | 'ready' | 'in_progress' | 'completed' | 'partially_invoiced' | 'invoiced' | 'cancelled';
-type WorkOrderTab = 'overview' | 'economy' | 'articles' | 'time';
+type WorkOrderTab = 'overview' | 'economy' | 'articles' | 'files' | 'time';
 type FortnoxSyncStatus = 'not_synced' | 'pending' | 'synced' | 'failed';
 
 // One delfakturering round: the per-article quantities billed + the Fortnox invoice it produced.
@@ -247,6 +249,9 @@ export default function WorkOrderDetailClient({ workOrderId, fortnoxConnected, c
     timeEntries, comments, mentionUsers, timeEntriesLoading, commentsLoading,
     createTimeEntry, updateTimeEntry, deleteTimeEntry, createComment, updateComment, deleteComment,
   } = useWorkOrderActivity(workOrderId);
+
+  // Ritningar och bilder på jobbet. Egen hook — fältvyn monterar samma flik med samma hook.
+  const workOrderFiles = useWorkOrderFiles(workOrderId);
 
   // Load work order
   useEffect(() => {
@@ -526,7 +531,7 @@ export default function WorkOrderDetailClient({ workOrderId, fortnoxConnected, c
   // Comments live at the bottom of the overview (not a separate tab), so an @-mention notification
   // lands you straight on the thread without hunting for a tab.
   const tabs: Array<[WorkOrderTab, string]> = [
-    ['overview', 'Översikt'], ['economy', 'Ekonomi'], ['articles', 'Artiklar'], ['time', 'Tid'],
+    ['overview', 'Översikt'], ['economy', 'Ekonomi'], ['articles', 'Artiklar'], ['files', 'Filer'], ['time', 'Tid'],
   ];
 
   // Read-only field display used when the overview is locked.
@@ -1088,6 +1093,22 @@ export default function WorkOrderDetailClient({ workOrderId, fortnoxConnected, c
           // Avskrivning finns kvar även när editorn är låst — det är hela poängen. Utom på en
           // färdigfakturerad order, där det inte finns något kvar att skriva av.
           onSave={saveArticles}
+        />
+      ) : null}
+
+      {/* ─── Files ─── */}
+      {activeTab === 'files' ? (
+        <WorkOrderFilesTab
+          workOrderId={workOrderId}
+          files={workOrderFiles.files}
+          loading={workOrderFiles.loading}
+          currentUserId={currentUserId}
+          canUpload={workOrderFiles.canUpload}
+          canMarkInternal={workOrderFiles.canMarkInternal}
+          canDeleteAny={workOrderFiles.canDeleteAny}
+          uploadProgress={workOrderFiles.uploadProgress}
+          onUpload={workOrderFiles.uploadFiles}
+          onDelete={workOrderFiles.deleteFile}
         />
       ) : null}
 

--- a/app/crm/arbetsorder/WorkOrderFilesTab.tsx
+++ b/app/crm/arbetsorder/WorkOrderFilesTab.tsx
@@ -1,0 +1,402 @@
+"use client";
+
+import { useEffect, useRef, useState } from 'react';
+import { cn } from '@/lib/shared/cn';
+import { crm } from '@/app/crm/lib/crmTokens';
+import { formatDate } from '@/app/crm/lib/format';
+import {
+  WORK_ORDER_FILE_CATEGORIES,
+  WORK_ORDER_FILE_CATEGORY_ORDER,
+  workOrderFileCategoryLabel,
+  type WorkOrderFileCategory,
+  type WorkOrderFileView,
+} from '@/lib/domains/crm/workOrderFiles/types';
+
+// Filfliken. Monteras av BÅDE kontorsvyn (/crm/arbetsorder) och fältvyn (/arbetsorder), därför
+// helt presentational: data och callbacks in som props, inga egna fetch-anrop, inga toasts.
+//
+// `--crm-primary` är scopad till .crm-shell och saknas i fältvyn — därför fallbacken i var().
+
+type Props = {
+  workOrderId: string;
+  files: WorkOrderFileView[];
+  loading: boolean;
+  currentUserId: string | null;
+  canUpload: boolean;
+  canMarkInternal: boolean;
+  canDeleteAny: boolean;
+  uploadProgress: { current: number; total: number } | null;
+  onUpload: (files: File[], meta: { category: WorkOrderFileCategory; isInternal: boolean }) => Promise<boolean>;
+  onDelete: (id: string) => Promise<boolean>;
+};
+
+const ACCEPT = 'image/jpeg,image/png,image/webp,image/heic,image/heif,application/pdf,.heic,.heif';
+
+function formatBytes(bytes: number | null): string {
+  if (!bytes || bytes <= 0) return '';
+  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} kB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1).replace('.', ',')} MB`;
+}
+
+function fileExtension(name: string): string {
+  return name.split('.').pop()?.toUpperCase().slice(0, 4) || 'FIL';
+}
+
+export default function WorkOrderFilesTab({
+  workOrderId,
+  files,
+  loading,
+  currentUserId,
+  canUpload,
+  canMarkInternal,
+  canDeleteAny,
+  uploadProgress,
+  onUpload,
+  onDelete,
+}: Props) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [composerOpen, setComposerOpen] = useState(false);
+  const [category, setCategory] = useState<WorkOrderFileCategory>('drawing');
+  const [isInternal, setIsInternal] = useState(false);
+  const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
+  const [busyId, setBusyId] = useState<string | null>(null);
+  // Id och inte hela raden: listan hämtas om var 25:e minut (de signerade URL:erna går ut), och
+  // en kopia av raden hade fortsatt peka på en död URL medan visaren stod öppen.
+  const [viewerId, setViewerId] = useState<string | null>(null);
+  const viewerFile = files.find((file) => file.id === viewerId) || null;
+
+  const uploading = uploadProgress !== null;
+
+  async function handlePicked(picked: FileList | null) {
+    if (!picked || picked.length === 0) return;
+    const ok = await onUpload(Array.from(picked), { category, isInternal });
+    // Nollställ alltid inputen, även vid fel: annars går samma fil inte att välja igen.
+    if (inputRef.current) inputRef.current.value = '';
+    if (ok) {
+      setComposerOpen(false);
+      setIsInternal(false);
+    }
+  }
+
+  async function confirmDelete(id: string) {
+    setBusyId(id);
+    await onDelete(id);
+    setBusyId(null);
+    setConfirmDeleteId(null);
+  }
+
+  // Kategorierna är inte en godtycklig taxonomi utan ett jobbs kronologi: ritningen och
+  // förberedelserna finns innan besättningen åker, fotona kommer under och efter. Ordningen är
+  // därför fast och inte alfabetisk. Tomma kategorier hoppas över — en rubrik utan innehåll är
+  // brus på en telefonskärm.
+  const groups = WORK_ORDER_FILE_CATEGORY_ORDER
+    .map((key) => ({ key, items: files.filter((file) => file.category === key) }))
+    .filter((group) => group.items.length > 0);
+
+  return (
+    <div className={cn(crm.cardInner, 'grid gap-4')}>
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <p className={crm.sectionTitle}>Filer</p>
+        {canUpload ? (
+          <button
+            type="button"
+            onClick={() => setComposerOpen((open) => !open)}
+            disabled={uploading}
+            className={cn(crm.formButton, 'px-3')}
+            style={{ backgroundColor: 'var(--crm-primary, #1a3f26)' }}
+          >
+            {uploading
+              ? `Laddar upp (${uploadProgress.current}/${uploadProgress.total})…`
+              : composerOpen ? 'Avbryt' : 'Ladda upp filer'}
+          </button>
+        ) : null}
+      </div>
+
+      {/* Uppladdningen ligger bakom en knapp och inte som en permanent yta överst: den som öppnar
+          fliken i fält gör det för att TITTA på ritningen, och en dropzone hade tryckt ner den
+          under skärmkanten på en telefon. */}
+      {canUpload && composerOpen ? (
+        <div className="grid gap-3 rounded-xl border border-solid border-[#cfdcc9] bg-[#f1f5ee] p-3">
+          <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-end">
+            <label className="grid gap-1">
+              <span className={crm.label}>Kategori</span>
+              <select
+                value={category}
+                onChange={(e) => setCategory(e.target.value as WorkOrderFileCategory)}
+                className={crm.select}
+              >
+                {WORK_ORDER_FILE_CATEGORIES.map((key) => (
+                  <option key={key} value={key}>{workOrderFileCategoryLabel[key]}</option>
+                ))}
+              </select>
+            </label>
+
+            {canMarkInternal ? (
+              <label className="flex items-center gap-2 pb-1 text-[13px] text-slate-600">
+                <input
+                  type="checkbox"
+                  checked={isInternal}
+                  onChange={(e) => setIsInternal(e.target.checked)}
+                  className="h-4 w-4 shrink-0 accent-[#1a3f26]"
+                />
+                Intern — visas inte för besättningen
+              </label>
+            ) : null}
+          </div>
+
+          <label
+            htmlFor="work-order-file-input"
+            className="grid cursor-pointer place-items-center gap-1 rounded-xl border border-dashed border-[#cfdcc9] bg-white px-4 py-6 text-center transition hover:border-[#1a3f26]"
+          >
+            <span className="text-sm font-semibold text-slate-700">Välj filer</span>
+            <span className="text-xs text-slate-500">Bilder och PDF, max 25 MB per fil</span>
+          </label>
+          <input
+            id="work-order-file-input"
+            ref={inputRef}
+            type="file"
+            multiple
+            accept={ACCEPT}
+            onChange={(e) => handlePicked(e.target.files)}
+            disabled={uploading}
+            className="sr-only"
+          />
+        </div>
+      ) : null}
+
+      {loading ? <div className="text-sm text-slate-500">Laddar filer…</div> : null}
+
+      {!loading && files.length === 0 ? (
+        <div className="rounded-xl border border-dashed border-[#cfdcc9] bg-[#f1f5ee] px-4 py-6 text-sm text-slate-500">
+          {canUpload
+            ? 'Inga filer än. Ladda upp ritningar och bilder här så har besättningen dem när de öppnar jobbet.'
+            : 'Inga filer på den här arbetsordern än.'}
+        </div>
+      ) : null}
+
+      {!loading && groups.map((group) => (
+        <section key={group.key} className="grid gap-2">
+          <div className="flex items-baseline gap-2">
+            <h3 className={crm.sectionTitle}>{workOrderFileCategoryLabel[group.key]}</h3>
+            <span className="text-[11px] font-semibold text-slate-400">{group.items.length}</span>
+          </div>
+
+          {/* EN kolumn på telefon. Två kolumner gav ~160 px breda kort där filnamnet kapades mitt
+              i ("IMG_4125.jp"), metaraden bröt sig över tre rader och "Ta bort? Ja Nej" klipptes av
+              kortkanten. Det är också fel prioritering: den som öppnar fliken i fält vill SE
+              ritningen, inte se två frimärken. */}
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+            {group.items.map((file) => {
+              const canRemove = canDeleteAny || (!!currentUserId && file.created_by === currentUserId);
+              const href = `/api/crm/work-orders/${workOrderId}/files/${file.id}?redirect=1`;
+              const isImage = !!file.url;
+
+              return (
+                <figure
+                  key={file.id}
+                  className="grid overflow-hidden rounded-xl border border-solid border-[#e0e8dc] bg-white"
+                >
+                  {/* Bilder öppnas i appens egen visare; PDF i webbläsarens. Se kommentaren på
+                      FileViewer längst ner i filen för varför de två skiljer sig åt. */}
+                  {isImage ? (
+                    <button
+                      type="button"
+                      onClick={() => setViewerId(file.id)}
+                      className="block aspect-[4/3] w-full cursor-zoom-in border-none bg-[#f1f5ee] p-0"
+                      aria-label={`Visa ${file.file_name}`}
+                    >
+                      <img src={file.url as string} alt="" className="h-full w-full object-cover" />
+                    </button>
+                  ) : (
+                    <a
+                      href={href}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="grid aspect-[4/3] w-full place-items-center bg-[#f1f5ee] no-underline"
+                      aria-label={`Öppna ${file.file_name}`}
+                    >
+                      <span className="text-sm font-bold tracking-wide text-slate-400">
+                        {fileExtension(file.file_name)}
+                      </span>
+                    </a>
+                  )}
+
+                  <figcaption className="grid gap-1.5 px-3 py-2.5">
+                    {isImage ? (
+                      <button
+                        type="button"
+                        onClick={() => setViewerId(file.id)}
+                        className="truncate border-none bg-transparent p-0 text-left text-[13px] font-semibold text-slate-900"
+                        title={file.file_name}
+                      >
+                        {file.file_name}
+                      </button>
+                    ) : (
+                      <a
+                        href={href}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="truncate text-[13px] font-semibold text-slate-900 no-underline hover:underline"
+                        title={file.file_name}
+                      >
+                        {file.file_name}
+                      </a>
+                    )}
+
+                    <div className="flex flex-wrap items-center gap-x-1.5 text-[11px] text-slate-400">
+                      <span className="min-w-0 truncate">{file.created_by_name}</span>
+                      <span aria-hidden>·</span>
+                      <span className="whitespace-nowrap">{formatDate(file.created_at)}</span>
+                      {formatBytes(file.size_bytes) ? (
+                        <>
+                          <span aria-hidden>·</span>
+                          <span className="whitespace-nowrap">{formatBytes(file.size_bytes)}</span>
+                        </>
+                      ) : null}
+                    </div>
+
+                    {file.is_internal ? (
+                      <span className={cn(crm.badge, 'justify-self-start border-amber-300 bg-amber-50 text-amber-800')}>
+                        Intern
+                      </span>
+                    ) : null}
+
+                    {/* Egen rad, aldrig i samma flöde som metan — det var den som klipptes.
+                        "Ladda ner" ligger här och inte bara i visaren: den som förbereder dagen
+                        sitter ofta i bilen och har ingen täckning på plats. En ritning som ligger
+                        i telefonen går att öppna ändå. */}
+                    <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-1 border-x-0 border-b-0 border-t border-solid border-[#eef2ec] pt-2 text-xs">
+                      <a
+                        href={`${href}&download=1`}
+                        className="font-medium text-slate-500 no-underline hover:text-slate-800"
+                      >
+                        Ladda ner
+                      </a>
+
+                      {canRemove ? (
+                        confirmDeleteId === file.id ? (
+                          <span className="flex flex-wrap items-center gap-x-3 gap-y-1">
+                            <span className="text-slate-500">Ta bort?</span>
+                            <button
+                              type="button"
+                              onClick={() => confirmDelete(file.id)}
+                              disabled={busyId === file.id}
+                              className="border-none bg-transparent p-0 font-semibold text-rose-600 hover:text-rose-700"
+                            >
+                              {busyId === file.id ? 'Tar bort…' : 'Ja'}
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() => setConfirmDeleteId(null)}
+                              className="border-none bg-transparent p-0 text-slate-400 hover:text-slate-600"
+                            >
+                              Nej
+                            </button>
+                          </span>
+                        ) : (
+                          <button
+                            type="button"
+                            onClick={() => setConfirmDeleteId(file.id)}
+                            className="border-none bg-transparent p-0 font-medium text-slate-400 hover:text-rose-500"
+                          >
+                            Ta bort
+                          </button>
+                        )
+                      ) : null}
+                    </div>
+                  </figcaption>
+                </figure>
+              );
+            })}
+          </div>
+        </section>
+      ))}
+
+      {viewerFile?.url ? (
+        <FileViewer
+          fileName={viewerFile.file_name}
+          url={viewerFile.url}
+          openHref={`/api/crm/work-orders/${workOrderId}/files/${viewerFile.id}?redirect=1`}
+          downloadHref={`/api/crm/work-orders/${workOrderId}/files/${viewerFile.id}?redirect=1&download=1`}
+          onClose={() => setViewerId(null)}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+// Bildvisare i appen.
+//
+// VARFÖR BARA BILDER: att öppna en fil i en ny flik fungerar bra på datorn men illa på telefonen —
+// man kastas ur appen till en naken flik utan väg tillbaka annat än fliklistan. För BILDER finns
+// ingen anledning till det: vi har redan den signerade URL:en, och en overlay som stänger med ett
+// tryck är både snabbare och mindre desorienterande.
+//
+// PDF öppnas fortfarande i webbläsarens egen visare, med flit. En ritning ska gå att nypzooma och
+// bläddra mellan sidor i, och telefonens inbyggda PDF-visare gör det bättre än något vi bygger —
+// dessutom renderar iOS Safari en PDF i <iframe> som en enda sida utan scroll, så en inbäddad
+// variant hade varit sämre än länken vi har.
+//
+// "Öppna i ny flik" finns kvar också för bilder: det är vägen till riktig nypzoom när man behöver
+// läsa en detalj i en ritning som fotats av.
+function FileViewer({
+  fileName,
+  url,
+  openHref,
+  downloadHref,
+  onClose,
+}: {
+  fileName: string;
+  url: string;
+  openHref: string;
+  downloadHref: string;
+  onClose: () => void;
+}) {
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
+    document.addEventListener('keydown', onKey);
+    // Lås bakgrundsscrollen så telefonen inte scrollar ordern bakom bilden.
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.removeEventListener('keydown', onKey);
+      document.body.style.overflow = previousOverflow;
+    };
+  }, [onClose]);
+
+  const actionClass =
+    'inline-flex h-9 items-center rounded-lg border border-solid border-white/25 bg-white/10 px-3 text-[13px] font-semibold text-white no-underline transition hover:bg-white/20';
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={fileName}
+      className="fixed inset-0 z-[2800] grid grid-rows-[auto_1fr] bg-slate-950/95"
+      // Tryck utanför bilden stänger. Knappraden stoppar sin egen bubbling nedan.
+      onClick={onClose}
+    >
+      <div
+        className="flex flex-wrap items-center justify-between gap-2 px-4 py-3"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <span className="min-w-0 flex-1 truncate text-sm font-semibold text-white">{fileName}</span>
+        <div className="flex shrink-0 items-center gap-2">
+          <a href={openHref} target="_blank" rel="noreferrer" className={actionClass}>Öppna</a>
+          <a href={downloadHref} className={actionClass}>Ladda ner</a>
+          <button type="button" onClick={onClose} className={actionClass} aria-label="Stäng">Stäng</button>
+        </div>
+      </div>
+
+      <div className="grid min-h-0 place-items-center overflow-auto p-4">
+        {/* Klick på själva bilden ska INTE stänga — man zoomar och panorerar i den. */}
+        <img
+          src={url}
+          alt={fileName}
+          onClick={(e) => e.stopPropagation()}
+          className="max-h-full max-w-full object-contain"
+        />
+      </div>
+    </div>
+  );
+}

--- a/app/crm/arbetsorder/useWorkOrderFiles.ts
+++ b/app/crm/arbetsorder/useWorkOrderFiles.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { createClientComponentClient } from '@supabase/auth-helpers-nextjs';
 import { useToast } from '@/lib/Toast';
 import { prepareFileForUpload } from '@/lib/shared/imageCompression';
@@ -17,7 +17,13 @@ import type { WorkOrderFileCategory, WorkOrderFileView } from '@/lib/domains/crm
 //
 // Som överallt annars i modulen: alla toasts ligger HÄR, aldrig i flikkomponenten, och varje
 // mutation returnerar en boolean så anroparen kan nollställa sitt eget formulär vid framgång.
-export function useWorkOrderFiles(workOrderId: string) {
+// `enabled: false` hoppar över hämtningen helt — samma mönster som `includeTimeEntries` i
+// useWorkOrderActivity, och av samma skäl: en lista som ingenting renderar kostar en extra
+// rundtur på en telefon i fält varje gång ett jobb öppnas, och listsvaret signerar dessutom en URL
+// per bild på servern. Så fort fliken öppnats en gång stannar hämtningen på (fliken ska vara
+// omedelbar när man växlar tillbaka).
+export function useWorkOrderFiles(workOrderId: string, options?: { enabled?: boolean }) {
+  const enabled = options?.enabled !== false;
   const toast = useToast();
   const supabase = useMemo(() => createClientComponentClient(), []);
   const [files, setFiles] = useState<WorkOrderFileView[]>([]);
@@ -27,41 +33,59 @@ export function useWorkOrderFiles(workOrderId: string) {
   const [canDeleteAny, setCanDeleteAny] = useState(false);
   const [uploadProgress, setUploadProgress] = useState<{ current: number; total: number } | null>(null);
 
-  const load = useCallback(async () => {
-    const res = await fetch(`/api/crm/work-orders/${workOrderId}/files`, { cache: 'no-store' });
-    const json = await res.json().catch(() => ({}));
-    if (!res.ok || !json.ok) return null;
-    return json.data as {
-      items: WorkOrderFileView[];
-      can_upload: boolean;
-      can_mark_internal: boolean;
-      can_delete_any: boolean;
-    };
-  }, [workOrderId]);
+  const [activated, setActivated] = useState(enabled);
+  useEffect(() => { if (enabled) setActivated(true); }, [enabled]);
 
-  useEffect(() => {
-    let active = true;
-    setLoading(true);
+  // ⚠️ SEKVENSNUMMER, inte bara en `active`-vakt.
+  //
+  // Listan hämtas om i bakgrunden (intervall + visibilitychange), och OS:ets filväljare utlöser
+  // FAKTISKT visibilitychange när man kommer tillbaka från den. Utan det här numret ser flödet ut
+  // så här: användaren väljer filer → vi startar en GET → uppladdningen blir klar och lägger till
+  // raden lokalt → den gamla GET:en landar och skriver över med en lista utan den nyss uppladdade
+  // filen. Användaren ser en grön toast och en fil som försvann.
+  //
+  // Varje lokal ändring (uppladdning, radering) räknar också upp numret, så ett svar som hunnits
+  // om av en mutation kasseras — inte bara ett som hunnits om av en nyare GET.
+  const requestSeq = useRef(0);
 
-    const apply = (data: Awaited<ReturnType<typeof load>>) => {
-      if (!active || !data) return;
+  const refresh = useCallback(async () => {
+    const seq = ++requestSeq.current;
+    try {
+      const res = await fetch(`/api/crm/work-orders/${workOrderId}/files`, { cache: 'no-store' });
+      const json = await res.json().catch(() => ({}));
+      if (!res.ok || !json.ok) return;
+      if (seq !== requestSeq.current) return; // omsprungen — kasta svaret
+      const data = json.data as {
+        items: WorkOrderFileView[];
+        can_upload: boolean;
+        can_mark_internal: boolean;
+        can_delete_any: boolean;
+      };
       setFiles(data.items || []);
       setCanUpload(!!data.can_upload);
       setCanMarkInternal(!!data.can_mark_internal);
       setCanDeleteAny(!!data.can_delete_any);
-    };
+    } catch {
+      /* non-fatal */
+    }
+  }, [workOrderId]);
 
-    load().then(apply).catch(() => { /* non-fatal */ }).finally(() => { if (active) setLoading(false); });
+  useEffect(() => {
+    if (!activated) return;
+    let active = true;
+    setLoading(true);
+
+    refresh().finally(() => { if (active) setLoading(false); });
 
     // Miniatyrernas URL:er är signerade i 30 minuter (SIGNED_URL_TTL_SECONDS). En arbetsorder ligger
     // ofta uppe längre än så — kontoret har den öppen halva förmiddagen — och utan omhämtning möts
     // man då av en flik full av trasiga bilder utan något sätt att få tillbaka dem.
     // Hämtas om var 25:e minut, med marginal före utgången.
-    const interval = setInterval(() => { load().then(apply).catch(() => { /* non-fatal */ }); }, 25 * 60 * 1000);
+    const interval = setInterval(() => { refresh(); }, 25 * 60 * 1000);
 
     // Fliken kan ha legat i bakgrunden längre än så (en telefon som sovit över natten). Timers
     // stryps eller pausas då, så vi hämtar också om när användaren kommer tillbaka till fliken.
-    const onVisible = () => { if (document.visibilityState === 'visible') load().then(apply).catch(() => {}); };
+    const onVisible = () => { if (document.visibilityState === 'visible') refresh(); };
     document.addEventListener('visibilitychange', onVisible);
 
     return () => {
@@ -69,7 +93,7 @@ export function useWorkOrderFiles(workOrderId: string) {
       clearInterval(interval);
       document.removeEventListener('visibilitychange', onVisible);
     };
-  }, [load]);
+  }, [refresh, activated]);
 
   // En fil hela vägen genom de tre stegen. Kastar vid fel så anroparen kan räkna misslyckanden
   // per fil utan att en trasig fil stoppar de övriga.
@@ -145,6 +169,9 @@ export function useWorkOrderFiles(workOrderId: string) {
     setUploadProgress(null);
 
     if (uploaded.length > 0) {
+      // Ogiltigförklara varje GET som är i luften — annars kan filväljarens visibilitychange-hämtning
+      // landa efter det här och radera de nyss uppladdade raderna ur listan.
+      requestSeq.current += 1;
       setFiles((current) => [...uploaded, ...current]);
       toast.success(uploaded.length === 1 ? 'Filen uppladdad' : `${uploaded.length} filer uppladdade`);
     }
@@ -159,6 +186,8 @@ export function useWorkOrderFiles(workOrderId: string) {
       const res = await fetch(`/api/crm/work-orders/${workOrderId}/files/${id}`, { method: 'DELETE' });
       const json = await res.json().catch(() => ({}));
       if (!res.ok || !json.ok) { toast.error(json?.error || 'Kunde inte ta bort filen'); return false; }
+      // Samma skäl som vid uppladdning: en GET i luften får inte återuppliva den raderade raden.
+      requestSeq.current += 1;
       setFiles((current) => current.filter((file) => file.id !== id));
       toast.success('Filen borttagen');
       return true;

--- a/app/crm/arbetsorder/useWorkOrderFiles.ts
+++ b/app/crm/arbetsorder/useWorkOrderFiles.ts
@@ -1,0 +1,169 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { createClientComponentClient } from '@supabase/auth-helpers-nextjs';
+import { useToast } from '@/lib/Toast';
+import { prepareFileForUpload } from '@/lib/shared/imageCompression';
+import type { WorkOrderFileCategory, WorkOrderFileView } from '@/lib/domains/crm/workOrderFiles/types';
+
+// Filer på en arbetsorder — hämtning, uppladdning och radering. Delas av kontorsvyn (/crm) och
+// fältvyn (/arbetsorder) så skrivlogiken bor på ett ställe, precis som useWorkOrderActivity.
+//
+// Uppladdningen går i tre steg och byten passerar ALDRIG en route handler:
+//   1. be servern om en signerad uppladdningslänk (den gatar skrivrätten),
+//   2. ladda upp direkt till lagringen,
+//   3. bekräfta, varpå servern läser filens faktiska storlek/typ och skapar raden.
+// Skälet är ritningarna: en PDF på 20 MB är vanlig och ska inte behöva rymmas i en request-kropp.
+//
+// Som överallt annars i modulen: alla toasts ligger HÄR, aldrig i flikkomponenten, och varje
+// mutation returnerar en boolean så anroparen kan nollställa sitt eget formulär vid framgång.
+export function useWorkOrderFiles(workOrderId: string) {
+  const toast = useToast();
+  const supabase = useMemo(() => createClientComponentClient(), []);
+  const [files, setFiles] = useState<WorkOrderFileView[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [canUpload, setCanUpload] = useState(false);
+  const [canMarkInternal, setCanMarkInternal] = useState(false);
+  const [canDeleteAny, setCanDeleteAny] = useState(false);
+  const [uploadProgress, setUploadProgress] = useState<{ current: number; total: number } | null>(null);
+
+  const load = useCallback(async () => {
+    const res = await fetch(`/api/crm/work-orders/${workOrderId}/files`, { cache: 'no-store' });
+    const json = await res.json().catch(() => ({}));
+    if (!res.ok || !json.ok) return null;
+    return json.data as {
+      items: WorkOrderFileView[];
+      can_upload: boolean;
+      can_mark_internal: boolean;
+      can_delete_any: boolean;
+    };
+  }, [workOrderId]);
+
+  useEffect(() => {
+    let active = true;
+    setLoading(true);
+
+    const apply = (data: Awaited<ReturnType<typeof load>>) => {
+      if (!active || !data) return;
+      setFiles(data.items || []);
+      setCanUpload(!!data.can_upload);
+      setCanMarkInternal(!!data.can_mark_internal);
+      setCanDeleteAny(!!data.can_delete_any);
+    };
+
+    load().then(apply).catch(() => { /* non-fatal */ }).finally(() => { if (active) setLoading(false); });
+
+    // Miniatyrernas URL:er är signerade i 30 minuter (SIGNED_URL_TTL_SECONDS). En arbetsorder ligger
+    // ofta uppe längre än så — kontoret har den öppen halva förmiddagen — och utan omhämtning möts
+    // man då av en flik full av trasiga bilder utan något sätt att få tillbaka dem.
+    // Hämtas om var 25:e minut, med marginal före utgången.
+    const interval = setInterval(() => { load().then(apply).catch(() => { /* non-fatal */ }); }, 25 * 60 * 1000);
+
+    // Fliken kan ha legat i bakgrunden längre än så (en telefon som sovit över natten). Timers
+    // stryps eller pausas då, så vi hämtar också om när användaren kommer tillbaka till fliken.
+    const onVisible = () => { if (document.visibilityState === 'visible') load().then(apply).catch(() => {}); };
+    document.addEventListener('visibilitychange', onVisible);
+
+    return () => {
+      active = false;
+      clearInterval(interval);
+      document.removeEventListener('visibilitychange', onVisible);
+    };
+  }, [load]);
+
+  // En fil hela vägen genom de tre stegen. Kastar vid fel så anroparen kan räkna misslyckanden
+  // per fil utan att en trasig fil stoppar de övriga.
+  async function uploadOne(file: File, meta: { category: WorkOrderFileCategory; isInternal: boolean }) {
+    const prepared = await prepareFileForUpload(file);
+
+    const urlRes = await fetch(`/api/crm/work-orders/${workOrderId}/files/upload-url`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        file_name: prepared.fileName,
+        content_type: prepared.contentType,
+        size_bytes: prepared.blob.size,
+      }),
+    });
+    const urlJson = await urlRes.json().catch(() => ({}));
+    if (!urlRes.ok || !urlJson.ok) throw new Error(urlJson?.error || 'Kunde inte förbereda uppladdningen');
+
+    const { bucket, path, token } = urlJson.data as { bucket: string; path: string; token: string };
+
+    const { error: uploadError } = await supabase.storage
+      .from(bucket)
+      .uploadToSignedUrl(path, token, prepared.blob);
+    if (uploadError) throw new Error(uploadError.message || 'Uppladdningen misslyckades');
+
+    // Bekräftelsen. Servern litar inte på något härifrån utom sökvägen (som den kontrollerar mot
+    // ordern) — storlek och mimetype läser den ur lagringen.
+    const confirmRes = await fetch(`/api/crm/work-orders/${workOrderId}/files`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        storage_path: path,
+        file_name: prepared.fileName,
+        category: meta.category,
+        is_internal: meta.isInternal,
+      }),
+    });
+    const confirmJson = await confirmRes.json().catch(() => ({}));
+    if (!confirmRes.ok || !confirmJson.ok) throw new Error(confirmJson?.error || 'Kunde inte spara filen');
+
+    return confirmJson.data?.item as WorkOrderFileView;
+  }
+
+  async function uploadFiles(
+    selected: File[],
+    meta: { category: WorkOrderFileCategory; isInternal: boolean },
+  ): Promise<boolean> {
+    if (selected.length === 0) return false;
+
+    const total = selected.length;
+    let completed = 0;
+    const uploaded: WorkOrderFileView[] = [];
+    const failures: string[] = [];
+    setUploadProgress({ current: 0, total });
+
+    // Concurrency 3, som dokumentbiblioteket. Fel samlas in per fil i stället för att kasta —
+    // att nio av tio bilder kom fram är ett bättre utfall än att allt rullas tillbaka.
+    const queue = [...selected];
+    const workers = Array.from({ length: Math.min(3, total) }, async () => {
+      for (let next = queue.shift(); next; next = queue.shift()) {
+        try {
+          uploaded.push(await uploadOne(next, meta));
+        } catch (e: any) {
+          failures.push(next.name);
+          if (failures.length === 1 && e?.message) toast.error(e.message);
+        } finally {
+          completed += 1;
+          setUploadProgress({ current: completed, total });
+        }
+      }
+    });
+    await Promise.all(workers);
+    setUploadProgress(null);
+
+    if (uploaded.length > 0) {
+      setFiles((current) => [...uploaded, ...current]);
+      toast.success(uploaded.length === 1 ? 'Filen uppladdad' : `${uploaded.length} filer uppladdade`);
+    }
+    if (failures.length > 0 && uploaded.length > 0) {
+      toast.error(`Kunde inte ladda upp: ${failures.join(', ')}`);
+    }
+    return failures.length === 0;
+  }
+
+  async function deleteFile(id: string): Promise<boolean> {
+    try {
+      const res = await fetch(`/api/crm/work-orders/${workOrderId}/files/${id}`, { method: 'DELETE' });
+      const json = await res.json().catch(() => ({}));
+      if (!res.ok || !json.ok) { toast.error(json?.error || 'Kunde inte ta bort filen'); return false; }
+      setFiles((current) => current.filter((file) => file.id !== id));
+      toast.success('Filen borttagen');
+      return true;
+    } catch { toast.error('Kunde inte ta bort filen'); return false; }
+  }
+
+  return { files, loading, canUpload, canMarkInternal, canDeleteAny, uploadProgress, uploadFiles, deleteFile };
+}

--- a/lib/domains/crm/work-orders.ts
+++ b/lib/domains/crm/work-orders.ts
@@ -4,6 +4,7 @@ import { resolveCrmContact, type CrmContactSource } from './contacts';
 import { computePricing, type PricingLineItem } from './pricing';
 import { activeLineItems, computeInvoiceState, validateLineItemEdit, type InvoiceRound } from '@/lib/domains/fortnox/partialInvoices';
 import { isValidPersonalNumber, PERSONAL_NUMBER_ERROR } from './personalNumber';
+import type { CreateWorkOrderFileInput } from './workOrderFiles/types';
 
 export const crmWorkOrderSelect = `
   id,
@@ -880,4 +881,100 @@ export async function deleteCrmWorkOrderComment(supabase: SupabaseClient, id: st
     .eq('created_by', userId)
     .select('id')
     .maybeSingle();
+}
+
+// ── Filer på ordern (ritningar, förberedelser, foto före/efter) ──────────────
+//
+// INGEN profiles-join, till skillnad från crmWorkOrderCommentSelect ovan. `profiles` är
+// self-read-only (profiles_select_self i auth_roles_setup.sql:71 är enda SELECT-policyn), så
+// `uploader:profiles(full_name)` hade gett null för alla utom en själv — det är samma skäl som
+// gör att listMentionableProfiles går via admin-klienten. Uppladdarens namn snapshottas därför i
+// created_by_name när raden skapas.
+export const crmWorkOrderFileSelect = `
+  id,
+  work_order_id,
+  category,
+  is_internal,
+  file_name,
+  storage_bucket,
+  storage_path,
+  content_type,
+  size_bytes,
+  created_by,
+  created_by_name,
+  created_at
+`;
+
+export async function listCrmWorkOrderFiles(supabase: SupabaseClient, workOrderId: string) {
+  return supabase
+    .from('crm_work_order_files')
+    .select(crmWorkOrderFileSelect)
+    .eq('work_order_id', workOrderId)
+    .order('created_at', { ascending: false });
+}
+
+export async function createCrmWorkOrderFile(supabase: SupabaseClient, input: CreateWorkOrderFileInput) {
+  return supabase.from('crm_work_order_files').insert(input).select(crmWorkOrderFileSelect).single();
+}
+
+// Finns redan en rad som pekar på det här objektet?
+//
+// Bekräftelsesteget städar bort objektet när raden inte kan skrivas, och den städningen får ALDRIG
+// träffa en fil som redan tillhör någon. Sökvägen till en bild går att läsa ut ur den signerade
+// URL:en i listan, så en klient kan spela tillbaka en sökväg som redan är registrerad — och utan
+// den här kontrollen hade ett nekat insert då raderat den befintliga filens byte.
+// Ett unikt index på storage_path är backstoppen; det här är det begripliga svaret (409).
+export async function findCrmWorkOrderFileByPath(supabase: SupabaseClient, storagePath: string) {
+  return supabase
+    .from('crm_work_order_files')
+    .select('id')
+    .eq('storage_path', storagePath)
+    .maybeSingle();
+}
+
+export async function getCrmWorkOrderFile(supabase: SupabaseClient, fileId: string, workOrderId: string) {
+  return supabase
+    .from('crm_work_order_files')
+    .select(crmWorkOrderFileSelect)
+    .eq('id', fileId)
+    .eq('work_order_id', workOrderId)
+    .maybeSingle();
+}
+
+// `ownerId = null` betyder kontoret (crm.workorder.write) — ingen ägarfiltrering. Annars filtreras
+// raden på uppladdaren, så en installatör bara kan ta bort sitt eget.
+//
+// Ägarskapet uttrycks som predikat i queryn och inte som en assert, precis som
+// deleteCrmWorkOrderComment: en främmande rad matchar helt enkelt ingenting och routen svarar 404.
+// `.eq('work_order_id', ...)` är inte överflödigt trots att id:t är unikt — utan den kan ett
+// fil-id från en ANNAN order raderas genom den här orderns adress.
+//
+// Raden raderas FÖRE objektet och returnerar sin adress i samma vända, till skillnad från
+// dokumentbiblioteket som läser först och raderar sen. En rundtur i stället för två, och
+// radraderingen blir atomär. Misslyckas storage-städningen efteråt ligger byte kvar utan rad —
+// osynligt skräp, vilket är den bättre av de två felmoderna (en rad som pekar på ingenting ger
+// ett trasigt kort i listan).
+export async function deleteCrmWorkOrderFile(
+  supabase: SupabaseClient,
+  fileId: string,
+  workOrderId: string,
+  ownerId: string | null,
+) {
+  const query = supabase
+    .from('crm_work_order_files')
+    .delete()
+    .eq('id', fileId)
+    .eq('work_order_id', workOrderId);
+
+  if (ownerId) query.eq('created_by', ownerId);
+
+  return query.select('id, storage_bucket, storage_path').maybeSingle();
+}
+
+// Besättningsfrågan, ställd till samma SECURITY DEFINER-funktion som RLS-policyerna kallar
+// (20260810_crm_work_order_crew_access.sql). Routen som gatar en skrivning måste ge SAMMA svar som
+// policyn — härleder den i stället svaret ur rollen glider de två isär, och användaren får ett
+// 200 på något databasen sedan tyst nekar.
+export async function isUserOnWorkOrder(supabase: SupabaseClient, userId: string, workOrderId: string) {
+  return supabase.rpc('is_user_on_work_order', { p_uid: userId, p_wo: workOrderId });
 }

--- a/lib/domains/crm/workOrderFiles/mappers.ts
+++ b/lib/domains/crm/workOrderFiles/mappers.ts
@@ -1,0 +1,31 @@
+import { toWorkOrderFileCategory, type WorkOrderFileRow, type WorkOrderFileView } from './types';
+
+// Rad → vy. `storage_bucket` och `storage_path` följer inte med som fält.
+//
+// ⚠️ DET ÄR INTE SAMMA SAK SOM ATT SÖKVÄGEN ÄR HEMLIG. En signerad URL har formen
+// `/object/sign/<bucket>/<path>?token=…`, så för varje rad som får en miniatyr kan klienten läsa
+// ut både bucket och sökväg ur URL:en. Att utelämna fälten håller bara nere ytan — det är ingen
+// säkerhetsgräns, och inget får bero på att sökvägen är okänd.
+//
+// Det som faktiskt bär säkerheten ligger på skrivsidan: uppladdarens id är en del av sökvägen, och
+// bekräftelsesteget avvisar både en sökväg som inte är anroparens egen och en som redan är
+// registrerad (app/api/crm/work-orders/[id]/files/route.ts). Utan dem hade en läsbehörig användare
+// kunnat spela tillbaka en sökväg härifrån och få filen raderad.
+//
+// SUPABASE_CONVENTIONS: "Row-level is not column-level" — policyn öppnar raden, kolumngränsen dras
+// här.
+export function mapWorkOrderFileRow(row: WorkOrderFileRow, url: string | null): WorkOrderFileView {
+  return {
+    id: row.id,
+    work_order_id: row.work_order_id,
+    category: toWorkOrderFileCategory(row.category),
+    is_internal: row.is_internal,
+    file_name: row.file_name,
+    content_type: row.content_type,
+    size_bytes: row.size_bytes,
+    created_by: row.created_by,
+    created_by_name: row.created_by_name,
+    created_at: row.created_at,
+    url,
+  };
+}

--- a/lib/domains/crm/workOrderFiles/storage.ts
+++ b/lib/domains/crm/workOrderFiles/storage.ts
@@ -1,0 +1,161 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+// Lagring för arbetsorderfiler.
+//
+// VARFÖR INGEN EGEN BUCKET: samma svar som för appärendena (lib/domains/support/storage.ts rad
+// 5-9). Den befintliga bucketen används redan med prefix per område (Documents/, Egenkontroller/,
+// Support/) och all läsning sker via signerade URL:er som servern skapar med service-role-nyckeln.
+// En ny bucket hade krävt egna storage-policyer utan att ge något — åtkomsten gatas ändå av
+// crm_work_order_files-RLS innan URL:en signeras. Bucketnamnet sparas per rad i DB
+// (storage_bucket), så en framtida flytt inte gör gamla rader olästbara.
+
+const WORK_ORDER_FILE_PREFIX = 'Arbetsorder';
+
+// Signerad URL:s livstid. Kort med flit — den passerar genom ett JSON-svar och hamnar i
+// webbläsarhistorik och loggar. 30 minuter är samma tid som dokumentbiblioteket och appärendena
+// använder; en fjärde TTL i en fjärde modul vore sämre än marginalen den köper.
+export const SIGNED_URL_TTL_SECONDS = 60 * 30;
+
+export function getWorkOrderFileBucket(): string {
+  return process.env.SUPABASE_WORK_ORDER_FILES_BUCKET || process.env.SUPABASE_BUCKET || 'pdfs';
+}
+
+// Samma teckenregler som dokumentbiblioteket och appärendena — duplicerad med flit: domänlagret
+// ska inte importera ur app/api, och support-domänen är inte vår att bero på. Tar bort
+// sökvägstecken och allt utanför [A-Za-z0-9_.-] (åäö blir `_`) så storage-nyckeln blir ren ASCII.
+// Filnamnet i DB (file_name) bär det riktiga namnet, så förlusten är bara kosmetisk i sökvägen.
+export function sanitizeWorkOrderFileName(name: string): string {
+  const cleaned = String(name || '')
+    .trim()
+    .replace(/[\\/]+/g, '-')
+    .replace(/\s+/g, '-')
+    .replace(/\.+\./g, '.')
+    .replace(/[^\w.-]+/g, '_')
+    .trim();
+  return cleaned.slice(0, 120) || 'fil';
+}
+
+// Sökvägen bär BÅDE arbetsordern och uppladdaren:
+//   Arbetsorder/<work_order_id>/<uploader_id>/<uuid>-<sanerat namn>
+//
+// Uppladdarsegmentet är inte bokföring utan en spärr. Sökvägen till en bild går att läsa ut ur den
+// signerade URL:en vi skickar till klienten (Supabase signerar `/object/sign/<bucket>/<path>?token`),
+// så vad som helst i listan kan spelas tillbaka till bekräftelsesteget. Ligger någon annans id i
+// sökvägen kan den aldrig passera isWorkOrderFilePath för den som skickar den, och en läsbehörig
+// användare kan därmed inte peka ut kontorets ritning och få den behandlad som sin egen.
+export function buildWorkOrderFileDir(workOrderId: string, uploaderId: string): string {
+  return `${WORK_ORDER_FILE_PREFIX}/${workOrderId}/${uploaderId}`;
+}
+
+export function buildWorkOrderFilePath(
+  workOrderId: string,
+  uploaderId: string,
+  fileName: string,
+  uid: string,
+): string {
+  return `${buildWorkOrderFileDir(workOrderId, uploaderId)}/${uid}-${sanitizeWorkOrderFileName(fileName)}`;
+}
+
+// Klienten laddar upp direkt till lagringen och skickar sedan tillbaka sökvägen den fick. Den
+// sökvägen är ett PÅSTÅENDE tills vi kontrollerat den: en signerad upload-token binder bara
+// sökvägen, och en klient som hittar på en annan sökväg hade kunnat koppla ett Support/- eller
+// Documents/-objekt — eller en kollegas fil — till sin egen arbetsorder. Därför den här; den ska
+// anropas på VARJE väg som tar emot en sökväg utifrån.
+export function isWorkOrderFilePath(path: string, workOrderId: string, uploaderId: string): boolean {
+  if (typeof path !== 'string' || path.length === 0) return false;
+  if (!uploaderId) return false;
+  if (path.includes('..')) return false;
+  const dir = `${buildWorkOrderFileDir(workOrderId, uploaderId)}/`;
+  if (!path.startsWith(dir)) return false;
+  // Exakt en nivå under katalogen — inga egna underkataloger.
+  return !path.slice(dir.length).includes('/');
+}
+
+// Myntar en engångs-URL som klienten laddar upp till. Ingen DB-rad skapas här: raden skrivs först
+// när uppladdningen bekräftats, så en avbruten uppladdning aldrig lämnar en rad som pekar på
+// ingenting. Motsatt ordning (rad först) hade gett trasiga kort i listan.
+export async function createWorkOrderFileUploadUrl(
+  admin: SupabaseClient,
+  bucket: string,
+  path: string,
+): Promise<{ signedUrl: string | null; token: string | null; error: { message: string } | null }> {
+  const { data, error } = await admin.storage.from(bucket).createSignedUploadUrl(path);
+  if (error || !data) return { signedUrl: null, token: null, error: { message: error?.message || 'Kunde inte skapa uppladdningslänk.' } };
+  return { signedUrl: data.signedUrl, token: data.token, error: null };
+}
+
+// Läser objektets FAKTISKA storlek och mimetype ur lagringen. Det är den enda försvarslinjen mot
+// en klient som påstod 2 MB och laddade upp 40 — upload-token bär ingen storleks- eller
+// typbindning.
+//
+// `list(dir, { search })` och inte `.info(path)`: info() bygger /object/info/<bucket>/<path> i
+// storage-js 2.7.0, utan `authenticated`-segmentet, och är opålitlig mot en privat bucket.
+// list() är dessutom det anrop repot redan använder (app/api/storage/list-all/route.ts).
+export async function readWorkOrderFileInfo(
+  admin: SupabaseClient,
+  bucket: string,
+  path: string,
+): Promise<{ size: number; contentType: string | null } | null> {
+  const lastSlash = path.lastIndexOf('/');
+  const dir = lastSlash >= 0 ? path.slice(0, lastSlash) : '';
+  const name = lastSlash >= 0 ? path.slice(lastSlash + 1) : path;
+
+  const { data, error } = await admin.storage.from(bucket).list(dir, { limit: 1, search: name });
+  if (error || !data) return null;
+
+  // `search` är en delsträngsmatchning, inte en exakt träff — jämför namnet själv.
+  const match = data.find((entry) => entry.name === name);
+  if (!match) return null;
+
+  const metadata = (match.metadata || {}) as { size?: number; mimetype?: string };
+  return {
+    size: typeof metadata.size === 'number' ? metadata.size : 0,
+    contentType: metadata.mimetype || null,
+  };
+}
+
+// Batch-signering för listan: ETT anrop för alla sökvägar i stället för N. createSignedUrls
+// returnerar ett `error` PER RAD — en fil vars objekt saknas ger ingen URL, och den raden ska
+// renderas som "kunde inte hämtas" i stället för att fälla hela svaret.
+export async function signWorkOrderFileUrls(
+  admin: SupabaseClient,
+  bucket: string,
+  paths: string[],
+): Promise<Map<string, string>> {
+  const urls = new Map<string, string>();
+  if (paths.length === 0) return urls;
+
+  const { data, error } = await admin.storage.from(bucket).createSignedUrls(paths, SIGNED_URL_TTL_SECONDS);
+  if (error || !data) return urls;
+
+  for (const entry of data) {
+    if (entry.path && entry.signedUrl && !entry.error) urls.set(entry.path, entry.signedUrl);
+  }
+  return urls;
+}
+
+// Enskild läs-URL. Anroparen MÅSTE ha gatat åtkomsten först (RLS-läsningen av raden) — den här
+// funktionen använder service-role och frågar inte vem som tittar.
+// `downloadName` sätter Content-Disposition: attachment, samma knep som dokumentbiblioteket
+// använder för att skilja "förhandsgranska" från "ladda ner" på samma URL-generator.
+export async function signWorkOrderFileUrl(
+  admin: SupabaseClient,
+  bucket: string,
+  path: string,
+  downloadName?: string,
+): Promise<string | null> {
+  const { data, error } = await admin.storage
+    .from(bucket)
+    .createSignedUrl(path, SIGNED_URL_TTL_SECONDS, downloadName ? { download: downloadName } : undefined);
+  if (error || !data?.signedUrl) return null;
+  return data.signedUrl;
+}
+
+// Best-effort städning. Ett kvarglömt objekt är skräp, inte ett fel användaren ska se.
+export async function removeWorkOrderFileObject(admin: SupabaseClient, bucket: string, path: string): Promise<void> {
+  try {
+    await admin.storage.from(bucket).remove([path]);
+  } catch {
+    /* ignoreras med flit */
+  }
+}

--- a/lib/domains/crm/workOrderFiles/types.ts
+++ b/lib/domains/crm/workOrderFiles/types.ts
@@ -1,0 +1,87 @@
+// Typer och kategorikatalog för filer på arbetsordern.
+//
+// Kategorierna bor HÄR och ingen annanstans: Zod-schemat i app/api/crm/work-orders/_lib.ts läser
+// arrayen, UI:t läser etikettkartan, och ett test låser båda mot CHECK-listan i
+// supabase/sql/20260815_crm_work_order_files.sql. En array, tre konsumenter.
+
+export const WORK_ORDER_FILE_CATEGORIES = [
+  'drawing',
+  'preparation',
+  'photo_before',
+  'photo_after',
+  'other',
+] as const;
+
+export type WorkOrderFileCategory = (typeof WORK_ORDER_FILE_CATEGORIES)[number];
+
+// Databasen håller stabila engelska nycklar; svenskan lever bara i visningslagret.
+export const workOrderFileCategoryLabel: Record<WorkOrderFileCategory, string> = {
+  drawing: 'Ritning',
+  preparation: 'Förberedelser',
+  photo_before: 'Foto före',
+  photo_after: 'Foto efter',
+  other: 'Övrigt',
+};
+
+// Visningsordningen i fliken. Ritningen först — den är det installatören öppnar ordern för.
+export const WORK_ORDER_FILE_CATEGORY_ORDER: readonly WorkOrderFileCategory[] = [
+  'drawing',
+  'preparation',
+  'photo_before',
+  'photo_after',
+  'other',
+];
+
+export function toWorkOrderFileCategory(value: unknown): WorkOrderFileCategory {
+  return WORK_ORDER_FILE_CATEGORIES.includes(value as WorkOrderFileCategory)
+    ? (value as WorkOrderFileCategory)
+    : 'other';
+}
+
+// Raden som den ligger i databasen.
+export type WorkOrderFileRow = {
+  id: string;
+  work_order_id: string;
+  category: string;
+  is_internal: boolean;
+  file_name: string;
+  storage_bucket: string;
+  storage_path: string;
+  content_type: string | null;
+  size_bytes: number | null;
+  created_by: string | null;
+  created_by_name: string;
+  created_at: string;
+};
+
+// Raden som den lämnar servern. `storage_bucket` och `storage_path` är MEDVETET utelämnade —
+// klienten behöver bara den signerade URL:en, och sökvägen är en intern lokaliserare som inte har
+// på en klient att göra (SUPABASE_CONVENTIONS: "Row-level is not column-level").
+export type WorkOrderFileView = {
+  id: string;
+  work_order_id: string;
+  category: WorkOrderFileCategory;
+  is_internal: boolean;
+  file_name: string;
+  content_type: string | null;
+  size_bytes: number | null;
+  created_by: string | null;
+  created_by_name: string;
+  created_at: string;
+  // Kortlivad signerad URL. Sätts bara för bilder (miniatyrer i listan); PDF får null och öppnas
+  // via /files/<id>?redirect=1 vid klick, så vi inte signerar det som ändå inte visas.
+  url: string | null;
+};
+
+export type CreateWorkOrderFileInput = {
+  work_order_id: string;
+  category: WorkOrderFileCategory;
+  is_internal: boolean;
+  file_name: string;
+  storage_bucket: string;
+  storage_path: string;
+  content_type: string | null;
+  size_bytes: number | null;
+  created_by: string;
+  created_by_name: string;
+};

--- a/lib/domains/crm/workOrderFiles/validation.ts
+++ b/lib/domains/crm/workOrderFiles/validation.ts
@@ -1,0 +1,55 @@
+// Validering av filer på arbetsordern. Sidoeffektfri med flit — den körs på två ställen (på det
+// PÅSTÅDDA innan vi myntar en upload-URL, och på det FAKTISKA när vi läser objektet ur storage
+// efteråt) och enhetstestas fristående.
+//
+// Speglar validateScreenshot i lib/domains/support/schemas.ts, med tre skillnader: PDF är tillåtet
+// (ritningen är hela poängen), taket är högre (en arkitektritning är inte en skärmdump), och gif
+// är borta (ingen har bett om animerade bilder på ett jobb).
+
+// 25 MB. En okomprimerad ritning ligger typiskt på 5-20 MB; bilder komprimeras på klienten till
+// ~2 MB innan de går iväg. Taket finns för att en felvald fil ska stoppas, inte för att strypa
+// riktiga ritningar. Byten passerar aldrig våra funktioner (klienten laddar upp direkt till
+// lagringen med en signerad URL), så taket är en produktregel och inte en plattformsgräns.
+export const WORK_ORDER_FILE_MAX_BYTES = 25 * 1024 * 1024;
+
+export const WORK_ORDER_FILE_CONTENT_TYPES = [
+  'image/jpeg',
+  'image/png',
+  'image/webp',
+  'image/heic',
+  'image/heif',
+  'application/pdf',
+] as const;
+
+const ALLOWED_EXTENSION_RE = /\.(jpe?g|png|webp|heic|heif|pdf)$/i;
+const TYPE_ERROR = 'Bara bilder (jpg, png, webp, heic) och PDF kan laddas upp.';
+
+export function validateWorkOrderFile(file: { size: number; type: string; name: string }): string | null {
+  if (file.size === 0) return 'Filen är tom.';
+  if (file.size > WORK_ORDER_FILE_MAX_BYTES) return 'Filen är för stor (max 25 MB).';
+
+  // Vissa mobilbrowsers skickar tom type för HEIC — fall tillbaka på filändelsen. Utan den här
+  // grenen kan en installatör inte ladda upp från iPhone alls.
+  const type = (file.type || '').toLowerCase();
+  if (type) {
+    if (!WORK_ORDER_FILE_CONTENT_TYPES.includes(type as (typeof WORK_ORDER_FILE_CONTENT_TYPES)[number])) {
+      return TYPE_ERROR;
+    }
+    return null;
+  }
+
+  if (!ALLOWED_EXTENSION_RE.test(file.name)) return TYPE_ERROR;
+  return null;
+}
+
+// Styr om raden får en signerad miniatyr-URL i listsvaret. PDF renderas som ikon och signeras
+// först vid klick — annars signerar vi N URL:er som ingen tittar på.
+//
+// HEIC räknas INTE som förhandsvisbar: Chrome och Firefox på desktop renderar inte HEIC i <img>,
+// så en miniatyr hade blivit en trasig bildikon. Klienten konverterar normalt HEIC till JPEG före
+// uppladdning; en HEIC som ändå tagit sig hit visas som filkort.
+export function isPreviewableImage(contentType: string | null): boolean {
+  if (!contentType) return false;
+  const type = contentType.toLowerCase();
+  return type === 'image/jpeg' || type === 'image/png' || type === 'image/webp';
+}

--- a/lib/shared/imageCompression.ts
+++ b/lib/shared/imageCompression.ts
@@ -1,0 +1,122 @@
+// Klientsidig bildkomprimering.
+//
+// Lyft ur app/egenkontroll/page.tsx (som fortsätter använda sin egen data-URL-variant — PDF:en den
+// bygger behöver en data-URL, och den här skivan rör inte egenkontrollen). Skillnaden här är
+// `canvas.toBlob` i stället för `toDataURL`: resultatet ska laddas upp som binär fil, och en
+// data-URL hade svällt den ~33 % på vägen.
+//
+// Ingen "use client" behövs — modulen importeras bara av klientkomponenter, men den rör inga React-
+// API:er och kan därför enhetstestas som vanlig kod.
+
+// createImageBitmap med `imageOrientation: 'from-image'` är raden som gör att mobilfoton inte
+// kommer in liggande: telefonen lagrar bilden i sensorns riktning och rotationen i EXIF, och en
+// canvas som ritar bitmappen rakt av tappar den. Fallbacken via <img> finns för äldre webbläsare.
+async function loadBitmap(file: Blob): Promise<ImageBitmap | HTMLImageElement> {
+  try {
+    if (typeof createImageBitmap === 'function') {
+      return await createImageBitmap(file, { imageOrientation: 'from-image' });
+    }
+  } catch {
+    /* faller igenom till <img> nedan */
+  }
+  const img = new Image();
+  img.decoding = 'async';
+  const url = URL.createObjectURL(file);
+  return await new Promise((resolve, reject) => {
+    img.onload = () => { URL.revokeObjectURL(url); resolve(img); };
+    img.onerror = (e) => { URL.revokeObjectURL(url); reject(e); };
+    img.src = url;
+  });
+}
+
+export async function compressImageToBlob(file: Blob, maxDim = 1600, quality = 0.72): Promise<Blob> {
+  const bmp = await loadBitmap(file);
+  const sw = 'width' in bmp ? (bmp as any).width : (bmp as any).naturalWidth;
+  const sh = 'height' in bmp ? (bmp as any).height : (bmp as any).naturalHeight;
+  const scale = Math.min(1, maxDim / Math.max(sw, sh));
+  const tw = Math.max(1, Math.round(sw * scale));
+  const th = Math.max(1, Math.round(sh * scale));
+
+  const canvas = document.createElement('canvas');
+  canvas.width = tw;
+  canvas.height = th;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) throw new Error('Canvas stöds inte');
+  ctx.imageSmoothingQuality = 'high';
+  ctx.imageSmoothingEnabled = true;
+  ctx.drawImage(bmp as any, 0, 0, tw, th);
+
+  const blob = await new Promise<Blob | null>((resolve) => canvas.toBlob(resolve, 'image/jpeg', quality));
+  try { (bmp as any).close?.(); } catch { /* ignoreras */ }
+  if (!blob) throw new Error('Kunde inte komprimera bilden');
+  return blob;
+}
+
+// Trappa nedåt tills filen ryms under taket. Samma steg som egenkontrollen använder — de är
+// intrimmade mot riktiga mobilbilder.
+export async function compressImageUnderCap(file: Blob, capBytes = 2_000_000): Promise<Blob> {
+  const attempts = [
+    { maxDim: 1600, q: 0.72 },
+    { maxDim: 1280, q: 0.65 },
+    { maxDim: 1024, q: 0.6 },
+    { maxDim: 800, q: 0.6 },
+  ];
+  let last: Blob | null = null;
+  for (const attempt of attempts) {
+    const blob = await compressImageToBlob(file, attempt.maxDim, attempt.q);
+    last = blob;
+    if (blob.size <= capBytes) return blob;
+  }
+  if (!last) throw new Error('Kunde inte komprimera bilden');
+  return last;
+}
+
+// Härleder mimetype ur filändelsen när webbläsaren inte satte någon. Safari och en del
+// Android-webbläsare skickar tom `type` för HEIC.
+const EXTENSION_CONTENT_TYPES: Record<string, string> = {
+  pdf: 'application/pdf',
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  png: 'image/png',
+  webp: 'image/webp',
+  heic: 'image/heic',
+  heif: 'image/heif',
+};
+
+export function guessContentTypeFromName(name: string): string {
+  const ext = (name.split('.').pop() || '').toLowerCase();
+  return EXTENSION_CONTENT_TYPES[ext] || 'application/octet-stream';
+}
+
+// Förbereder en vald fil för uppladdning.
+//
+// PDF passerar orört — en ritning går inte att komprimera och ska inte heller behöva det.
+//
+// Bilder konverteras till JPEG, vilket gör mer än att spara bandbredd: det löser HEIC-visningen.
+// Chrome och Firefox på desktop renderar inte HEIC i <img>, så ett okonverterat fältfoto hade
+// blivit en trasig miniatyr för kontoret. Misslyckas konverteringen (Chrome kan inte avkoda HEIC
+// alls) laddas originalet upp — hellre en fil utan miniatyr än ingen fil.
+//
+// ⚠️ BLOBBEN MÅSTE BÄRA RÄTT `type`. `uploadToSignedUrl` lägger en Blob i en FormData-del utan att
+// sätta content-type (fileOptions.contentType används BARA för strömmar, se storage-js 2.7.0), så
+// lagringen härleder mimetypen ur blobbens egen type. En HEIC med tom type hade blivit
+// application/octet-stream i bucketen — och sedan avvisats av vår egen validering på vägen
+// tillbaka. Därför packas fallbacken om med en härledd type.
+export async function prepareFileForUpload(file: File): Promise<{ blob: Blob; fileName: string; contentType: string }> {
+  const declaredType = (file.type || '').toLowerCase();
+  const type = declaredType || guessContentTypeFromName(file.name);
+
+  if (type === 'application/pdf') {
+    const blob = declaredType ? file : new Blob([file], { type });
+    return { blob, fileName: file.name, contentType: type };
+  }
+
+  try {
+    const blob = await compressImageUnderCap(file);
+    const fileName = file.name.replace(/\.[^.]+$/, '') + '.jpg';
+    return { blob, fileName, contentType: 'image/jpeg' };
+  } catch {
+    const blob = declaredType ? file : new Blob([file], { type });
+    return { blob, fileName: file.name, contentType: type };
+  }
+}

--- a/supabase/sql/20260815_crm_work_order_files.sql
+++ b/supabase/sql/20260815_crm_work_order_files.sql
@@ -1,0 +1,203 @@
+-- Filer på arbetsordern — ritningar, förberedelser, foto före/efter.
+--
+-- VARFÖR: installatörerna ska kunna förbereda dagen ur ordern i stället för ur en tråd i mobilen.
+-- Både kontoret och besättningen laddar upp; interna filer är dolda för fält.
+--
+-- VARFÖR INGEN NY BUCKET, INGA STORAGE-POLICYER: samma linje som Support och Dokument. Den
+-- befintliga privata bucketen används med prefix per område (Documents/, Egenkontroller/,
+-- Support/, nu Arbetsorder/). All läsning sker via en kortlivad signerad URL som servern skapar
+-- med service-role EFTER att policyerna nedan gatat raden. Bucketnamnet sparas PER RAD, så en
+-- framtida bucketflytt inte gör gamla rader olästbara.
+--
+-- VARFÖR created_by_name: `profiles` är self-read-only (profiles_select_self i
+-- auth_roles_setup.sql:71 är enda SELECT-policyn), så en PostgREST-join `uploader:profiles(...)`
+-- ger null för alla utom en själv — det är redan skälet till att listMentionableProfiles går via
+-- admin-klienten. Namnet snapshottas på raden, precis som app_tickets.reporter_name och
+-- fault_reports.reporter_name, med samma motivering.
+--
+-- DEPLOY-ORDNING: KÖR DEN HÄR FILEN FÖRE KODEN. Ändringen är helt additiv (ny tabell, inga
+-- ändringar på befintliga objekt), men utan tabellen myntar upload-url-routen en signerad URL,
+-- klienten laddar upp bytes över mobilnätet, och bekräftelsen dör på "relation does not exist" —
+-- fail-closed men fult, och användaren har redan betalat för uppladdningen.
+--
+-- Kör i Supabase SQL editor. Idempotent (kör den två gånger innan du litar på påståendet).
+
+-- ---------------------------------------------------------------------------
+-- Tabell
+-- ---------------------------------------------------------------------------
+
+create table if not exists public.crm_work_order_files (
+  id              uuid primary key default gen_random_uuid(),
+  work_order_id   uuid not null references public.crm_work_orders(id) on delete cascade,
+
+  -- text + CHECK, inte enum och inte uppslagstabell: samma stil som crm_work_orders.status,
+  -- crm_customers.status och app_tickets.area. Enum går inte att utöka idempotent (`alter type
+  -- ... add value` kan inte köras om), och fem fasta värden är ingen datamängd att förvalta i en
+  -- egen tabell. Svenska etiketter bor i lib/domains/crm/workOrderFiles/types.ts; databasen håller
+  -- stabila engelska nycklar.
+  category        text not null default 'other',
+
+  -- Intern = dold för fält. `not null default false` är inte kosmetik: en nullbar kolumn hade
+  -- gjort `is_internal = false` i SELECT-policyn nedan FALSK för NULL, och varje rad utan
+  -- uttryckligt värde hade blivit osynlig för hela besättningen — ett tyst, totalt bortfall.
+  is_internal     boolean not null default false,
+
+  file_name       text not null,
+  storage_bucket  text not null,
+  storage_path    text not null,
+  content_type    text,
+  size_bytes      bigint,
+
+  -- on delete set null: en avslutad anställd ska inte hindra radering av profilen, och filen
+  -- (ritningen) ska överleva. created_by_name bär visningen vidare, se huvudet.
+  created_by      uuid references public.profiles(id) on delete set null,
+  created_by_name text not null,
+  created_at      timestamptz not null default now(),
+
+  constraint crm_work_order_files_category_chk
+    check (category in ('drawing', 'preparation', 'photo_before', 'photo_after', 'other'))
+);
+
+-- MEDVETET INGET UNIKT INDEX PÅ (work_order_id, lower(file_name)) — till skillnad från
+-- documents_files. Två foton från samma telefon heter ofta IMG_0001.HEIC, och att andra bilden
+-- avvisas som dubblett är fel svar på ett jobb där hela poängen är att dokumentera.
+
+-- Listfrågan: where work_order_id = $1 order by created_at desc.
+create index if not exists crm_work_order_files_work_order_idx
+  on public.crm_work_order_files (work_order_id, created_at desc);
+
+-- Stöder policy-predikatet created_by = auth.uid() (SELECT + DELETE).
+create index if not exists crm_work_order_files_created_by_idx
+  on public.crm_work_order_files (created_by);
+
+-- ⚠️ SÄKERHETSSPÄRR, inte en datastädning. Ett lagringsobjekt får bäras av exakt EN rad.
+--
+-- Bekräftelsesteget (POST /files) städar bort objektet när raden inte kan skrivas. Sökvägen till en
+-- bild går att läsa ut ur den signerade URL:en som listan skickar till klienten, så en klient kan
+-- spela tillbaka en sökväg som redan tillhör någon annan. Utan det här indexet skulle en andra rad
+-- kunna registrera samma objekt — och när den raden tas bort försvinner byten under den första
+-- radens fötter, som då blir ett trasigt kort i listan.
+-- Routen kontrollerar samma sak i förväg och svarar 409; indexet är spärren som håller även om
+-- kontrollen någon gång tas bort.
+create unique index if not exists crm_work_order_files_storage_path_key
+  on public.crm_work_order_files (storage_path);
+
+alter table public.crm_work_order_files enable row level security;
+
+-- ---------------------------------------------------------------------------
+-- Grants
+-- ---------------------------------------------------------------------------
+-- En radpolicy gör INGENTING utan tabellprivilegiet: PostgreSQL nekar satsen innan RLS ens
+-- utvärderas. Repot har blivit bitet av precis det en gång
+-- (20260629_crm_work_order_comments_update_grant.sql — varje kommentarsredigering gav 500 i drift).
+--
+-- INGEN UPDATE, med flit — och därför inte heller någon UPDATE-policy. Att i efterhand ändra
+-- kategori eller kryssa i "intern" ingår inte i den här omgången, och ett grant utan policy är
+-- lika fel som en policy utan grant. Vill man ha det senare är det en egen liten fil med BÅDA:
+--   grant update on public.crm_work_order_files to authenticated;
+--   create policy crm_wo_files_update on public.crm_work_order_files for update to authenticated
+--     using (public.has_permission('crm.workorder.write'))
+--     with check (public.has_permission('crm.workorder.write'));
+grant select, insert, delete on public.crm_work_order_files to authenticated;
+
+-- ---------------------------------------------------------------------------
+-- Policyer
+-- ---------------------------------------------------------------------------
+-- Grenordning: billigast först (samma princip som 20260811_time_entries_rls.sql:54-77).
+-- Kolumnjämförelse → has_permission (ett svar per fråga) → is_user_on_work_order (slår i
+-- ops_segments/ops_*_crew och kan utvärderas per rad). Inuti besättningsgrenen står
+-- `is_internal = false` FÖRE funktionen, så en intern rad aldrig kostar ett funktionsanrop.
+--
+-- INGEN assigned_to-gren, till skillnad från crm_work_orders_select_visible. crm_work_orders.assigned_to
+-- pekar på ansvarig kontorsanvändare, och de bär alla crm.workorder.read — grenen hade varit död
+-- vikt som besättningen betalar för på varje rad. Kontrollera antagandet en gång, se verifiering 6.
+--
+-- Hjälpfunktionen public.is_user_on_work_order(uuid, uuid) finns sedan
+-- 20260810_crm_work_order_crew_access.sql och definieras INTE om här.
+
+drop policy if exists crm_wo_files_select on public.crm_work_order_files;
+create policy crm_wo_files_select
+  on public.crm_work_order_files
+  for select
+  to authenticated
+  using (
+    created_by = auth.uid()
+    or public.has_permission('crm.workorder.read')
+    or (is_internal = false and public.is_user_on_work_order(auth.uid(), work_order_id))
+  );
+
+-- INSERT: alltid som sig själv. Kontoret behöver crm.workorder.WRITE — konsult är läsbehörig i
+-- hela CRM (crm.workorder.read men inte .write, se 20260608_permissions_model.sql:263) och ska
+-- inte kunna ladda upp. Besättningen får ladda upp på sitt eget jobb men ALDRIG internt: det
+-- villkoret sitter här och inte bara i routen, så en handskriven POST inte kan gömma en fil för
+-- sina kollegor.
+drop policy if exists crm_wo_files_insert on public.crm_work_order_files;
+create policy crm_wo_files_insert
+  on public.crm_work_order_files
+  for insert
+  to authenticated
+  with check (
+    created_by = auth.uid()
+    and (
+      public.has_permission('crm.workorder.write')
+      or (is_internal = false and public.is_user_on_work_order(auth.uid(), work_order_id))
+    )
+  );
+
+-- DELETE: var och en raderar sitt eget, kontoret raderar allt på ordern. Installatören kan alltså
+-- ångra en felvänd bild men inte råka ta bort kontorets ritning.
+-- `write` och inte `read` — annars hade konsult kunnat radera andras filer.
+drop policy if exists crm_wo_files_delete on public.crm_work_order_files;
+create policy crm_wo_files_delete
+  on public.crm_work_order_files
+  for delete
+  to authenticated
+  using (
+    created_by = auth.uid()
+    or public.has_permission('crm.workorder.write')
+  );
+
+-- ── Verifiering (kör efter applicering) ──────────────────────────────────────
+--
+-- 1. Tre policyer, RLS på, och INGEN update-policy (den ska saknas i den här omgången):
+--
+--      select policyname, cmd from pg_policies
+--      where schemaname = 'public' and tablename = 'crm_work_order_files'
+--      order by cmd, policyname;
+--
+--      select relrowsecurity from pg_class where oid = 'public.crm_work_order_files'::regclass;
+--
+-- 2. Grants ska vara exakt SELECT/INSERT/DELETE för authenticated — inget UPDATE:
+--
+--      select privilege_type from information_schema.role_table_grants
+--      where table_schema = 'public' and table_name = 'crm_work_order_files'
+--        and grantee = 'authenticated'
+--      order by 1;
+--
+-- 3. CHECK:en ska neka en okänd kategori (förväntat: fel om crm_work_order_files_category_chk):
+--
+--      insert into public.crm_work_order_files
+--        (work_order_id, category, file_name, storage_bucket, storage_path, created_by_name)
+--      values ('<work_order_id>', 'sketch', 'x.pdf', 'pdfs', 'Arbetsorder/x', 'Test');
+--
+-- 4. Hjälpfunktionen som besättningsgrenen vilar på ska svara. true för besättningen på jobbet,
+--    false för alla andra (samma punktprov som 20260810_crm_work_order_crew_access.sql):
+--
+--      select p.full_name, public.is_user_on_work_order(p.id, '<work_order_id>') as pa_jobbet
+--      from public.profiles p
+--      order by pa_jobbet desc, p.full_name;
+--
+-- 5. Intern fil ska vara osynlig för besättningen. Lägg upp en rad med is_internal = true som
+--    kontoret, impersonera sedan installatören enligt metoden i
+--    20260811_crm_work_order_rls_perf_probe.sql — rollbytet, frågan och avläsningen MÅSTE ligga i
+--    EN sats — och räkna raderna:
+--
+--      select count(*) from public.crm_work_order_files where work_order_id = '<work_order_id>';
+--
+--    Kontoret ska se N, besättningen N minus de interna.
+--
+-- 6. Antagandet bakom att assigned_to-grenen utelämnats. Ska vara 0:
+--
+--      select count(*) from public.crm_work_orders w
+--      join public.profiles p on p.id = w.assigned_to
+--      where p.role = 'member';

--- a/tests/crm/workOrderFiles.domain.test.ts
+++ b/tests/crm/workOrderFiles.domain.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect } from 'vitest';
+import {
+  WORK_ORDER_FILE_CATEGORIES,
+  WORK_ORDER_FILE_CATEGORY_ORDER,
+  toWorkOrderFileCategory,
+  workOrderFileCategoryLabel,
+  type WorkOrderFileRow,
+} from '@/lib/domains/crm/workOrderFiles/types';
+import {
+  WORK_ORDER_FILE_MAX_BYTES,
+  isPreviewableImage,
+  validateWorkOrderFile,
+} from '@/lib/domains/crm/workOrderFiles/validation';
+import {
+  buildWorkOrderFilePath,
+  isWorkOrderFilePath,
+  sanitizeWorkOrderFileName,
+} from '@/lib/domains/crm/workOrderFiles/storage';
+import { mapWorkOrderFileRow } from '@/lib/domains/crm/workOrderFiles/mappers';
+
+const WORK_ORDER_ID = '55555555-5555-4555-8555-555555555555';
+const UPLOADER = 'user-member-1';
+
+describe('validateWorkOrderFile', () => {
+  it('släpper igenom en vanlig ritning och ett vanligt foto', () => {
+    expect(validateWorkOrderFile({ size: 4_000_000, type: 'application/pdf', name: 'ritning.pdf' })).toBeNull();
+    expect(validateWorkOrderFile({ size: 900_000, type: 'image/jpeg', name: 'IMG_0001.jpg' })).toBeNull();
+  });
+
+  it('avvisar en tom fil', () => {
+    expect(validateWorkOrderFile({ size: 0, type: 'image/jpeg', name: 'x.jpg' })).toBe('Filen är tom.');
+  });
+
+  it('avvisar en fil över taket', () => {
+    const over = { size: WORK_ORDER_FILE_MAX_BYTES + 1, type: 'application/pdf', name: 'stor.pdf' };
+    expect(validateWorkOrderFile(over)).toBe('Filen är för stor (max 25 MB).');
+  });
+
+  it('avvisar en filtyp utanför listan', () => {
+    // Ett kalkylark på en arbetsorder är inte en ritning, och installatören kan inte öppna det.
+    const res = validateWorkOrderFile({ size: 1000, type: 'application/vnd.ms-excel', name: 'kalkyl.xls' });
+    expect(res).toContain('Bara bilder');
+  });
+
+  // Den här grenen är hela skälet till att en installatör kan ladda upp från iPhone: Safari och
+  // en del Android-webbläsare skickar TOM mimetype för HEIC. Faller den bort går fältuppladdning
+  // sönder utan att något test blir rött någon annanstans.
+  it('faller tillbaka på filändelsen när webbläsaren inte satte någon mimetype', () => {
+    expect(validateWorkOrderFile({ size: 3_000_000, type: '', name: 'IMG_4821.HEIC' })).toBeNull();
+    expect(validateWorkOrderFile({ size: 3_000_000, type: '', name: 'ritning.pdf' })).toBeNull();
+  });
+
+  it('avvisar tom mimetype med okänd filändelse', () => {
+    expect(validateWorkOrderFile({ size: 3_000_000, type: '', name: 'arkiv.zip' })).toContain('Bara bilder');
+  });
+});
+
+describe('isPreviewableImage', () => {
+  it('pekar ut det webbläsaren faktiskt kan rita som miniatyr', () => {
+    expect(isPreviewableImage('image/jpeg')).toBe(true);
+    expect(isPreviewableImage('image/png')).toBe(true);
+    expect(isPreviewableImage('image/webp')).toBe(true);
+  });
+
+  // HEIC renderas inte i <img> av Chrome eller Firefox på desktop. Signerar vi en URL för den får
+  // kontoret en trasig bildikon i stället för ett filkort.
+  it('räknar inte HEIC eller PDF som förhandsvisbart', () => {
+    expect(isPreviewableImage('image/heic')).toBe(false);
+    expect(isPreviewableImage('application/pdf')).toBe(false);
+    expect(isPreviewableImage(null)).toBe(false);
+  });
+});
+
+describe('sanitizeWorkOrderFileName', () => {
+  it('gör om svenska tecken och blanksteg till ren ASCII', () => {
+    expect(sanitizeWorkOrderFileName('Ritning över vinden.pdf')).toBe('Ritning-_ver-vinden.pdf');
+  });
+
+  it('tar bort sökvägstecken', () => {
+    expect(sanitizeWorkOrderFileName('../../etc/passwd')).not.toContain('/');
+    expect(sanitizeWorkOrderFileName('a\\b/c.pdf')).toBe('a-b-c.pdf');
+  });
+
+  it('kapar långa namn och har en fallback för tomma', () => {
+    expect(sanitizeWorkOrderFileName('a'.repeat(300)).length).toBe(120);
+    expect(sanitizeWorkOrderFileName('   ')).toBe('fil');
+  });
+});
+
+describe('buildWorkOrderFilePath', () => {
+  it('lägger filen under ordern OCH uppladdaren', () => {
+    const path = buildWorkOrderFilePath(WORK_ORDER_ID, UPLOADER, 'ritning.pdf', 'uid-1');
+    expect(path).toBe(`Arbetsorder/${WORK_ORDER_ID}/${UPLOADER}/uid-1-ritning.pdf`);
+  });
+});
+
+// Sökvägen kommer tillbaka från klienten i bekräftelsesteget, och upload-token binder bara just
+// den sökvägen — inte vem som får läsa den. Sökvägen går dessutom att läsa ut ur den signerade
+// URL:en i listan, så vad som helst som visas kan spelas tillbaka hit. Den här funktionen är det
+// som gör bekräftelsestegets uppstädning ofarlig.
+describe('isWorkOrderFilePath', () => {
+  it('godkänner den egna sökvägen under den egna ordern', () => {
+    expect(isWorkOrderFilePath(`Arbetsorder/${WORK_ORDER_ID}/${UPLOADER}/uid-ritning.pdf`, WORK_ORDER_ID, UPLOADER)).toBe(true);
+  });
+
+  // Kärnan i regressionen: en läsbehörig användare (konsult) kunde annars ta kontorets filsökväg
+  // ur miniatyrens URL, posta tillbaka den, bli nekad av RLS — och få kontorets fil raderad av
+  // uppstädningen.
+  it('nekar en annan användares sökväg på samma order', () => {
+    const office = 'user-sales-1';
+    expect(isWorkOrderFilePath(`Arbetsorder/${WORK_ORDER_ID}/${office}/uid-ritning.pdf`, WORK_ORDER_ID, UPLOADER)).toBe(false);
+  });
+
+  it('nekar ett annat område i bucketen', () => {
+    expect(isWorkOrderFilePath('Support/uid-skarmbild.png', WORK_ORDER_ID, UPLOADER)).toBe(false);
+    expect(isWorkOrderFilePath('Documents/root/uid-avtal.pdf', WORK_ORDER_ID, UPLOADER)).toBe(false);
+  });
+
+  it('nekar en annan arbetsorders prefix', () => {
+    const other = '99999999-9999-4999-8999-999999999999';
+    expect(isWorkOrderFilePath(`Arbetsorder/${other}/${UPLOADER}/uid-ritning.pdf`, WORK_ORDER_ID, UPLOADER)).toBe(false);
+  });
+
+  it('nekar traversering och egna underkataloger', () => {
+    expect(isWorkOrderFilePath(`Arbetsorder/${WORK_ORDER_ID}/${UPLOADER}/../../Support/x.png`, WORK_ORDER_ID, UPLOADER)).toBe(false);
+    expect(isWorkOrderFilePath(`Arbetsorder/${WORK_ORDER_ID}/${UPLOADER}/sub/x.png`, WORK_ORDER_ID, UPLOADER)).toBe(false);
+    expect(isWorkOrderFilePath('', WORK_ORDER_ID, UPLOADER)).toBe(false);
+    expect(isWorkOrderFilePath(`Arbetsorder/${WORK_ORDER_ID}/${UPLOADER}/x.png`, WORK_ORDER_ID, '')).toBe(false);
+  });
+});
+
+describe('kategorikatalogen', () => {
+  // En källa, tre konsumenter: Zod-schemat, UI:t och CHECK:en i databasen. Glider de isär blir
+  // felet ett 500 vid insert, inte ett rött test — därför låses listan mot strängliteralen ur
+  // supabase/sql/20260815_crm_work_order_files.sql.
+  it('matchar CHECK-listan i migrationen', () => {
+    expect([...WORK_ORDER_FILE_CATEGORIES]).toEqual([
+      'drawing', 'preparation', 'photo_before', 'photo_after', 'other',
+    ]);
+  });
+
+  it('har en etikett per kategori', () => {
+    for (const key of WORK_ORDER_FILE_CATEGORIES) {
+      expect(workOrderFileCategoryLabel[key]).toBeTruthy();
+    }
+    expect(Object.keys(workOrderFileCategoryLabel).sort()).toEqual([...WORK_ORDER_FILE_CATEGORIES].sort());
+  });
+
+  it('visar kategorierna i jobbets kronologi, inte i bokstavsordning', () => {
+    expect([...WORK_ORDER_FILE_CATEGORY_ORDER]).toEqual([
+      'drawing', 'preparation', 'photo_before', 'photo_after', 'other',
+    ]);
+  });
+
+  it('faller tillbaka på "other" för ett okänt värde', () => {
+    expect(toWorkOrderFileCategory('sketch')).toBe('other');
+    expect(toWorkOrderFileCategory(null)).toBe('other');
+    expect(toWorkOrderFileCategory('drawing')).toBe('drawing');
+  });
+});
+
+describe('mapWorkOrderFileRow', () => {
+  const row: WorkOrderFileRow = {
+    id: 'file-1',
+    work_order_id: WORK_ORDER_ID,
+    category: 'drawing',
+    is_internal: false,
+    file_name: 'ritning.pdf',
+    storage_bucket: 'pdfs',
+    storage_path: `Arbetsorder/${WORK_ORDER_ID}/${UPLOADER}/uid-ritning.pdf`,
+    content_type: 'application/pdf',
+    size_bytes: 4000,
+    created_by: 'user-sales-1',
+    created_by_name: 'Anna Andersson',
+    created_at: '2026-08-15T08:00:00.000Z',
+  };
+
+  it('tar inte med storage_path eller storage_bucket som fält', () => {
+    const view = mapWorkOrderFileRow(row, null);
+    expect(view).not.toHaveProperty('storage_path');
+    expect(view).not.toHaveProperty('storage_bucket');
+  });
+
+  // ⚠️ Det här testet finns för att INTE lura nästa läsare. Ett tidigare påstående här var att
+  // sökvägen aldrig når klienten — det var fel: en signerad URL har formen
+  // /object/sign/<bucket>/<path>?token=…, så varje rad med miniatyr bär sin sökväg i URL:en.
+  // Skyddet ligger på skrivsidan (uppladdarens id i sökvägen + 409 på redan registrerad sökväg),
+  // inte på att sökvägen skulle vara okänd. Bygg aldrig något som antar det motsatta.
+  it('bär sökvägen i den signerade URL:en — sökvägen är inte hemlig', () => {
+    const signed = `https://x.supabase.co/storage/v1/object/sign/pdfs/${row.storage_path}?token=abc`;
+    const view = mapWorkOrderFileRow(row, signed);
+    expect(view.url).toContain(row.storage_path);
+  });
+
+  it('behåller det fliken faktiskt visar', () => {
+    const view = mapWorkOrderFileRow(row, 'https://signed.example/x');
+    expect(view.file_name).toBe('ritning.pdf');
+    expect(view.created_by_name).toBe('Anna Andersson');
+    expect(view.category).toBe('drawing');
+    expect(view.url).toBe('https://signed.example/x');
+  });
+});

--- a/tests/crm/workOrderFiles.route.test.ts
+++ b/tests/crm/workOrderFiles.route.test.ts
@@ -1,0 +1,380 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { effectivePermissionsForRole, konsultUser, memberUser, salesUser } from './helpers/supabase';
+
+// Filerna på arbetsordern. Byten passerar aldrig en route handler — klienten laddar upp direkt till
+// lagringen med en signerad URL — vilket flyttar hela tilliten till bekräftelsesteget. Det som
+// prövas här är därför framför allt att servern inte tror på klienten: sökvägen ska kontrolleras
+// mot ordern, storleken och mimetypen ska läsas ur lagringen och inte ur kroppen, och en
+// installatör ska inte kunna gömma en fil för sina kollegor.
+
+vi.mock('@/lib/auth/route', () => ({ getCurrentUser: vi.fn() }));
+
+vi.mock('@/lib/auth/permissions', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/auth/permissions')>();
+  return { ...actual, getEffectivePermissions: vi.fn() };
+});
+
+vi.mock('@/lib/domains/crm/work-orders', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/domains/crm/work-orders')>();
+  return {
+    ...actual,
+    listCrmWorkOrderFiles: vi.fn(),
+    createCrmWorkOrderFile: vi.fn(),
+    getCrmWorkOrderFile: vi.fn(),
+    deleteCrmWorkOrderFile: vi.fn(),
+    findCrmWorkOrderFileByPath: vi.fn(),
+    isUserOnWorkOrder: vi.fn(),
+  };
+});
+
+vi.mock('@/lib/domains/crm/workOrderFiles/storage', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/domains/crm/workOrderFiles/storage')>();
+  return {
+    ...actual,
+    createWorkOrderFileUploadUrl: vi.fn(),
+    readWorkOrderFileInfo: vi.fn(),
+    removeWorkOrderFileObject: vi.fn(),
+    signWorkOrderFileUrls: vi.fn(),
+    signWorkOrderFileUrl: vi.fn(),
+  };
+});
+
+vi.mock('@/lib/supabase/server', () => ({ getSupabaseAdmin: vi.fn(() => ({})) }));
+vi.mock('@supabase/auth-helpers-nextjs', () => ({ createRouteHandlerClient: vi.fn(() => ({})) }));
+vi.mock('next/headers', () => ({ cookies: vi.fn() }));
+
+import { getCurrentUser } from '@/lib/auth/route';
+import { getEffectivePermissions } from '@/lib/auth/permissions';
+import {
+  createCrmWorkOrderFile,
+  deleteCrmWorkOrderFile,
+  findCrmWorkOrderFileByPath,
+  isUserOnWorkOrder,
+  listCrmWorkOrderFiles,
+} from '@/lib/domains/crm/work-orders';
+import {
+  createWorkOrderFileUploadUrl,
+  readWorkOrderFileInfo,
+  removeWorkOrderFileObject,
+  signWorkOrderFileUrls,
+} from '@/lib/domains/crm/workOrderFiles/storage';
+
+const { POST: UPLOAD_URL } = await import('@/app/api/crm/work-orders/[id]/files/upload-url/route');
+const { GET: LIST, POST: CONFIRM } = await import('@/app/api/crm/work-orders/[id]/files/route');
+const { DELETE } = await import('@/app/api/crm/work-orders/[id]/files/[fileId]/route');
+
+const mockUser = vi.mocked(getCurrentUser);
+const mockPerms = vi.mocked(getEffectivePermissions);
+const mockList = vi.mocked(listCrmWorkOrderFiles);
+const mockCreate = vi.mocked(createCrmWorkOrderFile);
+const mockDelete = vi.mocked(deleteCrmWorkOrderFile);
+const mockOnJob = vi.mocked(isUserOnWorkOrder);
+const mockFindByPath = vi.mocked(findCrmWorkOrderFileByPath);
+const mockUploadUrl = vi.mocked(createWorkOrderFileUploadUrl);
+const mockInfo = vi.mocked(readWorkOrderFileInfo);
+const mockRemove = vi.mocked(removeWorkOrderFileObject);
+const mockSignMany = vi.mocked(signWorkOrderFileUrls);
+
+const WORK_ORDER_ID = '55555555-5555-4555-8555-555555555555';
+const FILE_ID = '77777777-7777-4777-8777-777777777777';
+// Sökvägen bär uppladdarens id — spärren mot att spela tillbaka någon annans fil.
+const PATH = `Arbetsorder/${WORK_ORDER_ID}/${salesUser.id}/uid-ritning.pdf`;
+const MEMBER_PATH = `Arbetsorder/${WORK_ORDER_ID}/${memberUser.id}/uid-foto.jpg`;
+
+const ctx = { params: { id: WORK_ORDER_ID } };
+const fileCtx = { params: { id: WORK_ORDER_ID, fileId: FILE_ID } };
+
+function jsonReq(payload: unknown) {
+  return new Request('http://localhost/api/crm/work-orders/x/files', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+}
+const getReq = () => new Request('http://localhost/api/crm/work-orders/x/files');
+
+const CONFIRM_BODY = { storage_path: PATH, file_name: 'ritning.pdf', category: 'drawing', is_internal: false };
+
+function fileRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: FILE_ID,
+    work_order_id: WORK_ORDER_ID,
+    category: 'drawing',
+    is_internal: false,
+    file_name: 'ritning.pdf',
+    storage_bucket: 'pdfs',
+    storage_path: PATH,
+    content_type: 'application/pdf',
+    size_bytes: 4000,
+    created_by: 'user-sales-1',
+    created_by_name: 'Anna Andersson',
+    created_at: '2026-08-15T08:00:00.000Z',
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockUser.mockResolvedValue(salesUser);
+  mockPerms.mockImplementation(async () => effectivePermissionsForRole((await mockUser())?.role));
+  mockOnJob.mockResolvedValue({ data: false, error: null } as any);
+  mockFindByPath.mockResolvedValue({ data: null, error: null } as any);
+  mockUploadUrl.mockResolvedValue({ signedUrl: 'https://signed.example/upload', token: 'tok', error: null } as any);
+  mockInfo.mockResolvedValue({ size: 4000, contentType: 'application/pdf' });
+  mockCreate.mockResolvedValue({ data: fileRow(), error: null } as any);
+  mockList.mockResolvedValue({ data: [fileRow()], error: null } as any);
+  mockDelete.mockResolvedValue({ data: { id: FILE_ID, storage_bucket: 'pdfs', storage_path: PATH }, error: null } as any);
+  mockSignMany.mockResolvedValue(new Map());
+});
+
+describe('POST /files/upload-url', () => {
+  it('kräver inloggning', async () => {
+    mockUser.mockResolvedValue(null);
+    expect((await UPLOAD_URL(jsonReq({ file_name: 'a.pdf', content_type: 'application/pdf', size_bytes: 10 }), ctx)).status).toBe(401);
+  });
+
+  it('avvisar en för stor fil INNAN den kostar en storage-runda', async () => {
+    const res = await UPLOAD_URL(
+      jsonReq({ file_name: 'stor.pdf', content_type: 'application/pdf', size_bytes: 40 * 1024 * 1024 }),
+      ctx,
+    );
+    expect(res.status).toBe(400);
+    expect(mockUploadUrl).not.toHaveBeenCalled();
+  });
+
+  it('avvisar fel filtyp innan den kostar en storage-runda', async () => {
+    const res = await UPLOAD_URL(
+      jsonReq({ file_name: 'kalkyl.xls', content_type: 'application/vnd.ms-excel', size_bytes: 1000 }),
+      ctx,
+    );
+    expect(res.status).toBe(400);
+    expect(mockUploadUrl).not.toHaveBeenCalled();
+  });
+
+  it('släpper igenom kontoret', async () => {
+    const res = await UPLOAD_URL(jsonReq({ file_name: 'a.pdf', content_type: 'application/pdf', size_bytes: 1000 }), ctx);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ ok: true, data: { path: expect.stringContaining(`Arbetsorder/${WORK_ORDER_ID}/`) } });
+  });
+
+  // konsult är READONLY i hela CRM (crm.workorder.read men inte .write) och är inte besättning.
+  it('nekar konsult', async () => {
+    mockUser.mockResolvedValue(konsultUser);
+    const res = await UPLOAD_URL(jsonReq({ file_name: 'a.pdf', content_type: 'application/pdf', size_bytes: 1000 }), ctx);
+    expect(res.status).toBe(403);
+    expect(mockUploadUrl).not.toHaveBeenCalled();
+  });
+
+  it('släpper igenom en installatör som är besättning på jobbet', async () => {
+    mockUser.mockResolvedValue(memberUser);
+    mockOnJob.mockResolvedValue({ data: true, error: null } as any);
+    expect((await UPLOAD_URL(jsonReq({ file_name: 'foto.jpg', content_type: 'image/jpeg', size_bytes: 1000 }), ctx)).status).toBe(200);
+  });
+
+  it('nekar en installatör som inte är på jobbet', async () => {
+    mockUser.mockResolvedValue(memberUser);
+    mockOnJob.mockResolvedValue({ data: false, error: null } as any);
+    expect((await UPLOAD_URL(jsonReq({ file_name: 'foto.jpg', content_type: 'image/jpeg', size_bytes: 1000 }), ctx)).status).toBe(403);
+  });
+});
+
+describe('POST /files (bekräftelsen)', () => {
+  it('kräver inloggning', async () => {
+    mockUser.mockResolvedValue(null);
+    expect((await CONFIRM(jsonReq(CONFIRM_BODY), ctx)).status).toBe(401);
+  });
+
+  // Utan den här kontrollen kan en klient koppla någon annans fil till sin egen arbetsorder och få
+  // den signerad.
+  it('nekar en sökväg utanför den egna ordern', async () => {
+    const res = await CONFIRM(jsonReq({ ...CONFIRM_BODY, storage_path: 'Support/uid-skarmbild.png' }), ctx);
+    expect(res.status).toBe(400);
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  // ── REGRESSION: läsbehörig användare kunde få kontorets fil raderad ──────────
+  //
+  // Uppstädningen i den här routen raderar ett lagringsobjekt med service-role-nyckeln. Sökvägen
+  // till varje bild går att läsa ut ur den signerade URL:en i listan. En konsult (READONLY, men
+  // med crm.workorder.read) kunde alltså läsa kontorets filsökväg, posta tillbaka den, bli nekad
+  // av RLS på insert:en — och få kontorets fil borttagen på vägen ut. Raden blev kvar, byten
+  // försvann. Två spärrar håller det nu: uppladdarens id i sökvägen, och 409 på en sökväg som
+  // redan är registrerad.
+  it('nekar en konsult som spelar tillbaka kontorets filsökväg — och rör INTE lagringen', async () => {
+    mockUser.mockResolvedValue(konsultUser);
+    const res = await CONFIRM(jsonReq({ ...CONFIRM_BODY, storage_path: PATH }), ctx);
+    expect(res.status).toBe(400);
+    expect(mockCreate).not.toHaveBeenCalled();
+    expect(mockRemove).not.toHaveBeenCalled();
+  });
+
+  it('nekar en installatör som spelar tillbaka en kollegas filsökväg', async () => {
+    mockUser.mockResolvedValue(memberUser);
+    mockOnJob.mockResolvedValue({ data: true, error: null } as any);
+    const res = await CONFIRM(jsonReq({ ...CONFIRM_BODY, storage_path: PATH }), ctx);
+    expect(res.status).toBe(400);
+    expect(mockRemove).not.toHaveBeenCalled();
+  });
+
+  // ── REGRESSION: dubbelregistrering kunde riva en delad fil ───────────────────
+  //
+  // Även sin EGEN sökväg får bara registreras en gång. Annars kan två rader peka på samma objekt,
+  // och den som tar bort sin rad river byten under den andra radens fötter.
+  it('svarar 409 på en redan registrerad sökväg och rör inte lagringen', async () => {
+    mockFindByPath.mockResolvedValue({ data: { id: 'redan-har' }, error: null } as any);
+    const res = await CONFIRM(jsonReq(CONFIRM_BODY), ctx);
+    expect(res.status).toBe(409);
+    expect(mockCreate).not.toHaveBeenCalled();
+    expect(mockRemove).not.toHaveBeenCalled();
+  });
+
+  it('städar inte när det unika indexet nekar insert:en (kapplöpning om samma sökväg)', async () => {
+    mockCreate.mockResolvedValue({ data: null, error: { code: '23505', message: 'duplicate key' } } as any);
+    const res = await CONFIRM(jsonReq(CONFIRM_BODY), ctx);
+    expect(res.status).toBe(409);
+    expect(mockRemove).not.toHaveBeenCalled();
+  });
+
+  it('nekar när objektet aldrig kom fram till lagringen', async () => {
+    mockInfo.mockResolvedValue(null);
+    const res = await CONFIRM(jsonReq(CONFIRM_BODY), ctx);
+    expect(res.status).toBe(400);
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  // Kärnan i hela tvåstegsflödet: klientens påstående om storleken är inte bindande.
+  it('litar på lagringen och inte på klienten om storleken — och städar bort filen', async () => {
+    mockInfo.mockResolvedValue({ size: 40 * 1024 * 1024, contentType: 'application/pdf' });
+    const res = await CONFIRM(jsonReq(CONFIRM_BODY), ctx);
+    expect(res.status).toBe(400);
+    expect(mockCreate).not.toHaveBeenCalled();
+    expect(mockRemove).toHaveBeenCalledWith(expect.anything(), expect.any(String), PATH);
+  });
+
+  it('tar arbetsordern ur URL:en, inte ur kroppen', async () => {
+    await CONFIRM(jsonReq({ ...CONFIRM_BODY, work_order_id: 'nagon-annan-order' }), ctx);
+    expect(mockCreate.mock.calls[0][1]).toMatchObject({ work_order_id: WORK_ORDER_ID });
+  });
+
+  it('snapshottar uppladdarens namn på raden', async () => {
+    mockUser.mockResolvedValue({ ...salesUser, name: 'Anna Andersson' });
+    await CONFIRM(jsonReq(CONFIRM_BODY), ctx);
+    expect(mockCreate.mock.calls[0][1]).toMatchObject({ created_by_name: 'Anna Andersson' });
+  });
+
+  it('låter kontoret markera en fil som intern', async () => {
+    await CONFIRM(jsonReq({ ...CONFIRM_BODY, is_internal: true }), ctx);
+    expect(mockCreate.mock.calls[0][1]).toMatchObject({ is_internal: true });
+  });
+
+  // "Intern" är ett kontorsbegrepp. En installatör ska inte kunna lägga upp något besättningen
+  // inte ser — RLS gör om samma kontroll, det här är det snälla svaret.
+  it('tvingar is_internal till false för en installatör', async () => {
+    mockUser.mockResolvedValue(memberUser);
+    mockOnJob.mockResolvedValue({ data: true, error: null } as any);
+    await CONFIRM(jsonReq({ ...CONFIRM_BODY, storage_path: MEMBER_PATH, is_internal: true }), ctx);
+    expect(mockCreate.mock.calls[0][1]).toMatchObject({ is_internal: false });
+  });
+
+  // z.coerce.boolean() gör Boolean(värde), och Boolean("false") === true. Strängen "false" hade
+  // alltså DOLT filen för besättningen — raka motsatsen till vad avsändaren bad om, och tyst.
+  it('tolkar strängen "false" som false, inte som true', async () => {
+    await CONFIRM(jsonReq({ ...CONFIRM_BODY, is_internal: 'false' }), ctx);
+    expect(mockCreate.mock.calls[0][1]).toMatchObject({ is_internal: false });
+  });
+
+  it('tolkar strängen "true" som true', async () => {
+    await CONFIRM(jsonReq({ ...CONFIRM_BODY, is_internal: 'true' }), ctx);
+    expect(mockCreate.mock.calls[0][1]).toMatchObject({ is_internal: true });
+  });
+
+  it('städar bort objektet när raden inte kunde skrivas', async () => {
+    mockCreate.mockResolvedValue({ data: null, error: { message: 'nekad' } } as any);
+    const res = await CONFIRM(jsonReq(CONFIRM_BODY), ctx);
+    expect(res.status).toBe(500);
+    expect(mockRemove).toHaveBeenCalledWith(expect.anything(), expect.any(String), PATH);
+  });
+
+  it('svarar 201 med raden när allt gick igenom', async () => {
+    const res = await CONFIRM(jsonReq(CONFIRM_BODY), ctx);
+    expect(res.status).toBe(201);
+    expect(mockRemove).not.toHaveBeenCalled();
+  });
+});
+
+describe('GET /files', () => {
+  it('kräver inloggning', async () => {
+    mockUser.mockResolvedValue(null);
+    expect((await LIST(getReq(), ctx)).status).toBe(401);
+  });
+
+  it('läcker aldrig sökvägen till klienten', async () => {
+    const res = await LIST(getReq(), ctx);
+    expect(JSON.stringify(await res.json())).not.toContain('Arbetsorder/');
+  });
+
+  it('signerar inte PDF-rader i listan — de öppnas först vid klick', async () => {
+    await LIST(getReq(), ctx);
+    expect(mockSignMany).toHaveBeenCalledWith(expect.anything(), expect.any(String), []);
+  });
+
+  it('batch-signerar bildrader i ETT anrop', async () => {
+    const imagePath = `Arbetsorder/${WORK_ORDER_ID}/uid-foto.jpg`;
+    mockList.mockResolvedValue({
+      data: [fileRow({ content_type: 'image/jpeg', storage_path: imagePath }), fileRow()],
+      error: null,
+    } as any);
+    await LIST(getReq(), ctx);
+    expect(mockSignMany).toHaveBeenCalledTimes(1);
+    expect(mockSignMany).toHaveBeenCalledWith(expect.anything(), expect.any(String), [imagePath]);
+  });
+
+  it('säger till kontoret att det får markera filer som interna', async () => {
+    const json = await (await LIST(getReq(), ctx)).json();
+    expect(json.data).toMatchObject({ can_upload: true, can_mark_internal: true, can_delete_any: true });
+  });
+
+  it('nekar installatören den möjligheten men låter hen ladda upp på sitt jobb', async () => {
+    mockUser.mockResolvedValue(memberUser);
+    mockOnJob.mockResolvedValue({ data: true, error: null } as any);
+    const json = await (await LIST(getReq(), ctx)).json();
+    expect(json.data).toMatchObject({ can_upload: true, can_mark_internal: false, can_delete_any: false });
+  });
+});
+
+describe('DELETE /files/[fileId]', () => {
+  it('kräver inloggning', async () => {
+    mockUser.mockResolvedValue(null);
+    expect((await DELETE(getReq(), fileCtx)).status).toBe(401);
+  });
+
+  // Kontorets undantag uttrycks som att ägarfiltret utelämnas (null), inte som en assert.
+  it('låter kontoret radera vad som helst på ordern', async () => {
+    await DELETE(getReq(), fileCtx);
+    expect(mockDelete).toHaveBeenCalledWith(expect.anything(), FILE_ID, WORK_ORDER_ID, null);
+  });
+
+  it('begränsar installatören till sina egna uppladdningar', async () => {
+    mockUser.mockResolvedValue(memberUser);
+    await DELETE(getReq(), fileCtx);
+    expect(mockDelete).toHaveBeenCalledWith(expect.anything(), FILE_ID, WORK_ORDER_ID, memberUser.id);
+  });
+
+  it('begränsar konsult likaså — läsbehörig är inte raderingsbehörig', async () => {
+    mockUser.mockResolvedValue(konsultUser);
+    await DELETE(getReq(), fileCtx);
+    expect(mockDelete).toHaveBeenCalledWith(expect.anything(), FILE_ID, WORK_ORDER_ID, konsultUser.id);
+  });
+
+  it('svarar 404 när ingen rad matchade, och rör då inte lagringen', async () => {
+    mockDelete.mockResolvedValue({ data: null, error: null } as any);
+    const res = await DELETE(getReq(), fileCtx);
+    expect(res.status).toBe(404);
+    expect(mockRemove).not.toHaveBeenCalled();
+  });
+
+  it('städar bort objektet när raden försvann', async () => {
+    expect((await DELETE(getReq(), fileCtx)).status).toBe(200);
+    expect(mockRemove).toHaveBeenCalledWith(expect.anything(), 'pdfs', PATH);
+  });
+});


### PR DESCRIPTION
## Vad

Ny **Filer**-flik på arbetsordern, i både kontorsvyn (`/crm/arbetsorder/[id]`) och installatörens fältvy (`/arbetsorder/[id]`). Samma komponent i båda, som kommentarsfliken.

Kontoret laddar upp ritningar och förberedelser; besättningen ser dem när de öppnar jobbet och kan själva lägga upp platsfoton.

| Fråga | Beslut |
| --- | --- |
| Vem laddar upp | Kontoret **och** installatörer |
| Struktur | Kategorier: Ritning, Förberedelser, Foto före, Foto efter, Övrigt |
| Notiser | Nej |
| Offert | Nej — bara arbetsorder i den här omgången |
| Intern flagga | Ja — dold för fält |
| Filtyper | Bilder (JPEG, PNG, HEIC/HEIF, WebP) + PDF |
| Fältets rättigheter | Ladda upp + radera sina egna |

Ingen PATCH i v1 — fel kategori rättas genom att ta bort och ladda upp igen.

## ⚠️ SQL

`supabase/sql/20260815_crm_work_order_files.sql` — **körd 2026-08-15.** Additiv (ny tabell, inga ändringar på befintliga objekt). Ingen ny behörighetsnyckel.

## Uppladdningen går inte genom en route handler

Klienten hämtar en signerad upload-URL, laddar upp direkt till lagringen, och bekräftar sedan — varpå servern läser filens **faktiska** storlek och mimetype ur lagringen innan raden skapas. Skälet är ritningarna: en PDF på 10–30 MB är vanlig, går inte att komprimera, och ska inte behöva rymmas i en request-kropp.

Ingen ny bucket och inga storage-policyer, samma linje som Support och Dokument: prefix per område i den befintliga privata bucketen, all läsning via kortlivad signerad URL som servern skapar **efter** att RLS gatat raden.

## Det viktigaste att granska

**Den signerade URL:en bär sökvägen** (`/object/sign/<bucket>/<path>?token=…`). Första versionen antog motsatsen, och då kunde en **konsult** (READONLY) läsa kontorets filsökväg ur en miniatyr, posta tillbaka den, bli nekad av RLS — och få kontorets fil raderad av den kompenserande uppstädningen. Raden blev kvar, byten försvann.

Två spärrar håller det, båda med regressionstester:
1. uppladdarens id ligger i sökvägen, så en annans sökväg aldrig passerar `isWorkOrderFilePath`,
2. en redan registrerad sökväg ger 409 utan att röra lagringen — med unikt index på `storage_path` som backstop.

Bygg inget som antar att sökvägen är hemlig.

## Övrigt värt att veta

- `created_by_name` snapshottas på raden: `profiles` är self-read-only, så en PostgREST-join hade gett `null` för alla utom en själv.
- Interna filer filtreras i **RLS**, inte i koden, så en glömd filtrering inte kan läcka dem.
- Bilder öppnas i en visare i appen; **PDF i webbläsarens egen, med flit** — iOS Safari renderar en PDF i `<iframe>` som en enda sida utan scroll.
- "Ladda ner" finns på varje kort: den som förbereder dagen har ofta ingen täckning på plats.
- `SUPABASE_CONVENTIONS.md` är gitignorerad — raden i "Reviewed elevations" finns bara lokalt.

## Testat

`npm run type-check` · `npm run lint` · `npm test` (89 filer, **1337** tester) · `npm run build` — alla gröna. 59 nya tester.

Granskning körd på grenen; två fynd rättade i `8ac3318` (kapplöpning som kunde radera en nyss uppladdad fil ur listan, och onödig hämtning innan fliken öppnats).

### Kvar att verifiera manuellt
- HEIC-uppladdning från en riktig iPhone.
- Att en installatör som **är besättning** på jobbet ser filerna i drift, och att en intern fil inte syns för hen (verifieringsfråga 5 i SQL-filen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)