### PR TITLE
feat(admin): våg 2 av CRM-standard-migreringen — Blikk, Depå-uttag, Nyheter

### DIFF
--- a/app/admin/blikk/AdminBlikkUsersMapping.tsx
+++ b/app/admin/blikk/AdminBlikkUsersMapping.tsx
@@ -1,14 +1,10 @@
 "use client";
 import React from 'react';
-import Badge from '../../../components/ui/Badge';
-import Button from '../../../components/ui/Button';
-import EmptyState from '../../../components/ui/EmptyState';
-import ErrorState from '../../../components/ui/ErrorState';
 import Input from '../../../components/ui/Input';
-import LoadingState from '../../../components/ui/LoadingState';
-import PageShell from '../../../components/ui/PageShell';
 import Select from '../../../components/ui/Select';
+import { crm } from '../../crm/lib/crmTokens';
 import { cn } from '../../../lib/shared/cn';
+import { ADMIN_CARD, ADMIN_ERROR_BOX, ADMIN_INSET, ADMIN_LABEL, AdminEmptyState, AdminFilterChip, roleBadgeClass } from '../components/adminUi';
 
 type ProfileRow = {
   id: string;
@@ -21,13 +17,34 @@ type ProfileRow = {
 
 type BlikkUserLite = { id: number; email: string | null; name: string | null };
 
+// Status utgår ALLTID från sparat läge (row.blikk_id) — aldrig från utkastet i
+// dropdownen. Utkastet lever i `drafts` tills Spara lyckas; annars ljuger både
+// badge, räknare och statusfilter om vad som faktiskt ligger i databasen.
+type StatusKey = 'mapped' | 'suggested' | 'unmapped';
+type StatusFilter = 'all' | StatusKey;
+
+const STATUS_META: Record<StatusKey, { label: string; badge: string }> = {
+  mapped: { label: 'Kopplad', badge: 'border-emerald-200 bg-emerald-50 text-emerald-700' },
+  suggested: { label: 'Förslag finns', badge: 'border-amber-200 bg-amber-50 text-amber-800' },
+  unmapped: { label: 'Okopplad', badge: 'border-slate-200 bg-slate-50 text-slate-600' },
+};
+
+function statusKeyFor(row: ProfileRow): StatusKey {
+  if (row.blikk_id != null) return 'mapped';
+  if (row.bestMatch) return 'suggested';
+  return 'unmapped';
+}
+
 export default function AdminBlikkUsersMapping() {
   const [loading, setLoading] = React.useState(true);
   const [error, setError] = React.useState<string | null>(null);
   const [rows, setRows] = React.useState<ProfileRow[]>([]);
   const [blikkUsers, setBlikkUsers] = React.useState<BlikkUserLite[]>([]);
   const [saving, setSaving] = React.useState<Record<string, boolean>>({});
+  // Osparade dropdown-val per profil-id. `undefined` = inget utkast.
+  const [drafts, setDrafts] = React.useState<Record<string, number | null>>({});
   const [search, setSearch] = React.useState('');
+  const [statusFilter, setStatusFilter] = React.useState<StatusFilter>('all');
 
   React.useEffect(() => {
     (async () => {
@@ -65,72 +82,88 @@ export default function AdminBlikkUsersMapping() {
         return;
       }
       setRows((list) => list.map((r) => (r.id === userId ? { ...r, blikk_id: blikkId } : r)));
+      // Sparat = utkastet är förbrukat.
+      setDrafts((d) => {
+        const next = { ...d };
+        delete next[userId];
+        return next;
+      });
     } finally {
       setSaving((s) => ({ ...s, [userId]: false }));
     }
   }
 
+  // Rent klientside-filter på SPARAT läge — påverkar aldrig saveMapping-payloads.
+  const term = search.trim().toLowerCase();
   const filteredRows = rows.filter((row) => {
-    const term = search.trim().toLowerCase();
+    if (statusFilter === 'unmapped' && row.blikk_id != null) return false;
+    if (statusFilter === 'mapped' && row.blikk_id == null) return false;
+    if (statusFilter === 'suggested' && statusKeyFor(row) !== 'suggested') return false;
     if (!term) return true;
     return [row.email, row.full_name || '', row.role, String(row.blikk_id || ''), row.bestMatch?.name || '', row.bestMatch?.email || ''].some((value) => value.toLowerCase().includes(term));
   });
 
   const mappedCount = rows.filter((row) => row.blikk_id != null).length;
-  const suggestionCount = rows.filter((row) => row.bestMatch != null).length;
+  const suggestedCount = rows.filter((row) => statusKeyFor(row) === 'suggested').length;
 
   return (
-    <PageShell className="max-w-[1280px] gap-5 px-3 py-3 sm:px-4 lg:px-5">
-      <section className="grid gap-4 rounded-[24px] border border-ui-border bg-[linear-gradient(180deg,#ffffff_0%,#f9fbf7_100%)] p-5 shadow-[0_14px_36px_rgba(15,23,42,0.04)]">
-        <div className="flex flex-wrap items-start justify-between gap-4">
-          <div className="grid max-w-[760px] gap-1.5">
-            <div className="flex flex-wrap gap-2">
-              <Badge variant="accent" className="px-2.5 py-1 text-[11px] uppercase tracking-[0.35px]">Blikk-koppling</Badge>
-              <Badge>{rows.length} profiler</Badge>
-              <Badge>{mappedCount} kopplade</Badge>
-            </div>
-            <h1 className="m-0 text-[28px] text-slate-900">Synka profiler mot rätt Blikk-användare</h1>
-            <p className="m-0 text-sm text-slate-700">
-              Matcha interna profiler mot Blikk-användare så tidrapporter och uppgifter får rätt användar-ID.
-            </p>
-          </div>
-          <Input value={search} onChange={(e) => setSearch(e.target.value)} placeholder="Sök e-post, namn, roll eller Blikk-ID" className="min-w-[280px] sm:w-[320px]" />
+    <div className="grid gap-4 p-5">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="grid gap-1">
+          <h2 className="m-0 text-lg font-bold text-slate-900">Blikk-koppling</h2>
+          <p className="m-0 text-sm text-slate-600">Matcha profiler mot Blikk-användare så tidrapporter får rätt användar-ID.</p>
         </div>
-        <div className="grid gap-2 [grid-template-columns:repeat(auto-fit,minmax(160px,1fr))]">
-          <div className="grid gap-1 rounded-2xl border border-ui-border bg-white px-3 py-2.5"><span className="text-[11px] font-extrabold uppercase tracking-[0.3px] text-slate-500">Kopplade</span><strong className="text-xl font-extrabold text-slate-900">{mappedCount}</strong></div>
-          <div className="grid gap-1 rounded-2xl border border-ui-border bg-white px-3 py-2.5"><span className="text-[11px] font-extrabold uppercase tracking-[0.3px] text-slate-500">Förslag finns</span><strong className="text-xl font-extrabold text-slate-900">{suggestionCount}</strong></div>
-          <div className="grid gap-1 rounded-2xl border border-ui-border bg-white px-3 py-2.5"><span className="text-[11px] font-extrabold uppercase tracking-[0.3px] text-slate-500">Okopplade</span><strong className="text-xl font-extrabold text-slate-900">{rows.length - mappedCount}</strong></div>
-        </div>
-      </section>
-      {loading && <LoadingState label="Laddar profiler" description="Hämtar profiler och Blikk-användare för matchning." />}
-      {error && <ErrorState title="Kunde inte läsa Blikk-kopplingar" message={error} />}
-      {!loading && rows.length === 0 && <EmptyState title="Inga profiler att visa" description="När profiler finns här kan de kopplas mot rätt Blikk-användare." />}
+        <Input value={search} onChange={(e) => setSearch(e.target.value)} placeholder="Sök e-post, namn, roll eller Blikk-ID" className="sm:w-[320px]" />
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        <AdminFilterChip active={statusFilter === 'all'} onClick={() => setStatusFilter('all')} count={rows.length}>
+          Alla
+        </AdminFilterChip>
+        <AdminFilterChip active={statusFilter === 'mapped'} onClick={() => setStatusFilter('mapped')} count={mappedCount}>
+          Kopplade
+        </AdminFilterChip>
+        <AdminFilterChip active={statusFilter === 'suggested'} onClick={() => setStatusFilter('suggested')} count={suggestedCount}>
+          Förslag finns
+        </AdminFilterChip>
+        <AdminFilterChip active={statusFilter === 'unmapped'} onClick={() => setStatusFilter('unmapped')} count={rows.length - mappedCount}>
+          Okopplade
+        </AdminFilterChip>
+      </div>
+
+      {loading && <p role="status" className="m-0 text-sm text-slate-400">Laddar…</p>}
+      {error && <div role="alert" className={ADMIN_ERROR_BOX}>{error}</div>}
+      {!loading && rows.length === 0 && !error && (
+        <AdminEmptyState title="Inga profiler att visa" description="När profiler finns här kan de kopplas mot rätt Blikk-användare." />
+      )}
       {!loading && rows.length > 0 && (
         <div className="grid gap-3">
           {filteredRows.map((row) => {
-            const selectedId = row.blikk_id ?? row.bestMatch?.id ?? null;
-            const status = row.blikk_id != null ? 'Kopplad' : row.bestMatch ? 'Förslag finns' : 'Okopplad';
+            const draft = drafts[row.id];
+            const selectedId = draft !== undefined ? draft : (row.blikk_id ?? row.bestMatch?.id ?? null);
+            const isDirty = draft !== undefined && draft !== row.blikk_id;
+            const statusKey = statusKeyFor(row);
 
             return (
-              <article key={row.id} className="grid gap-4 rounded-[20px] border border-ui-border bg-white p-4 shadow-[0_10px_28px_rgba(15,23,42,0.03)]">
+              <article key={row.id} className={cn(ADMIN_CARD, 'grid gap-3 p-4')}>
                 <div className="flex flex-wrap items-start justify-between gap-3">
-                  <div className="grid min-w-0 flex-1 basis-[260px] gap-1.5">
+                  <div className="grid min-w-0 flex-1 basis-[260px] gap-1">
                     <div className="flex flex-wrap items-center gap-2">
-                      <strong className="text-base text-slate-900">{row.full_name || 'Namn saknas'}</strong>
-                      <Badge className={cn('px-2 py-1 text-[11px] font-extrabold uppercase tracking-[0.35px]', roleBadgeClassName(row.role))}>{row.role}</Badge>
-                      <Badge className={cn('px-2 py-1 text-[11px] font-extrabold uppercase tracking-[0.3px]', statusBadgeClassName(status))}>{status}</Badge>
+                      <strong className="text-[13px] font-bold text-slate-900">{row.full_name || 'Namn saknas'}</strong>
+                      <span className={cn(crm.badge, roleBadgeClass(row.role))}>{row.role}</span>
+                      <span className={cn(crm.badge, STATUS_META[statusKey].badge)}>{STATUS_META[statusKey].label}</span>
                     </div>
-                    <span className="break-all text-[13px] text-slate-500">{row.email}</span>
+                    <span className="break-all text-[11px] text-slate-500">{row.email}</span>
                   </div>
-                  <div className="grid gap-1.5 justify-items-start sm:justify-items-end">
-                    <span className="text-[11px] font-extrabold uppercase tracking-[0.3px] text-slate-500">Nuvarande Blikk-ID</span>
-                    <strong className="text-lg text-slate-900">{row.blikk_id ?? '—'}</strong>
+                  <div className="grid gap-1 justify-items-start sm:justify-items-end">
+                    <span className={ADMIN_LABEL}>Nuvarande Blikk-ID</span>
+                    <strong className="text-lg tabular-nums text-slate-900">{row.blikk_id ?? '—'}</strong>
                   </div>
                 </div>
 
                 <div className="grid gap-3 [grid-template-columns:repeat(auto-fit,minmax(240px,1fr))]">
-                  <div className="grid gap-2 rounded-2xl border border-slate-200 bg-slate-50 px-3 py-3">
-                    <span className="text-[11px] font-extrabold uppercase tracking-[0.3px] text-slate-500">Förslag</span>
+                  <div className={cn(ADMIN_INSET, 'grid gap-2 px-3 py-2.5')}>
+                    <span className={ADMIN_LABEL}>Förslag</span>
                     {row.bestMatch ? (
                       <div className="grid gap-0.5">
                         <strong className="text-slate-900">#{row.bestMatch.id} • {row.bestMatch.name || row.bestMatch.email || '—'}</strong>
@@ -141,58 +174,58 @@ export default function AdminBlikkUsersMapping() {
                     )}
                   </div>
 
-                  <div className="grid gap-2 rounded-2xl border border-slate-200 bg-slate-50 px-3 py-3">
-                    <span className="text-[11px] font-extrabold uppercase tracking-[0.3px] text-slate-500">Välj Blikk-användare</span>
+                  <div className={cn(ADMIN_INSET, 'grid gap-2 px-3 py-2.5')}>
+                    <span className={ADMIN_LABEL}>Välj Blikk-användare</span>
                     <BlikkUserSelect
                       users={blikkUsers}
                       value={selectedId}
-                      onChange={(val) => setRows((list) => list.map((x) => (x.id === row.id ? { ...x, blikk_id: val } : x)))}
+                      onChange={(val) => setDrafts((d) => ({ ...d, [row.id]: val }))}
                     />
                   </div>
                 </div>
 
-                <div className="flex flex-wrap items-center justify-between gap-3">
-                  <span className="text-xs text-slate-500">
-                    Spara när rätt Blikk-användare är vald för att låsa kopplingen på profilen.
-                  </span>
-                  <div className="flex flex-wrap gap-2">
-                    {row.bestMatch && row.blikk_id == null && (
-                      <Button
-                        onClick={() => setRows((list) => list.map((x) => (x.id === row.id ? { ...x, blikk_id: row.bestMatch!.id } : x)))}
-                        variant="secondary"
-                        size="sm"
-                        className="border-emerald-200 text-emerald-700 hover:bg-emerald-50"
-                      >
-                        Använd förslag
-                      </Button>
-                    )}
-                    <Button
-                      onClick={() => saveMapping(row.id, selectedId)}
-                      disabled={saving[row.id]}
-                      variant="primary"
-                      size="sm"
+                <div className="flex flex-wrap items-center justify-end gap-2">
+                  {isDirty && (
+                    <span className={cn(crm.badge, 'border-amber-200 bg-amber-50 text-amber-800')}>Osparat val</span>
+                  )}
+                  {row.bestMatch && row.blikk_id == null && (
+                    <button
+                      type="button"
+                      onClick={() => setDrafts((d) => ({ ...d, [row.id]: row.bestMatch!.id }))}
+                      className={cn(crm.ghostButton, 'hover:border-emerald-300 hover:text-emerald-700')}
                     >
-                      {saving[row.id] ? 'Sparar…' : 'Spara koppling'}
-                    </Button>
-                    {row.blikk_id != null && (
-                      <Button
-                        onClick={() => saveMapping(row.id, null)}
-                        disabled={saving[row.id]}
-                        variant="secondary"
-                        size="sm"
-                      >
-                        Rensa
-                      </Button>
-                    )}
-                  </div>
+                      Använd förslag
+                    </button>
+                  )}
+                  <button
+                    type="button"
+                    onClick={() => saveMapping(row.id, selectedId)}
+                    disabled={saving[row.id]}
+                    className={crm.formButton}
+                    style={{ backgroundColor: 'var(--crm-primary, #1a3f26)' }}
+                  >
+                    {saving[row.id] ? 'Sparar…' : 'Spara koppling'}
+                  </button>
+                  {row.blikk_id != null && (
+                    <button
+                      type="button"
+                      onClick={() => saveMapping(row.id, null)}
+                      disabled={saving[row.id]}
+                      className={crm.ghostButton}
+                    >
+                      Rensa
+                    </button>
+                  )}
                 </div>
               </article>
             );
           })}
         </div>
       )}
-      {!loading && rows.length > 0 && filteredRows.length === 0 && <EmptyState title="Ingen profil matchar sökningen" description="Justera söktermen för att visa profiler igen." />}
-    </PageShell>
+      {!loading && rows.length > 0 && filteredRows.length === 0 && (
+        <AdminEmptyState title="Ingen profil matchar" description="Justera sökningen eller statusfiltret för att visa profiler igen." />
+      )}
+    </div>
   );
 }
 
@@ -207,17 +240,4 @@ function BlikkUserSelect({ users, value, onChange }: { users: BlikkUserLite[]; v
       ))}
     </Select>
   );
-}
-
-function roleBadgeClassName(role: string) {
-  if (role === 'admin') return 'border-red-200 bg-red-50 text-red-800';
-  if (role === 'sales') return 'border-emerald-200 bg-emerald-50 text-emerald-700';
-  if (role === 'konsult') return 'border-amber-200 bg-amber-50 text-amber-800';
-  return 'border-slate-200 bg-slate-50 text-slate-600';
-}
-
-function statusBadgeClassName(status: string) {
-  if (status === 'Kopplad') return 'border-emerald-200 bg-emerald-50 text-emerald-700';
-  if (status === 'Förslag finns') return 'border-amber-200 bg-amber-50 text-amber-800';
-  return 'border-slate-200 bg-slate-50 text-slate-600';
 }

--- a/app/admin/components/adminUi.tsx
+++ b/app/admin/components/adminUi.tsx
@@ -19,17 +19,29 @@ export const ADMIN_ERROR_BOX = 'rounded-xl border border-rose-200 bg-rose-50 px-
 // Konsumeras från våg 3–4 (profileditorns success-ruta, Behörigheternas förklaring).
 export const ADMIN_NOTICE_BOX = 'rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-900';
 export const ADMIN_EMPTY_BOX = 'rounded-2xl border border-dashed border-[#d5e0cf] bg-[#f4f8f1] px-4 py-8 text-center';
-// Tomrutans brödtext: <p className="m-0 text-sm text-slate-500">…</p>
-// Laddar: <p className="m-0 text-sm text-slate-400">Laddar…</p> (ingen hjälpare behövs)
+// Laddar: <p role="status" className="m-0 text-sm text-slate-400">Laddar…</p> (ingen hjälpare behövs)
+
+// Innehållskort (vitt på flikkortets sage) respektive inre inset (sage på vitt).
+// Padding ägs av anropsplatsen (p-4 för kort, px-3 py-2.5/p-3.5 för inset).
+export const ADMIN_CARD = 'rounded-2xl border border-[#e0e8dc] bg-white';
+export const ADMIN_INSET = 'rounded-xl border border-[#e0e8dc] bg-[#f9fbf7]';
 
 // Roll → badgefärger. Renderas som cn(crm.badge, roleBadgeClass(role)).
-// OBS: AdminBlikkUsersMapping bär ännu sin egen bytidentiska kopia — den byts
-// när fliken migreras (våg 2); färgändringar här måste tills dess speglas där.
 export function roleBadgeClass(role: string): string {
   if (role === 'admin') return 'border-red-200 bg-red-50 text-red-800';
   if (role === 'sales') return 'border-emerald-200 bg-emerald-50 text-emerald-700';
   if (role === 'konsult') return 'border-amber-200 bg-amber-50 text-amber-800';
   return 'border-slate-200 bg-slate-50 text-slate-600';
+}
+
+// Tomruta med rubrik + förklaring — en komponent i stället för N handskrivna kopior.
+export function AdminEmptyState({ title, description }: { title: string; description?: string }) {
+  return (
+    <div className={ADMIN_EMPTY_BOX}>
+      <strong className="text-sm font-semibold text-slate-700">{title}</strong>
+      {description ? <p className="m-0 mt-1 text-sm text-slate-500">{description}</p> : null}
+    </div>
+  );
 }
 
 // Fältomslag — ersätter flikarnas lokala FieldBlock/Field-hjälpare.
@@ -63,7 +75,7 @@ export function AdminFilterChip({
         'inline-flex shrink-0 items-center gap-1.5 rounded-xl border px-2.5 py-1 text-[13px] font-semibold transition',
         active ? 'border-transparent text-white' : 'border-slate-200 bg-white text-slate-600 hover:border-slate-300',
       )}
-      style={active ? { backgroundColor: 'var(--crm-primary)' } : undefined}
+      style={active ? { backgroundColor: 'var(--crm-primary, #1a3f26)' } : undefined}
     >
       {children}
       {count != null ? (

--- a/app/admin/depots/AdminDepotUsage.tsx
+++ b/app/admin/depots/AdminDepotUsage.tsx
@@ -1,13 +1,11 @@
 "use client";
 import React, { useEffect, useMemo, useState } from 'react';
 import { createClientComponentClient } from '@supabase/auth-helpers-nextjs';
-import Badge from '../../../components/ui/Badge';
-import EmptyState from '../../../components/ui/EmptyState';
-import ErrorState from '../../../components/ui/ErrorState';
 import Input from '../../../components/ui/Input';
-import LoadingState from '../../../components/ui/LoadingState';
-import PageShell from '../../../components/ui/PageShell';
 import Select from '../../../components/ui/Select';
+import { crm } from '../../crm/lib/crmTokens';
+import { cn } from '../../../lib/shared/cn';
+import { ADMIN_CARD, ADMIN_ERROR_BOX, ADMIN_INSET, ADMIN_LABEL, AdminEmptyState } from '../components/adminUi';
 
 type UsageRow = {
   id: string;
@@ -127,83 +125,68 @@ export default function AdminDepotUsage() {
   const uniqueDepots = new Set(filtered.map((row) => row.depot_id)).size;
 
   return (
-    <PageShell className="max-w-[1240px] gap-5 px-3 py-3 sm:px-4 lg:px-5">
-      <section className="grid gap-4 rounded-[24px] border border-ui-border bg-[linear-gradient(180deg,#ffffff_0%,#f9fbf7_100%)] p-5 shadow-[0_14px_36px_rgba(15,23,42,0.04)]">
-        <div className="flex flex-wrap items-start justify-between gap-4">
-          <div className="grid max-w-[760px] gap-1.5">
-            <div className="flex flex-wrap gap-2">
-              <Badge variant="accent" className="px-2.5 py-1 text-[11px] uppercase tracking-[0.35px]">Depå-uttag</Badge>
-              <Badge>{filtered.length} rader</Badge>
-              <Badge>{days} dagar</Badge>
-            </div>
-            <h1 className="m-0 text-[28px] text-slate-900">Förbrukning och uttag i ett tydligare flöde</h1>
-            <p className="m-0 text-sm leading-[1.55] text-slate-600">Följ senaste depåuttag, filtrera på projekt eller depå och få en snabb summering av förbrukningen.</p>
-          </div>
-          <div className="flex w-full flex-wrap items-center gap-3 lg:w-[460px]">
-            <Input value={q} onChange={e=>setQ(e.target.value)} placeholder="Sök ordernummer, projekt, depå eller nyckel" className="min-w-[260px] flex-1" />
-            <label className="flex items-center gap-2 text-sm text-slate-700">
-              <span>Visa dagar:</span>
-              <Select value={days} onChange={e=>setDays(Number(e.target.value))} className="w-auto min-w-[92px]">
-                <option value={7}>7</option>
-                <option value={14}>14</option>
-                <option value={30}>30</option>
-                <option value={90}>90</option>
-              </Select>
-            </label>
-          </div>
+    <div className="grid gap-4 p-5">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="grid gap-1">
+          <h2 className="m-0 text-lg font-bold text-slate-900">Depå-uttag</h2>
+          <p className="m-0 text-sm text-slate-600">Senaste uttagen per depå och projekt.</p>
         </div>
+        <div className="flex w-full flex-wrap items-center gap-3 lg:w-[460px]">
+          <Input value={q} onChange={e=>setQ(e.target.value)} placeholder="Sök ordernummer, projekt, depå eller nyckel" className="min-w-[260px] flex-1" />
+          <label className="flex w-auto items-center gap-2 text-sm text-slate-700">
+            <span>Visa dagar:</span>
+            <Select value={days} onChange={e=>setDays(Number(e.target.value))} className="w-auto min-w-[92px]">
+              <option value={7}>7</option>
+              <option value={14}>14</option>
+              <option value={30}>30</option>
+              <option value={90}>90</option>
+            </Select>
+          </label>
+        </div>
+      </div>
 
-        <div className="grid gap-2 [grid-template-columns:repeat(auto-fit,minmax(160px,1fr))]">
-          <div className="grid gap-1 rounded-2xl border border-ui-border bg-white px-3 py-2.5">
-            <span className="text-[11px] font-extrabold uppercase tracking-[0.3px] text-slate-500">Säckar</span>
-            <strong className="text-xl font-extrabold text-slate-900">{totalBags}</strong>
-          </div>
-          <div className="grid gap-1 rounded-2xl border border-ui-border bg-white px-3 py-2.5">
-            <span className="text-[11px] font-extrabold uppercase tracking-[0.3px] text-slate-500">Projekt</span>
-            <strong className="text-xl font-extrabold text-slate-900">{uniqueProjects}</strong>
-          </div>
-          <div className="grid gap-1 rounded-2xl border border-ui-border bg-white px-3 py-2.5">
-            <span className="text-[11px] font-extrabold uppercase tracking-[0.3px] text-slate-500">Depåer</span>
-            <strong className="text-xl font-extrabold text-slate-900">{uniqueDepots}</strong>
-          </div>
-        </div>
-      </section>
-      {error && <ErrorState title="Kunde inte läsa depåuttag" message={error} />}
+      <p className="m-0 text-[11px] text-slate-500">
+        <span className="font-semibold tabular-nums">{totalBags}</span> säckar · <span className="tabular-nums">{uniqueProjects}</span> projekt · <span className="tabular-nums">{uniqueDepots}</span> depåer
+      </p>
+
+      {error && <div role="alert" className={ADMIN_ERROR_BOX}>{error}</div>}
       {loading ? (
-        <LoadingState label="Laddar depåuttag" description={`Hämtar poster för de senaste ${days} dagarna.`} />
+        <p role="status" className="m-0 text-sm text-slate-400">Laddar…</p>
       ) : (
         <div className="grid gap-2.5">
           {filtered.map(r => (
-            <article key={r.id} className="grid gap-3 rounded-[18px] border border-ui-border bg-white p-[14px] shadow-[0_8px_20px_rgba(15,23,42,0.03)]">
+            <article key={r.id} className={cn(ADMIN_CARD, 'grid gap-3 p-4')}>
               <div className="flex flex-wrap items-start justify-between gap-3">
                 <div className="grid min-w-0 flex-1 basis-[220px] gap-1">
-                  <div className="font-bold text-slate-900">{depotName(r.depot_id)}</div>
-                  <div className="text-xs text-slate-500">{new Date(r.created_at).toLocaleString('sv-SE')}</div>
+                  <div className="text-[13px] font-bold text-slate-900">{depotName(r.depot_id)}</div>
+                  <div className="text-[11px] text-slate-500">{new Date(r.created_at).toLocaleString('sv-SE')}</div>
                 </div>
-                <Badge variant="accent" className="justify-center whitespace-nowrap px-2.5 py-2 text-[13px] font-extrabold">{r.bags_used} säckar</Badge>
+                <span className={cn(crm.badge, 'border-emerald-200 bg-emerald-50 text-emerald-700 tabular-nums')}>{r.bags_used} säckar</span>
               </div>
 
               <div className="grid gap-2.5 [grid-template-columns:repeat(auto-fit,minmax(180px,1fr))]">
-                <div className="min-w-0 grid gap-1 rounded-[14px] border border-slate-200 bg-slate-50 px-3 py-2.5">
-                  <span className="text-[11px] font-extrabold uppercase tracking-[0.3px] text-slate-500">Order</span>
-                  <strong className="min-w-0 break-all text-sm font-bold text-slate-900">{r.order_number ? `#${r.order_number}` : projectLabel(r.project_id)}</strong>
+                <div className={cn(ADMIN_INSET, 'min-w-0 grid gap-1 px-3 py-2.5')}>
+                  <span className={ADMIN_LABEL}>Order</span>
+                  <strong className="min-w-0 break-all text-sm font-semibold text-slate-900">{r.order_number ? `#${r.order_number}` : projectLabel(r.project_id)}</strong>
                   <span className="break-words text-xs text-slate-500">Projekt-ID: {r.project_id}</span>
                 </div>
-                <div className="min-w-0 grid gap-1 rounded-[14px] border border-slate-200 bg-slate-50 px-3 py-2.5">
-                  <span className="text-[11px] font-extrabold uppercase tracking-[0.3px] text-slate-500">Installationsdatum</span>
-                  <strong className="min-w-0 break-all text-sm font-bold text-slate-900">{r.installation_date || '—'}</strong>
+                <div className={cn(ADMIN_INSET, 'min-w-0 grid gap-1 px-3 py-2.5')}>
+                  <span className={ADMIN_LABEL}>Installationsdatum</span>
+                  <strong className="min-w-0 break-all text-sm font-semibold text-slate-900">{r.installation_date || '—'}</strong>
                 </div>
-                <div className="min-w-0 grid gap-1 rounded-[14px] border border-slate-200 bg-slate-50 px-3 py-2.5">
-                  <span className="text-[11px] font-extrabold uppercase tracking-[0.3px] text-slate-500">Källa</span>
-                  <strong className="min-w-0 break-all text-sm font-bold text-slate-900">{r.source_key || '—'}</strong>
+                <div className={cn(ADMIN_INSET, 'min-w-0 grid gap-1 px-3 py-2.5')}>
+                  <span className={ADMIN_LABEL}>Källa</span>
+                  <strong className="min-w-0 break-all text-sm font-semibold text-slate-900">{r.source_key || '—'}</strong>
                 </div>
               </div>
             </article>
           ))}
-          {filtered.length === 0 && <EmptyState title="Inga uttag funna" description="Prova fler dagar eller en bredare sökning för att se fler poster." />}
+          {filtered.length === 0 && !error && (
+            <AdminEmptyState title="Inga uttag funna" description="Prova fler dagar eller en bredare sökning för att se fler poster." />
+          )}
         </div>
       )}
-    </PageShell>
+    </div>
   );
 }
 

--- a/app/admin/news/AdminNews.tsx
+++ b/app/admin/news/AdminNews.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import React, { useState } from 'react';
-import Badge from '../../../components/ui/Badge';
-import Button from '../../../components/ui/Button';
 import Input from '../../../components/ui/Input';
-import PageShell from '../../../components/ui/PageShell';
 import Textarea from '../../../components/ui/Textarea';
+import { crm } from '../../crm/lib/crmTokens';
+import { cn } from '../../../lib/shared/cn';
+import { ADMIN_CARD, ADMIN_ERROR_BOX, ADMIN_INSET, AdminField } from '../components/adminUi';
 
 export default function AdminNews() {
   const [headline, setHeadline] = useState('');
@@ -48,44 +48,27 @@ export default function AdminNews() {
     }
   }
 
-  const headlineLength = headline.trim().length;
-  const bodyLength = body.trim().length;
-  const statusLabel = status === 'saved' ? 'Sparad' : status === 'saving' ? 'Sparar…' : status === 'error' ? 'Fel' : 'Redigeras';
-
   return (
-    <PageShell className="max-w-[1240px] gap-5 px-3 py-3 sm:px-4 lg:px-5">
-      <section className="grid gap-4 rounded-[24px] border border-ui-border bg-[linear-gradient(180deg,#ffffff_0%,#f9fbf7_100%)] p-5 shadow-[0_14px_36px_rgba(15,23,42,0.04)]">
-        <div className="flex flex-wrap items-start justify-between gap-4">
-          <div className="grid max-w-[700px] gap-1.5">
-            <div className="flex flex-wrap gap-2">
-              <Badge variant="accent" className="px-2.5 py-1 text-[11px] uppercase tracking-[0.35px]">Nyheter</Badge>
-              <Badge>{headlineLength} tecken i rubrik</Badge>
-              <Badge>{bodyLength} tecken i text</Badge>
-            </div>
-            <h1 className="m-0 text-[30px] text-slate-900">Publicera dashboardnyheter med bättre kontroll</h1>
-            <p className="m-0 text-sm leading-[1.55] text-slate-600">Skriv nyheten, förhandsgranska hur den läses och publicera när innehållet känns klart.</p>
-          </div>
-          <div className="grid min-w-[160px] gap-1 rounded-2xl border border-ui-border bg-white px-3 py-2.5">
-            <span className="text-[11px] font-extrabold uppercase tracking-[0.3px] text-slate-500">Status</span>
-            <strong className="text-xl font-extrabold text-slate-900">{statusLabel}</strong>
-          </div>
-        </div>
-      </section>
+    <div className="grid gap-4 p-5">
+      <div className="grid gap-1">
+        <h2 className="m-0 text-lg font-bold text-slate-900">Nyheter</h2>
+        <p className="m-0 text-sm text-slate-600">Nyheten visas en gång per nyhet och webbläsare som modal på dashboarden.</p>
+      </div>
 
-      <section className="grid items-start gap-5 xl:[grid-template-columns:minmax(0,1.1fr)_minmax(320px,0.9fr)]">
-        <section className="grid gap-4 rounded-[20px] border border-slate-200 bg-white p-5 shadow-[0_10px_28px_rgba(15,23,42,0.03)]">
-          <h2 className="m-0 text-lg text-slate-900">Skapa ny nyhet</h2>
+      <section className="grid items-start gap-4 xl:[grid-template-columns:minmax(0,1.1fr)_minmax(320px,0.9fr)]">
+        <section className={cn(ADMIN_CARD, 'grid gap-3 p-4')}>
+          <h3 className="m-0 text-base font-bold text-slate-900">Skapa ny nyhet</h3>
           <form onSubmit={submit} className="grid gap-3">
-            <Field label="Rubrik">
+            <AdminField label="Rubrik">
               <Input
                 required
                 value={headline}
                 onChange={e => setHeadline(e.target.value)}
                 placeholder="t.ex. Ny uppdatering i planeringen"
               />
-            </Field>
+            </AdminField>
 
-            <Field label="Text">
+            <AdminField label="Text">
               <Textarea
                 required
                 value={body}
@@ -94,65 +77,46 @@ export default function AdminNews() {
                 rows={6}
                 className="min-h-[144px]"
               />
-            </Field>
+            </AdminField>
 
-            <Field label="Bild-URL (valfritt)">
+            <AdminField label="Bild-URL (valfritt)">
               <Input
                 value={imageUrl}
                 onChange={e => setImageUrl(e.target.value)}
                 placeholder="https://…"
               />
-            </Field>
+            </AdminField>
 
-            <div className="flex flex-wrap items-center gap-2.5">
-              <Button
-                type="submit"
-                disabled={status === 'saving' || headlineLength === 0 || bodyLength === 0}
-                variant="primary"
-              >
-                {status === 'saving' ? 'Sparar…' : (status === 'saved' ? 'Sparat ✓' : 'Publicera nyhet')}
-              </Button>
-              {error && <span className="text-sm text-red-700">{error}</span>}
-            </div>
+            <button
+              type="submit"
+              disabled={status === 'saving' || !headline.trim() || !body.trim()}
+              className={cn(crm.formButton, 'justify-self-start')}
+              style={{ backgroundColor: 'var(--crm-primary, #1a3f26)' }}
+            >
+              {status === 'saving' ? 'Sparar…' : (status === 'saved' ? 'Sparat ✓' : 'Publicera nyhet')}
+            </button>
+            {error && <div role="alert" className={ADMIN_ERROR_BOX}>{error}</div>}
           </form>
-
-          <div className="text-xs text-slate-500">
-            Nyheten visas som en modal på dashboarden en gång per nyhet per webbläsare via localStorage.
-          </div>
-
-          <div className="grid gap-2 rounded-2xl border border-slate-200 bg-slate-50 px-3.5 py-3">
-            <strong className="text-[13px] text-slate-900">Snabb check innan publicering</strong>
-            <span className="text-xs text-slate-500">Håll rubriken kort, skriv ett tydligt syfte först och lägg bara till bild när den faktiskt tillför sammanhang.</span>
-          </div>
         </section>
 
-        <section className="grid content-start gap-4 rounded-[20px] border border-slate-200 bg-white p-5 shadow-[0_10px_28px_rgba(15,23,42,0.03)]">
-          <h2 className="m-0 text-lg text-slate-900">Förhandsvisning</h2>
-          <div className="grid gap-3 rounded-[20px] border border-ui-border bg-[linear-gradient(180deg,#ffffff_0%,#f9fbf7_100%)] p-4">
+        <section className={cn(ADMIN_CARD, 'grid content-start gap-3 p-4')}>
+          <h3 className="m-0 text-base font-bold text-slate-900">Förhandsvisning</h3>
+          <div className={cn(ADMIN_INSET, 'grid gap-3 p-4')}>
             {imageUrl.trim() ? (
               <div
-                className="aspect-video w-full rounded-2xl border border-ui-border bg-cover bg-center"
+                className="aspect-video w-full rounded-2xl border border-[#e0e8dc] bg-cover bg-center"
                 style={{ backgroundImage: `url(${imageUrl.trim()})` }}
               />
             ) : (
               <div className="grid aspect-video w-full place-items-center rounded-2xl border border-dashed border-slate-300 text-[13px] text-slate-400">Ingen bild vald</div>
             )}
             <div className="grid gap-2">
-              <strong className="text-[22px] leading-[1.15] text-slate-900">{headline.trim() || 'Rubriken visas här'}</strong>
+              <strong className="text-lg font-bold leading-[1.2] text-slate-900">{headline.trim() || 'Rubriken visas här'}</strong>
               <p className="m-0 whitespace-pre-wrap text-sm leading-[1.6] text-slate-600">{body.trim() || 'Brödtexten visas här när du börjar skriva nyheten.'}</p>
             </div>
           </div>
         </section>
       </section>
-    </PageShell>
-  );
-}
-
-function Field({ label, children }: { label: string; children: React.ReactNode }) {
-  return (
-    <label className="grid gap-1.5 text-xs font-semibold text-slate-700">
-      <span>{label}</span>
-      {children}
-    </label>
+    </div>
   );
 }

--- a/app/admin/users/AdminUsers.tsx
+++ b/app/admin/users/AdminUsers.tsx
@@ -6,7 +6,7 @@ import Select from '../../../components/ui/Select';
 import { crm } from '../../crm/lib/crmTokens';
 import { cn } from '../../../lib/shared/cn';
 import AdminPromptDialog from '../components/AdminPromptDialog';
-import { ADMIN_EMPTY_BOX, ADMIN_ERROR_BOX, ADMIN_LABEL, AdminField, AdminFilterChip, roleBadgeClass } from '../components/adminUi';
+import { ADMIN_CARD, ADMIN_ERROR_BOX, ADMIN_INSET, ADMIN_LABEL, AdminEmptyState, AdminField, AdminFilterChip, roleBadgeClass } from '../components/adminUi';
 
 interface AdminUserRow {
   id: string;
@@ -107,7 +107,7 @@ export default function AdminUsers() {
       </div>
 
       <section className="grid gap-4 xl:[grid-template-columns:minmax(300px,380px)_minmax(0,1fr)]">
-        <section className="grid content-start gap-3 rounded-2xl border border-[#e0e8dc] bg-white p-4">
+        <section className={cn(ADMIN_CARD, 'grid content-start gap-3 p-4')}>
           <h3 className="m-0 text-base font-bold text-slate-900">Skapa konto</h3>
 
           <form onSubmit={createUser} className="grid gap-3">
@@ -131,7 +131,7 @@ export default function AdminUsers() {
           </form>
         </section>
 
-        <section className="grid gap-4 rounded-2xl border border-[#e0e8dc] bg-white p-4">
+        <section className={cn(ADMIN_CARD, 'grid gap-4 p-4')}>
           <div className="flex flex-wrap items-start justify-between gap-3">
             <h3 className="m-0 text-base font-bold text-slate-900">Alla användare</h3>
             <Input
@@ -156,10 +156,7 @@ export default function AdminUsers() {
           {loadError && <div role="alert" className={ADMIN_ERROR_BOX}>{loadError}</div>}
           {loading && <p role="status" className="m-0 text-sm text-slate-400">Laddar…</p>}
           {!loading && users.length === 0 && !loadError && (
-            <div className={ADMIN_EMPTY_BOX}>
-              <strong className="text-sm font-semibold text-slate-700">Inga användare hittades</strong>
-              <p className="m-0 mt-1 text-sm text-slate-500">Skapa första kontot eller uppdatera sidan igen senare.</p>
-            </div>
+            <AdminEmptyState title="Inga användare hittades" description="Skapa första kontot eller uppdatera sidan igen senare." />
           )}
           {!loading && users.length > 0 && (
           <div className="grid gap-3">
@@ -169,10 +166,7 @@ export default function AdminUsers() {
           </div>
         )}
           {!loading && users.length > 0 && filteredUsers.length === 0 && (
-            <div className={ADMIN_EMPTY_BOX}>
-              <strong className="text-sm font-semibold text-slate-700">Ingen användare matchar</strong>
-              <p className="m-0 mt-1 text-sm text-slate-500">Justera sökningen eller rollfiltret för att visa fler resultat.</p>
-            </div>
+            <AdminEmptyState title="Ingen användare matchar" description="Justera sökningen eller rollfiltret för att visa fler resultat." />
           )}
         </section>
       </section>
@@ -219,7 +213,7 @@ function UserCard({ user, onChanged, onDeleted }: { user: AdminUserRow; onChange
   }
 
   return (
-    <article className="grid gap-3 rounded-xl border border-[#e0e8dc] bg-[#f9fbf7] p-3.5">
+    <article className={cn(ADMIN_INSET, 'grid gap-3 p-3.5')}>
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div className="grid min-w-0 flex-1 gap-1 basis-[280px]">
           <div className="flex flex-wrap items-center gap-2">
@@ -229,7 +223,7 @@ function UserCard({ user, onChanged, onDeleted }: { user: AdminUserRow; onChange
           <span className="break-all text-[11px] text-slate-500">{user.email}</span>
         </div>
         <div className="flex flex-wrap items-center gap-2">
-          <span className="text-[11px] text-slate-400">Skapad {new Date(user.created_at).toLocaleDateString()}</span>
+          <span className="text-[11px] text-slate-500">Skapad {new Date(user.created_at).toLocaleDateString()}</span>
           <Link href={`/admin/users/${user.id}`} className={crm.ghostButton}>
             Öppna profil
           </Link>
@@ -253,7 +247,7 @@ function UserCard({ user, onChanged, onDeleted }: { user: AdminUserRow; onChange
               onClick={saveChanges}
               disabled={saving}
               className={crm.formButton}
-              style={{ backgroundColor: 'var(--crm-primary)' }}
+              style={{ backgroundColor: 'var(--crm-primary, #1a3f26)' }}
             >
               {saving ? '...' : 'Spara'}
             </button>


### PR DESCRIPTION
## Sammanfattning

Andra vågen av admin-migreringen (efter #87). Tre dialekt A-flikar till standardskelettet: hero-skal, `text-[28px]`-h1:or, nästlade `PageShell`s och alla statistik-plattor ersatta med h2 + subline, filterchips med räknare och de nya delade recepten.

- **Blikk-koppling** — chips Alla/Kopplade/Förslag finns/Okopplade (rent klientside-filter), kortrecepten på tokens, knapptrion → crm-tokens
- **Depå-uttag** — plattorna → en summeringsrad (säckar · projekt · depåer), kortlistan på `ADMIN_CARD`/`ADMIN_INSET`
- **Nyheter** — formulär + förhandsvisning som matchande syskonkort, lokala `Field` → `AdminField`
- **adminUi** — nya `AdminEmptyState`, `ADMIN_CARD`, `ADMIN_INSET`; `AdminUsers` (våg 1) konvergerad på samma hjälpare

## Viktigast: granskningen hittade en riktig bugg i mitt eget första utkast

Statusfiltret läste det **osparade** `blikk_id` som dropdownen muterar optimistiskt — med "Okopplade" aktivt försvann kortet i samma ögonblick man valde en användare i dropdownen, *före* Spara, och badge/räknare visade osparade val som sanning (det senare fanns redan i produktion). Fixen: en draft-map skiljer utkast från sparat läge; allt statusdrivet läser sparat, dirty rader får **"Osparat val"**-badge. `saveMapping`-payloaden är byte-identisk.

## Avsiktligt synliga ändringar

- Rubrikskalan ned till `text-lg` (samma som #87/#85)
- Blikk: badge/Blikk-ID/räknare uppdateras nu först **efter** lyckad Spara (tidigare direkt vid dropdown-val — det var en UI-lögn)
- Nyheter-sublinen rättad: nyheten visas en gång **per nyhet** och webbläsare
- Depå: fel- och tomruta visas inte längre samtidigt vid fetch-fel

## Verifiering

- `npm run type-check` ✅ · `npm run lint` ✅ · `npm run build` ✅ · `npm test` 1345/1345 ✅
- Granskning på grenen (8 vinklar): 15 fynd åtgärdade, 3 medvetet lämnade (globala chipräknare = våg 1-konsekvens; Intl-format per keystroke = förekommande; 1200 ms-sparsignalen = ekvivalent med gamla plattan)

### Manuell QA-checklista
- [ ] Blikk: välj i dropdown under "Okopplade" — kortet ska **inte** försvinna; "Osparat val" visas; Spara koppling → badge/ID/räknare uppdateras; Rensa fungerar; misslyckad POST behåller utkastet
- [ ] Depå: sök + dagar-select; summeringsraden räknar rätt
- [ ] Nyheter: publicera → formulär rensas; förhandsvisningen speglar; felruta vid API-fel
- [ ] Alla flikar: växling, djuplänkar, ingen horisontell scroll vid 375 px

🤖 Generated with [Claude Code](https://claude.com/claude-code)