### PR TITLE
feat(admin): våg 4 av CRM-standard-migreringen — Behörigheter, Tidkoder

### DIFF
--- a/app/admin/components/adminUi.tsx
+++ b/app/admin/components/adminUi.tsx
@@ -9,9 +9,10 @@ import { cn } from '../../../lib/shared/cn';
 // under WCAG AA som instruerande text).
 export const ADMIN_LABEL = 'text-[11px] font-bold uppercase tracking-[0.12em] text-slate-600';
 
-// Kolumnhuvudsraden i listkort (CustomersClient-receptet).
-// Konsumeras från våg 3–4 av admin-migreringen (Kontakter/Tidkoder).
-export const ADMIN_COLHEAD = 'text-[10px] font-bold uppercase tracking-[0.12em] text-slate-400';
+// Kolumnhuvudsraden i listkort och tabeller. CRM:s recept men i slate-500, inte
+// slate-400: i admin är kolumnrubriken ofta ENDA etiketten för sin kolumn (t.ex.
+// Tidkoders kryssrutekolumner), och slate-400 @10px ligger under WCAG AA.
+export const ADMIN_COLHEAD = 'text-[10px] font-bold uppercase tracking-[0.12em] text-slate-500';
 
 // Inline-tillståndsrutor — dialekt B-recepten som Ärenden/Changelog/Behörigheter redan använder.
 // Sätt role="alert" på felrutan så skärmläsare annonserar den.
@@ -71,6 +72,8 @@ export function AdminFilterChip({
     <button
       type="button"
       onClick={onClick}
+      // aria-pressed: aktivt läge signaleras annars bara med bakgrundsfärg.
+      aria-pressed={active}
       className={cn(
         'inline-flex shrink-0 items-center gap-1.5 rounded-xl border px-2.5 py-1 text-[13px] font-semibold transition',
         active ? 'border-transparent text-white' : 'border-slate-200 bg-white text-slate-600 hover:border-slate-300',

--- a/app/admin/permissions/AdminPermissions.tsx
+++ b/app/admin/permissions/AdminPermissions.tsx
@@ -1,6 +1,10 @@
 "use client";
 import React from 'react';
-import Badge from '../../../components/ui/Badge';
+import { crm } from '../../crm/lib/crmTokens';
+import { cn } from '../../../lib/shared/cn';
+import { ADMIN_CARD, ADMIN_ERROR_BOX, ADMIN_LABEL, ADMIN_NOTICE_BOX, AdminFilterChip } from '../components/adminUi';
+
+const CHECKBOX_CLASS = 'h-4 w-4 rounded border-slate-300 accent-emerald-600';
 
 type CatalogEntry = { key: string; description: string };
 type RoleBundles = Record<string, string[]>;
@@ -128,40 +132,38 @@ export default function AdminPermissions() {
     }
   }
 
-  if (loading) return <div className="p-6 text-sm text-slate-500">Laddar behörigheter…</div>;
+  if (loading) return <p role="status" className="m-0 p-5 text-sm text-slate-400">Laddar…</p>;
 
   return (
-    <div className="grid gap-6 p-5">
+    <div className="grid gap-4 p-5">
+      <div className="grid gap-1">
+        <h2 className="m-0 text-lg font-bold text-slate-900">Behörigheter</h2>
+        <p className="m-0 text-sm text-slate-600">Roller är knippen av behörigheter; per-användar-overrides läggs ovanpå (neka vinner).</p>
+      </div>
+
       {error ? (
-        <div className="rounded-xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700">
+        <div role="alert" className={ADMIN_ERROR_BOX}>
           {error}
           <button type="button" onClick={() => setError(null)} className="ml-3 underline">Stäng</button>
         </div>
       ) : null}
 
-      <div className="rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-900">
-        Roller är knippen av behörigheter. Per-användar-overrides läggs <strong>ovanpå</strong> rollen
-        (revoke vinner). Ändringar slår igenom direkt i både appen och databasen (RLS).
+      <div className={ADMIN_NOTICE_BOX}>
+        Ändringar slår igenom direkt i både appen och databasen (RLS).
       </div>
 
       {/* ── Role bundles ─────────────────────────────────────────── */}
       <section className="grid gap-3">
-        <h2 className="m-0 text-lg font-bold text-slate-900">Rollbehörigheter</h2>
+        <h3 className="m-0 text-base font-bold text-slate-900">Rollbehörigheter</h3>
         <div className="flex flex-wrap gap-2">
           {roles.map((role) => (
-            <button
+            <AdminFilterChip
               key={role}
-              type="button"
+              active={selectedRole === role}
               onClick={() => setSelectedRole(role)}
-              className={
-                'rounded-full border px-3.5 py-1.5 text-sm font-semibold transition ' +
-                (selectedRole === role
-                  ? 'border-slate-900 bg-slate-900 text-white'
-                  : 'border-slate-200 bg-white text-slate-700 hover:border-slate-300')
-              }
             >
               {ROLE_LABELS[role] ?? role}
-            </button>
+            </AdminFilterChip>
           ))}
         </div>
 
@@ -171,20 +173,20 @@ export default function AdminPermissions() {
 
         <div className="grid gap-4">
           {grouped.map(([domain, entries]) => (
-            <div key={domain} className="rounded-xl border border-slate-200 bg-white p-4">
-              <div className="mb-2 text-[11px] font-extrabold uppercase tracking-wide text-slate-500">{domain}</div>
+            <div key={domain} className={cn(ADMIN_CARD, 'p-4')}>
+              <div className={cn('mb-2', ADMIN_LABEL)}>{domain}</div>
               <div className="grid gap-1.5 sm:grid-cols-2">
                 {entries.map((entry) => {
                   const checked = (roleBundles[selectedRole] ?? []).includes(entry.key);
                   const disabled = selectedRole === 'admin' || busyKey === `role:${entry.key}`;
                   return (
-                    <label key={entry.key} className="flex items-start gap-2.5 rounded-lg px-2 py-1.5 hover:bg-slate-50">
+                    <label key={entry.key} className="flex w-auto items-start gap-2.5 rounded-lg px-2 py-1.5 hover:bg-[#f9fbf7]">
                       <input
                         type="checkbox"
                         checked={checked}
                         disabled={disabled}
                         onChange={(e) => toggleRole(entry.key, e.target.checked)}
-                        className="mt-0.5 h-4 w-4"
+                        className={cn('mt-0.5', CHECKBOX_CLASS)}
                       />
                       <span className="grid">
                         <span className="font-mono text-[12px] text-slate-800">{entry.key}</span>
@@ -201,11 +203,11 @@ export default function AdminPermissions() {
 
       {/* ── Per-user overrides ───────────────────────────────────── */}
       <section className="grid gap-3">
-        <h2 className="m-0 text-lg font-bold text-slate-900">Per användare</h2>
+        <h3 className="m-0 text-base font-bold text-slate-900">Per användare</h3>
         <select
           value={selectedUserId}
           onChange={(e) => loadUser(e.target.value)}
-          className="max-w-md rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm"
+          className={cn(crm.select, 'max-w-md')}
         >
           <option value="">Välj användare…</option>
           {users.map((u) => (
@@ -215,17 +217,17 @@ export default function AdminPermissions() {
           ))}
         </select>
 
-        {userLoading ? <div className="text-sm text-slate-500">Laddar…</div> : null}
+        {userLoading ? <p role="status" className="m-0 text-sm text-slate-400">Laddar…</p> : null}
 
         {userState ? (
           <div className="grid gap-4">
-            <div className="flex flex-wrap items-center gap-2 text-sm text-slate-600">
-              <Badge>Roll: {ROLE_LABELS[userState.role] ?? userState.role}</Badge>
-              <Badge>{userState.effective.length} effektiva behörigheter</Badge>
+            <div className="flex flex-wrap items-center gap-2">
+              <span className={cn(crm.badge, 'border-slate-200 bg-slate-50 text-slate-600')}>Roll: {ROLE_LABELS[userState.role] ?? userState.role}</span>
+              <span className={cn(crm.badge, 'border-slate-200 bg-slate-50 text-slate-600 tabular-nums')}>{userState.effective.length} effektiva behörigheter</span>
             </div>
             {grouped.map(([domain, entries]) => (
-              <div key={domain} className="rounded-xl border border-slate-200 bg-white p-4">
-                <div className="mb-2 text-[11px] font-extrabold uppercase tracking-wide text-slate-500">{domain}</div>
+              <div key={domain} className={cn(ADMIN_CARD, 'p-4')}>
+                <div className={cn('mb-2', ADMIN_LABEL)}>{domain}</div>
                 <div className="grid gap-1.5">
                   {entries.map((entry) => {
                     const fromRole = userState.roleKeys.includes(entry.key);
@@ -234,29 +236,35 @@ export default function AdminPermissions() {
                     const busy = busyKey === `user:${entry.key}`;
                     const current: 'inherit' | 'grant' | 'revoke' = override?.effect ?? 'inherit';
                     return (
-                      <div key={entry.key} className="flex flex-wrap items-center gap-2 rounded-lg px-2 py-1.5 hover:bg-slate-50">
+                      <div key={entry.key} className="flex flex-wrap items-center gap-2 rounded-lg px-2 py-1.5 hover:bg-[#f9fbf7]">
                         <span className="min-w-[200px] grow">
                           <span className="font-mono text-[12px] text-slate-800">{entry.key}</span>
-                          <span className="ml-2 text-[11px] text-slate-400">{fromRole ? 'i rollen' : 'ej i rollen'}</span>
+                          <span className="ml-2 text-[11px] text-slate-500">{fromRole ? 'i rollen' : 'ej i rollen'}</span>
                         </span>
-                        <Badge variant={effective ? 'accent' : undefined}>{effective ? 'aktiv' : 'av'}</Badge>
-                        <div className="flex overflow-hidden rounded-lg border border-slate-200">
+                        <span className={cn(crm.badge, effective ? 'border-emerald-200 bg-emerald-50 text-emerald-700' : 'border-slate-200 bg-slate-50 text-slate-500')}>
+                          {effective ? 'aktiv' : 'av'}
+                        </span>
+                        {/* Segmenterad trestatuskontroll — strukturen behålls med flit
+                            (Ärv/Ge/Neka är ett val, inte tre knappar); precedent i
+                            AdminTimeCorrectionModal:s kind-väljare. */}
+                        <div className="flex overflow-hidden rounded-lg border border-[#e0e8dc]">
                           {(['inherit', 'grant', 'revoke'] as const).map((mode) => (
                             <button
                               key={mode}
                               type="button"
+                              aria-pressed={current === mode}
                               disabled={busy || (mode === 'revoke' && entry.key === 'crm.admin' && userState.role === 'admin')}
                               onClick={() => setUserOverride(entry.key, mode === 'inherit' ? null : mode)}
-                              className={
-                                'px-2.5 py-1 text-[11px] font-semibold ' +
-                                (current === mode
+                              className={cn(
+                                'px-2.5 py-1 text-[11px] font-semibold transition',
+                                current === mode
                                   ? mode === 'revoke'
                                     ? 'bg-rose-600 text-white'
                                     : mode === 'grant'
                                       ? 'bg-emerald-600 text-white'
                                       : 'bg-slate-700 text-white'
-                                  : 'bg-white text-slate-600 hover:bg-slate-100')
-                              }
+                                  : 'bg-white text-slate-600 hover:bg-[#f9fbf7]',
+                              )}
                             >
                               {mode === 'inherit' ? 'Ärv' : mode === 'grant' ? 'Ge' : 'Neka'}
                             </button>

--- a/app/admin/tid/AdminTimeReference.tsx
+++ b/app/admin/tid/AdminTimeReference.tsx
@@ -1,7 +1,11 @@
 "use client";
 import React from 'react';
-import Badge from '../../../components/ui/Badge';
+import { crm } from '../../crm/lib/crmTokens';
+import { cn } from '../../../lib/shared/cn';
+import { ADMIN_CARD, ADMIN_COLHEAD, ADMIN_ERROR_BOX, ADMIN_NOTICE_BOX } from '../components/adminUi';
 import type { TimeReferenceItem, TimeReferenceKind } from '../../../lib/domains/time/reference';
+
+const CHECKBOX_CLASS = 'h-4 w-4 rounded border-slate-300 accent-emerald-600';
 
 // Admin → Tidkoder. Referensdatan för tidrapporteringen (fas 4.1).
 //
@@ -125,19 +129,19 @@ export default function AdminTimeReference() {
     }
   }
 
-  if (loading) return <div className="p-6 text-sm text-slate-500">Laddar referensdata…</div>;
+  if (loading) return <p role="status" className="m-0 p-5 text-sm text-slate-400">Laddar…</p>;
 
   return (
-    <div className="grid gap-6 p-5">
+    <div className="grid gap-4 p-5">
       {error ? (
-        <div className="rounded-xl border border-solid border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700">
+        <div role="alert" className={ADMIN_ERROR_BOX}>
           {error}
           <button type="button" onClick={() => setError(null)} className="ml-3 underline">Stäng</button>
         </div>
       ) : null}
 
       {notice ? (
-        <div className="rounded-xl border border-solid border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-900">
+        <div role="status" className={ADMIN_NOTICE_BOX}>
           {notice}
           <button type="button" onClick={() => setNotice(null)} className="ml-3 underline">Stäng</button>
         </div>
@@ -146,7 +150,7 @@ export default function AdminTimeReference() {
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div className="grid max-w-[720px] gap-1">
           <h2 className="m-0 text-lg font-bold text-slate-900">Tidkoder och referensdata</h2>
-          <p className="m-0 text-sm text-slate-500">
+          <p className="m-0 text-sm text-slate-600">
             Listorna som tidrapporteringen väljer ur. De hämtas en gång från Blikk och underhålls sedan här —
             efter att Blikk kopplats bort är det här enda stället de finns.
           </p>
@@ -155,14 +159,14 @@ export default function AdminTimeReference() {
           type="button"
           onClick={() => void importFromBlikk()}
           disabled={importing}
-          className="rounded-xl border border-solid border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-slate-400 disabled:cursor-not-allowed disabled:opacity-60"
+          className={crm.ghostButton}
         >
           {importing ? 'Hämtar…' : 'Hämta från Blikk'}
         </button>
       </div>
 
       {missingPayrollCode > 0 ? (
-        <div className="rounded-xl border border-solid border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900">
+        <div className="rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900">
           <strong>{missingPayrollCode}</strong> aktiva rader saknar lönesort. Löneunderlaget kan inte placera deras
           timmar förrän fältet är ifyllt — Blikk-importen tar inte med det, det är er byrås benämning.
         </div>
@@ -174,14 +178,14 @@ export default function AdminTimeReference() {
           <section key={section.kind} className="grid gap-2">
             <div className="flex flex-wrap items-baseline gap-2">
               <h3 className="m-0 text-base font-bold text-slate-900">{section.label}</h3>
-              <Badge>{items.length}</Badge>
+              <span className={cn(crm.badge, 'border-slate-200 bg-slate-50 text-slate-600 tabular-nums')}>{items.length}</span>
               <span className="text-sm text-slate-500">{section.help}</span>
             </div>
 
-            <div className="overflow-x-auto rounded-xl border border-solid border-slate-200 bg-white">
+            <div className={cn(ADMIN_CARD, 'overflow-x-auto')}>
               <table className="w-full min-w-[720px] border-collapse text-sm">
                 <thead>
-                  <tr className="border-x-0 border-t-0 border-b border-solid border-slate-200 text-left text-[11px] font-extrabold uppercase tracking-wide text-slate-500">
+                  <tr className={cn('border-x-0 border-t-0 border-b border-[#e0e8dc] bg-[#f9fbf7] text-left', ADMIN_COLHEAD)}>
                     <th className="px-3 py-2">Namn</th>
                     <th className="px-3 py-2">Kod</th>
                     <th className="px-3 py-2">Lönesort</th>
@@ -201,31 +205,30 @@ export default function AdminTimeReference() {
                   {items.map((item) => {
                     const busy = busyKey === `${section.kind}:${item.id}`;
                     return (
-                      <tr key={item.id} className={'border-x-0 border-t-0 border-b border-solid border-slate-100 ' + (item.is_active ? '' : 'text-slate-400')}>
+                      <tr key={item.id} className={cn('border-x-0 border-t-0 border-b border-slate-100', !item.is_active && 'text-slate-400')}>
                         <td className="px-3 py-2 font-medium">
                           {item.name}
-                          {item.blikk_id ? <span className="ml-2 text-xs text-slate-400">Blikk #{item.blikk_id}</span> : null}
+                          {item.blikk_id ? <span className="ml-2 text-xs text-slate-500">Blikk #{item.blikk_id}</span> : null}
                         </td>
                         <td className="px-3 py-2 text-slate-500">{item.code || '—'}</td>
                         <td className="px-3 py-2">
                           {/* Sparas på blur, inte per tangenttryck: fältet är fritext och admin skriver
                               av byråns benämning i lugn och ro. */}
-                          <span className="inline-block w-32">
-                            <input
-                              defaultValue={item.payroll_code || ''}
-                              onBlur={(e) => {
-                                const value = e.target.value.trim();
-                                if (value === (item.payroll_code || '')) return;
-                                void patchItem(section.kind, item, { payroll_code: value || null });
-                              }}
-                              placeholder="—"
-                              disabled={busy}
-                              className={
-                                'rounded-lg border border-solid px-2 py-1 text-sm ' +
-                                (item.is_active && !item.payroll_code ? 'border-amber-300 bg-amber-50' : 'border-slate-200')
-                              }
-                            />
-                          </span>
+                          <input
+                            defaultValue={item.payroll_code || ''}
+                            onBlur={(e) => {
+                              const value = e.target.value.trim();
+                              if (value === (item.payroll_code || '')) return;
+                              void patchItem(section.kind, item, { payroll_code: value || null });
+                            }}
+                            placeholder="—"
+                            disabled={busy}
+                            className={cn(
+                              crm.input,
+                              'h-8 w-32 px-2',
+                              item.is_active && !item.payroll_code && 'border-amber-300 bg-amber-50',
+                            )}
+                          />
                         </td>
                         <td className="px-3 py-2">
                           <input
@@ -233,6 +236,8 @@ export default function AdminTimeReference() {
                             checked={item.requires_note}
                             disabled={busy}
                             onChange={(e) => void patchItem(section.kind, item, { requires_note: e.target.checked })}
+                            className={CHECKBOX_CLASS}
+                            aria-label={`Kommentar krävs för ${item.name}`}
                           />
                         </td>
                         {section.kind === 'time_code' ? (
@@ -242,6 +247,8 @@ export default function AdminTimeReference() {
                               checked={item.billable === true}
                               disabled={busy}
                               onChange={(e) => void patchItem(section.kind, item, { billable: e.target.checked })}
+                              className={CHECKBOX_CLASS}
+                              aria-label={`Debiterbar: ${item.name}`}
                             />
                           </td>
                         ) : null}
@@ -253,6 +260,8 @@ export default function AdminTimeReference() {
                             checked={item.is_active}
                             disabled={busy}
                             onChange={(e) => void patchItem(section.kind, item, { is_active: e.target.checked })}
+                            className={CHECKBOX_CLASS}
+                            aria-label={`Aktiv: ${item.name}`}
                           />
                         </td>
                       </tr>
@@ -263,20 +272,19 @@ export default function AdminTimeReference() {
             </div>
 
             <div className="flex flex-wrap items-center gap-2">
-              <span className="inline-block w-64">
-                <input
-                  value={newName[section.kind] || ''}
-                  onChange={(e) => setNewName((prev) => ({ ...prev, [section.kind]: e.target.value }))}
-                  onKeyDown={(e) => { if (e.key === 'Enter') void addItem(section.kind); }}
-                  placeholder={`Ny ${section.label.toLowerCase().replace(/er$/, '')}…`}
-                  className="rounded-lg border border-solid border-slate-200 px-2.5 py-1.5 text-sm"
-                />
-              </span>
+              <input
+                value={newName[section.kind] || ''}
+                onChange={(e) => setNewName((prev) => ({ ...prev, [section.kind]: e.target.value }))}
+                onKeyDown={(e) => { if (e.key === 'Enter') void addItem(section.kind); }}
+                placeholder={`Ny ${section.label.toLowerCase().replace(/er$/, '')}…`}
+                className={cn(crm.input, 'w-64')}
+              />
               <button
                 type="button"
                 onClick={() => void addItem(section.kind)}
                 disabled={!((newName[section.kind] || '').trim()) || busyKey === `${section.kind}:new`}
-                className="rounded-lg border border-solid border-slate-300 bg-white px-3 py-1.5 text-sm font-semibold text-slate-700 transition hover:border-slate-400 disabled:cursor-not-allowed disabled:opacity-60"
+                className={crm.formButton}
+                style={{ backgroundColor: 'var(--crm-primary, #1a3f26)' }}
               >
                 Lägg till
               </button>


### PR DESCRIPTION
## Sammanfattning

Fjärde vågen (efter #87–#89): de två rå-Tailwind-avvikarna — filerna som helt saknade primitiver och byggde klassnamn med strängkonkatenering.

- **Behörigheter** — fliken saknade `h2` helt, nu standardheader; slate-900-rollpillarna → `AdminFilterChip`; domänkort → `ADMIN_CARD`; rå `<select>` → `crm.select`; `Badge` → `crm.badge`; kryssrutor får enhetlig `accent-emerald-600`; segmenterade **Ärv/Ge/Neka** behåller strukturen (det är ett trestatusval, inte tre knappar) men skrivs om på tokens + `cn()` + `aria-pressed`
- **Tidkoder** — alla 10 döda `border-solid` bort; tabellram/huvud på `ADMIN_CARD`/`ADMIN_COLHEAD`; lönekod-inputen → `crm.input` med **blur-spar och amber-varningslogiken oförändrad**; "Hämta från Blikk" → `crm.ghostButton`; "Lägg till" → `crm.formButton`; kryssrutorna får `aria-label` (kolumnrubriken var deras enda etikett)

De `inline-block`-omslag som tidigare styrde fältbredd är borta — sedan `:where()`-flytten (PR #84) vinner breddklassen direkt på fältet, vilket filens egen kommentar redan förutsåg.

## Granskningsfynd — åtgärdade i den delade hjälpfilen

Båda fixade i `adminUi.tsx` så att alla anropsplatser täcks på en gång:
1. **`ADMIN_COLHEAD` → slate-500** — slate-400 @10px ligger under WCAG AA, och i admin är kolumnrubriken ofta enda etiketten för sin kolumn (Tidkoders tre kryssrutekolumner). Samma resonemang som redan motiverar `ADMIN_LABEL`
2. **`AdminFilterChip` får `aria-pressed`** — aktivt läge signalerades bara med bakgrundsfärg; täcker även Användare- och Blikk-flikarna från våg 1–2

## Ingen logik ändrad

Handlers, `disabled`-predikat, den optimistiska uppdateringen med revert i `toggleRole` och blur-dirty-checken är intakta. Alla kommentarer som dokumenterar bärande beteende är bevarade ordagrant.

## Verifiering

- `npm run type-check` ✅ · `npm run lint` ✅ · `npm run build` ✅ · `npm test` 1345/1345 ✅

### Manuell QA-checklista
- [ ] Behörigheter: rollchip-växling, kryssruta av/på (optimistisk + revert vid fel), användarväljare laddar overrides, Ärv/Ge/Neka postar
- [ ] Tidkoder: Blikk-import, lönekod blur-spar (inkl. amber-markering på aktiv rad utan kod), tre kryssrutor, lägg till rad + Enter
- [ ] Ingen horisontell scroll vid 375 px

🤖 Generated with [Claude Code](https://claude.com/claude-code)