### PR TITLE
Arbetsschemat hämtade fel veckas jobb i SSR

### DIFF
--- a/components/dashboard/DashboardSchedule.tsx
+++ b/components/dashboard/DashboardSchedule.tsx
@@ -8,6 +8,8 @@ import Textarea from '../ui/Textarea';
 import Badge from '../ui/Badge';
 import DashboardCardHeader from './DashboardCardHeader';
 import { crmJobToScheduleItem, type CrmJobRow } from '@/lib/domains/planning/myJobs';
+import { defaultScheduleDayIndex, scheduleWeekRange } from '@/lib/domains/planning/scheduleWeek';
+import { stockholmTodayISO } from '@/lib/domains/planning/timezone';
 
 const MONTHS_SHORT = ['jan', 'feb', 'mar', 'apr', 'maj', 'jun', 'jul', 'aug', 'sep', 'okt', 'nov', 'dec'];
 
@@ -16,12 +18,8 @@ const MONTHS_SHORT = ['jan', 'feb', 'mar', 'apr', 'maj', 'jun', 'jul', 'aug', 's
  *
  * Veckoväljaren visade tidigare de råa ISO-datumen ('2026-08-17 – 2026-08-23').
  *
- * Fälten plockas ur strängen i stället för via `new Date()`, så själva formateringen inte kan flytta
- * dagen. ⚠️ MEN INDATA KAN DET: `range` byggs av `startOfISOWeek(new Date())` med LOKALA getters, och
- * servern går på UTC. Måndag 01:30 svensk tid landar därför på föregående ISO-vecka i server-
- * renderingen och rättas först vid hydreringen — hela komponenten hämtar då fel veckas jobb, inte
- * bara etiketten. Befintlig bugg som ligger utanför den här omgången (att flytta ankaret ändrar
- * vilka rader RPC:erna får tillbaka, alltså beteende och inte form). Samma felklass som PR #69.
+ * Fälten plockas ur strängen i stället för via `new Date()`, så formateringen inte kan flytta dagen.
+ * Indata är sedan 2026-08-16 förankrade i svensk tid — se `scheduleWeekRange`.
  */
 function weekRangeLabel(startISO: string, endISO: string): string {
   const start = startISO.split('-').map(Number);
@@ -39,23 +37,6 @@ function weekRangeLabel(startISO: string, endISO: string): string {
 // every one of them has to skip these rows.
 const isCrmItem = (it: { source?: string } | null | undefined) => it?.source === 'crm';
 
-function startOfISOWeek(d: Date) {
-  const day = d.getDay(); // 0..6, 1=Mon
-  const mondayDelta = (day + 6) % 7; // days since Monday
-  const res = new Date(d);
-  res.setHours(0, 0, 0, 0);
-  res.setDate(res.getDate() - mondayDelta);
-  return res;
-}
-function addDays(d: Date, n: number) { const x = new Date(d); x.setDate(x.getDate() + n); return x; }
-function toISODateLocal(d: Date) { const y = d.getFullYear(); const m = String(d.getMonth()+1).padStart(2,'0'); const dd = String(d.getDate()).padStart(2,'0'); return `${y}-${m}-${dd}`; }
-function getISOWeekNumber(d: Date) {
-  const date = new Date(d);
-  date.setHours(0, 0, 0, 0);
-  date.setDate(date.getDate() + 3 - ((date.getDay() + 6) % 7));
-  const week1 = new Date(date.getFullYear(), 0, 4);
-  return 1 + Math.round(((date.getTime() - week1.getTime()) / 86400000 - 3 + ((week1.getDay() + 6) % 7)) / 7);
-}
 function normalizePersonName(value: string | null | undefined) {
   return String(value || '')
     .normalize('NFD')
@@ -81,11 +62,8 @@ export default function DashboardSchedule({ compact = false, onReportTime }: { c
   const [segmentSortIndexMap, setSegmentSortIndexMap] = useState<Record<string, number | null>>({});
   const [currentUserId, setCurrentUserId] = useState<string | null>(null);
   const [currentUserName, setCurrentUserName] = useState<string | null>(null);
-  const [dayIdx, setDayIdx] = useState<number | null>(() => {
-    // Default to current weekday (Mon=0..Fri=4). On weekend, show all (null).
-    const dow = new Date().getDay(); // Sun=0 .. Sat=6
-    return dow >= 1 && dow <= 5 ? dow - 1 : null;
-  }); // 0=Mon .. 4=Fri, null=all
+  // 0=mån .. 4=fre, null=alla. Svensk veckodag, inte serverns — se scheduleWeek.ts.
+  const [dayIdx, setDayIdx] = useState<number | null>(() => defaultScheduleDayIndex());
 
   // Detail modal state
   const [detailOpen, setDetailOpen] = useState(false);
@@ -154,7 +132,9 @@ export default function DashboardSchedule({ compact = false, onReportTime }: { c
     try {
   const s = (it.job_day as string) || (it.start_day as string) || null;
   const e = (it.job_day as string) || (it.end_day as string) || s;
-      const today = toISODateLocal(new Date());
+      // Svensk dag, inte enhetens: värdet är förifyllt i säckrapporten och SPARAS som den dag
+      // rapporten gäller, så en telefon i fel zon hade skrivit rapporten på fel datum.
+      const today = stockholmTodayISO();
       const def = s && e && s <= today && today <= e ? today : (s || today);
       setReportDraft({ day: def, amount: '' });
     } catch { setReportDraft({ day: '', amount: '' }); }
@@ -212,19 +192,10 @@ export default function DashboardSchedule({ compact = false, onReportTime }: { c
     setCommentsExpanded(false);
   }, []);
 
-  const range = useMemo(() => {
-    const today = new Date();
-    const weekStart = startOfISOWeek(today);
-    const base = addDays(weekStart, weekOffset * 7);
-    const startISO = toISODateLocal(base);
-    const endISO = toISODateLocal(addDays(base, 6));
-    const weekNumber = getISOWeekNumber(base);
-    const year = base.getFullYear();
-    const label = weekOffset === 0 ? 'Denna vecka' : weekOffset === -1 ? 'Förra veckan' : weekOffset === 1 ? 'Nästa vecka' : weekOffset < 0 ? `${Math.abs(weekOffset)} veckor bak` : `${weekOffset} veckor fram`;
-    // Build Mon..Sun ISO dates; only show Mon..Fri selector
-    const days = Array.from({ length: 7 }, (_, i) => toISODateLocal(addDays(base, i)));
-    return { startISO, endISO, label, weekNumber, year, weekStartISO: startISO, days };
-  }, [weekOffset]);
+  // startISO/endISO går rakt in i get_my_jobs / get_my_crm_jobs, alltså avgör de VILKA JOBB som
+  // hämtas — inte bara vad etiketten säger. Beräkningen och dess tidszonsankare ligger i
+  // lib/domains/planning/scheduleWeek.ts med tester (tests/planning/scheduleWeek.test.ts).
+  const range = useMemo(() => scheduleWeekRange(weekOffset), [weekOffset]);
 
   useEffect(() => {
     // Load current user and name

--- a/lib/domains/planning/scheduleWeek.ts
+++ b/lib/domains/planning/scheduleWeek.ts
@@ -1,0 +1,82 @@
+// Veckofönstret för arbetsschemat på startsidan.
+//
+// Bor här och inte i komponenten av två skäl. Det ena är att det går att testa: värdena styr vilka
+// rader `get_my_jobs` / `get_my_crm_jobs` hämtar, alltså vilka jobb en installatör faktiskt ser, och
+// det förtjänar ett regressionsskydd snarare än ögon. Det andra är att zonankaret redan bor i den
+// här domänen (./timezone) och användes av allt UTOM den här ytan.
+//
+// ⚠️ ALLA DATUMHJÄLPARE HÄR LÄSER LOKALA FÄLT (getDay/getDate/getFullYear). Det är därför ankaret
+// måste vara `stockholmToday()`, som ger LOKAL midnatt med Sveriges kalenderdatum i fälten — inte
+// `stockholmDay` i app/crm/rapportering/reportRanges.ts, som är UTC-förankrad för att dess egen
+// aritmetik läser UTC-getters. Fel ankare av de två flyttar hela veckan ett dygn.
+
+import { stockholmToday } from './timezone';
+
+// Det gamla objektet i komponenten bar också `year` och `weekStartISO`. Båda är borta med flit:
+// `weekStartISO` var en ordagrann kopia av `startISO`, och `year` var MÅNDAGENS kalenderår, vilket
+// motsäger `weekNumber` bredvid — veckan som börjar måndag 2025-12-29 är ISO-vecka 1 av 2026, men
+// fältet sa 2025. Sju sådana veckor mellan 2020 och 2035. Ingen läste något av dem, och ett
+// exporterat fält som är subtilt fel är värre än inget fält.
+export type ScheduleWeekRange = {
+  /** Måndagen, YYYY-MM-DD. Skickas som `start_date` till RPC:erna. */
+  startISO: string;
+  /** Söndagen, YYYY-MM-DD. Skickas som `end_date` till RPC:erna. */
+  endISO: string;
+  /** ISO-veckonummer. Behöver du året till det måste det vara ISO-VECKOÅRET, inte måndagens. */
+  weekNumber: number;
+  /** Måndag..söndag som YYYY-MM-DD. Dagväljaren indexerar 0=mån..4=fre i den här. */
+  days: string[];
+};
+
+function startOfISOWeek(d: Date) {
+  const day = d.getDay(); // 0..6, 1=Mon
+  const mondayDelta = (day + 6) % 7; // days since Monday
+  const res = new Date(d);
+  res.setHours(0, 0, 0, 0);
+  res.setDate(res.getDate() - mondayDelta);
+  return res;
+}
+
+function addDays(d: Date, n: number) { const x = new Date(d); x.setDate(x.getDate() + n); return x; }
+
+function toISODateLocal(d: Date) {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const dd = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${dd}`;
+}
+
+function getISOWeekNumber(d: Date) {
+  const date = new Date(d);
+  date.setHours(0, 0, 0, 0);
+  date.setDate(date.getDate() + 3 - ((date.getDay() + 6) % 7));
+  const week1 = new Date(date.getFullYear(), 0, 4);
+  return 1 + Math.round(((date.getTime() - week1.getTime()) / 86400000 - 3 + ((week1.getDay() + 6) % 7)) / 7);
+}
+
+/**
+ * Veckan `weekOffset` steg från den vecka Sverige befinner sig i just nu.
+ *
+ * `now` är en parameter enbart för testerna; produktionskoden läser klockan här.
+ */
+export function scheduleWeekRange(weekOffset: number, now: Date = new Date()): ScheduleWeekRange {
+  const base = addDays(startOfISOWeek(stockholmToday(now)), weekOffset * 7);
+  return {
+    startISO: toISODateLocal(base),
+    endISO: toISODateLocal(addDays(base, 6)),
+    weekNumber: getISOWeekNumber(base),
+    days: Array.from({ length: 7 }, (_, i) => toISODateLocal(addDays(base, i))),
+  };
+}
+
+/**
+ * Dagen som ska vara förvald i dagväljaren: 0=mån..4=fre, eller null på helgen ("Alla").
+ *
+ * Måste läsa svensk veckodag av samma skäl som veckan. Söndag 23:30 UTC är måndag i Sverige — en
+ * server som läser sin egen kalender väljer "Alla" medan webbläsaren väljer "Mån", och då byter
+ * både den intryckta knappen och den filtrerade listan utseende vid hydreringen.
+ */
+export function defaultScheduleDayIndex(now: Date = new Date()): number | null {
+  const dow = stockholmToday(now).getDay(); // Sun=0 .. Sat=6
+  return dow >= 1 && dow <= 5 ? dow - 1 : null;
+}

--- a/tests/planning/scheduleWeek.test.ts
+++ b/tests/planning/scheduleWeek.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { defaultScheduleDayIndex, scheduleWeekRange } from '@/lib/domains/planning/scheduleWeek';
+
+// Startsidans arbetsschema läste tidigare `new Date()` med lokala getters. Sidan är force-dynamic,
+// alltså server-renderad före hydrering, och servern går på UTC — så mellan 00:00 och 02:00 svensk
+// tid satt de två klockorna på olika kalenderdagar. Är den dagen dessutom en MÅNDAG blir det inte en
+// dags fel utan en hel veckas: startISO/endISO matar get_my_jobs / get_my_crm_jobs, så installatören
+// fick förra veckans jobb serverade och rätt vecka först vid hydreringen.
+//
+// Assertionerna nedan är oberoende av vilken zon testet självt körs i: allt jämförs som ISO-strängar
+// som toISODateLocal läser tillbaka ur precis de lokala fält stockholmToday satte.
+
+describe('scheduleWeekRange', () => {
+  it('bygger måndag–söndag för en vanlig vardag', () => {
+    // Onsdag 2026-08-12, mitt på dagen — ingen zon i närheten av ett dygnsbyte.
+    const range = scheduleWeekRange(0, new Date('2026-08-12T10:00:00Z'));
+    expect(range.startISO).toBe('2026-08-10');
+    expect(range.endISO).toBe('2026-08-16');
+    expect(range.weekNumber).toBe(33);
+    expect(range.days).toEqual([
+      '2026-08-10', '2026-08-11', '2026-08-12', '2026-08-13', '2026-08-14', '2026-08-15', '2026-08-16',
+    ]);
+  });
+
+  it('⚠️ måndag 01:30 svensk tid ger måndagens vecka, inte föregående (sommartid, UTC+2)', () => {
+    // 2026-08-16T23:30Z = måndag 2026-08-17 kl 01:30 i Stockholm.
+    // Den gamla koden läste UTC på servern, såg söndag den 16:e och backade en hel vecka.
+    const range = scheduleWeekRange(0, new Date('2026-08-16T23:30:00Z'));
+    expect(range.startISO).toBe('2026-08-17');
+    expect(range.endISO).toBe('2026-08-23');
+    expect(range.weekNumber).toBe(34);
+  });
+
+  it('⚠️ måndag 00:30 svensk tid ger måndagens vecka även på vintertid (UTC+1)', () => {
+    // 2026-01-04T23:30Z = måndag 2026-01-05 kl 00:30 i Stockholm.
+    const range = scheduleWeekRange(0, new Date('2026-01-04T23:30:00Z'));
+    expect(range.startISO).toBe('2026-01-05');
+    expect(range.endISO).toBe('2026-01-11');
+  });
+
+  it('bläddrar bakåt och framåt utan att tappa veckolängden', () => {
+    const now = new Date('2026-08-12T10:00:00Z');
+    expect(scheduleWeekRange(-1, now).startISO).toBe('2026-08-03');
+    expect(scheduleWeekRange(-1, now).endISO).toBe('2026-08-09');
+    expect(scheduleWeekRange(1, now).startISO).toBe('2026-08-17');
+    expect(scheduleWeekRange(1, now).endISO).toBe('2026-08-23');
+  });
+
+  it('korsar ett årsskifte med rätt ISO-veckonummer', () => {
+    // Torsdag 2026-12-31 ligger i ISO-vecka 53, som börjar måndag den 28:e.
+    const range = scheduleWeekRange(0, new Date('2026-12-31T10:00:00Z'));
+    expect(range.startISO).toBe('2026-12-28');
+    expect(range.endISO).toBe('2027-01-03');
+    expect(range.weekNumber).toBe(53);
+  });
+});
+
+describe('defaultScheduleDayIndex', () => {
+  it('väljer dagens vardag, 0=mån..4=fre', () => {
+    expect(defaultScheduleDayIndex(new Date('2026-08-10T10:00:00Z'))).toBe(0); // måndag
+    expect(defaultScheduleDayIndex(new Date('2026-08-14T10:00:00Z'))).toBe(4); // fredag
+  });
+
+  it('väljer "Alla" (null) på helgen', () => {
+    expect(defaultScheduleDayIndex(new Date('2026-08-15T10:00:00Z'))).toBeNull(); // lördag
+    expect(defaultScheduleDayIndex(new Date('2026-08-16T10:00:00Z'))).toBeNull(); // söndag
+  });
+
+  it('⚠️ måndag 01:30 svensk tid väljer måndag, inte helgens "Alla"', () => {
+    // Samma instant som veckotestet ovan: UTC säger söndag, Sverige säger måndag.
+    expect(defaultScheduleDayIndex(new Date('2026-08-16T23:30:00Z'))).toBe(0);
+  });
+});


### PR DESCRIPTION
Uppföljning på #85, som lämnade den här medvetet.

> ⚠️ **Beteendeändring, avsiktlig.** Mellan 00:00 och 02:00 svensk tid returnerar `get_my_jobs` / `get_my_crm_jobs` nu andra rader än förut. Det är själva rättelsen, inte en bieffekt.

## Felet

Arbetsschemat läste `new Date()` med lokala getters. Startsidan är `force-dynamic`, alltså server-renderad före hydrering, och servern går på UTC — mellan 00:00 och 02:00 svensk tid satt de två klockorna på olika kalenderdagar. Är den dagen dessutom en **måndag** blir det inte en dags fel utan en hel veckas, eftersom `startISO`/`endISO` går rakt in i RPC:erna.

Uppmätt vid måndag 01:30 svensk tid (instant `2026-08-16T23:30Z`), med den gamla logiken:

```
TZ=Europe/Stockholm   startISO=2026-08-17  endISO=2026-08-23  dayIdx=0
TZ=UTC                startISO=2026-08-10  endISO=2026-08-16  dayIdx=null (Alla)
```

Installatören fick alltså **förra veckans jobb** serverade, och rätt vecka först vid hydreringen.

## Tre klockavläsningar, inte en

| Var | Konsekvens |
|---|---|
| Veckofönstret | fel veckas jobb hämtas från RPC:erna |
| Dagväljarens förval | hydreringsskillnad i både intryckt knapp och filtrerad lista |
| Säckrapportens förifyllda datum | **sparas** som den dag rapporten gäller |

Den sista är den som blir fel *data* och inte bara fel vy.

Alla tre går nu via `stockholmToday` / `stockholmTodayISO` i planeringsdomänen — samma hjälpare som planeringstavlan, `PlanningAdminModal` och insights-routen redan använder. Arbetsschemat var den enda ytan som saknade den.

## Testbarhet

Veckoberäkningen är utbruten till `lib/domains/planning/scheduleWeek.ts` med `now` som parameter, så felet går att skriva ett test på. Åtta tester täcker måndag 01:30 på både sommar- och vintertid, veckobläddring, årsskifte och helgfallet.

Testerna är oberoende av vilken zon de körs i — hela sviten är verifierad grön under både `Europe/Stockholm` och `TZ=UTC`.

Utbrytningen tog bort två fält utan konsumenter: `weekStartISO` var en ordagrann kopia av `startISO`, och `year` var måndagens kalenderår, vilket motsäger `weekNumber` bredvid (veckan från måndag 2025-12-29 är ISO-vecka 1 av **2026**, men fältet sa 2025).

## Validering

`npm run type-check`, `npm run lint`, `npm test` (1345 tester, +8) och `npm run build` gröna. Sviten dessutom körd under `TZ=UTC`. Ingen SQL.

## Kvar, rörs inte här

`TimeReportModal.tsx:126` har samma felklass — den förifyller sitt datum via `toISOString()` (UTC), och värdet både skickas in och styr vilken jobblista som hämtas. Den modalen är Blikks tidrapportering och ligger under stående do-not-touch, så den lämnas orörd och rapporteras i stället.

🤖 Generated with [Claude Code](https://claude.com/claude-code)