### PR TITLE
Slå på Tailwind preflight app-vitt

### DIFF
--- a/app/admin/changelog/AdminChangelog.tsx
+++ b/app/admin/changelog/AdminChangelog.tsx
@@ -23,9 +23,6 @@ import {
 // Utkast (published_at = null) finns för att en post oftast skrivs innan ändringen är ute. RLS
 // döljer dem för alla utom admin.
 //
-// OBS preflight är av (tailwind.config.js) — rot-elementet bär `support-surface`, som återställer
-// border-reseten. Skriv `border` som vanligt, lägg ALDRIG till `border-solid`.
-
 export default function AdminChangelog() {
   const [entries, setEntries] = React.useState<ChangelogDraftView[]>([]);
   const [loading, setLoading] = React.useState(true);
@@ -50,7 +47,7 @@ export default function AdminChangelog() {
   React.useEffect(() => { load(); }, [load]);
 
   return (
-    <div className="support-surface grid grid-cols-1 gap-4 p-5">
+    <div className="grid grid-cols-1 gap-4 p-5">
       <div className="grid gap-1">
         <h2 className="m-0 text-lg font-bold text-slate-900">Changelog</h2>
         <p className="m-0 text-sm text-slate-600">

--- a/app/admin/support/AdminSupportTickets.tsx
+++ b/app/admin/support/AdminSupportTickets.tsx
@@ -29,13 +29,6 @@ import {
 // jämföra ärenden med varandra. Modalen är dessutom mönstret på varje annan CRM-yta (offert, kund,
 // felanmälan), så den är redan inlärd.
 //
-// OBS preflight är av (tailwind.config.js), så border-utilities beter sig INTE som i vanlig Tailwind
-// — därför bär rot-elementet klassen `support-surface`, som återställer reseten (globals.css). Utan
-// den ritar `border` på en <div> ingen linje alls, och `border-t border-solid` blir en LÅDA: stilen
-// sätts på alla fyra sidor men bredden bara på toppen, så de tre andra faller tillbaka på
-// webbläsarens `medium` (~3px). Med klassen på plats: skriv `border`/`border-t` som vanligt, och
-// lägg ALDRIG till `border-solid` här.
-
 type StateFilter = 'open' | 'closed' | 'any';
 
 const STATE_LABEL: Record<StateFilter, string> = {
@@ -98,9 +91,8 @@ export default function AdminSupportTickets() {
 
   return (
     // p-5 matchar de andra adminflikarna (Behörigheter, Tidkoder) — AdminTabsClient lägger inget
-    // innerutrymme i sitt kort. `support-surface` återställer border-reseten för hela trädet,
-    // modalen inkluderad (den renderas som barn här nere).
-    <div className="support-surface grid grid-cols-1 gap-4 p-5">
+    // innerutrymme i sitt kort.
+    <div className="grid grid-cols-1 gap-4 p-5">
       <div className="grid gap-1">
         <h2 className="m-0 text-lg font-bold text-slate-900">Ärenden</h2>
         <p className="m-0 text-sm text-slate-600">

--- a/app/admin/tid/AdminTimeApprovals.tsx
+++ b/app/admin/tid/AdminTimeApprovals.tsx
@@ -50,8 +50,8 @@ import {
 // även härifrån, och varje rättelse av någon annans rad skrivs till crm_time_entry_audit av en
 // databastrigger.
 //
-// OBS preflight är av (tailwind.config.js): `border` på en <div> ritar ingen linje utan
-// `border-solid`, och <input> får `width: 100%` från globals.css.
+// OBS <input> får `width: 100%` från en global element-regel i globals.css, som vinner över
+// Tailwinds breddklasser.
 
 const STATUS_TONE: Record<TimePeriodStatus, string> = {
   open: 'bg-slate-100 text-slate-600',

--- a/app/admin/tid/AdminTimeReference.tsx
+++ b/app/admin/tid/AdminTimeReference.tsx
@@ -10,9 +10,8 @@ import type { TimeReferenceItem, TimeReferenceKind } from '../../../lib/domains/
 // kolumn lönebyrån bryr sig om — den är tom efter importen och måste fyllas i för hand, så den
 // har en egen varningsruta högst upp.
 //
-// OBS globala element-regler i app/globals.css (preflight är av): en <div> med bara `border` ritar
-// INGEN linje utan `border-solid`, och <input> får `width: 100%` — därför breddstyrning på
-// omslutande element i stället för på fältet.
+// OBS en global element-regel i app/globals.css ger <input> `width: 100%` och vinner över Tailwinds
+// breddklasser — därför breddstyrning på omslutande element i stället för på fältet.
 
 type Section = { kind: TimeReferenceKind; label: string; help: string };
 

--- a/app/components/ReportIssueLauncher.tsx
+++ b/app/components/ReportIssueLauncher.tsx
@@ -55,13 +55,8 @@ export default function ReportIssueLauncher({ loggedIn }: { loggedIn: boolean })
     // Utan den var `var(--crm-primary)` odefinierad och Skicka-knappen blev vit text på ingen
     // bakgrund: osynlig.
     //
-    // `support-surface` återställer Tailwinds border-reset (preflight är av). Utan den ritar
-    // `border` på en <div> ingen linje, och `border-t border-solid` blir en LÅDA — bredden sätts
-    // bara på toppen medan de tre andra sidorna faller tillbaka på webbläsarens `medium` (~3px).
-    // Med den: skriv `border`/`border-t` som vanligt och lägg ALDRIG till `border-solid` här.
-    //
     // Div:en är layoutneutral: allt inuti är `fixed`.
-    <div className="crm-shell support-surface">
+    <div className="crm-shell">
       <button
         type="button"
         onClick={() => {

--- a/app/crm/coach/CoachClient.tsx
+++ b/app/crm/coach/CoachClient.tsx
@@ -518,7 +518,7 @@ export default function CoachClient({ userName }: { userName: string | null }) {
                           ].map(({ title, items: listItems }) => (
                             <div key={title} className="grid gap-2 rounded-xl border border-slate-200 bg-white px-3 py-3">
                               <strong className="text-sm font-semibold text-slate-900">{title}</strong>
-                              <ul className="m-0 grid gap-1.5 pl-5 text-sm leading-5 text-slate-600">
+                              <ul className="m-0 grid list-disc gap-1.5 pl-5 text-sm leading-5 text-slate-600">
                                 {listItems.map((entry) => <li key={entry}>{entry}</li>)}
                               </ul>
                             </div>
@@ -606,7 +606,7 @@ export default function CoachClient({ userName }: { userName: string | null }) {
 
             <div className="grid gap-2 rounded-2xl border border-slate-100 bg-slate-50/60 p-4">
               <p className={crm.sectionTitle}>Framtidssäkrat</p>
-              <ul className="m-0 grid gap-2 pl-5 text-sm leading-5 text-slate-600">
+              <ul className="m-0 grid list-disc gap-2 pl-5 text-sm leading-5 text-slate-600">
                 <li>Frågan skickas redan genom en dedikerad coach-route.</li>
                 <li>Kontext väljs som tydlig referens i stället för att hårdkodas i UI:t.</li>
                 <li>Svaret kommer i ett kontrakt som senare kan fyllas av riktig AI-koppling.</li>

--- a/app/crm/components/ChangelogCard.tsx
+++ b/app/crm/components/ChangelogCard.tsx
@@ -30,10 +30,6 @@ import type { ChangelogItemView } from '@/lib/domains/changelog/types';
 // vid första besöket", vilket hade gjort själva lanseringen osynlig för alla utom den som råkade
 // titta efter nästa publicering.
 //
-// OBS preflight är av (tailwind.config.js) — rot-elementet bär `support-surface`, som återställer
-// border-reseten för hela trädet (globals.css). Skriv `border`/`border-t` som vanligt här, och lägg
-// ALDRIG till `border-solid`.
-
 const SEEN_KEY = 'crm.changelog.seenAt';
 const CARD_ITEM_COUNT = 3;
 
@@ -120,7 +116,7 @@ export default function ChangelogCard() {
   const preview = items.slice(0, CARD_ITEM_COUNT);
 
   return (
-    <section className={cn('support-surface', crm.cardInner, 'grid grid-cols-1 gap-2.5')} aria-labelledby="changelog-heading">
+    <section className={cn(crm.cardInner, 'grid grid-cols-1 gap-2.5')} aria-labelledby="changelog-heading">
       <div className="flex flex-wrap items-center justify-between gap-2">
         <div className="flex items-center gap-2">
           <h2 id="changelog-heading" className={crm.sectionTitle}>Nytt i appen</h2>

--- a/app/crm/components/CrmPlaceholder.tsx
+++ b/app/crm/components/CrmPlaceholder.tsx
@@ -23,7 +23,7 @@ export default function CrmPlaceholder({
 
       <SectionCard className="grid gap-3 p-5 md:p-6">
         <strong className="text-base font-bold text-slate-900">Planerad första implementation</strong>
-        <ul className="m-0 grid gap-2 pl-5 text-sm leading-6 text-slate-600">
+        <ul className="m-0 grid list-disc gap-2 pl-5 text-sm leading-6 text-slate-600">
           {bullets.map((bullet) => (
             <li key={bullet}>{bullet}</li>
           ))}

--- a/app/crm/offerter/QuoteFormClient.tsx
+++ b/app/crm/offerter/QuoteFormClient.tsx
@@ -2946,11 +2946,7 @@ export default function QuoteFormClient({ quoteId }: { quoteId?: string }) {
                         ovägt snitt av radernas procent hade låtit en småpostrad väga lika tungt
                         som huvudposten. Visas bara när minst en rad går att bedöma.
 
-                        INGEN ram och särskilt inte `border-t border-solid`: med preflight av
-                        sätter border-solid stilen på ALLA fyra sidor medan border-t bara sätter
-                        bredden upptill, så övriga sidor ärver webbläsarens `medium` (3px) och det
-                        blir en fantomram runt hela blocket. Se FRONTEND_SYSTEM.md. Raderna ovanför
-                        separeras med luft, så den här gör likadant. */}
+                        Ingen ram — raderna ovanför separeras med luft, så den här gör likadant. */}
                     {quoteMarginResult.marginPercent != null ? (
                       <div className="mt-2.5 grid gap-1">
                         <div className="flex items-center justify-between text-xs">

--- a/app/crm/planering/ActivityLogModal.tsx
+++ b/app/crm/planering/ActivityLogModal.tsx
@@ -180,7 +180,7 @@ export default function ActivityLogModal({ onClose }: { onClose: () => void }) {
   return (
     <div className="fixed inset-0 z-[2800] flex items-center justify-center bg-slate-900/40 p-4 sm:p-6" onClick={onClose}>
       <div
-        className="planning-modal flex max-h-[88vh] w-full max-w-2xl flex-col overflow-hidden rounded-2xl border border-[#e0e8dc] bg-[#f9fbf7] shadow-xl"
+        className="flex max-h-[88vh] w-full max-w-2xl flex-col overflow-hidden rounded-2xl border border-[#e0e8dc] bg-[#f9fbf7] shadow-xl"
         onClick={(e) => e.stopPropagation()}
       >
         <div className="flex items-center justify-between border-b border-[#e0e8dc] bg-white px-4 py-3">

--- a/app/crm/planering/PlaceholderModal.tsx
+++ b/app/crm/planering/PlaceholderModal.tsx
@@ -60,7 +60,7 @@ export default function PlaceholderModal({
 
   return (
     <div className="fixed inset-0 z-[2800] flex items-center justify-center bg-slate-900/40 p-4" onClick={onClose}>
-      <div className="planning-modal w-full max-w-sm rounded-2xl border border-[#e0e8dc] bg-[#f9fbf7] p-4 shadow-xl" onClick={(e) => e.stopPropagation()}>
+      <div className="w-full max-w-sm rounded-2xl border border-[#e0e8dc] bg-[#f9fbf7] p-4 shadow-xl" onClick={(e) => e.stopPropagation()}>
         <h3 className="mb-0.5 text-[14px] font-bold text-slate-900">Ny platshållare</h3>
         <p className="mb-3 text-[11px] text-slate-500">Boka en bil/dag innan den riktiga arbetsordern finns.</p>
 

--- a/app/crm/planering/PlanningAdminModal.tsx
+++ b/app/crm/planering/PlanningAdminModal.tsx
@@ -95,7 +95,7 @@ export default function PlanningAdminModal({
   return (
     <div className="fixed inset-0 z-[2800] flex items-center justify-center bg-slate-900/40 p-4 sm:p-6" onClick={onClose}>
       <div
-        className="planning-modal flex max-h-[90vh] w-full max-w-5xl flex-col overflow-hidden rounded-2xl border border-[#e0e8dc] bg-[#f9fbf7] shadow-xl"
+        className="flex max-h-[90vh] w-full max-w-5xl flex-col overflow-hidden rounded-2xl border border-[#e0e8dc] bg-[#f9fbf7] shadow-xl"
         onClick={(e) => e.stopPropagation()}
       >
         {/* Header */}

--- a/app/crm/planering/PlanningClient.tsx
+++ b/app/crm/planering/PlanningClient.tsx
@@ -1032,7 +1032,7 @@ export default function PlanningClient({
       {/* Truck picker (month placement) */}
       {truckPicker && (
         <div className="fixed inset-0 z-[2800] flex items-center justify-center bg-slate-900/40 p-4" onClick={() => setTruckPicker(null)}>
-          <div className="planning-modal w-full max-w-xs rounded-2xl border border-[#e0e8dc] bg-[#f9fbf7] p-4 shadow-xl" onClick={(e) => e.stopPropagation()}>
+          <div className="w-full max-w-xs rounded-2xl border border-[#e0e8dc] bg-[#f9fbf7] p-4 shadow-xl" onClick={(e) => e.stopPropagation()}>
             <h3 className="mb-3 text-[13px] font-bold text-slate-900">Välj bil</h3>
             <div className="grid gap-1.5">
               {trucks.map((t) => (
@@ -1054,7 +1054,7 @@ export default function PlanningClient({
       {/* Copy-to-truck picker (freestanding duplicate of a scheduled job) */}
       {copySeg && (
         <div className="fixed inset-0 z-[2800] flex items-center justify-center bg-slate-900/40 p-4" onClick={() => setCopySeg(null)}>
-          <div className="planning-modal w-full max-w-xs rounded-2xl border border-[#e0e8dc] bg-[#f9fbf7] p-4 shadow-xl" onClick={(e) => e.stopPropagation()}>
+          <div className="w-full max-w-xs rounded-2xl border border-[#e0e8dc] bg-[#f9fbf7] p-4 shadow-xl" onClick={(e) => e.stopPropagation()}>
             <h3 className="text-[13px] font-bold text-slate-900">Kopiera till bil</h3>
             <p className="mb-3 mt-0.5 text-[11px] text-slate-500">
               Skapar en kopia av <strong>{copySeg.job?.ref ?? 'jobbet'}</strong> på vald bil ({copySeg.start_day === copySeg.end_day ? copySeg.start_day : `${copySeg.start_day}–${copySeg.end_day}`}).

--- a/app/globals.css
+++ b/app/globals.css
@@ -8,12 +8,31 @@
    `medium` (~3px). De tre scopade reseterna som simulerade detta för `.planning-density`,
    `.planning-modal` och `.support-surface` är därmed borttagna — de var en brygga med slutdatum.
 
-   ⚠️ Lägg INTE till `border-solid` i nya komponenter. Det var lösningen medan preflight var av; nu
-   sätter det bara stilen på alla fyra sidor igen och återinför fantomkanten på sidor utan bredd.
+   ⚠️ Lägg INTE till `border-solid` i nya komponenter. Det var lösningen medan preflight var av och
+   är nu bara överflödigt — det kan INTE återinföra fantomkanten, eftersom preflightens
+   `*{border-width:0}` nollar varje sida som saknar breddklass. De ~100 som redan står kvar i koden
+   är ofarliga; ta bort dem när du ändå är i filen, inte som en egen vandring.
+
+   Preflight ändrar mer än kanter, och tre av dem är värda att känna till:
+   - `box-sizing: border-box` gäller nu ALLA element (bara input/label/.spinner hade det förut), så
+     bredd/höjd inkluderar padding och kant.
+   - `html { line-height: 1.5 }` ersätter webbläsarens ~1.2. Tailwinds `text-*` bär egen line-height,
+     så de ytorna är opåverkade; inline-stylade äldre ytor blir ~25 % högre per rad.
+   - `input/select/textarea` ärver nu body-typsnittet i stället för webbläsarens formulärtypsnitt.
 
    Kvar att veta: element-reglerna längre ner i den här filen (`button { padding: 10px 14px }`,
    `input { width: 100% }`, `label { display: block }`) ligger UTANFÖR `@layer base` och vinner
    därför fortfarande över preflight. De är en separat städning. */
+
+@layer base {
+  /* Preflight sätter `h1–h6 { font-weight: inherit }`. Ett sextiotal rubriker i appen sätter bara
+     storlek och litar på webbläsarens fetstil — de skulle annars renderas i brödtextvikt, bland
+     annat "Tack!" och "Beställningsbekräftelse" på den KUNDVÄNDA offertsigneringssidan. Återställ
+     UA-vikten här i base-lagret: utilities-lagret ligger efter, så varje `font-normal`/`font-medium`
+     och varje inline `fontWeight` vinner fortfarande. Storleken återställs medvetet INTE — den är
+     explicit satt överallt utom i gamla `app/plannering`, som får vara ful. */
+  h1, h2, h3, h4, h5, h6 { font-weight: bold; }
+}
 
 /* Planning density: the board was designed a touch large, so scale the whole planning surface down
    to a denser default (≈ two Safari zoom-out notches). `zoom` re-rasterises like browser zoom, so

--- a/app/globals.css
+++ b/app/globals.css
@@ -2,50 +2,18 @@
 @tailwind components;
 @tailwind utilities;
 
-/* Tailwind preflight is disabled project-wide (see tailwind.config.js → corePlugins.preflight:false),
-   so there is no global `border-width: 0 / border-style: solid` reset. A plain `border` utility on a
-   <div>/<span> then draws NOTHING (style defaults to none), and a `border-solid` without a width util
-   gets a phantom `medium` (~3px) border. Restore Tailwind's own preflight border reset scoped to the
-   whole planning surface (in @layer base so real width utilities like `border`/`border-l` still win),
-   so every bordered element — cards, grid lines, badges, the backlog — draws a clean hairline with no
-   phantom borders. The app-wide fix is deferred (would surface hidden borders on not-yet-rebuilt
-   non-CRM surfaces), hence the scope to .planning-density. */
-@layer base {
-  .planning-density *,
-  .planning-density *::before,
-  .planning-density *::after {
-    border-width: 0;
-    border-style: solid;
-  }
+/* Tailwind preflight är PÅ (2026-08-16). Dess border-reset (`border-width: 0; border-style: solid`
+   på allt) gäller nu app-vitt, så `border`/`border-t` beter sig som i vanlig Tailwind överallt: en
+   `<div>` med `border` ritar en hairline, och sidor utan breddklass får 0 istället för webbläsarens
+   `medium` (~3px). De tre scopade reseterna som simulerade detta för `.planning-density`,
+   `.planning-modal` och `.support-surface` är därmed borttagna — de var en brygga med slutdatum.
 
-  /* The custom planning overlays (admin, activity log, placeholder) use plain `border` utilities on
-     <div>s, which render nothing with preflight off (no border-style). Restore Tailwind's own
-     preflight border reset (width:0 + style:solid) scoped to those modals, so width utilities draw a
-     hairline and elements without one get no phantom `medium` border. */
-  .planning-modal *,
-  .planning-modal *::before,
-  .planning-modal *::after {
-    border-width: 0;
-    border-style: solid;
-  }
+   ⚠️ Lägg INTE till `border-solid` i nya komponenter. Det var lösningen medan preflight var av; nu
+   sätter det bara stilen på alla fyra sidor igen och återinför fantomkanten på sidor utan bredd.
 
-  /* Appärendena (Rapportera-knappen + backloggen i admin) OCH changeloggen — samma familj: det
-     användarna säger in, och det som går ut till dem. Samma reset, samma skäl — men värt att stava
-     ut vilket fel den tar bort, för det var inte uppenbart: `border-t border-solid` sätter stilen
-     på ALLA fyra sidor och bredden bara på toppen, så de tre andra föll tillbaka på webbläsarens
-     `medium` (~3px) och en tänkt avdelarlinje blev en låda runt hela sektionen. Med reseten beter
-     sig varje border-utility som i vanlig Tailwind, och `border-solid` behöver inte strös ut i
-     komponenterna.
-
-     ⚠️ TEMPORÄR. Preflight ska slås på app-vitt när de gamla ytorna stängts ner — då ska den här
-     regeln och sina syskon ovan raderas, inte utökas med fler selektorer. */
-  .support-surface *,
-  .support-surface *::before,
-  .support-surface *::after {
-    border-width: 0;
-    border-style: solid;
-  }
-}
+   Kvar att veta: element-reglerna längre ner i den här filen (`button { padding: 10px 14px }`,
+   `input { width: 100% }`, `label { display: block }`) ligger UTANFÖR `@layer base` och vinner
+   därför fortfarande över preflight. De är en separat städning. */
 
 /* Planning density: the board was designed a touch large, so scale the whole planning surface down
    to a denser default (≈ two Safari zoom-out notches). `zoom` re-rasterises like browser zoom, so

--- a/app/tid/TidClient.tsx
+++ b/app/tid/TidClient.tsx
@@ -895,8 +895,8 @@ function CompensationSection({
           ) : null}
 
           {/* Inmatningen försvinner när månaden är inlämnad — ersättningar är löneunderlag och fryser
-              med perioden, precis som timmarna. Villkorlig rendering och inte `hidden`: preflight är
-              av, så `hidden` och `flex` bråkar om display på samma element. */}
+              med perioden, precis som timmarna. Villkorlig rendering och inte `hidden`, eftersom
+              `hidden` och `flex` bråkar om display på samma element. */}
           {locked ? null : (
             <div className="grid gap-2 rounded-xl bg-[#f1f5ee] p-3">
               <div className="grid gap-2 sm:grid-cols-2">

--- a/app/tid/TimeEntryModal.tsx
+++ b/app/tid/TimeEntryModal.tsx
@@ -58,9 +58,8 @@ const KINDS: Array<{ key: TimeEntryKind; label: string }> = [
   { key: 'absence', label: 'Frånvaro' },
 ];
 
-// Fältstil på ett ställe. Preflight är av, så `border` utan `border-solid` ritar ingen linje —
-// och globals.css ger <select>/<textarea> ingen egen ram att ärva.
-const FIELD = 'w-full rounded-xl border border-solid border-[#dbe4d6] bg-white px-3 py-2 text-sm text-slate-900';
+// Fältstil på ett ställe.
+const FIELD = 'w-full rounded-xl border border-[#dbe4d6] bg-white px-3 py-2 text-sm text-slate-900';
 
 /**
  * Etikett för ETT FÄLT — medvetet inte `crm.sectionTitle`.

--- a/components/ui/Badge.tsx
+++ b/components/ui/Badge.tsx
@@ -2,11 +2,7 @@ import * as React from 'react';
 import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/lib/shared/cn';
 
-// ⚠️ `border-solid` är inte dekoration. Preflight är av (tailwind.config.js), och en <span> har
-// ingen kant från webbläsarens standardmall — så `border` ensamt sätter bredd och färg men lämnar
-// border-style på `none`, och ramen ritas ALDRIG. Formulärfält ser bortkomna ut på samma sätt men
-// klarar sig, eftersom <input> ärver en kantstil från UA-mallen. En <span> gör det inte.
-export const badgeVariants = cva('inline-flex items-center rounded-full border border-solid px-2 py-1 text-xs font-bold', {
+export const badgeVariants = cva('inline-flex items-center rounded-full border px-2 py-1 text-xs font-bold', {
   variants: {
     variant: {
       neutral: 'border-slate-200 bg-slate-50 text-slate-600',

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,9 +5,6 @@ module.exports = {
     './components/**/*.{js,ts,jsx,tsx,mdx}',
     './lib/**/*.{js,ts,jsx,tsx,mdx}',
   ],
-  corePlugins: {
-    preflight: false,
-  },
   theme: {
     extend: {
       colors: {


### PR DESCRIPTION
Tar bort `corePlugins.preflight: false` och raderar de tre scopade border-reseterna (`.planning-density`, `.planning-modal`, `.support-surface`) som simulerade preflight lokalt. De var en brygga med slutdatum — regeln i `globals.css` sa uttryckligen att de skulle raderas, inte utökas.

`border`/`border-t` beter sig nu som i vanlig Tailwind överallt: en `<div>` med `border` ritar en hairline, och sidor utan breddklass får 0 i stället för webbläsarens `medium` (~3px).

## Fallouten, mätt

**714 ställen** har en border-breddklass. **691 av dem bär en explicit färgklass** — någon skrev en färg, kanten var avsedd och har varit osynlig sedan den skrevs. De ritas nu. Resten är badges där `crm.badge` bär bredden och färgen kommer från en status-map; samtliga mappar är kontrollerade och bär kantfärg.

Två saker gör typografi-hälften mildare än väntat: typsnittet sätts **inline på `<body>`** och slår därför preflight, och CRM:s titeltokens (`crm.pageTitle` = `text-lg font-bold`, `crm.sectionTitle` = `text-[10px] font-bold`) bär både storlek och vikt.

## Vad granskningen fångade

Den första analysen kollade rubrikernas storlek men inte deras **vikt**, och missade `box-sizing` och `line-height` helt. Fyra äkta regressioner, alla rättade i andra commiten:

| Fynd | Åtgärd |
| --- | --- |
| 59 rubriker tappade fetstil — varav fyra på den **kundvända** offertsigneringssidan ("Tack!", "Beställningsbekräftelse") | Base-regel `h1–h6 { font-weight: bold }`. Utilities ligger efter i kaskaden, så explicita val vinner fortfarande. Noll av de 59 låg i `app/crm` — därför fångade genomgången av CRM dem inte. |
| Tre punktlistor med `pl-5` tappade sina punkter | `list-disc` |
| Min kommentar i `globals.css` påstod felaktigt att `border-solid` "återinför fantomkanten" | Rättad — `*{border-width:0}` gör den bara överflödig |
| `FRONTEND_SYSTEM.md` (source of truth per CLAUDE.md) + tio kodkommentarer instruerade fortfarande i den gamla lösningen | Omskrivna; nio döda `support-surface`/`planning-modal`-klasser borttagna |

## Kvar efter denna

Element-reglerna längre ner i `globals.css` — `button { padding: 10px 14px }`, `input { width: 100% }`, `label { display: block }` — ligger **utanför** `@layer base` och vinner därför fortfarande över preflight. Det är preflight-familjens andra hälft och en separat städning.

Två breda effekter är medvetet accepterade som förbättringar: `box-sizing: border-box` gäller nu alla element, och `line-height` går från webbläsarens ~1.2 till 1.5 (Tailwinds `text-*` bär egen line-height, så de ytorna är opåverkade).

## Testning

Build, type-check, lint och 1337 tester gröna. Manuell genomgång av CRM-ytorna utan fynd.

🤖 Generated with [Claude Code](https://claude.com/claude-code)