### PR TITLE
feat(admin): våg 1 av CRM-standard-migreringen — hjälpare, flikskal, Användare

### DIFF
--- a/app/admin/AdminTabsClient.tsx
+++ b/app/admin/AdminTabsClient.tsx
@@ -1,22 +1,27 @@
 "use client";
 import React from 'react';
-import AdminUsers from './users/AdminUsers';
 import dynamic from 'next/dynamic';
-import AdminBlikkUsersMapping from './blikk/AdminBlikkUsersMapping';
-import Badge from '../../components/ui/Badge';
+// AdminUsers är default-fliken och importeras statiskt med flit: som dynamic-chunk
+// betalade varje /admin-besök en extra nätverksrunda (chunk → mount → API-fetch)
+// och visade en tom panel innan komponenten dök upp.
+import AdminUsers from './users/AdminUsers';
 import PageShell from '../../components/ui/PageShell';
 import { TabsList, TabsTrigger } from '../../components/ui/Tabs';
 import { crm } from '../crm/lib/crmTokens';
 import { cn } from '../../lib/shared/cn';
 
-const AdminContacts = dynamic(() => import('./contacts/AdminContacts'), { ssr: false });
-const AdminDepotUsage = dynamic(() => import('./depots/AdminDepotUsage'), { ssr: false });
-const AdminNews = dynamic(() => import('./news/AdminNews'), { ssr: false });
-const AdminPermissions = dynamic(() => import('./permissions/AdminPermissions'), { ssr: false });
-const AdminTimeReference = dynamic(() => import('./tid/AdminTimeReference'), { ssr: false });
-const AdminTimeApprovals = dynamic(() => import('./tid/AdminTimeApprovals'), { ssr: false });
-const AdminSupportTickets = dynamic(() => import('./support/AdminSupportTickets'), { ssr: false });
-const AdminChangelog = dynamic(() => import('./changelog/AdminChangelog'), { ssr: false });
+// Övriga flikar lazy-laddas; fallbacken förhindrar tom-panel-blink vid flikbyte
+// (crm.card saknar padding — p-5 här matchar flikkropparnas egen padding).
+const tabLoading = () => <p className="m-0 p-5 text-sm text-slate-400">Laddar…</p>;
+const AdminBlikkUsersMapping = dynamic(() => import('./blikk/AdminBlikkUsersMapping'), { ssr: false, loading: tabLoading });
+const AdminContacts = dynamic(() => import('./contacts/AdminContacts'), { ssr: false, loading: tabLoading });
+const AdminDepotUsage = dynamic(() => import('./depots/AdminDepotUsage'), { ssr: false, loading: tabLoading });
+const AdminNews = dynamic(() => import('./news/AdminNews'), { ssr: false, loading: tabLoading });
+const AdminPermissions = dynamic(() => import('./permissions/AdminPermissions'), { ssr: false, loading: tabLoading });
+const AdminTimeReference = dynamic(() => import('./tid/AdminTimeReference'), { ssr: false, loading: tabLoading });
+const AdminTimeApprovals = dynamic(() => import('./tid/AdminTimeApprovals'), { ssr: false, loading: tabLoading });
+const AdminSupportTickets = dynamic(() => import('./support/AdminSupportTickets'), { ssr: false, loading: tabLoading });
+const AdminChangelog = dynamic(() => import('./changelog/AdminChangelog'), { ssr: false, loading: tabLoading });
 
 type AdminTab = 'users'|'permissions'|'contacts'|'depots'|'blikk'|'tid'|'attest'|'news'|'arenden'|'changelog';
 
@@ -62,25 +67,16 @@ export default function AdminTabsClient() {
   return (
     <PageShell className="max-w-[1460px]">
       <section className={cn(crm.cardInner, 'grid gap-4')}>
-        <div className="flex flex-wrap items-start justify-between gap-3">
-          <div className="grid max-w-[760px] gap-1">
-            <div className="flex flex-wrap items-center gap-2">
-              <Badge variant="accent" className="px-2.5 py-1 text-[11px] uppercase tracking-[0.35px]">
-                Admincenter
-              </Badge>
-              <Badge>{tabs.length} arbetsytor</Badge>
-            </div>
-            <h1 className={crm.pageTitle}>Administration</h1>
-            <p className={crm.pageSubtitle}>
-              Hantera användare, behörigheter, kontakter, depåer, Blikk-matchning och nyheter från en gemensam adminyta.
-            </p>
-          </div>
-        </div>
+        <h1 className={cn('m-0', crm.pageTitle)}>Administration</h1>
 
         <TabsList aria-label="Adminytor" className="gap-2">
           {tabs.map((tabDef) => (
             <TabsTrigger
               key={tabDef.id}
+              id={`admin-tab-${tabDef.id}`}
+              // Bara aktiv flik har sin panel i DOM — aria-controls på inaktiva
+              // flikar vore dinglande referenser (axe: aria-valid-attr-value).
+              aria-controls={tab === tabDef.id ? `admin-tabpanel-${tabDef.id}` : undefined}
               onClick={() => setTab(tabDef.id)}
               active={tab === tabDef.id}
               title={tabDef.summary}
@@ -91,7 +87,12 @@ export default function AdminTabsClient() {
         </TabsList>
       </section>
 
-      <section className={crm.card}>
+      <section
+        role="tabpanel"
+        id={`admin-tabpanel-${tab}`}
+        aria-labelledby={`admin-tab-${tab}`}
+        className={crm.card}
+      >
         {tab==='users' && <AdminUsers />}
         {tab==='permissions' && <AdminPermissions />}
         {tab==='contacts' && <AdminContacts />}

--- a/app/admin/components/AdminPromptDialog.tsx
+++ b/app/admin/components/AdminPromptDialog.tsx
@@ -35,12 +35,17 @@ export default function AdminPromptDialog({
   const isPrompt = defaultValue !== undefined;
   const [value, setValue] = useState(defaultValue ?? '');
   const inputRef = useRef<HTMLInputElement | null>(null);
+  const confirmRef = useRef<HTMLButtonElement | null>(null);
 
   useEffect(() => {
+    // Prompt-läget fokuserar inputen; confirm-läget fokuserar bekräfta-knappen så
+    // fokus hamnar innanför dialogen (CrmModal har ingen egen fokusfälla).
     if (isPrompt) inputRef.current?.focus();
+    else confirmRef.current?.focus();
   }, [isPrompt]);
 
   function submit() {
+    if (busy) return; // Enter i prompt-läget får inte dubbelskjuta onConfirm mitt i en pågående operation.
     const trimmed = value.trim();
     if (isPrompt && !trimmed) return;
     onConfirm(trimmed);
@@ -48,7 +53,11 @@ export default function AdminPromptDialog({
 
   return (
     <CrmModal
-      onClose={onClose}
+      // Escape/overlay/X får inte stänga mitt i en pågående operation — dialogen
+      // såg annars avbruten ut medan t.ex. en DELETE fullföljdes i bakgrunden.
+      onClose={() => {
+        if (!busy) onClose();
+      }}
       ariaLabel={title}
       maxWidth="sm:max-w-[420px]"
       header={<h2 className="text-base font-bold text-slate-900">{title}</h2>}
@@ -58,6 +67,7 @@ export default function AdminPromptDialog({
             Avbryt
           </button>
           <button
+            ref={confirmRef}
             type="button"
             form="admin-prompt-form"
             onClick={submit}

--- a/app/admin/components/adminUi.tsx
+++ b/app/admin/components/adminUi.tsx
@@ -1,0 +1,81 @@
+import type { ReactNode } from 'react';
+import { cn } from '../../../lib/shared/cn';
+
+// Delade admin-recept för CRM-standarden. Strängar och småkomponenter — inga nya
+// primitiver utanför admin (CLAUDE.md: inga förtida delade abstraktioner).
+
+// AA-säker fältetikett — samma recept och samma skäl som TidClient.tsx:139-143 /
+// AdminTimeApprovals.tsx:71. Medvetet inte `crm.sectionTitle` (slate-400 @10px är
+// under WCAG AA som instruerande text).
+export const ADMIN_LABEL = 'text-[11px] font-bold uppercase tracking-[0.12em] text-slate-600';
+
+// Kolumnhuvudsraden i listkort (CustomersClient-receptet).
+// Konsumeras från våg 3–4 av admin-migreringen (Kontakter/Tidkoder).
+export const ADMIN_COLHEAD = 'text-[10px] font-bold uppercase tracking-[0.12em] text-slate-400';
+
+// Inline-tillståndsrutor — dialekt B-recepten som Ärenden/Changelog/Behörigheter redan använder.
+// Sätt role="alert" på felrutan så skärmläsare annonserar den.
+export const ADMIN_ERROR_BOX = 'rounded-xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700';
+// Konsumeras från våg 3–4 (profileditorns success-ruta, Behörigheternas förklaring).
+export const ADMIN_NOTICE_BOX = 'rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-900';
+export const ADMIN_EMPTY_BOX = 'rounded-2xl border border-dashed border-[#d5e0cf] bg-[#f4f8f1] px-4 py-8 text-center';
+// Tomrutans brödtext: <p className="m-0 text-sm text-slate-500">…</p>
+// Laddar: <p className="m-0 text-sm text-slate-400">Laddar…</p> (ingen hjälpare behövs)
+
+// Roll → badgefärger. Renderas som cn(crm.badge, roleBadgeClass(role)).
+// OBS: AdminBlikkUsersMapping bär ännu sin egen bytidentiska kopia — den byts
+// när fliken migreras (våg 2); färgändringar här måste tills dess speglas där.
+export function roleBadgeClass(role: string): string {
+  if (role === 'admin') return 'border-red-200 bg-red-50 text-red-800';
+  if (role === 'sales') return 'border-emerald-200 bg-emerald-50 text-emerald-700';
+  if (role === 'konsult') return 'border-amber-200 bg-amber-50 text-amber-800';
+  return 'border-slate-200 bg-slate-50 text-slate-600';
+}
+
+// Fältomslag — ersätter flikarnas lokala FieldBlock/Field-hjälpare.
+export function AdminField({ label, children, className }: { label: string; children: ReactNode; className?: string }) {
+  return (
+    <label className={cn('grid gap-1', className)}>
+      <span className={ADMIN_LABEL}>{label}</span>
+      {children}
+    </label>
+  );
+}
+
+// Filterchip med valfri räknare — CustomersClient.tsx-receptet ordagrant:
+// aktiv = var(--crm-primary)-solid + vitt, räknarpiller bg-white/20 resp. bg-slate-100.
+export function AdminFilterChip({
+  active,
+  onClick,
+  children,
+  count,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: ReactNode;
+  count?: number;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        'inline-flex shrink-0 items-center gap-1.5 rounded-xl border px-2.5 py-1 text-[13px] font-semibold transition',
+        active ? 'border-transparent text-white' : 'border-slate-200 bg-white text-slate-600 hover:border-slate-300',
+      )}
+      style={active ? { backgroundColor: 'var(--crm-primary)' } : undefined}
+    >
+      {children}
+      {count != null ? (
+        <span
+          className={cn(
+            'rounded-full px-1.5 py-0.5 text-[10px] font-bold tabular-nums',
+            active ? 'bg-white/20 text-white' : 'bg-slate-100 text-slate-500',
+          )}
+        >
+          {count}
+        </span>
+      ) : null}
+    </button>
+  );
+}

--- a/app/admin/users/AdminUsers.tsx
+++ b/app/admin/users/AdminUsers.tsx
@@ -1,14 +1,12 @@
 "use client";
 import React, { useEffect, useState } from 'react';
 import Link from 'next/link';
-import Badge from '../../../components/ui/Badge';
-import Button from '../../../components/ui/Button';
-import EmptyState from '../../../components/ui/EmptyState';
-import ErrorState from '../../../components/ui/ErrorState';
 import Input from '../../../components/ui/Input';
-import LoadingState from '../../../components/ui/LoadingState';
 import Select from '../../../components/ui/Select';
+import { crm } from '../../crm/lib/crmTokens';
 import { cn } from '../../../lib/shared/cn';
+import AdminPromptDialog from '../components/AdminPromptDialog';
+import { ADMIN_EMPTY_BOX, ADMIN_ERROR_BOX, ADMIN_LABEL, AdminField, AdminFilterChip, roleBadgeClass } from '../components/adminUi';
 
 interface AdminUserRow {
   id: string;
@@ -19,6 +17,19 @@ interface AdminUserRow {
   created_at: string;
   tags?: string[];
 }
+
+// En källa för rollistan — chips och båda rollväljarna deriverar härifrån.
+const ROLES: Array<{ id: 'member' | 'sales' | 'konsult' | 'admin'; label: string }> = [
+  { id: 'member', label: 'Member' },
+  { id: 'sales', label: 'Sales' },
+  { id: 'konsult', label: 'Konsult' },
+  { id: 'admin', label: 'Admin' },
+];
+
+const ROLE_FILTERS: Array<{ id: 'all' | (typeof ROLES)[number]['id']; label: string }> = [
+  { id: 'all', label: 'Alla' },
+  ...ROLES,
+];
 
 export default function AdminUsers() {
   const [loading, setLoading] = useState(true);
@@ -89,91 +100,67 @@ export default function AdminUsers() {
   }, {});
 
   return (
-    <div className="grid gap-[18px] p-3">
-      <section className="grid gap-4 rounded-[24px] border border-ui-border bg-[linear-gradient(180deg,#ffffff_0%,#f9fbf7_100%)] p-5 shadow-[0_14px_36px_rgba(15,23,42,0.04)]">
-        <div className="flex flex-wrap items-start justify-between gap-4">
-          <div className="grid max-w-[720px] gap-1.5">
-            <div className="flex flex-wrap gap-2">
-              <Badge variant="accent" className="px-2.5 py-1 text-[11px] uppercase tracking-[0.35px]">
-                Användare
-              </Badge>
-              <Badge>{users.length} totalt</Badge>
-              <Badge>{roleCounts.admin || 0} admins</Badge>
-            </div>
-            <h1 className="m-0 text-[28px] leading-[1.08] tracking-[-0.4px] text-slate-900">Konton, roller och snabbare administration</h1>
-            <p className="m-0 text-sm leading-[1.55] text-slate-600">Skapa användare, filtrera listan och gör snabba ändringar utan att tabeller och knappar bryter layouten.</p>
-          </div>
-          <div className="grid min-w-full gap-2 [grid-template-columns:repeat(auto-fit,minmax(140px,1fr))] sm:min-w-[360px]">
-            <div className="grid gap-1 rounded-2xl border border-ui-border bg-white px-3 py-2.5">
-              <span className="text-[11px] font-extrabold uppercase tracking-[0.3px] text-slate-500">Medlemmar</span>
-              <strong className="text-xl font-extrabold text-slate-900">{roleCounts.member || 0}</strong>
-            </div>
-            <div className="grid gap-1 rounded-2xl border border-ui-border bg-white px-3 py-2.5">
-              <span className="text-[11px] font-extrabold uppercase tracking-[0.3px] text-slate-500">Sales</span>
-              <strong className="text-xl font-extrabold text-slate-900">{roleCounts.sales || 0}</strong>
-            </div>
-            <div className="grid gap-1 rounded-2xl border border-ui-border bg-white px-3 py-2.5">
-              <span className="text-[11px] font-extrabold uppercase tracking-[0.3px] text-slate-500">Konsulter</span>
-              <strong className="text-xl font-extrabold text-slate-900">{roleCounts.konsult || 0}</strong>
-            </div>
-          </div>
-        </div>
-      </section>
+    <div className="grid gap-4 p-5">
+      <div className="grid gap-1">
+        <h2 className="m-0 text-lg font-bold text-slate-900">Användare</h2>
+        <p className="m-0 text-sm text-slate-600">Skapa konton, sätt roller och redigera direkt i listan.</p>
+      </div>
 
       <section className="grid gap-4 xl:[grid-template-columns:minmax(300px,380px)_minmax(0,1fr)]">
-        <section className="grid content-start gap-[18px] rounded-[20px] border border-ui-border bg-white p-[18px] shadow-[0_10px_28px_rgba(15,23,42,0.03)]">
-          <div className="grid gap-1">
-            <span className="text-[11px] font-extrabold uppercase tracking-[0.35px] text-slate-500">Ny användare</span>
-            <h2 className="m-0 text-xl text-slate-900">Skapa konto</h2>
-            <span className="text-[13px] text-slate-500">Lägg till konto och sätt rätt grundroll direkt.</span>
-          </div>
+        <section className="grid content-start gap-3 rounded-2xl border border-[#e0e8dc] bg-white p-4">
+          <h3 className="m-0 text-base font-bold text-slate-900">Skapa konto</h3>
 
           <form onSubmit={createUser} className="grid gap-3">
             <Input required type="email" placeholder="E-post" value={email} onChange={e => setEmail(e.target.value)} />
             <Input required type="password" placeholder="Lösenord" value={password} onChange={e => setPassword(e.target.value)} />
             <Input type="text" placeholder="Namn (valfritt)" value={name} onChange={e => setName(e.target.value)} />
-            <label className="grid gap-1 text-xs font-medium text-slate-700">
-              <span>Roll</span>
+            <AdminField label="Roll">
               <Select
                 value={role}
                 onChange={e => setRole(e.target.value as any)}
               >
-                <option value="member">Member</option>
-                <option value="sales">Sales</option>
-                <option value="konsult">Konsult</option>
-                <option value="admin">Admin</option>
+                {ROLES.map((r) => (
+                  <option key={r.id} value={r.id}>{r.label}</option>
+                ))}
               </Select>
-            </label>
-            <Button disabled={creating} type="submit" variant="primary">
+            </AdminField>
+            <button type="submit" disabled={creating} className={crm.saveButton}>
               {creating ? 'Skapar…' : 'Skapa användare'}
-            </Button>
-            {createError && <div className="text-sm text-red-700">{createError}</div>}
+            </button>
+            {createError && <div role="alert" className={ADMIN_ERROR_BOX}>{createError}</div>}
           </form>
         </section>
 
-        <section className="grid gap-4 rounded-[20px] border border-ui-border bg-white p-[18px] shadow-[0_10px_28px_rgba(15,23,42,0.03)]">
+        <section className="grid gap-4 rounded-2xl border border-[#e0e8dc] bg-white p-4">
           <div className="flex flex-wrap items-start justify-between gap-3">
-            <div className="grid gap-1">
-              <h2 className="m-0 text-xl text-slate-900">Alla användare</h2>
-              <span className="text-[13px] text-slate-500">Sök, filtrera och uppdatera direkt i en mer läsbar listvy.</span>
-            </div>
-            <div className="grid w-full gap-2 [grid-template-columns:repeat(auto-fit,minmax(180px,1fr))] sm:[width:min(100%,560px)]">
-              <Input value={search} onChange={(e) => setSearch(e.target.value)} placeholder="Sök e-post, namn, telefon eller tagg" />
-              <Select
-                value={roleFilter}
-                onChange={(e) => setRoleFilter(e.target.value as any)}
-              >
-                <option value="all">Alla roller</option>
-                <option value="member">Member</option>
-                <option value="sales">Sales</option>
-                <option value="konsult">Konsult</option>
-                <option value="admin">Admin</option>
-              </Select>
-            </div>
+            <h3 className="m-0 text-base font-bold text-slate-900">Alla användare</h3>
+            <Input
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Sök e-post, namn, telefon eller tagg"
+              className="sm:w-[320px]"
+            />
           </div>
-          {loadError && <ErrorState title="Kunde inte läsa användare" message={loadError} />}
-          {loading && <LoadingState label="Laddar användare" description="Hämtar konton, roller och taggar för adminlistan." />}
-          {!loading && users.length === 0 && <EmptyState title="Inga användare hittades" description="Skapa första kontot eller uppdatera sidan igen senare." />}
+          <div className="flex flex-wrap gap-2">
+            {ROLE_FILTERS.map((filter) => (
+              <AdminFilterChip
+                key={filter.id}
+                active={roleFilter === filter.id}
+                onClick={() => setRoleFilter(filter.id)}
+                count={filter.id === 'all' ? users.length : roleCounts[filter.id] || 0}
+              >
+                {filter.label}
+              </AdminFilterChip>
+            ))}
+          </div>
+          {loadError && <div role="alert" className={ADMIN_ERROR_BOX}>{loadError}</div>}
+          {loading && <p role="status" className="m-0 text-sm text-slate-400">Laddar…</p>}
+          {!loading && users.length === 0 && !loadError && (
+            <div className={ADMIN_EMPTY_BOX}>
+              <strong className="text-sm font-semibold text-slate-700">Inga användare hittades</strong>
+              <p className="m-0 mt-1 text-sm text-slate-500">Skapa första kontot eller uppdatera sidan igen senare.</p>
+            </div>
+          )}
           {!loading && users.length > 0 && (
           <div className="grid gap-3">
             {filteredUsers.map(u => (
@@ -181,7 +168,12 @@ export default function AdminUsers() {
             ))}
           </div>
         )}
-          {!loading && users.length > 0 && filteredUsers.length === 0 && <EmptyState title="Ingen användare matchar" description="Justera sökningen eller rollfiltret för att visa fler resultat." />}
+          {!loading && users.length > 0 && filteredUsers.length === 0 && (
+            <div className={ADMIN_EMPTY_BOX}>
+              <strong className="text-sm font-semibold text-slate-700">Ingen användare matchar</strong>
+              <p className="m-0 mt-1 text-sm text-slate-500">Justera sökningen eller rollfiltret för att visa fler resultat.</p>
+            </div>
+          )}
         </section>
       </section>
     </div>
@@ -216,35 +208,39 @@ function UserCard({ user, onChanged, onDeleted }: { user: AdminUserRow; onChange
   }
   async function deleteUser() {
     setBusyDelete(true);
-    await fetch(`/api/admin/users/${user.id}`, { method: 'DELETE' });
-    onDeleted(user.id);
+    try {
+      await fetch(`/api/admin/users/${user.id}`, { method: 'DELETE' });
+      onDeleted(user.id);
+    } catch {
+      // Nätverksfel: släpp busy så dialogen går att stänga igen (busy spärrar
+      // alla stängvägar i AdminPromptDialog).
+      setBusyDelete(false);
+    }
   }
 
   return (
-    <article className="grid gap-3.5 rounded-[18px] border border-slate-200 bg-slate-50/60 p-4 shadow-[inset_0_1px_0_rgba(255,255,255,0.6)]">
+    <article className="grid gap-3 rounded-xl border border-[#e0e8dc] bg-[#f9fbf7] p-3.5">
       <div className="flex flex-wrap items-start justify-between gap-3">
-        <div className="grid min-w-0 flex-1 gap-1.5 basis-[280px]">
+        <div className="grid min-w-0 flex-1 gap-1 basis-[280px]">
           <div className="flex flex-wrap items-center gap-2">
-            <span className="text-base font-extrabold text-slate-900">{user.full_name || 'Namn saknas'}</span>
-            <Badge className={cn('px-2 py-1 text-[11px] font-extrabold uppercase tracking-[0.35px]', roleBadgeClassName(roleDraft))}>
-              {roleDraft}
-            </Badge>
+            <span className="text-[13px] font-bold text-slate-900">{user.full_name || 'Namn saknas'}</span>
+            <span className={cn(crm.badge, roleBadgeClass(roleDraft))}>{roleDraft}</span>
           </div>
-          <span className="break-all text-[13px] text-slate-500">{user.email}</span>
+          <span className="break-all text-[11px] text-slate-500">{user.email}</span>
         </div>
         <div className="flex flex-wrap items-center gap-2">
-          <span className="text-xs font-semibold text-slate-500">Skapad {new Date(user.created_at).toLocaleDateString()}</span>
-          <Link
-            href={`/admin/users/${user.id}`}
-            className="inline-flex min-h-9 items-center justify-center rounded-xl border border-slate-300 bg-white px-3 text-[13px] font-semibold text-slate-900 transition-colors hover:bg-slate-100"
-          >
+          <span className="text-[11px] text-slate-400">Skapad {new Date(user.created_at).toLocaleDateString()}</span>
+          <Link href={`/admin/users/${user.id}`} className={crm.ghostButton}>
             Öppna profil
           </Link>
         </div>
       </div>
 
       <div className="grid gap-3 [grid-template-columns:repeat(auto-fit,minmax(180px,1fr))]">
-        <FieldBlock label="Namn">
+        {/* Medvetet div + span, inte AdminField: blocket innehåller knappar, och en
+            <label> utan htmlFor aktiverar sin första knapp vid klick på rubriken. */}
+        <div className="grid gap-1">
+        <span className={ADMIN_LABEL}>Namn</span>
         {editingName ? (
           <div className="flex flex-wrap gap-2">
             <Input
@@ -252,18 +248,34 @@ function UserCard({ user, onChanged, onDeleted }: { user: AdminUserRow; onChange
               onChange={e=>setNameDraft(e.target.value)}
               className="min-h-9 min-w-[180px] flex-1 basis-[180px] px-2.5 py-2 text-[13px]"
             />
-            <Button onClick={saveChanges} disabled={saving} size="sm" variant="primary">{saving ? '...' : 'Spara'}</Button>
-            <Button onClick={()=>{setEditingName(false); setNameDraft(user.full_name||'');}} size="sm" variant="secondary">Avbryt</Button>
+            <button
+              type="button"
+              onClick={saveChanges}
+              disabled={saving}
+              className={crm.formButton}
+              style={{ backgroundColor: 'var(--crm-primary)' }}
+            >
+              {saving ? '...' : 'Spara'}
+            </button>
+            <button
+              type="button"
+              onClick={()=>{setEditingName(false); setNameDraft(user.full_name||'');}}
+              className={crm.ghostButton}
+            >
+              Avbryt
+            </button>
           </div>
         ) : (
           <div className="flex flex-wrap items-center gap-2">
             <span className="text-sm text-slate-900">{user.full_name || '—'}</span>
-            <Button onClick={()=>setEditingName(true)} size="sm" variant="secondary" className="min-h-8 px-2 text-xs" aria-label="Redigera namn">✏️</Button>
+            <button type="button" onClick={()=>setEditingName(true)} className={crm.ghostButton}>
+              Redigera
+            </button>
           </div>
         )}
-        </FieldBlock>
+        </div>
 
-        <FieldBlock label="Telefon">
+        <AdminField label="Telefon">
         <Input
           value={phoneDraft}
           onChange={e=>setPhoneDraft(e.target.value)}
@@ -271,18 +283,17 @@ function UserCard({ user, onChanged, onDeleted }: { user: AdminUserRow; onChange
           placeholder="070-123 45 67"
           className="min-h-9 min-w-0 px-2.5 py-2 text-[13px]"
         />
-        </FieldBlock>
+        </AdminField>
 
-        <FieldBlock label="Roll">
+        <AdminField label="Roll">
         <Select value={roleDraft} onChange={e=>setRoleDraft(e.target.value)} onBlur={saveChanges} className="min-h-9 px-2.5 py-2 text-[13px]">
-          <option value="member">member</option>
-          <option value="sales">sales</option>
-          <option value="konsult">konsult</option>
-          <option value="admin">admin</option>
+          {ROLES.map((r) => (
+            <option key={r.id} value={r.id}>{r.label}</option>
+          ))}
         </Select>
-        </FieldBlock>
+        </AdminField>
 
-        <FieldBlock label="Taggar">
+        <AdminField label="Taggar">
         <Input
           value={tagsDraft}
           onChange={e=>setTagsDraft(e.target.value)}
@@ -290,52 +301,37 @@ function UserCard({ user, onChanged, onDeleted }: { user: AdminUserRow; onChange
           placeholder="t.ex. crew, trainee"
           className="min-h-9 min-w-0 px-2.5 py-2 text-[13px]"
         />
-        </FieldBlock>
+        </AdminField>
       </div>
 
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div className="flex flex-wrap gap-2">
           {(user.tags || []).length > 0 && user.tags!.map((tag) => (
-            <Badge key={tag} variant="info" className="px-2 py-1 text-[11px] font-bold">{tag}</Badge>
+            <span key={tag} className={cn(crm.badge, 'border-slate-200 bg-slate-50 text-slate-600')}>{tag}</span>
           ))}
           {(!user.tags || user.tags.length === 0) && <span className="text-xs text-slate-400">Inga taggar ännu</span>}
         </div>
-        <div className="relative flex items-center gap-2">
-          <Button onClick={()=>setConfirmDelete(true)} disabled={busyDelete} size="sm" variant="secondary" className="min-h-8 px-2 text-xs text-red-700 hover:bg-red-50" aria-label="Ta bort">🗑️</Button>
-          {confirmDelete && (
-            <div
-              role="dialog"
-              aria-modal="true"
-              aria-label="Bekräfta borttagning"
-              className="absolute right-0 top-[calc(100%+8px)] z-10 flex min-w-[210px] flex-col gap-2 rounded-xl border border-slate-200 bg-white p-3 shadow-[0_8px_28px_rgba(0,0,0,0.12)]"
-            >
-              <div className="text-[13px] font-medium text-slate-900">Ta bort användare?</div>
-              <div className="text-xs text-slate-500">{user.email}</div>
-              <div className="flex justify-end gap-2">
-                <Button onClick={()=>setConfirmDelete(false)} disabled={busyDelete} size="sm" variant="secondary">Avbryt</Button>
-                <Button onClick={deleteUser} disabled={busyDelete} size="sm" className="border-red-700 bg-red-700 text-white hover:bg-red-800">{busyDelete ? 'Tar bort…' : 'Ta bort'}</Button>
-              </div>
-            </div>
-          )}
-        </div>
+        <button
+          type="button"
+          onClick={()=>setConfirmDelete(true)}
+          disabled={busyDelete}
+          className={crm.dangerButton}
+        >
+          Ta bort
+        </button>
       </div>
+
+      {confirmDelete && (
+        <AdminPromptDialog
+          title="Ta bort användare?"
+          message={user.email}
+          confirmLabel="Ta bort"
+          danger
+          busy={busyDelete}
+          onConfirm={() => deleteUser()}
+          onClose={() => setConfirmDelete(false)}
+        />
+      )}
     </article>
   );
 }
-
-function FieldBlock({ label, children }: { label: string; children: React.ReactNode }) {
-  return (
-    <label className="grid gap-1.5">
-      <span className="text-[11px] font-extrabold uppercase tracking-[0.35px] text-slate-500">{label}</span>
-      {children}
-    </label>
-  );
-}
-
-function roleBadgeClassName(role: string) {
-  if (role === 'admin') return 'border-red-200 bg-red-50 text-red-800';
-  if (role === 'sales') return 'border-emerald-200 bg-emerald-50 text-emerald-700';
-  if (role === 'konsult') return 'border-amber-200 bg-amber-50 text-amber-800';
-  return 'border-slate-200 bg-slate-50 text-slate-600';
-}
-


### PR DESCRIPTION
## Sammanfattning

Första vågen av admin-panelens migrering till CRM-standarden (plan: 5 vågor, en PR per våg).

- **Ny `app/admin/components/adminUi.tsx`** — delade recept för alla vågor: AA-säker fältetikett (`ADMIN_LABEL`, slate-600 — medvetet inte `crm.sectionTitle` som är sub-AA), fel/notis/tom-rutor, `roleBadgeClass`, `AdminField`, `AdminFilterChip` (CustomersClient-receptet). `ADMIN_COLHEAD`/`ADMIN_NOTICE_BOX` får sina konsumenter i våg 3–4.
- **AdminTabsClient** — badges + marknadsprosa bort ur headern; tabpanel-a11y (`aria-controls` bara på aktiv flik, inaktiva paneler finns inte i DOM); `loading`-fallback på de nio lazy-flikarna. `AdminUsers` förblir statiskt importerad med flit — det är default-fliken, dynamic gav dubbel nätverksvattenfall + tom panel.
- **AdminUsers** — hero-skal, `text-[28px]`-h1 och statistik-plattor → standardskelettet (h2 `text-lg`); rollfiltrets `Select` → chips med räknare (plattornas siffror lever vidare där); `ui/Button` → crm-tokens; ✏️/🗑️ → textknappar (`crm.dangerButton`); radera-popovern → `AdminPromptDialog`; rollistan enkällad.
- **AdminPromptDialog härdad** (granskningsfynd): `busy` gatar nu Escape/overlay/X och Enter-submit — en delete kunde tidigare se avbruten ut men fullföljas; confirm-läget fokuserar bekräfta-knappen; `deleteUser` släpper busy vid nätverksfel så dialogen inte fastnar.

## Avsiktligt synliga ändringar — "fixa" inte tillbaka

- Rubrikskalan sjunker `text-[28px]` → `text-lg` (samma medvetna tapp som PR #85 på startsidan).
- Rollfilter som chips i stället för dropdown (semantiken identisk).
- Raderingsbekräftelsen är nu centrerad modal med Escape/overlay-stöd i stället för popover.

## Beteende fryst

Flik-id:n, `?tab=`-djuplänkar, `localStorage['admin.activeTab']` och samtliga API-anrop oförändrade. Kända förekommande brister lämnade orörda med flit (optimistisk sparning vid PATCH-fel, `res.ok` ignoreras vid DELETE) — noterade för separat åtgärd.

## Verifiering

- `npm run type-check` ✅ · `npm run lint` ✅ · `npm run build` ✅ · `npm test` 1345/1345 ✅
- Granskning körd på grenen (8 vinklar): 12 fynd åtgärdade, 3 medvetet lämnade (se ovan)

### Manuell QA-checklista
- [ ] `/admin` laddar, alla 10 flikar växlar, refresh återställer senaste flik
- [ ] Djuplänkar `?tab=blikk` / `?tab=users` öppnar rätt flik
- [ ] Skapa användare, rollchips + sök filtrerar, namnredigering, blur-spar (telefon/roll/taggar)
- [ ] Radera-modalen: Escape stänger (men inte under pågående delete), bekräfta raderar
- [ ] Ingen horisontell scroll vid 375 px

🤖 Generated with [Claude Code](https://claude.com/claude-code)