### PR TITLE
Startsidan efter /tid:s mönster

### DIFF
--- a/components/dashboard/ClientDashboard.tsx
+++ b/components/dashboard/ClientDashboard.tsx
@@ -120,6 +120,25 @@ const baseExtra: Record<string, Omit<QuickLink, 'href' | 'title'>> = {
 
 const cardClass = cn(crm.cardInner, 'min-h-0');
 
+/**
+ * Klockan i sidhuvudet, förankrad i Europe/Stockholm.
+ *
+ * ⚠️ SIDAN SERVER-RENDERAS (`export const dynamic = 'force-dynamic'` i app/page.tsx) och servern går
+ * på UTC. `new Date()` avläst med lokala getters gav därför olika svar på server och klient: hela
+ * sommaren låg serverns klocka två timmar efter, så mellan 08:00 och 10:00 svensk tid skrev servern
+ * "God morgon" och klienten "Hej", och mellan 00:00 och 02:00 stod fel veckodag och fel datum.
+ *
+ * Samma zonfälla som rapporteringen redan betalat för (PR #69), och samma lösning som /tid.
+ */
+const STOCKHOLM_HEADER_PARTS = new Intl.DateTimeFormat('sv-SE', {
+  timeZone: 'Europe/Stockholm',
+  weekday: 'long',
+  day: 'numeric',
+  month: 'long',
+  hour: 'numeric',
+  hourCycle: 'h23',
+});
+
 export function ClientDashboard({ role }: { role: UserRole | null }) {
   const NEWS_SEEN_KEY = 'dashboard.news.lastSeenId';
 
@@ -225,12 +244,13 @@ export function ClientDashboard({ role }: { role: UserRole | null }) {
   const toast = useToast();
 
   const todayMeta = useMemo(() => {
-    const now = new Date();
-    const weekday = now.toLocaleDateString('sv-SE', { weekday: 'long' });
-    const monthDay = now.toLocaleDateString('sv-SE', { day: 'numeric', month: 'long' });
-    const hour = now.getHours();
-    const greeting = hour < 10 ? 'God morgon' : hour < 17 ? 'Hej' : 'God kväll';
-    return { greeting, weekday: weekday.charAt(0).toUpperCase() + weekday.slice(1), monthDay };
+    const parts = STOCKHOLM_HEADER_PARTS.formatToParts(new Date());
+    const value = (type: string) => parts.find((part) => part.type === type)?.value ?? '';
+    const hour = Number(value('hour'));
+    return {
+      greeting: hour < 10 ? 'God morgon' : hour < 17 ? 'Hej' : 'God kväll',
+      date: `${value('weekday')} ${value('day')} ${value('month')}`,
+    };
   }, []);
 
   const isMember = effectiveRole === 'member';
@@ -252,21 +272,19 @@ export function ClientDashboard({ role }: { role: UserRole | null }) {
       {newsItem && <NewsModal open={newsOpen} item={newsItem} onClose={closeNews} />}
 
       <div className="mx-auto grid w-full max-w-[1200px] grid-cols-1 gap-4">
-        {/* Header */}
-        <div className="flex flex-wrap items-start justify-between gap-4">
+        {/* Sidhuvud. Samma form som resten av CRM: titel, EN underrad, åtgärden till höger.
+            Den gröna "God morgon ● Lördag"-pillen är borta — hälsningen och veckodagen var samma
+            information som underraden och behövde inte ett eget element. Kvar av underraden är
+            hälsningen och datumet; "fokus på det viktigaste först" sa ingenting man kan agera på. */}
+        <div className="flex flex-wrap items-start justify-between gap-3">
           <div>
-            <div className="inline-flex w-fit items-center gap-2 rounded-full border border-emerald-200 bg-emerald-50 px-2.5 py-1 text-[11px] font-bold uppercase tracking-[0.06em] text-emerald-700">
-              {todayMeta.greeting}
-              <span className="h-1 w-1 rounded-full bg-emerald-500" />
-              {todayMeta.weekday}
-            </div>
-            <h1 className="m-0 mt-1.5 text-xl font-bold tracking-tight text-slate-900">Översikt</h1>
-            <p className="m-0 mt-1 text-sm text-slate-500">{todayMeta.monthDay} · fokus på det viktigaste först</p>
+            <h1 className={cn('m-0', crm.pageTitle)}>Startsida</h1>
+            <p className={cn('m-0 mt-1', crm.pageSubtitle)}>{todayMeta.greeting} · {todayMeta.date}</p>
           </div>
           <button
             type="button"
             onClick={() => { setTimePrefill(null); setTimeModalOpen(true); }}
-            className="inline-flex items-center gap-1.5 rounded-xl px-3 py-1.5 text-sm font-semibold text-white transition hover:opacity-90"
+            className={crm.primaryButton}
             style={{ backgroundColor: 'var(--crm-primary)' }}
           >
             <svg width="16" height="16" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor" fill="none" aria-hidden><path d="M12 5v14M5 12h14" strokeLinecap="round" strokeLinejoin="round" /></svg>
@@ -277,10 +295,13 @@ export function ClientDashboard({ role }: { role: UserRole | null }) {
         {/* Installers (members) get the work schedule first — their most important view */}
         {isMember && scheduleSection}
 
-        {/* Quick links — only on phone/tablet; on desktop the sidebar is always open so
-            these would be redundant and just take space. */}
-        <section className={cn(crm.cardInner, 'lg:hidden')}>
-          <p className={cn('mb-3', crm.sectionTitle)}>Snabba genvägar</p>
+        {/* Snabba genvägar — bara på telefon/platta; på desktop står sidomenyn alltid öppen och
+            genvägarna vore bara en andra kopia av den.
+
+            Rubriken "Snabba genvägar" är borta: en grid av ikoner med titlar under säger redan vad
+            den är, och etiketten kostade en rad högst upp vid varje besök. Namnet ligger kvar som
+            aria-label, där en samling länkar faktiskt behöver ett. */}
+        <section className={cn(crm.cardInner, 'lg:hidden')} aria-label="Snabba genvägar">
           <QuickLinksGrid links={links} compact={isSmall} />
         </section>
 

--- a/components/dashboard/DashboardCardHeader.tsx
+++ b/components/dashboard/DashboardCardHeader.tsx
@@ -1,0 +1,40 @@
+import type { ReactNode } from 'react';
+import { cn } from '@/lib/shared/cn';
+
+/**
+ * Rubrikraden i startsidans kort.
+ *
+ * En rubrik, en valfri räknare, en valfri åtgärd — och ingen förklarande brödtext. Varje widget bar
+ * tidigare sin egen instruerande mening ("Visa det som fortfarande kräver åtgärd först, och dölj
+ * resten tills det behövs", "Dokument som kräver läsning eller godkännande ska fångas direkt"). De
+ * beskrev komponentens beteende snarare än användarens jobb, och ingen läser dem efter första
+ * besöket. Samma disciplin som /tid: informationen bär sin egen etikett.
+ *
+ * ⚠️ STORLEKEN ÄR text-base MED FLIT. Widgetrubrikerna var text-xl (20 px) medan sidans egen h1 är
+ * 18 px (`crm.pageTitle`) — korten skrek alltså högre än sidan de ligger på, och fyra likadana
+ * 20-pixelsrubriker under varandra gjorde det omöjligt att se vilket kort som var viktigast.
+ *
+ * `meta` är för ett tillstånd som ändras (ett antal, en status). Sätt det INTE när samma siffra
+ * redan står i kortets innehåll — det var precis den dubbleringen som gjorde dokumentkortet tungt.
+ */
+export default function DashboardCardHeader({
+  title,
+  meta,
+  action,
+  className,
+}: {
+  title: string;
+  meta?: ReactNode;
+  action?: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div className={cn('flex flex-wrap items-center justify-between gap-x-3 gap-y-1.5', className)}>
+      <div className="flex min-w-0 flex-wrap items-center gap-2">
+        <h2 className="m-0 text-base font-bold tracking-tight text-slate-900">{title}</h2>
+        {meta}
+      </div>
+      {action ? <div className="flex shrink-0 items-center gap-2">{action}</div> : null}
+    </div>
+  );
+}

--- a/components/dashboard/DashboardDocumentApprovals.tsx
+++ b/components/dashboard/DashboardDocumentApprovals.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import React, { useEffect, useMemo, useState } from 'react';
 import { cn } from '@/lib/shared/cn';
 import Badge from '../ui/Badge';
+import DashboardCardHeader from './DashboardCardHeader';
 
 type DashboardDocumentItem = {
   publicationId: string;
@@ -49,9 +50,6 @@ export default function DashboardDocumentApprovals({ compact, hideWhenEmpty, onV
   );
   const pendingCount = items.filter(item => !isCompleted(item)).length;
   const shouldRender = loading || !!error || pendingCount > 0;
-  const highlightTone = pendingCount > 0
-    ? { border: '1px solid #d6e6d3', background: '#f6f9f3' }
-    : { border: '1px solid #e5e7eb', background: '#ffffff' };
 
   useEffect(() => {
     onVisibilityChange?.(shouldRender);
@@ -62,21 +60,23 @@ export default function DashboardDocumentApprovals({ compact, hideWhenEmpty, onV
   }
 
   return (
-    <div className={cn('grid', compact ? 'gap-2.5' : 'gap-3.5')}>
-      <div className="flex items-center justify-between gap-3">
-        <div className="grid gap-1">
-          <div className="inline-flex flex-wrap items-center gap-2">
-            <h2 className={cn('m-0 font-bold text-slate-900', compact ? 'text-base' : 'text-xl')}>Dokument att kvittera</h2>
-            <Badge variant={pendingCount > 0 ? 'accent' : 'neutral'} className="gap-1.5 px-2 py-1 text-[11px]">
-              {pendingCount > 0 ? `${pendingCount} väntar` : 'Allt klart'}
-            </Badge>
-          </div>
-          {(!compact || pendingCount > 0) && <p className={cn('m-0 text-slate-500', compact ? 'text-xs' : 'text-[13px]')}>Dokument som kräver läsning eller godkännande ska fångas direkt.</p>}
-        </div>
-        <Link href="/mina-dokument" className="text-[13px] font-bold text-emerald-700 no-underline hover:text-emerald-800">
-          Öppna alla
-        </Link>
-      </div>
+    <div className="grid gap-3">
+      {/* Rubriken bar tidigare en badge som växlade mellan "N väntar" och "Allt klart", en mening om
+          vad kortet är till för, OCH en egen ruta under som upprepade samma siffra i klartext
+          ("N dokument väntar på att du läser eller godkänner dem"). Tre sätt att säga en sak.
+
+          "Allt klart"-läget är borta utan att något gick förlorat: startsidan skickar `hideWhenEmpty`
+          och döljer hela kortet vid noll (se retur-null ovan), så den varianten av badgen kunde
+          aldrig visas där. Nollfallets gröna rad nedan lever kvar för en anropare utan flaggan. */}
+      <DashboardCardHeader
+        title="Dokument att kvittera"
+        meta={pendingCount > 0 ? <Badge variant="accent">{pendingCount} väntar</Badge> : null}
+        action={
+          <Link href="/mina-dokument" className="text-[13px] font-bold text-emerald-700 no-underline hover:text-emerald-800">
+            Öppna alla
+          </Link>
+        }
+      />
 
       {loading && <p className="m-0 text-xs text-slate-500">Laddar…</p>}
       {error && <p className="m-0 text-xs text-red-700">{error}</p>}
@@ -88,17 +88,6 @@ export default function DashboardDocumentApprovals({ compact, hideWhenEmpty, onV
       )}
       {!loading && !error && pendingCount > 0 && (
         <>
-          <div
-            className={cn('grid gap-1 rounded-2xl', compact ? 'px-3 py-2.5' : 'px-3.5 py-3')}
-            style={highlightTone}
-          >
-            <p className={cn('m-0 font-bold text-slate-900', compact ? 'text-[13px]' : 'text-sm')}>
-              {pendingCount} dokument väntar på att du läser eller godkänner dem.
-            </p>
-            <p className={cn('m-0 text-slate-500', compact ? 'text-[11.5px]' : 'text-[12.5px]')}>
-              Börja med det som har deadline eller kräver aktiv kvittens.
-            </p>
-          </div>
           <div className="grid gap-2">
             {pendingItems.map(item => (
               <div key={item.publicationId} className={cn('grid gap-2 rounded-[14px] border border-[#e3e9df] bg-[#f9fbf7] shadow-[0_1px_2px_rgba(15,23,42,0.05)]', compact ? 'px-3 py-2.5' : 'px-3.5 py-3')}>

--- a/components/dashboard/DashboardNotes.tsx
+++ b/components/dashboard/DashboardNotes.tsx
@@ -7,6 +7,7 @@ import Badge from '../ui/Badge';
 import Button from '../ui/Button';
 import Input from '../ui/Input';
 import Textarea from '../ui/Textarea';
+import DashboardCardHeader from './DashboardCardHeader';
 
 interface NoteItem {
   id: string;
@@ -74,7 +75,6 @@ export function DashboardNotes({ compact, desktopMode }: { compact?: boolean; de
   const supabase = createClientComponentClient();
   const mounted = useRef(false);
   const [userId, setUserId] = useState<string | null>(null);
-  const [live, setLive] = useState<'connecting'|'on'|'off'>('off');
 
   const syncPushState = useCallback(async () => {
     if (typeof window === 'undefined') return;
@@ -190,7 +190,6 @@ export function DashboardNotes({ compact, desktopMode }: { compact?: boolean; de
   // Realtime subscription
   useEffect(() => {
     if (!userId) return;
-    setLive('connecting');
     const channel = supabase
       .channel('realtime:dashboard_notes')
       .on('postgres_changes', {
@@ -219,14 +218,10 @@ export function DashboardNotes({ compact, desktopMode }: { compact?: boolean; de
           }
         });
       })
-      .subscribe(status => {
-        if (status === 'SUBSCRIBED') setLive('on');
-        if (status === 'CHANNEL_ERROR' || status === 'CLOSED') setLive('off');
-      });
+      .subscribe();
 
     return () => {
       supabase.removeChannel(channel);
-      setLive('off');
     };
   }, [supabase, userId]);
 
@@ -621,85 +616,50 @@ export function DashboardNotes({ compact, desktopMode }: { compact?: boolean; de
     return priority?.label === 'Påminnelse sen';
   }).length;
   const activeNotesWithoutReminderCount = items.filter(item => item.status === 'active' && item.kind === 'note' && !item.remindAt).length;
-  const filterHelperText = getFilterHelperText(filter, {
-    openCount,
-    meetingCount,
-    todayCount,
-    doneCount,
-    overdueReminderCount,
-    urgentMeetingCount,
-    activeNotesWithoutReminderCount,
-  });
-  const liveTextClass =
-    live === 'on'
-      ? 'text-emerald-700'
-      : live === 'connecting'
-        ? 'text-amber-600'
-        : 'text-slate-500';
-  const liveDotClass =
-    live === 'on'
-      ? 'bg-emerald-500 shadow-[0_0_4px_#10b981]'
-      : live === 'connecting'
-        ? 'bg-amber-500'
-        : 'bg-slate-400';
   const composerFieldLabelClass = cn('grid gap-1 text-slate-700', compact ? 'text-[13px]' : 'text-xs');
   const composerInputClass = cn(compact ? 'min-h-11 px-3 py-2.5 text-[13px]' : 'min-h-10 px-3 py-2.5 text-sm');
 
   return (
-    <div className={cn('flex flex-col', compact ? 'gap-3' : 'gap-4')}>
-      <div className={cn('flex flex-wrap items-start', compact ? 'gap-2' : 'gap-3')}>
-        <div className="grid gap-1.5">
-          <h2 className={cn('m-0 flex flex-wrap items-center gap-2 font-bold text-slate-900', compact ? 'text-base' : 'text-xl')}>
-          Arbetsyta
-          <span className={cn('inline-flex items-center gap-1 text-[11px] font-medium', liveTextClass)}>
-            <span className={cn('h-2 w-2 rounded-full', liveDotClass)} />
-            {live==='on' ? 'Live' : live==='connecting' ? 'Ansluter…' : 'Offline'}
-          </span>
-          </h2>
-          <div className="flex flex-wrap gap-2">
-            <Badge className="px-2.5 py-1 text-[11px]">{openCount} öppna</Badge>
-            <span style={statusPillOpen}>{meetingCount} möten</span>
-            <Badge className="px-2.5 py-1 text-[11px]">{doneCount} klara</Badge>
-          </div>
-          <p className="m-0 text-xs leading-[1.5] text-slate-500">
-            {filterHelperText}
-          </p>
-        </div>
-        <div className={cn('ml-auto flex flex-wrap justify-end', compact ? 'gap-1' : 'gap-1.5')}>
-          {([
-            ['all', 'Alla'],
-            ['open', 'Öppna'],
-            ['meetings', `Möten ${meetingCount}`],
-            ['notes', 'Anteckningar'],
-            ['today', `Idag ${todayCount}`],
-            ['done', 'Klart'],
-          ] as const).map(([value, label]) => (
-            <button key={value} onClick={()=>setFilter(value)} style={{ ...filterBtn, ...(filter===value? filterBtnActive : {}), ...(compact ? compactFilterBtn : {}) }}>{label}</button>
-          ))}
-        </div>
+    <div className="flex flex-col gap-3">
+      {/* Rubriken bar tidigare tre badges (öppna / möten / klara) OCH en förklarande mening som
+          bytte text per filter. Mötesantalet står redan på filterknappen "Möten N", så badgen sa om
+          det; meningen beskrev vad filtret visar, vilket filterknappen redan gör. */}
+      <DashboardCardHeader
+        title="Arbetsyta"
+        meta={openCount > 0 ? <Badge variant="accent">{openCount} öppna</Badge> : null}
+      />
+
+      <div className="flex flex-wrap gap-1.5">
+        {([
+          ['all', 'Alla'],
+          ['open', 'Öppna'],
+          ['meetings', `Möten ${meetingCount}`],
+          ['notes', 'Anteckningar'],
+          ['today', `Idag ${todayCount}`],
+          ['done', `Klart ${doneCount}`],
+        ] as const).map(([value, label]) => (
+          <button key={value} onClick={()=>setFilter(value)} style={{ ...filterBtn, ...(filter===value? filterBtnActive : {}), ...(compact ? compactFilterBtn : {}) }}>{label}</button>
+        ))}
       </div>
       {error && (
         <div className="text-xs text-red-700">{error}</div>
       )}
-      <section style={utilityCardStyle}>
-        <div style={summaryGridStyle}>
-          <div style={summaryInfoCardStyle}>
-            <span style={summaryInfoLabelStyle}>Nästa möte</span>
-            <strong style={summaryInfoValueStyle}>{nextMeeting ? nextMeeting.title : 'Inget möte bokat'}</strong>
-            <span style={summaryInfoHintStyle}>{nextMeeting?.startsAt ? formatReminderLabel(nextMeeting.startsAt) : 'Skapa ett möte när du vill blocka tid eller följa upp något.'}</span>
-          </div>
-          <div style={summaryInfoCardStyle}>
-            <span style={summaryInfoLabelStyle}>Påminnelser att agera på</span>
-            <strong style={summaryInfoValueStyle}>{overdueReminderCount}</strong>
-            <span style={summaryInfoHintStyle}>{overdueReminderCount > 0 ? 'Det finns poster där påminnelsen redan passerat.' : 'Inga sena påminnelser just nu.'}</span>
-          </div>
-          <div style={summaryInfoCardStyle}>
-            <span style={summaryInfoLabelStyle}>Anteckningar utan tid</span>
-            <strong style={summaryInfoValueStyle}>{activeNotesWithoutReminderCount}</strong>
-            <span style={summaryInfoHintStyle}>{activeNotesWithoutReminderCount > 0 ? 'Bra för lösa idéer, men lägg gärna påminnelse på sådant som inte får tappas.' : 'Alla öppna anteckningar har redan en tidsmarkör eller är möten.'}</span>
-          </div>
-        </div>
-      </section>
+      {/* Tre siffror, inte tre stycken prosa. Varje kort hade tidigare en hel mening under värdet
+          ("Bra för lösa idéer, men lägg gärna påminnelse på sådant som inte får tappas") som gav råd
+          i stället för att svara på något.
+
+          Etiketterna står kvar med flit, till skillnad från t.ex. "Snabba genvägar": en naken tvåa
+          betyder ingenting, så här BÄR etiketten informationen. Nästa möte får behålla sin undertext
+          — den är mötets tid, alltså data och inte en uppmaning. */}
+      <div className="grid gap-2.5 rounded-xl border border-solid border-[#e3e9df] bg-white px-3 py-2.5 sm:grid-cols-3 sm:gap-3">
+        <SummaryStat
+          label="Nästa möte"
+          value={nextMeeting ? nextMeeting.title : 'Inget bokat'}
+          hint={nextMeeting?.startsAt ? formatReminderLabel(nextMeeting.startsAt) : undefined}
+        />
+        <SummaryStat label="Sena påminnelser" value={String(overdueReminderCount)} />
+        <SummaryStat label="Utan påminnelse" value={String(activeNotesWithoutReminderCount)} />
+      </div>
       <section style={utilityCardStyle}>
         <div className="grid gap-2.5">
           <div className="flex flex-wrap items-center justify-between gap-3">
@@ -1297,35 +1257,21 @@ function getRelevantTime(item: NoteItem) {
   return Number.isNaN(time) ? Number.MAX_SAFE_INTEGER : time;
 }
 
-function getFilterHelperText(filter: 'all'|'open'|'meetings'|'notes'|'today'|'done', stats: { openCount: number; meetingCount: number; todayCount: number; doneCount: number; overdueReminderCount: number; urgentMeetingCount: number; activeNotesWithoutReminderCount: number; }) {
-  switch (filter) {
-    case 'all':
-      return stats.urgentMeetingCount > 0
-        ? `${stats.urgentMeetingCount} möten behöver extra uppmärksamhet just nu. Resten ligger kvar i arbetsytan för överblick.`
-        : 'Här ser du hela din personliga arbetsyta med möten, anteckningar och sådant som redan är klart.';
-    case 'open':
-      return stats.overdueReminderCount > 0
-        ? `${stats.openCount} öppna poster, varav ${stats.overdueReminderCount} har en påminnelse som redan passerat.`
-        : `${stats.openCount} öppna poster som fortfarande kräver någon form av handling eller uppföljning.`;
-    case 'meetings':
-      return stats.meetingCount > 0
-        ? `${stats.meetingCount} aktiva möten. Lägg plats, länk och påminnelse för att göra dem självbärande.`
-        : 'Här samlas alla aktiva möten så att du snabbt ser vad som är bokat.';
-    case 'notes':
-      return stats.activeNotesWithoutReminderCount > 0
-        ? `${stats.activeNotesWithoutReminderCount} anteckningar saknar tid eller påminnelse och fungerar som fria kom-ihåg-poster.`
-        : 'Här ser du dina öppna anteckningar och uppföljningar som inte är bokade som möten.';
-    case 'today':
-      return stats.todayCount > 0
-        ? `${stats.todayCount} poster är tidsatta för idag via mötestid eller påminnelse.`
-        : 'Den här vyn hjälper dig fokusera på det som faktiskt landar idag.';
-    case 'done':
-      return stats.doneCount > 0
-        ? `${stats.doneCount} poster är klara eller stängda och ligger kvar för snabb återblick tills du rensar dem.`
-        : 'Här visas sådant som redan är klart eller avslutat.';
-    default:
-      return '';
-  }
+/**
+ * En siffra i arbetsytans sammanfattningsrad.
+ *
+ * `hint` är för data som hör till värdet (mötets tid), inte för råd om vad man borde göra med det.
+ */
+function SummaryStat({ label, value, hint }: { label: string; value: string; hint?: string }) {
+  return (
+    <div className="grid min-w-0 content-start gap-0.5">
+      <span className="text-[11px] font-bold uppercase tracking-[0.08em] text-slate-500">{label}</span>
+      {/* ⚠️ INTE `truncate`. Värdet är oftast en siffra, men "Nästa möte" är en mötestitel som
+          användaren själv skrivit — klipptes den på en telefon fanns ingen väg att läsa resten. */}
+      <strong className="break-words text-sm text-slate-900">{value}</strong>
+      {hint ? <span className="break-words text-[11.5px] text-slate-500">{hint}</span> : null}
+    </div>
+  );
 }
 
 function getEmptyStateTitle(filter: 'all'|'open'|'meetings'|'notes'|'today'|'done') {
@@ -1587,11 +1533,6 @@ const checkBtnDone: React.CSSProperties = { background:'#16a34a', border:'1px so
 const pushStateBadge: React.CSSProperties = { display:'inline-flex', alignItems:'center', padding:'6px 10px', borderRadius:999, border:'1px solid #d1d5db', fontSize:11.5, fontWeight:700 };
 const sectionCard: React.CSSProperties = { display:'grid', gap:10, padding:'16px 18px', border:'1px solid #e0e8dc', borderRadius:18, background:'#f9fbf7', boxShadow:'0 1px 3px rgba(20,44,27,0.06), 0 18px 36px -18px rgba(20,44,27,0.24)' };
 const compactUtilityCard: React.CSSProperties = { display:'grid', gap:8, padding:'12px 14px', border:'1px solid #e0e8dc', borderRadius:16, background:'#f9fbf7', boxShadow:'0 1px 3px rgba(20,44,27,0.06)' };
-const summaryGridStyle: React.CSSProperties = { display:'grid', gridTemplateColumns:'repeat(auto-fit, minmax(160px, 1fr))', gap:10 };
-const summaryInfoCardStyle: React.CSSProperties = { display:'grid', gap:4, padding:'12px 14px', border:'1px solid #e3e9df', borderRadius:16, background:'#ffffff', boxShadow:'0 1px 2px rgba(15,23,42,0.05)' };
-const summaryInfoLabelStyle: React.CSSProperties = { fontSize:11.5, color:'#64748b', fontWeight:700, textTransform:'uppercase', letterSpacing:'0.04em' };
-const summaryInfoValueStyle: React.CSSProperties = { fontSize:14, color:'#0f172a' };
-const summaryInfoHintStyle: React.CSSProperties = { fontSize:11.5, color:'#64748b', lineHeight:1.45 };
 const sectionTitle: React.CSSProperties = { fontSize:14, color:'#0f172a' };
 const helperText: React.CSSProperties = { fontSize:12, color:'#64748b', lineHeight:1.5 };
 const fieldLabel: React.CSSProperties = { fontSize:12, fontWeight:700, color:'#334155', letterSpacing:'0.01em' };

--- a/components/dashboard/DashboardSchedule.tsx
+++ b/components/dashboard/DashboardSchedule.tsx
@@ -5,7 +5,34 @@ import { createClientComponentClient } from '@supabase/auth-helpers-nextjs';
 import { cn } from '@/lib/shared/cn';
 import Input from '../ui/Input';
 import Textarea from '../ui/Textarea';
+import Badge from '../ui/Badge';
+import DashboardCardHeader from './DashboardCardHeader';
 import { crmJobToScheduleItem, type CrmJobRow } from '@/lib/domains/planning/myJobs';
+
+const MONTHS_SHORT = ['jan', 'feb', 'mar', 'apr', 'maj', 'jun', 'jul', 'aug', 'sep', 'okt', 'nov', 'dec'];
+
+/**
+ * '2026-08-17' + '2026-08-23' → '17–23 aug', eller '28 jul–3 aug' över ett månadsskifte.
+ *
+ * Veckoväljaren visade tidigare de råa ISO-datumen ('2026-08-17 – 2026-08-23').
+ *
+ * Fälten plockas ur strängen i stället för via `new Date()`, så själva formateringen inte kan flytta
+ * dagen. ⚠️ MEN INDATA KAN DET: `range` byggs av `startOfISOWeek(new Date())` med LOKALA getters, och
+ * servern går på UTC. Måndag 01:30 svensk tid landar därför på föregående ISO-vecka i server-
+ * renderingen och rättas först vid hydreringen — hela komponenten hämtar då fel veckas jobb, inte
+ * bara etiketten. Befintlig bugg som ligger utanför den här omgången (att flytta ankaret ändrar
+ * vilka rader RPC:erna får tillbaka, alltså beteende och inte form). Samma felklass som PR #69.
+ */
+function weekRangeLabel(startISO: string, endISO: string): string {
+  const start = startISO.split('-').map(Number);
+  const end = endISO.split('-').map(Number);
+  if (start.length !== 3 || end.length !== 3 || start.some(Number.isNaN) || end.some(Number.isNaN)) {
+    return `${startISO} – ${endISO}`;
+  }
+  return start[1] === end[1]
+    ? `${start[2]}–${end[2]} ${MONTHS_SHORT[end[1] - 1]}`
+    : `${start[2]} ${MONTHS_SHORT[start[1] - 1]}–${end[2]} ${MONTHS_SHORT[end[1] - 1]}`;
+}
 
 // A CRM-planned job carries source: 'crm'; legacy rows from get_my_jobs have no source field.
 // The enrichment queries, the detail modal and time reporting all assume the legacy world, so
@@ -525,118 +552,84 @@ export default function DashboardSchedule({ compact = false, onReportTime }: { c
     return { accent: '#64748b', badgeBg: '#f1f5f9', badgeFg: '#334155', label: null as string | null };
   }, []);
 
-  const selectedDayLabel = dayIdx == null ? 'Alla dagar' : ['Måndag', 'Tisdag', 'Onsdag', 'Torsdag', 'Fredag'][dayIdx];
   const visibleJobCount = grouped.reduce((sum, group) => sum + group.arr.length, 0);
-  const scheduleCardStyle: React.CSSProperties = {
-    border: '1px solid #e0e8dc',
-    background: '#f9fbf7',
-    borderRadius: compact ? 18 : 22,
-    padding: compact ? 12 : 18,
-    display: 'grid',
-    gap: compact ? 10 : 14,
-    boxShadow: '0 1px 3px rgba(20,44,27,0.06), 0 18px 36px -18px rgba(20,44,27,0.24)'
-  };
-  const weekNavButtonClass = cn(
-    'w-fit rounded-[12px] border border-[#dce4d8] bg-white font-semibold text-slate-700 shadow-[0_1px_2px_rgba(15,23,42,0.05)] transition-[transform,background-color,border-color,box-shadow] hover:-translate-y-0.5 hover:border-[#cfdcc9] hover:bg-[#f9fbf7] hover:text-slate-900 hover:shadow-[0_8px_20px_-10px_rgba(20,44,27,0.30)] active:translate-y-0',
-    compact ? 'min-w-[100px] px-2.5 py-[5px] text-[11px]' : 'min-w-[112px] px-3 py-1.5 text-xs'
-  );
-  const metaPillClass = cn(
-    'inline-flex shrink-0 items-center gap-1.5 whitespace-nowrap rounded-full border border-[#e0e8dc] bg-[linear-gradient(180deg,#ffffff_0%,#f9fbf7_100%)] font-semibold text-slate-600 shadow-[inset_0_1px_0_rgba(255,255,255,0.78)]',
-    compact ? 'px-[9px] py-[5px] text-[10.5px]' : 'px-[9px] py-[5px] text-[11.5px]'
+  const dayButtonClass = (active: boolean) => cn(
+    'w-full justify-center rounded-lg border border-solid px-1 py-1.5 text-xs transition',
+    active
+      ? 'border-transparent font-bold text-white shadow-sm [background:var(--crm-primary)]'
+      : 'border-[#d9e2d4] bg-white font-medium text-slate-600 hover:border-slate-400 hover:text-slate-900',
   );
 
+  // ⚠️ INGEN EGEN KORTRAM HÄR. ClientDashboard renderar redan <section className={cardClass}> runt
+  // den här komponenten, och det gjorde schemat till ett kort inuti ett kort: dubbel kant, dubbel
+  // bakgrund, dubbel skugga och dubbel padding. Det var därför schemat såg tyngre ut än allt annat
+  // på sidan. Uppgifter, Dokument och Arbetsytan returnerar alla en naken <div> — samma sak här nu.
   return (
-    <section
-      style={scheduleCardStyle}
-    >
-      <div className={cn('grid', compact ? 'gap-2' : 'gap-2.5')}>
-        <div className={cn('flex flex-wrap items-start justify-between', compact ? 'gap-2' : 'gap-3')}>
-          <div className="grid gap-1">
-            <div className="inline-flex flex-wrap items-center gap-2">
-              <h2 className={cn('m-0 text-slate-900', compact ? 'text-[15px]' : 'text-lg')}>Arbetsschema</h2>
-              <span className={cn('inline-flex items-center gap-1.5 rounded-full border border-emerald-200 bg-emerald-50 font-bold text-emerald-700', compact ? 'px-2 py-1 text-[10.5px]' : 'px-2 py-1 text-[11px]')}>
-                Vecka {range.weekNumber}
-              </span>
-            </div>
-            <span className={cn('text-slate-500', compact ? 'text-[11px]' : 'text-xs')}>{range.label} • {range.startISO} – {range.endISO}</span>
-            <div className={cn('flex items-center gap-2', compact ? 'max-w-full flex-nowrap overflow-x-auto pb-0.5 pr-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden' : 'flex-wrap')}>
-              <span className={metaPillClass}>
-                {visibleJobCount} {visibleJobCount === 1 ? 'jobb' : 'jobb'}
-              </span>
-              <span className={metaPillClass}>
-                {selectedDayLabel}
-              </span>
-            </div>
-          </div>
-        </div>
+    <div className="grid gap-3">
+      {/* "Vecka 33" stod tidigare BÅDE i en badge här och i veckoväljaren under. Veckan hör hemma i
+          väljaren — det är där man ändrar den. Kvar i rubriken: antalet jobb, som inte står någon
+          annanstans. Metapillen "Alla dagar" är borta; dagväljaren visar redan vilken dag som är
+          vald genom vilken knapp som är intryckt. */}
+      <DashboardCardHeader
+        title="Arbetsschema"
+        meta={<Badge variant="accent">{visibleJobCount} jobb</Badge>}
+      />
 
-        <div className={cn('grid w-full box-border items-center gap-1.5 rounded-[16px] border border-[#e0e8dc] bg-[linear-gradient(180deg,#ffffff_0%,#f9fbf7_100%)] shadow-[inset_0_1px_0_rgba(255,255,255,0.85)] [grid-template-columns:minmax(0,1fr)_auto_minmax(0,1fr)]', compact ? 'p-1.5' : 'p-2.5')}>
-          <button
-            type="button"
-            onClick={()=>setWeekOffset(prev => prev - 1)}
-            className={cn(weekNavButtonClass, 'justify-self-start')}
-          >
-            <span aria-hidden="true" className="text-[12px] leading-none">←</span>
-            <span className="leading-none">Föregående</span>
-          </button>
-          <div className={cn('inline-flex items-center justify-center rounded-[10px] font-bold text-slate-900', compact ? 'min-w-[116px] px-2.5 py-[5px] text-[11px]' : 'min-w-[132px] px-3 py-1.5 text-xs')}>
-            Vecka {range.weekNumber}
-          </div>
-          <button
-            type="button"
-            onClick={()=>setWeekOffset(prev => prev + 1)}
-            className={cn(weekNavButtonClass, 'justify-self-end')}
-          >
-            <span className="leading-none">Nästa</span>
-            <span aria-hidden="true" className="text-[12px] leading-none">→</span>
-          </button>
+      {/* Veckoväljaren, samma form som /tid: pilar i kanterna, veckan och datumen i mitten. */}
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={() => setWeekOffset(prev => prev - 1)}
+          aria-label="Föregående vecka"
+          className="h-10 w-10 shrink-0 rounded-xl border border-solid border-[#d9e2d4] bg-white p-0 text-slate-600 transition hover:border-slate-400"
+        >
+          ←
+        </button>
+        <div className="min-w-0 flex-1 text-center">
+          <div className="text-sm font-semibold text-slate-900">Vecka {range.weekNumber}</div>
+          <div className="text-xs tabular-nums text-slate-500">{weekRangeLabel(range.startISO, range.endISO)}</div>
         </div>
+        <button
+          type="button"
+          onClick={() => setWeekOffset(prev => prev + 1)}
+          aria-label="Nästa vecka"
+          className="h-10 w-10 shrink-0 rounded-xl border border-solid border-[#d9e2d4] bg-white p-0 text-slate-600 transition hover:border-slate-400"
+        >
+          →
+        </button>
       </div>
 
-      {/* Mon–Fri selector */}
-      <div className={cn('grid gap-2 rounded-[20px] border border-[#e0e8dc] bg-[linear-gradient(180deg,#ffffff_0%,#f9fbf7_100%)] shadow-[0_10px_22px_rgba(20,44,27,0.05)]', compact ? 'px-2.5 pb-2 pt-2.5' : 'p-3.5')}>
-        <div className="flex flex-wrap items-center justify-between gap-3">
-          <span className="text-xs font-semibold text-slate-500">Visa dag</span>
-          <span className={cn('text-slate-500', compact ? 'text-[10.5px]' : 'text-[11.5px]')}>{selectedDayLabel}</span>
-        </div>
-        <div className="grid w-full grid-cols-6 items-stretch gap-1.5">
-        {['Mån','Tis','Ons','Tor','Fre'].map((label, idx) => {
-          const active = dayIdx===idx;
-          return (
-            <button
-              key={label}
-              type="button"
-              onClick={() => setDayIdx(idx)}
-              aria-pressed={active}
-              className={cn(
-                'w-full justify-center rounded-full border transition-[background,color,border-color,box-shadow]',
-                compact ? 'px-2.5 py-[5px] text-[11px]' : 'px-3 py-1.5 text-xs',
-                active
-                  ? 'border-transparent font-bold text-white shadow-[0_8px_18px_rgba(20,44,27,0.24)] [background:var(--crm-primary)]'
-                  : 'border-[#dce4d8] bg-white font-medium text-slate-700 shadow-[0_1px_2px_rgba(15,23,42,0.05)] hover:border-[#cfdcc9] hover:bg-[#f9fbf7] hover:text-slate-900'
-              )}
-              title={range.days[idx]}
-            >{label}</button>
-          );
-        })}
-        {(() => {
-          const active = dayIdx==null;
-          return (
-            <button
-              type="button"
-              onClick={() => setDayIdx(null)}
-              aria-pressed={active}
-              className={cn(
-                'w-full justify-center rounded-full border transition-[background,color,border-color,box-shadow]',
-                compact ? 'px-2.5 py-[5px] text-[11px]' : 'px-3 py-1.5 text-xs',
-                active
-                  ? 'border-transparent font-bold text-white shadow-[0_8px_18px_rgba(20,44,27,0.24)] [background:var(--crm-primary)]'
-                  : 'border-[#dce4d8] bg-white font-medium text-slate-700 shadow-[0_1px_2px_rgba(15,23,42,0.05)] hover:border-[#cfdcc9] hover:bg-[#f9fbf7] hover:text-slate-900'
-              )}
-            >Alla</button>
-          );
-        })()}
-        </div>
+      {/* Ersätter etiketten "Denna vecka / Förra veckan": en knapp som tar dig tillbaka säger samma
+          sak och gör något åt det, och den syns bara när du faktiskt är bortbläddrad. */}
+      {weekOffset !== 0 ? (
+        <button
+          type="button"
+          onClick={() => setWeekOffset(0)}
+          className="justify-self-center rounded-lg py-1.5 text-sm font-semibold text-slate-600 underline underline-offset-2"
+        >
+          Gå till denna vecka
+        </button>
+      ) : null}
+
+      {/* Mån–fre plus "Alla". Rubriken "Visa dag" och den upprepade dagetiketten bredvid den är
+          borta — knapparna heter redan Mån…Fre, och den intryckta knappen är svaret. */}
+      <div className="grid grid-cols-6 gap-1.5">
+        {['Mån','Tis','Ons','Tor','Fre'].map((label, idx) => (
+          <button
+            key={label}
+            type="button"
+            onClick={() => setDayIdx(idx)}
+            aria-pressed={dayIdx === idx}
+            className={dayButtonClass(dayIdx === idx)}
+            title={range.days[idx]}
+          >{label}</button>
+        ))}
+        <button
+          type="button"
+          onClick={() => setDayIdx(null)}
+          aria-pressed={dayIdx == null}
+          className={dayButtonClass(dayIdx == null)}
+        >Alla</button>
       </div>
 
       {loading && <div className="px-0.5 pt-0 text-xs text-slate-500">Laddar…</div>}
@@ -1155,6 +1148,6 @@ export default function DashboardSchedule({ compact = false, onReportTime }: { c
           </div>
         );
       })()}
-    </section>
+    </div>
   );
 }

--- a/components/dashboard/DashboardTasks.tsx
+++ b/components/dashboard/DashboardTasks.tsx
@@ -4,6 +4,7 @@ import { createClientComponentClient } from '@supabase/auth-helpers-nextjs';
 import { cn } from '@/lib/shared/cn';
 import Button from '../ui/Button';
 import Badge from '../ui/Badge';
+import DashboardCardHeader from './DashboardCardHeader';
 
 type Task = {
   id: string;
@@ -24,7 +25,6 @@ export default function DashboardTasks({ compact, hideWhenEmpty, onVisibilityCha
   const [items, setItems] = useState<Task[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [live, setLive] = useState<'connecting'|'on'|'off'>('off');
   const mounted = useRef(false);
 
   useEffect(() => {
@@ -55,7 +55,6 @@ export default function DashboardTasks({ compact, hideWhenEmpty, onVisibilityCha
   // Realtime for assigned + created
   useEffect(() => {
     if (!userId) return;
-    setLive('connecting');
     const channel = supabase
       .channel('realtime:tasks')
       .on('postgres_changes', { event: '*', schema: 'public', table: 'tasks' }, (payload) => {
@@ -80,11 +79,8 @@ export default function DashboardTasks({ compact, hideWhenEmpty, onVisibilityCha
           }
         });
       })
-      .subscribe(status => {
-        if (status === 'SUBSCRIBED') setLive('on');
-        if (status === 'CHANNEL_ERROR' || status === 'CLOSED') setLive('off');
-      });
-    return () => { supabase.removeChannel(channel); setLive('off'); };
+      .subscribe();
+    return () => { supabase.removeChannel(channel); };
   }, [supabase, userId]);
 
   const grouped = useMemo(() => {
@@ -111,37 +107,14 @@ export default function DashboardTasks({ compact, hideWhenEmpty, onVisibilityCha
     return null;
   }
 
-  const liveTextClass =
-    live === 'on'
-      ? 'text-emerald-700'
-      : live === 'connecting'
-        ? 'text-amber-600'
-        : 'text-slate-500';
-
-  const liveDotClass =
-    live === 'on'
-      ? 'bg-emerald-500'
-      : live === 'connecting'
-        ? 'bg-amber-500'
-        : 'bg-slate-400';
-
   return (
-    <div className={cn('flex flex-col', compact ? 'gap-3' : 'gap-4')}>
-      <div className="flex flex-wrap items-start justify-between gap-3">
-        <div className="grid gap-1">
-          <h2 className={cn('m-0 flex flex-wrap items-center gap-2 font-bold text-slate-900', compact ? 'text-base' : 'text-xl')}>
-            Uppgifter
-            <span className={cn('inline-flex items-center gap-1 text-[11px] font-medium', liveTextClass)}>
-              <span className={cn('h-2 w-2 rounded-full', liveDotClass)} />
-              {live==='on' ? 'Live' : live==='connecting' ? 'Ansluter…' : 'Offline'}
-            </span>
-          </h2>
-          {(!compact || grouped.open.length > 0) && <p className={cn('m-0 text-slate-500', compact ? 'text-xs' : 'text-[13px]')}>Visa det som fortfarande kräver åtgärd först, och dölj resten tills det behövs.</p>}
-        </div>
-        <Badge className="gap-2 px-2.5 py-1 text-[11.5px] text-slate-700">
-          {grouped.open.length} öppna
-        </Badge>
-      </div>
+    <div className="flex flex-col gap-3">
+      {/* Räknaren visas bara när det FINNS öppna uppgifter. Vid noll stod "0 öppna" i badgen och
+          "Inga öppna uppgifter just nu." i rutan strax under — samma besked två gånger. */}
+      <DashboardCardHeader
+        title="Uppgifter"
+        meta={grouped.open.length > 0 ? <Badge variant="accent">{grouped.open.length} öppna</Badge> : null}
+      />
       {loading && <p className="m-0 text-xs text-slate-500">Laddar…</p>}
       {error && <p className="m-0 text-xs text-red-700">{error}</p>}
       {!loading && grouped.open.length === 0 && grouped.done.length === 0 && (

--- a/components/dashboard/QuickLinks.tsx
+++ b/components/dashboard/QuickLinks.tsx
@@ -29,26 +29,32 @@ function QuickLinkInner({
   className,
   iconClassName,
   titleClassName,
-  descClassName,
-  showDescription,
 }: {
   link: QuickLink;
   className: string;
   iconClassName: string;
   titleClassName: string;
-  descClassName?: string;
-  showDescription?: boolean;
 }) {
   return (
     <div className={className} aria-disabled={link.disabled || undefined}>
       <span className={iconClassName}>{link.icon}</span>
       <div className={titleClassName}>{link.title}</div>
-      {showDescription ? <div className={descClassName}>{link.desc}</div> : null}
       {link.disabled ? <DisabledBadge note={link.disabledNote} /> : null}
     </div>
   );
 }
 
+/**
+ * Genvägarna på startsidan: ikon och titel, ingenting mer.
+ *
+ * Rutorna hade tidigare två utseenden. Under 769 px en naken bricka, över 769 px ett eget kort med
+ * kant, skugga OCH en beskrivningsrad ("Skapa & arkivera egenkontroller" under rubriken "Skapa
+ * egenkontroll"). Det andra utseendet var en olyckshändelse och inte ett val: sektionen som ritar
+ * gridden är `lg:hidden`, så kortvarianten kunde bara någonsin synas i bandet 769–1023 px — och där
+ * la den ett kort inuti sektionens kort och upprepade titeln med andra ord.
+ *
+ * Ett utseende nu. Titeln namnger målet; beskrivningen sa om samma sak.
+ */
 export function QuickLinksGrid({ links, compact, extraCompact }: { links: QuickLink[]; compact?: boolean; extraCompact?: boolean }) {
   return (
     <div
@@ -62,14 +68,15 @@ export function QuickLinksGrid({ links, compact, extraCompact }: { links: QuickL
       )}
     >
       {links.map(link => {
-        const isDesktopy = !compact && !extraCompact;
         const content = (
           <QuickLinkInner
             link={link}
             className={cn(
-              'flex flex-col items-center justify-start gap-1.5 border-none text-center outline-none',
-              extraCompact ? 'p-2.5' : compact ? 'p-3' : 'p-2.5',
-              link.disabled ? 'cursor-not-allowed opacity-60' : 'cursor-pointer'
+              // `active:` och inte bara `hover:` — sektionen är `lg:hidden`, alltså syns gridden
+              // bara på pekskärmar där :hover aldrig utlöses. Utan tryckläget vore återkopplingen
+              // en ren skrivbordsdekoration som ingen av de faktiska användarna ser.
+              'flex flex-col items-center justify-start gap-1.5 rounded-xl border-none p-3 text-center outline-none transition',
+              link.disabled ? 'cursor-not-allowed opacity-60' : 'cursor-pointer hover:bg-white active:bg-white'
             )}
             iconClassName={cn(
               'inline-flex items-center justify-center rounded-xl bg-emerald-50 text-emerald-700',
@@ -77,36 +84,11 @@ export function QuickLinksGrid({ links, compact, extraCompact }: { links: QuickL
             )}
             titleClassName={cn(
               'text-center font-bold leading-tight tracking-[-0.2px] text-slate-900',
-              extraCompact ? 'text-xs' : compact ? 'text-[13px]' : 'text-sm'
+              extraCompact ? 'text-xs' : 'text-[13px]'
             )}
-            descClassName="text-center text-xs leading-5 text-slate-500"
-            showDescription={isDesktopy}
           />
         );
 
-        // For desktop-sized tiles, wrap with a bordered card to bring back visual affordance
-        if (isDesktopy) {
-          const wrapper = (
-            <div
-              className={cn(
-                'relative flex flex-col gap-2 rounded-2xl border border-[#e0e8dc] bg-[#f9fbf7] px-4 pb-[18px] pt-4 text-slate-900 shadow-[0_1px_3px_rgba(20,44,27,0.06)] outline-none transition-[border-color,box-shadow,transform]',
-                link.disabled
-                  ? 'cursor-not-allowed opacity-70'
-                  : 'cursor-pointer hover:border-[#cfdcc9] hover:shadow-[0_8px_20px_-10px_rgba(20,44,27,0.30)]'
-              )}
-            >
-              {content}
-            </div>
-          );
-          if (link.disabled) return <div key={link.href}>{wrapper}</div>;
-          return (
-            <Link key={link.href} href={link.href} className="no-underline">
-              {wrapper}
-            </Link>
-          );
-        }
-
-        // Compact/extra-compact: keep minimal, no outer card
         if (link.disabled) return <div key={link.href}>{content}</div>;
         return (
           <Link key={link.href} href={link.href} className="no-underline">


### PR DESCRIPTION
Startsidan matchade inte CRM-standarden. Widgetrubrikerna var `text-xl` (20 px) medan sidans egen h1 är 18 px — korten skrek högre än sidan de ligger på. Varje kort bar dessutom en instruerande mening om sitt eget beteende, och samma uppgift stod på två till tre ställen.

Förlagan är `/tid`: informationen bär sin egen etikett, ingenting sägs två gånger, ett kort-token.

Netto **−61 rader** (277 in / 338 ut) plus en ny delad komponent.

## Delad kortrubrik

Ny `components/dashboard/DashboardCardHeader.tsx` som alla fyra widgets använder: rubrik, valfri räknare, valfri åtgärd. Ingen brödtext. Rubriken är `text-base` med flit.

## Borta

- Instruktionsprosan i Uppgifter, Dokument, Arbetsytan och Arbetsschemat — den beskrev komponentens beteende, inte användarens jobb
- `Live / Ansluter… / Offline`-pillarna i Uppgifter och Arbetsytan, och hela `live`-tillståndet bakom dem. Prenumerationerna är orörda
- Etiketterna "Snabba genvägar" och "Visa dag". Den förra lever kvar som `aria-label`, där en samling länkar faktiskt behöver ett namn
- Dubbletterna: "Vecka N" stod två gånger i schemat, dokumentkortets antal på tre ställen, arbetsytans mötesantal både i en badge och på filterknappen

Kvar med flit: etiketterna i arbetsytans sifferrad. En naken tvåa betyder ingenting — där *bär* etiketten informationen.

## Sidhuvudet

Tre element blev två rader:

```
Startsida                    [+ Rapportera tid]
God morgon · söndag 16 augusti
```

`crm.pageTitle` + `crm.pageSubtitle` + `crm.primaryButton`.

## Två buggar på vägen

**Schemat renderade ett kort inuti ett kort.** `DashboardSchedule` hade en egen `<section>` med kant, bakgrund, skugga och padding — inuti `ClientDashboard`s kortsektion. Dubbelt allt, och skälet till att schemat såg tyngre ut än resten av sidan. Alla fyra widgets returnerar nu en naken `<div>`; kortet är alltid `ClientDashboard`s.

**Sidhuvudets klocka lästes i UTC på servern.** Sidan är `force-dynamic`, så hela sommaren skrev servern "God morgon" medan klienten skrev "Hej" mellan 08 och 10, och mellan 00 och 02 stod fel veckodag och fel datum. Nu förankrad i `Europe/Stockholm` och verifierad mot dygnsbytet.

## Utanför den här ändringen

`Rapportera tid`-knappen och dess modal går mot Blikk och är funktionellt orörda — bara knappklassen är utbytt mot `crm.primaryButton`.

**Känd, ej åtgärdad:** `DashboardSchedule`s `range` byggs av `startOfISOWeek(new Date())` med lokala getters och matar `get_my_jobs` / `get_my_crm_jobs`. Måndag 01:30 svensk tid hämtar därför fel veckas jobb i SSR — inte bara fel etikett. Att flytta ankaret ändrar vilka rader som kommer tillbaka, alltså beteende och inte form. Tas i en egen ändring.

## Validering

`npm run type-check`, `npm run lint`, `npm test` (1337 tester) och `npm run build` gröna. Ingen SQL.

Granskning kördes före PR: fyra fynd, tre rättade (mötestiteln klipptes utan väg tillbaka, genvägarnas enda återkoppling var `hover:` på en pekskärmsyta, och en JSDoc påstod mer tidszonssäkerhet än den levererade). Det fjärde hade rätt om kommentaren men fel om koden — dokumentkortets "Allt klart" var oåtkomligt redan före ändringen, så kommentaren rättades och koden inte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)