### PR TITLE
feat(admin): våg 3 av CRM-standard-migreringen — Kontakter, användarprofilen

### DIFF
--- a/app/admin/contacts/AdminContacts.tsx
+++ b/app/admin/contacts/AdminContacts.tsx
@@ -1,14 +1,12 @@
 "use client";
 import React, { useEffect, useState, useMemo } from 'react';
-import Badge from '../../../components/ui/Badge';
-import Button from '../../../components/ui/Button';
 import { DataTable, DataTableCell, DataTableHeaderCell } from '../../../components/ui/DataTable';
-import EmptyState from '../../../components/ui/EmptyState';
-import ErrorState from '../../../components/ui/ErrorState';
 import Input from '../../../components/ui/Input';
 import { TabsList, TabsTrigger } from '../../../components/ui/Tabs';
+import { crm } from '../../crm/lib/crmTokens';
 import { cn } from '../../../lib/shared/cn';
 import AdminPromptDialog from '../components/AdminPromptDialog';
+import { ADMIN_CARD, ADMIN_COLHEAD, ADMIN_ERROR_BOX, ADMIN_INSET, ADMIN_LABEL, AdminEmptyState } from '../components/adminUi';
 
 type ContactsDialog =
   | { kind: 'deleteCategory'; id: string; name: string }
@@ -119,188 +117,203 @@ export default function AdminContacts() {
   }
 
   return (
-    <div className="mx-auto box-border grid w-full max-w-[1400px] gap-5 p-3">
-      <section className="grid gap-4 rounded-[24px] border border-ui-border bg-[linear-gradient(180deg,#ffffff_0%,#f9fbf7_100%)] p-5 shadow-[0_14px_36px_rgba(15,23,42,0.04)]">
-        <div className="flex flex-wrap items-start gap-4">
-          <div className="grid max-w-[760px] gap-1.5">
-            <div className="flex flex-wrap gap-2">
-              <Badge variant="accent" className="px-2.5 py-1 text-[11px] uppercase tracking-[0.35px]">Kontakter</Badge>
-              <Badge>{categories.length} kategorier</Badge>
-              <Badge>{contacts.length} personer</Badge>
-              <Badge>{addresses.length} adresser</Badge>
-            </div>
-            <h1 className="m-0 text-[30px] text-slate-900">Kontaktregister med tydligare arbetsyta</h1>
-            <p className="m-0 text-sm leading-[1.55] text-slate-600">Hantera kategorier, personer och adresser i samma vy med bättre filtrering och snabbare redigering.</p>
-          </div>
-          <div className="ml-auto flex flex-wrap gap-3">
-            <Button onClick={loadAll} disabled={loading} variant="secondary">{loading ? 'Laddar...' : 'Uppdatera'}</Button>
-          </div>
+    <div className="grid gap-4 p-5">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="grid gap-1">
+          <h2 className="m-0 text-lg font-bold text-slate-900">Kontakter</h2>
+          <p className="m-0 text-sm text-slate-600">Kategorier, personer och adresser för hela appen.</p>
         </div>
+        <button type="button" onClick={loadAll} disabled={loading} className={crm.ghostButton}>
+          {loading ? 'Laddar…' : 'Uppdatera'}
+        </button>
+      </div>
 
-        <div className="grid gap-2 [grid-template-columns:repeat(auto-fit,minmax(160px,1fr))]">
-          <div className="grid gap-1 rounded-2xl border border-ui-border bg-white px-3 py-2.5">
-            <span className="text-[11px] font-extrabold uppercase tracking-[0.3px] text-slate-500">Aktiv vy</span>
-            <strong className="text-xl font-extrabold text-slate-900">{view === 'contacts' ? 'Kontakter' : 'Adresser'}</strong>
-          </div>
-          <div className="grid gap-1 rounded-2xl border border-ui-border bg-white px-3 py-2.5">
-            <span className="text-[11px] font-extrabold uppercase tracking-[0.3px] text-slate-500">Vald kategori</span>
-            <strong className="text-xl font-extrabold text-slate-900">{activeCat ? (categories.find(c=>c.id===activeCat)?.name || 'Vald') : 'Alla'}</strong>
-          </div>
-          <div className="grid gap-1 rounded-2xl border border-ui-border bg-white px-3 py-2.5">
-            <span className="text-[11px] font-extrabold uppercase tracking-[0.3px] text-slate-500">Visar</span>
-            <strong className="text-xl font-extrabold text-slate-900">{view === 'contacts' ? filteredContacts.length : filteredAddresses.length}</strong>
-          </div>
-        </div>
-      </section>
+      {error && <div role="alert" className={ADMIN_ERROR_BOX}>{error}</div>}
 
-      {error && <ErrorState title="Kunde inte läsa kontaktregistret" message={error} />}
-      <section className="grid gap-6">
-        <div className="flex flex-wrap items-center justify-between gap-3">
-          <TabsList aria-label="Kontaktregister-vy" className="gap-3">
-            <TabsTrigger
-              onClick={()=>setView('contacts')}
-              active={view === 'contacts'}
-            >
-              Kontakter
-            </TabsTrigger>
-            <TabsTrigger
-              onClick={()=>setView('addresses')}
-              active={view === 'addresses'}
-            >
-              Adresser
-            </TabsTrigger>
-          </TabsList>
-          <Input
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
-            placeholder={view === 'contacts' ? 'Sök namn, telefon, plats eller roll' : 'Sök namn eller adress'}
-            className="min-w-[280px] sm:w-[360px]"
-          />
-        </div>
-        {view==='contacts' && (
-          <div className="grid items-start gap-6 xl:[grid-template-columns:minmax(250px,300px)_minmax(0,1fr)]">
-            <div className="min-w-0 flex flex-col gap-3 self-start rounded-[20px] border border-ui-border bg-white p-[18px] shadow-[0_10px_28px_rgba(15,23,42,0.03)]">
-              <h2 className="m-0 text-base text-slate-900">Kategorier</h2>
-              <div className="flex flex-col gap-1.5">
-                <div className="flex items-center gap-1.5">
-                  <Button onClick={()=>setActiveCat(null)} variant={!activeCat ? 'accent' : 'secondary'} size="sm" fullWidth className="justify-start">Alla kategorier</Button>
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <TabsList aria-label="Kontaktregister-vy" className="gap-2">
+          <TabsTrigger onClick={()=>setView('contacts')} active={view === 'contacts'}>
+            Kontakter
+          </TabsTrigger>
+          <TabsTrigger onClick={()=>setView('addresses')} active={view === 'addresses'}>
+            Adresser
+          </TabsTrigger>
+        </TabsList>
+        <Input
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder={view === 'contacts' ? 'Sök namn, telefon, plats eller roll' : 'Sök namn eller adress'}
+          className="sm:w-[360px]"
+        />
+      </div>
+
+      {view==='contacts' && (
+        <div className="grid items-start gap-4 xl:[grid-template-columns:minmax(250px,300px)_minmax(0,1fr)]">
+          <div className={cn(ADMIN_CARD, 'min-w-0 flex flex-col gap-3 self-start p-4')}>
+            <h3 className="m-0 text-base font-bold text-slate-900">Kategorier</h3>
+            <div className="flex flex-col gap-1.5">
+              <div className="flex">
+                <CategoryButton active={!activeCat} onClick={()=>setActiveCat(null)}>Alla kategorier</CategoryButton>
+              </div>
+              {categories.map(cat => (
+                // flex-wrap + basis: i den smala kategorikolumnen (250–300px) far
+                // annars namn + två textknappar ut ur kortet. Knapparna hoppar ned
+                // på egen rad i stället för att spilla över grannkortet.
+                <div key={cat.id} className="flex flex-wrap items-center gap-1.5">
+                  <CategoryButton active={activeCat===cat.id} onClick={()=>setActiveCat(cat.id)}>{cat.name}</CategoryButton>
+                  <button
+                    type="button"
+                    onClick={()=>setDialog({ kind:'renameCategory', id:cat.id, name:cat.name })}
+                    className={cn(crm.ghostButton, 'shrink-0')}
+                  >
+                    Byt namn
+                  </button>
+                  <button
+                    type="button"
+                    onClick={()=>setDialog({ kind:'deleteCategory', id:cat.id, name:cat.name })}
+                    className={cn(crm.dangerButton, 'h-8 shrink-0')}
+                    aria-label={`Ta bort kategorin ${cat.name}`}
+                  >
+                    Ta bort
+                  </button>
                 </div>
-                {categories.map(cat => (
-                  <div key={cat.id} className="flex items-center gap-1.5">
-                    <Button onClick={()=>setActiveCat(cat.id)} variant={activeCat===cat.id ? 'accent' : 'secondary'} size="sm" fullWidth className="justify-start">{cat.name}</Button>
-                    <Button onClick={()=>setDialog({ kind:'renameCategory', id:cat.id, name:cat.name })} variant="secondary" size="sm" className="min-h-8 px-2 text-xs" aria-label="Byt namn">✏️</Button>
-                    <Button onClick={()=>setDialog({ kind:'deleteCategory', id:cat.id, name:cat.name })} variant="secondary" size="sm" className="min-h-8 px-2 text-xs text-red-700 hover:bg-red-50" aria-label="Ta bort">🗑️</Button>
-                  </div>
-                ))}
-              </div>
-              <form onSubmit={e=>{e.preventDefault(); const fd=new FormData(e.currentTarget); const name=String(fd.get('name')||'').trim(); if(name) { (e.currentTarget as HTMLFormElement).reset(); createCategory(name);} }} className="mt-2 flex gap-2">
-                <Input name="name" placeholder="Ny kategori" className="min-h-9 px-2.5 py-2 text-[13px]" />
-                <Button type="submit" variant="primary" size="sm">Lägg till</Button>
-              </form>
+              ))}
             </div>
-            <div className="min-w-0 flex flex-col gap-4 rounded-[20px] border border-ui-border bg-white p-[18px] shadow-[0_10px_28px_rgba(15,23,42,0.03)]">
-              <div className="grid gap-1">
-                <h2 className="m-0 text-lg text-slate-900">Kontakter {activeCat && '• ' + (categories.find(c=>c.id===activeCat)?.name || '')}</h2>
-                <span className="text-[13px] text-slate-500">Inline-redigering med snabb filtrering och tydligare tabellstruktur.</span>
-              </div>
-              <div className="grid gap-3 md:hidden">
-                {filteredContacts.map(c => (
-                  <article key={c.id} className="grid gap-3 rounded-[18px] border border-slate-200 bg-slate-50/60 p-4 shadow-[inset_0_1px_0_rgba(255,255,255,0.6)]">
-                    <div className="flex items-start justify-between gap-3">
-                      <div className="grid min-w-0 gap-1">
-                        <span className="text-base font-bold text-slate-900">{c.name}</span>
-                        <span className="text-xs text-slate-500">Kontakt</span>
-                      </div>
-                      <Button onClick={()=>setDialog({ kind:'deleteContact', id:c.id, name:c.name })} variant="secondary" size="sm" className="min-h-8 px-2 text-xs text-red-700 hover:bg-red-50">🗑️</Button>
-                    </div>
-                    <div className="grid gap-3 sm:grid-cols-2">
-                      <FieldBlock label="Namn"><Editable value={c.name} onSave={v=> updateContact(c.id,{ name:v })} /></FieldBlock>
-                      <FieldBlock label="Telefon"><Editable value={c.phone||''} placeholder="—" onSave={v=> updateContact(c.id,{ phone:v })} /></FieldBlock>
-                      <FieldBlock label="Plats"><Editable value={c.location||''} placeholder="—" onSave={v=> updateContact(c.id,{ location:v })} /></FieldBlock>
-                      <FieldBlock label="Roll"><Editable value={c.role||''} placeholder="—" onSave={v=> updateContact(c.id,{ role:v })} /></FieldBlock>
-                    </div>
-                  </article>
-                ))}
-              </div>
-              <div className="hidden md:block">
-                <DataTable className="min-w-[700px]">
-                  <thead>
-                    <tr className="bg-slate-50">
-                      {['Namn','Telefon','Plats','Roll',' '].map(h=> <DataTableHeaderCell key={h}>{h}</DataTableHeaderCell>)}
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {filteredContacts.map(c => (
-                      <tr key={c.id} className="bg-white"> 
-                        <DataTableCell><Editable value={c.name} onSave={v=> updateContact(c.id,{ name:v })} /></DataTableCell>
-                        <DataTableCell><Editable value={c.phone||''} placeholder="—" onSave={v=> updateContact(c.id,{ phone:v })} /></DataTableCell>
-                        <DataTableCell><Editable value={c.location||''} placeholder="—" onSave={v=> updateContact(c.id,{ location:v })} /></DataTableCell>
-                        <DataTableCell><Editable value={c.role||''} placeholder="—" onSave={v=> updateContact(c.id,{ role:v })} /></DataTableCell>
-                        <DataTableCell className="w-[50px] text-right"><Button onClick={()=>setDialog({ kind:'deleteContact', id:c.id, name:c.name })} variant="secondary" size="sm" className="min-h-8 px-2 text-xs text-red-700 hover:bg-red-50">🗑️</Button></DataTableCell>
-                      </tr>
-                    ))}
-                  </tbody>
-                </DataTable>
-              </div>
-              {filteredContacts.length === 0 && <EmptyState title="Inga kontakter matchar" description="Byt kategori eller justera sökningen för att visa fler träffar." />}
-              {activeCat && (
-                <form onSubmit={e=>{e.preventDefault(); const fd=new FormData(e.currentTarget); const name=String(fd.get('name')||'').trim(); if(!name) return; const phone=String(fd.get('phone')||'').trim(); const location=String(fd.get('location')||'').trim(); const role=String(fd.get('role')||'').trim(); createContact({ category_id: activeCat, name, phone, location, role }); (e.currentTarget as HTMLFormElement).reset(); }} className="grid items-end gap-2 [grid-template-columns:repeat(auto-fit,minmax(140px,1fr))]">
-                  <Input name="name" placeholder="Namn" required />
-                  <Input name="phone" placeholder="Telefon" />
-                  <Input name="location" placeholder="Plats" />
-                  <Input name="role" placeholder="Roll" />
-                  <Button type="submit" variant="primary">Lägg till</Button>
-                </form>
-              )}
-            </div>
+            <form onSubmit={e=>{e.preventDefault(); const fd=new FormData(e.currentTarget); const name=String(fd.get('name')||'').trim(); if(name) { (e.currentTarget as HTMLFormElement).reset(); createCategory(name);} }} className="mt-2 flex gap-2">
+              <Input name="name" placeholder="Ny kategori" className="min-h-9 px-2.5 py-2 text-[13px]" />
+              <button type="submit" className={crm.formButton} style={{ backgroundColor: 'var(--crm-primary, #1a3f26)' }}>Lägg till</button>
+            </form>
           </div>
-        )}
-        {view==='addresses' && (
-          <div className="min-w-0 flex flex-col gap-4 rounded-[20px] border border-ui-border bg-white p-[18px] shadow-[0_10px_28px_rgba(15,23,42,0.03)]">
-            <div className="grid gap-1">
-              <h2 className="m-0 text-lg text-slate-900">Adresser</h2>
-              <span className="text-[13px] text-slate-500">Håll platsregistret uppdaterat för snabbare återanvändning i andra flöden.</span>
-            </div>
+
+          <div className={cn(ADMIN_CARD, 'min-w-0 flex flex-col gap-4 p-4')}>
+            <h3 className="m-0 text-base font-bold text-slate-900">Kontakter {activeCat && '• ' + (categories.find(c=>c.id===activeCat)?.name || '')}</h3>
             <div className="grid gap-3 md:hidden">
-              {filteredAddresses.map(a => (
-                <article key={a.id} className="grid gap-3 rounded-[18px] border border-slate-200 bg-slate-50/60 p-4 shadow-[inset_0_1px_0_rgba(255,255,255,0.6)]">
+              {filteredContacts.map(c => (
+                <article key={c.id} className={cn(ADMIN_INSET, 'grid gap-3 p-3.5')}>
                   <div className="flex items-start justify-between gap-3">
-                    <div className="grid min-w-0 gap-1">
-                      <span className="text-base font-bold text-slate-900">{a.name}</span>
-                      <span className="text-xs text-slate-500">Adresspost</span>
-                    </div>
-                    <Button onClick={()=>setDialog({ kind:'deleteAddress', id:a.id, name:a.name })} variant="secondary" size="sm" className="min-h-8 px-2 text-xs text-red-700 hover:bg-red-50">🗑️</Button>
+                    <span className="text-[13px] font-bold text-slate-900">{c.name}</span>
+                    <button
+                      type="button"
+                      onClick={()=>setDialog({ kind:'deleteContact', id:c.id, name:c.name })}
+                      className={cn(crm.dangerButton, 'h-8')}
+                    >
+                      Ta bort
+                    </button>
                   </div>
-                  <div className="grid gap-3">
-                    <FieldBlock label="Namn"><Editable value={a.name} onSave={v=> updateAddress(a.id,{ name:v })} /></FieldBlock>
-                    <FieldBlock label="Adress"><Editable value={a.address} onSave={v=> updateAddress(a.id,{ address:v })} /></FieldBlock>
+                  <div className="grid gap-3 sm:grid-cols-2">
+                    <FieldBlock label="Namn"><Editable value={c.name} onSave={v=> updateContact(c.id,{ name:v })} /></FieldBlock>
+                    <FieldBlock label="Telefon"><Editable value={c.phone||''} placeholder="—" onSave={v=> updateContact(c.id,{ phone:v })} /></FieldBlock>
+                    <FieldBlock label="Plats"><Editable value={c.location||''} placeholder="—" onSave={v=> updateContact(c.id,{ location:v })} /></FieldBlock>
+                    <FieldBlock label="Roll"><Editable value={c.role||''} placeholder="—" onSave={v=> updateContact(c.id,{ role:v })} /></FieldBlock>
                   </div>
                 </article>
               ))}
             </div>
             <div className="hidden md:block">
-              <DataTable className="min-w-[600px]">
-                <thead><tr className="bg-slate-50">{['Namn','Adress',' '].map(h=> <DataTableHeaderCell key={h}>{h}</DataTableHeaderCell>)}</tr></thead>
+              <DataTable className="min-w-[700px]" containerClassName="border-[#e0e8dc]">
+                <thead>
+                  <tr className="bg-[#f9fbf7]">
+                    {['Namn','Telefon','Plats','Roll',' '].map(h=> <DataTableHeaderCell key={h} className={ADMIN_COLHEAD}>{h}</DataTableHeaderCell>)}
+                  </tr>
+                </thead>
                 <tbody>
-                  {filteredAddresses.map(a => (
-                    <tr key={a.id} className="bg-white">
-                      <DataTableCell><Editable value={a.name} onSave={v=> updateAddress(a.id,{ name:v })} /></DataTableCell>
-                      <DataTableCell><Editable value={a.address} onSave={v=> updateAddress(a.id,{ address:v })} /></DataTableCell>
-                      <DataTableCell className="w-[50px] text-right"><Button onClick={()=>setDialog({ kind:'deleteAddress', id:a.id, name:a.name })} variant="secondary" size="sm" className="min-h-8 px-2 text-xs text-red-700 hover:bg-red-50">🗑️</Button></DataTableCell>
+                  {filteredContacts.map(c => (
+                    <tr key={c.id} className="bg-white">
+                      <DataTableCell><Editable value={c.name} onSave={v=> updateContact(c.id,{ name:v })} /></DataTableCell>
+                      <DataTableCell><Editable value={c.phone||''} placeholder="—" onSave={v=> updateContact(c.id,{ phone:v })} /></DataTableCell>
+                      <DataTableCell><Editable value={c.location||''} placeholder="—" onSave={v=> updateContact(c.id,{ location:v })} /></DataTableCell>
+                      <DataTableCell><Editable value={c.role||''} placeholder="—" onSave={v=> updateContact(c.id,{ role:v })} /></DataTableCell>
+                      <DataTableCell className="text-right">
+                        <button
+                          type="button"
+                          onClick={()=>setDialog({ kind:'deleteContact', id:c.id, name:c.name })}
+                          className={cn(crm.dangerButton, 'h-8')}
+                        >
+                          Ta bort
+                        </button>
+                      </DataTableCell>
                     </tr>
                   ))}
                 </tbody>
               </DataTable>
             </div>
-            {filteredAddresses.length === 0 && <EmptyState title="Inga adresser matchar" description="Justera sökningen eller lägg till en ny adress." />}
-            <form onSubmit={e=>{e.preventDefault(); const fd=new FormData(e.currentTarget); const name=String(fd.get('name')||'').trim(); const address=String(fd.get('address')||'').trim(); if(!name||!address) return; createAddress({ name, address }); (e.currentTarget as HTMLFormElement).reset(); }} className="grid items-end gap-2 [grid-template-columns:repeat(auto-fit,minmax(200px,1fr))]">
-              <Input name="name" placeholder="Namn" required />
-              <Input name="address" placeholder="Adress" required />
-              <Button type="submit" variant="primary">Lägg till</Button>
-            </form>
+            {loading && <p role="status" className="m-0 text-sm text-slate-400">Laddar…</p>}
+            {!loading && filteredContacts.length === 0 && !error && (
+              <AdminEmptyState title="Inga kontakter matchar" description="Byt kategori eller justera sökningen för att visa fler träffar." />
+            )}
+            {activeCat && (
+              <form onSubmit={e=>{e.preventDefault(); const fd=new FormData(e.currentTarget); const name=String(fd.get('name')||'').trim(); if(!name) return; const phone=String(fd.get('phone')||'').trim(); const location=String(fd.get('location')||'').trim(); const role=String(fd.get('role')||'').trim(); createContact({ category_id: activeCat, name, phone, location, role }); (e.currentTarget as HTMLFormElement).reset(); }} className="grid items-end gap-2 [grid-template-columns:repeat(auto-fit,minmax(140px,1fr))]">
+                <Input name="name" placeholder="Namn" required />
+                <Input name="phone" placeholder="Telefon" />
+                <Input name="location" placeholder="Plats" />
+                <Input name="role" placeholder="Roll" />
+                <button type="submit" className={crm.formButton} style={{ backgroundColor: 'var(--crm-primary, #1a3f26)' }}>Lägg till</button>
+              </form>
+            )}
           </div>
-        )}
-      </section>
+        </div>
+      )}
+
+      {view==='addresses' && (
+        <div className={cn(ADMIN_CARD, 'min-w-0 flex flex-col gap-4 p-4')}>
+          <h3 className="m-0 text-base font-bold text-slate-900">Adresser</h3>
+          <div className="grid gap-3 md:hidden">
+            {filteredAddresses.map(a => (
+              <article key={a.id} className={cn(ADMIN_INSET, 'grid gap-3 p-3.5')}>
+                <div className="flex items-start justify-between gap-3">
+                  <span className="text-[13px] font-bold text-slate-900">{a.name}</span>
+                  <button
+                    type="button"
+                    onClick={()=>setDialog({ kind:'deleteAddress', id:a.id, name:a.name })}
+                    className={cn(crm.dangerButton, 'h-8')}
+                  >
+                    Ta bort
+                  </button>
+                </div>
+                <div className="grid gap-3">
+                  <FieldBlock label="Namn"><Editable value={a.name} onSave={v=> updateAddress(a.id,{ name:v })} /></FieldBlock>
+                  <FieldBlock label="Adress"><Editable value={a.address} onSave={v=> updateAddress(a.id,{ address:v })} /></FieldBlock>
+                </div>
+              </article>
+            ))}
+          </div>
+          <div className="hidden md:block">
+            <DataTable className="min-w-[600px]" containerClassName="border-[#e0e8dc]">
+              <thead>
+                <tr className="bg-[#f9fbf7]">
+                  {['Namn','Adress',' '].map(h=> <DataTableHeaderCell key={h} className={ADMIN_COLHEAD}>{h}</DataTableHeaderCell>)}
+                </tr>
+              </thead>
+              <tbody>
+                {filteredAddresses.map(a => (
+                  <tr key={a.id} className="bg-white">
+                    <DataTableCell><Editable value={a.name} onSave={v=> updateAddress(a.id,{ name:v })} /></DataTableCell>
+                    <DataTableCell><Editable value={a.address} onSave={v=> updateAddress(a.id,{ address:v })} /></DataTableCell>
+                    <DataTableCell className="text-right">
+                      <button
+                        type="button"
+                        onClick={()=>setDialog({ kind:'deleteAddress', id:a.id, name:a.name })}
+                        className={cn(crm.dangerButton, 'h-8')}
+                      >
+                        Ta bort
+                      </button>
+                    </DataTableCell>
+                  </tr>
+                ))}
+              </tbody>
+            </DataTable>
+          </div>
+          {loading && <p role="status" className="m-0 text-sm text-slate-400">Laddar…</p>}
+          {!loading && filteredAddresses.length === 0 && !error && (
+            <AdminEmptyState title="Inga adresser matchar" description="Justera sökningen eller lägg till en ny adress." />
+          )}
+          <form onSubmit={e=>{e.preventDefault(); const fd=new FormData(e.currentTarget); const name=String(fd.get('name')||'').trim(); const address=String(fd.get('address')||'').trim(); if(!name||!address) return; createAddress({ name, address }); (e.currentTarget as HTMLFormElement).reset(); }} className="grid items-end gap-2 [grid-template-columns:repeat(auto-fit,minmax(200px,1fr))]">
+            <Input name="name" placeholder="Namn" required />
+            <Input name="address" placeholder="Adress" required />
+            <button type="submit" className={crm.formButton} style={{ backgroundColor: 'var(--crm-primary, #1a3f26)' }}>Lägg till</button>
+          </form>
+        </div>
+      )}
 
       {dialog && (dialog.kind === 'renameCategory' ? (
         <AdminPromptDialog
@@ -333,26 +346,48 @@ export default function AdminContacts() {
   );
 }
 
+function CategoryButton({ active, onClick, children }: { active: boolean; onClick: () => void; children: React.ReactNode }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        'inline-flex min-h-9 min-w-0 flex-1 basis-[140px] items-center justify-start truncate rounded-xl border px-3 text-sm font-semibold transition',
+        active ? 'border-transparent text-white' : 'border-slate-200 bg-white text-slate-600 hover:border-slate-300 hover:text-slate-800',
+      )}
+      style={active ? { backgroundColor: 'var(--crm-primary, #1a3f26)' } : undefined}
+    >
+      {children}
+    </button>
+  );
+}
+
 function Editable({ value, onSave, placeholder }: { value: string; onSave: (v:string)=>void; placeholder?: string }) {
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(value);
   useEffect(()=>{ setDraft(value); }, [value]);
-  if (!editing) return <div className="flex items-center gap-1.5"><span className={cn('text-sm', value ? 'text-slate-900' : 'text-slate-400')}>{value || placeholder || '—'}</span><Button onClick={()=>setEditing(true)} variant="secondary" size="sm" className="min-h-8 px-2 text-xs" aria-label="Redigera">✏️</Button></div>;
+  if (!editing) return (
+    <div className="flex items-center gap-1.5">
+      <span className={cn('text-sm', value ? 'text-slate-900' : 'text-slate-400')}>{value || placeholder || '—'}</span>
+      <button type="button" onClick={()=>setEditing(true)} className={cn(crm.ghostButton, 'shrink-0')}>Redigera</button>
+    </div>
+  );
   return (
     <form onSubmit={e=>{e.preventDefault(); onSave(draft.trim()); setEditing(false);}} className="flex gap-1.5">
       <Input autoFocus value={draft} onChange={e=>setDraft(e.target.value)} className="min-h-8 px-2 py-1.5 text-[13px]" />
-      <Button type="submit" variant="primary" size="sm">Spara</Button>
-      <Button type="button" onClick={()=>{ setEditing(false); setDraft(value); }} variant="secondary" size="sm">Avbryt</Button>
+      <button type="submit" className={crm.formButton} style={{ backgroundColor: 'var(--crm-primary, #1a3f26)' }}>Spara</button>
+      <button type="button" onClick={()=>{ setEditing(false); setDraft(value); }} className={crm.ghostButton}>Avbryt</button>
     </form>
   );
 }
 
+// Medvetet div + span, inte AdminField: blocken innehåller knappar (Editable),
+// och en <label> utan htmlFor aktiverar sin första knapp vid klick på rubriken.
 function FieldBlock({ label, children }: { label: string; children: React.ReactNode }) {
   return (
-    <label className="grid gap-1.5">
-      <span className="text-[11px] font-extrabold uppercase tracking-[0.35px] text-slate-500">{label}</span>
+    <div className="grid gap-1">
+      <span className={ADMIN_LABEL}>{label}</span>
       {children}
-    </label>
+    </div>
   );
 }
-

--- a/app/admin/users/[id]/AdminUserProfileEditor.tsx
+++ b/app/admin/users/[id]/AdminUserProfileEditor.tsx
@@ -2,12 +2,12 @@
 
 import React from 'react';
 import Link from 'next/link';
-import Badge from '../../../../components/ui/Badge';
-import Button from '../../../../components/ui/Button';
 import Input from '../../../../components/ui/Input';
 import PageShell from '../../../../components/ui/PageShell';
 import Textarea from '../../../../components/ui/Textarea';
+import { crm } from '../../../crm/lib/crmTokens';
 import { cn } from '../../../../lib/shared/cn';
+import { ADMIN_CARD, ADMIN_ERROR_BOX, ADMIN_NOTICE_BOX, AdminField, roleBadgeClass } from '../../components/adminUi';
 import type { EmployeeProfile, EmployeeSensitiveDetails } from '../../../../lib/profileDetails';
 
 interface AdminUserProfileEditorProps {
@@ -142,136 +142,99 @@ export default function AdminUserProfileEditor({ userId, authEmail, profile, sen
 
   return (
     <PageShell className="max-w-[1260px] gap-4">
-      <section className="grid gap-3 rounded-[22px] border border-ui-border bg-[linear-gradient(180deg,#ffffff_0%,#fbfdff_100%)] p-5 shadow-[0_10px_28px_rgba(15,23,42,0.04)]">
-        <div className="flex flex-wrap items-center justify-between gap-3">
-          <div className="flex flex-wrap items-center gap-2">
-            <Badge variant="accent" className="px-2.5 py-1 text-[11px] uppercase tracking-[0.4px]">Adminprofil</Badge>
-            <Badge>Roll: {profile.role}</Badge>
-            {profile.tags.length > 0 && <Badge>Taggar: {profile.tags.join(', ')}</Badge>}
-            <Badge className="bg-white">{authEmail}</Badge>
+      <section className={cn(crm.cardInner, 'grid gap-3')}>
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div className="grid gap-1">
+            <div className="flex flex-wrap items-center gap-2">
+              <span className={cn(crm.badge, roleBadgeClass(profile.role))}>{profile.role}</span>
+              {profile.tags.length > 0 && (
+                <span className={cn(crm.badge, 'border-slate-200 bg-slate-50 text-slate-600')}>{profile.tags.join(', ')}</span>
+              )}
+              <span className={cn(crm.badge, 'border-slate-200 bg-white text-slate-600')}>{authEmail}</span>
+            </div>
+            <h1 className={cn('m-0', crm.pageTitle)}>{form.full_name || authEmail}</h1>
+            <p className={cn('m-0', crm.pageSubtitle)}>Kontakt, anställning och känsliga uppgifter.</p>
           </div>
-          <Link
-            href="/admin?tab=users"
-            className="inline-flex min-h-10 items-center justify-center rounded-xl border border-slate-900 bg-slate-900 px-4 text-sm font-semibold text-white transition-colors hover:bg-slate-950"
-          >
+          <Link href="/admin?tab=users" className={crm.ghostButton}>
             Tillbaka till användare
           </Link>
-        </div>
-
-        <div className="grid gap-3 [grid-template-columns:repeat(auto-fit,minmax(260px,1fr))]">
-          <div className="grid max-w-[720px] gap-2">
-            <h1 className="m-0 text-[28px] leading-[1.08] tracking-[-0.5px] text-slate-900">{form.full_name || authEmail}</h1>
-            <p className="m-0 text-sm leading-[1.55] text-slate-600">
-              Hantera vardagsinfo, anställningsdata och känsliga uppgifter i en mer sammanhållen adminvy med tydligare prioritering mellan sektionerna.
-            </p>
-          </div>
-
-          <div className="grid content-start gap-2 [grid-template-columns:repeat(auto-fit,minmax(150px,1fr))]">
-            <StatusTile
-              label="Kontaktdata"
-              value={form.phone || form.private_email ? 'Kompletterad' : 'Behöver ses över'}
-              tone={form.phone || form.private_email ? 'good' : 'neutral'}
-            />
-            <StatusTile
-              label="Anställning"
-              value={form.job_title || form.department || form.employment_type ? 'Registrerad' : 'Saknar uppgifter'}
-              tone={form.job_title || form.department || form.employment_type ? 'good' : 'neutral'}
-            />
-            <StatusTile
-              label="Känsliga fält"
-              value={form.personal_identity_number || form.bank_account_number ? 'Ifyllda' : 'Ej kompletta'}
-              tone={form.personal_identity_number || form.bank_account_number ? 'good' : 'neutral'}
-            />
-          </div>
         </div>
       </section>
 
       <div className="grid gap-2.5">
-        {error && <section className="rounded-[14px] border border-red-200 bg-red-50 px-3 py-2.5 text-sm text-red-700">{error}</section>}
-        {success && <section className="rounded-[14px] border border-emerald-200 bg-emerald-50 px-3 py-2.5 text-sm text-emerald-700">{success}</section>}
+        {error && <div role="alert" className={ADMIN_ERROR_BOX}>{error}</div>}
+        {success && <div role="status" className={ADMIN_NOTICE_BOX}>{success}</div>}
       </div>
 
       <div className="grid items-start gap-4 [grid-template-columns:repeat(auto-fit,minmax(320px,1fr))]">
-        <section className="grid gap-[18px] rounded-[20px] border border-ui-border bg-white p-[18px] shadow-[0_10px_24px_rgba(15,23,42,0.04)]">
-          <div className="grid gap-1.5">
-            <div className="grid gap-1">
-              <span className="text-[11px] font-extrabold uppercase tracking-[0.45px] text-slate-500">Daglig profil</span>
-              <h2 className="m-0 text-[19px] tracking-[-0.2px] text-slate-900">Kontakt och vardagsinfo</h2>
-            </div>
-            <p className="m-0 text-[13px] leading-[1.5] text-slate-600">Uppgifter som ofta används i vardagen och som även den anställde delvis kan uppdatera själv.</p>
+        <section className={cn(ADMIN_CARD, 'grid gap-4 p-4')}>
+          <h2 className="m-0 text-base font-bold text-slate-900">Kontakt och vardagsinfo</h2>
+          <div className="grid gap-3 sm:grid-cols-2">
+            <AdminField label="Namn"><Input value={form.full_name} onChange={(event) => updateField('full_name', event.target.value)} /></AdminField>
+            <AdminField label="Telefon"><Input value={form.phone} onChange={(event) => updateField('phone', event.target.value)} /></AdminField>
+            <AdminField label="Privat e-post"><Input value={form.private_email} onChange={(event) => updateField('private_email', event.target.value)} /></AdminField>
+            <AdminField label="Inloggningsmail"><Input value={authEmail} readOnly className="bg-[#eef1ec] text-slate-500" /></AdminField>
+            <AdminField label="Adress"><Input value={form.address_line1} onChange={(event) => updateField('address_line1', event.target.value)} /></AdminField>
+            <AdminField label="Postnummer"><Input value={form.postal_code} onChange={(event) => updateField('postal_code', event.target.value)} /></AdminField>
+            <AdminField label="Ort"><Input value={form.city} onChange={(event) => updateField('city', event.target.value)} /></AdminField>
+            <AdminField label="Kontakt vid nödfall"><Input value={form.emergency_contact_name} onChange={(event) => updateField('emergency_contact_name', event.target.value)} /></AdminField>
+            <AdminField label="Telefon vid nödfall"><Input value={form.emergency_contact_phone} onChange={(event) => updateField('emergency_contact_phone', event.target.value)} /></AdminField>
+            <AdminField label="Klädstorlek"><Input value={form.clothing_size} onChange={(event) => updateField('clothing_size', event.target.value)} /></AdminField>
           </div>
-          <div className="grid gap-3 [grid-template-columns:repeat(auto-fit,minmax(210px,1fr))]">
-            <Field label="Namn"><Input value={form.full_name} onChange={(event) => updateField('full_name', event.target.value)} /></Field>
-            <Field label="Telefon"><Input value={form.phone} onChange={(event) => updateField('phone', event.target.value)} /></Field>
-            <Field label="Privat e-post"><Input value={form.private_email} onChange={(event) => updateField('private_email', event.target.value)} /></Field>
-            <Field label="Inloggningsmail"><Input value={authEmail} readOnly className="bg-slate-50 text-slate-500" /></Field>
-            <Field label="Adress"><Input value={form.address_line1} onChange={(event) => updateField('address_line1', event.target.value)} /></Field>
-            <Field label="Postnummer"><Input value={form.postal_code} onChange={(event) => updateField('postal_code', event.target.value)} /></Field>
-            <Field label="Ort"><Input value={form.city} onChange={(event) => updateField('city', event.target.value)} /></Field>
-            <Field label="Kontakt vid nödfall"><Input value={form.emergency_contact_name} onChange={(event) => updateField('emergency_contact_name', event.target.value)} /></Field>
-            <Field label="Telefon vid nödfall"><Input value={form.emergency_contact_phone} onChange={(event) => updateField('emergency_contact_phone', event.target.value)} /></Field>
-            <Field label="Klädstorlek"><Input value={form.clothing_size} onChange={(event) => updateField('clothing_size', event.target.value)} /></Field>
-          </div>
-          <div className="flex flex-wrap items-center justify-between gap-3">
-            <div className="min-h-[18px]" />
-            <Button type="button" onClick={() => saveSection('contact')} disabled={savingContact} variant="primary">
-              {savingContact ? 'Sparar…' : 'Spara kontaktdel'}
-            </Button>
-          </div>
+          <button
+            type="button"
+            onClick={() => saveSection('contact')}
+            disabled={savingContact}
+            className={cn(crm.formButton, 'justify-self-end')}
+            style={{ backgroundColor: 'var(--crm-primary, #1a3f26)' }}
+          >
+            {savingContact ? 'Sparar…' : 'Spara kontaktdel'}
+          </button>
         </section>
 
         <div className="grid content-start gap-4">
-          <section className="grid gap-4 rounded-[20px] border border-ui-border bg-white p-4 shadow-[0_10px_24px_rgba(15,23,42,0.04)]">
-            <div className="grid gap-1.5">
-              <div className="grid gap-1">
-                <span className="text-[11px] font-extrabold uppercase tracking-[0.45px] text-slate-500">Intern personaldata</span>
-                <h2 className="m-0 text-[19px] tracking-[-0.2px] text-slate-900">Anställningsuppgifter</h2>
-              </div>
-              <p className="m-0 text-[13px] leading-[1.5] text-slate-600">HR-liknande data och interna anteckningar som admin ansvarar för.</p>
+          <section className={cn(ADMIN_CARD, 'grid gap-4 p-4')}>
+            <h2 className="m-0 text-base font-bold text-slate-900">Anställningsuppgifter</h2>
+            <div className="grid gap-2.5 sm:grid-cols-2">
+              <AdminField label="Titel"><Input value={form.job_title} onChange={(event) => updateField('job_title', event.target.value)} /></AdminField>
+              <AdminField label="Avdelning"><Input value={form.department} onChange={(event) => updateField('department', event.target.value)} /></AdminField>
+              <AdminField label="Ansvarig chef"><Input value={form.manager_name} onChange={(event) => updateField('manager_name', event.target.value)} /></AdminField>
+              <AdminField label="Anställningsstart"><Input value={form.employment_start_date} onChange={(event) => updateField('employment_start_date', event.target.value)} placeholder="YYYY-MM-DD" /></AdminField>
+              <AdminField label="Anställningsform"><Input value={form.employment_type} onChange={(event) => updateField('employment_type', event.target.value)} /></AdminField>
             </div>
-            <div className="grid gap-2.5 [grid-template-columns:repeat(auto-fit,minmax(180px,1fr))]">
-              <Field label="Titel"><Input value={form.job_title} onChange={(event) => updateField('job_title', event.target.value)} /></Field>
-              <Field label="Avdelning"><Input value={form.department} onChange={(event) => updateField('department', event.target.value)} /></Field>
-              <Field label="Ansvarig chef"><Input value={form.manager_name} onChange={(event) => updateField('manager_name', event.target.value)} /></Field>
-              <Field label="Anställningsstart"><Input value={form.employment_start_date} onChange={(event) => updateField('employment_start_date', event.target.value)} placeholder="YYYY-MM-DD" /></Field>
-              <Field label="Anställningsform"><Input value={form.employment_type} onChange={(event) => updateField('employment_type', event.target.value)} /></Field>
-            </div>
-            <Field label="Certifikat och behörigheter"><Textarea value={form.certifications} onChange={(event) => updateField('certifications', event.target.value)} className="min-h-[104px] shadow-[inset_0_1px_0_rgba(255,255,255,0.7)]" /></Field>
-            <Field label="Adminanteckningar"><Textarea value={form.admin_notes} onChange={(event) => updateField('admin_notes', event.target.value)} className="min-h-[104px] shadow-[inset_0_1px_0_rgba(255,255,255,0.7)]" /></Field>
-            <div className="flex flex-wrap items-center justify-between gap-3">
-              <div className="min-h-[18px]" />
-              <Button type="button" onClick={() => saveSection('employment')} disabled={savingEmployment} variant="primary">
-                {savingEmployment ? 'Sparar…' : 'Spara anställningsdel'}
-              </Button>
-            </div>
+            <AdminField label="Certifikat och behörigheter"><Textarea value={form.certifications} onChange={(event) => updateField('certifications', event.target.value)} className="min-h-[104px]" /></AdminField>
+            <AdminField label="Adminanteckningar"><Textarea value={form.admin_notes} onChange={(event) => updateField('admin_notes', event.target.value)} className="min-h-[104px]" /></AdminField>
+            <button
+              type="button"
+              onClick={() => saveSection('employment')}
+              disabled={savingEmployment}
+              className={cn(crm.formButton, 'justify-self-end')}
+              style={{ backgroundColor: 'var(--crm-primary, #1a3f26)' }}
+            >
+              {savingEmployment ? 'Sparar…' : 'Spara anställningsdel'}
+            </button>
           </section>
 
-          <section className="grid gap-4 rounded-[20px] border border-ui-border bg-white p-4 shadow-[0_10px_24px_rgba(15,23,42,0.04)]">
-            <div className="grid gap-1.5">
-              <div className="grid gap-1">
-                <span className="text-[11px] font-extrabold uppercase tracking-[0.45px] text-slate-500">Separat säker del</span>
-                <h2 className="m-0 text-[19px] tracking-[-0.2px] text-slate-900">Känsliga uppgifter</h2>
-              </div>
+          <section className={cn(ADMIN_CARD, 'grid gap-4 p-4')}>
+            <div className="grid gap-1">
+              <h2 className="m-0 text-base font-bold text-slate-900">Känsliga uppgifter</h2>
               <p className="m-0 text-[13px] leading-[1.5] text-slate-600">Full redigering för admin. De här fälten ligger i separat säker modell och visas maskerat för användaren själv.</p>
             </div>
-            <div className="grid gap-2.5 [grid-template-columns:repeat(auto-fit,minmax(180px,1fr))]">
-              <Field label="Personnummer"><Input value={form.personal_identity_number} onChange={(event) => updateField('personal_identity_number', event.target.value)} /></Field>
-              <Field label="Kontonamn"><Input value={form.bank_account_name} onChange={(event) => updateField('bank_account_name', event.target.value)} /></Field>
-              <Field label="Clearingnummer"><Input value={form.bank_clearing_number} onChange={(event) => updateField('bank_clearing_number', event.target.value)} /></Field>
-              <Field label="Kontonummer"><Input value={form.bank_account_number} onChange={(event) => updateField('bank_account_number', event.target.value)} /></Field>
+            <div className="grid gap-2.5 sm:grid-cols-2">
+              <AdminField label="Personnummer"><Input value={form.personal_identity_number} onChange={(event) => updateField('personal_identity_number', event.target.value)} /></AdminField>
+              <AdminField label="Kontonamn"><Input value={form.bank_account_name} onChange={(event) => updateField('bank_account_name', event.target.value)} /></AdminField>
+              <AdminField label="Clearingnummer"><Input value={form.bank_clearing_number} onChange={(event) => updateField('bank_clearing_number', event.target.value)} /></AdminField>
+              <AdminField label="Kontonummer"><Input value={form.bank_account_number} onChange={(event) => updateField('bank_account_number', event.target.value)} /></AdminField>
             </div>
-            <div className="flex flex-wrap items-center justify-between gap-3">
-              <div className="min-h-[18px]" />
-              <Button
-                type="button"
-                onClick={() => saveSection('sensitive')}
-                disabled={savingSensitive}
-                variant="primary"
-                className="border-emerald-800 bg-emerald-800 text-white hover:bg-emerald-900"
-              >
-                {savingSensitive ? 'Sparar…' : 'Spara känsliga uppgifter'}
-              </Button>
-            </div>
+            <button
+              type="button"
+              onClick={() => saveSection('sensitive')}
+              disabled={savingSensitive}
+              className={cn(crm.formButton, 'justify-self-end')}
+              style={{ backgroundColor: 'var(--crm-primary, #1a3f26)' }}
+            >
+              {savingSensitive ? 'Sparar…' : 'Spara känsliga uppgifter'}
+            </button>
           </section>
         </div>
       </div>
@@ -279,20 +242,3 @@ export default function AdminUserProfileEditor({ userId, authEmail, profile, sen
   );
 }
 
-function StatusTile({ label, value, tone }: { label: string; value: string; tone: 'good' | 'neutral' }) {
-  return (
-    <div className={cn('grid min-h-[76px] gap-1 rounded-2xl border px-3 py-2.5', tone === 'good' ? 'border-emerald-200 bg-emerald-50' : 'border-ui-border bg-white')}>
-      <span className="text-[11px] font-extrabold uppercase tracking-[0.35px] text-slate-500">{label}</span>
-      <strong className="text-[15px] font-bold text-slate-900">{value}</strong>
-    </div>
-  );
-}
-
-function Field({ label, children }: { label: string; children: React.ReactNode }) {
-  return (
-    <label className="grid gap-1.5">
-      <span className="text-[11px] font-bold uppercase tracking-[0.45px] text-slate-500">{label}</span>
-      {children}
-    </label>
-  );
-}

--- a/app/admin/users/[id]/page.tsx
+++ b/app/admin/users/[id]/page.tsx
@@ -1,8 +1,8 @@
-import Link from 'next/link';
 import { notFound, redirect } from 'next/navigation';
 import { adminSupabase } from '../../../../lib/adminSupabase';
 import { getUserProfile } from '../../../../lib/getUserProfile';
 import PageShell from '../../../../components/ui/PageShell';
+import { crm } from '../../../crm/lib/crmTokens';
 import AdminUserProfileEditor from './AdminUserProfileEditor';
 import {
   asRecord,
@@ -24,9 +24,9 @@ export default async function AdminUserProfilePage({ params }: { params: { id: s
 
   if (!adminSupabase) {
     return (
-      <PageShell className="max-w-[1280px] gap-5">
-        <section className="rounded-[24px] border border-ui-border bg-white p-[22px] shadow-[0_12px_32px_rgba(15,23,42,0.04)]">
-          Service role saknas. Kan inte visa användarprofilen.
+      <PageShell className="max-w-[1280px]">
+        <section className={crm.cardInner}>
+          <p className="m-0 text-sm text-slate-600">Service role saknas. Kan inte visa användarprofilen.</p>
         </section>
       </PageShell>
     );
@@ -46,9 +46,9 @@ export default async function AdminUserProfilePage({ params }: { params: { id: s
 
   if (profileError || detailError || sensitiveError) {
     return (
-      <PageShell className="max-w-[1280px] gap-5">
-        <section className="rounded-[24px] border border-ui-border bg-white p-[22px] shadow-[0_12px_32px_rgba(15,23,42,0.04)]">
-          Kunde inte ladda användarprofilen.
+      <PageShell className="max-w-[1280px]">
+        <section className={crm.cardInner}>
+          <p className="m-0 text-sm text-slate-600">Kunde inte ladda användarprofilen.</p>
         </section>
       </PageShell>
     );


### PR DESCRIPTION
## Sammanfattning

Tredje vågen (efter #87, #88). Största kvarvarande dialekt A-filen plus användarprofil-editorn.

- **Kontakter** (358 r) — hero + tre plattor → standardskelettet; kategoriknappar på `var(--crm-primary)`; ✏️/🗑️ → textknappar; `DataTable` **behållen** men omskinnad (sage-ram, `ADMIN_COLHEAD`-huvuden) — cell-för-cell-redigeringen passar inte kortlisterader, så en konvertering vore en UX-omskrivning utanför reskin-scopet; mobilkorten på `ADMIN_INSET`
- **Användarprofilen** (297 r) — hero + `StatusTile`s → `crm.cardInner` med `pageTitle` + `roleBadgeClass`; tre sektionskort på `ADMIN_CARD` med `text-base`-rubriker; kickers och två prosastycken bort; `Field` → `AdminField`; tvåkolumnsgrid i stället för auto-fit som gick 3–4 kolumner bred (DESIGN_SYSTEM: max två kolumner)
- **users/[id]/page.tsx** — felskalen → `crm.cardInner`, oanvänd `Link`-import bort

## Detaljer värda att veta

- **`FieldBlock` i Kontakter förblir `div` + `span`, inte `AdminField`** — blocken innehåller `Editable`s knappar, och en `<label>` utan `htmlFor` aktiverar sin första knapp vid klick på rubriken (samma fälla som fixades i våg 1)
- Känsliga sektionens förklaringstext är **behållen** — den dokumenterar maskeringssemantiken, till skillnad från de två marknadsföringsstyckena som togs bort

## Granskningsfynd åtgärdade

1. **Kategoriraden spillde över grannkortet** — emoji-knapparna (~72px) blev textknappar (~168px) i en icke-wrappande flexrad i en 250–300px-kolumn; namn längre än ~10 tecken tryckte ut raden. Fix: `flex-wrap` + `truncate`/`min-w-0`
2. **Tomrutan visades under initial laddning** — vakten fick `!error` men inte `!loading`; nu gated + "Laddar…"-indikator

## Verifiering

- `npm run type-check` ✅ · `npm run lint` ✅ · `npm run build` ✅ · `npm test` 1345/1345 ✅

### Manuell QA-checklista
- [ ] Kontakter: kategori välj/byt namn/ta bort (dialogerna), cellredigering i tabell **och** mobilkort (<768 px), add-formulär för kontakt + adress, växling Kontakter/Adresser
- [ ] Långa kategorinamn spiller inte ut ur sidokolumnen vid xl+
- [ ] Profil: alla tre sparningar PATCH:ar och visar bekräftelse; "Tillbaka till användare" landar på rätt flik
- [ ] Ingen horisontell scroll vid 375 px

🤖 Generated with [Claude Code](https://claude.com/claude-code)