### PR TITLE
feat(admin): våg 5 (sista) — Attest-putsning, konvergens, dödkodssvep

### DIFF
--- a/app/admin/changelog/AdminChangelog.tsx
+++ b/app/admin/changelog/AdminChangelog.tsx
@@ -6,6 +6,7 @@ import { crm } from '../../crm/lib/crmTokens';
 import Input from '../../../components/ui/Input';
 import Select from '../../../components/ui/Select';
 import Textarea from '../../../components/ui/Textarea';
+import { ADMIN_EMPTY_BOX, ADMIN_ERROR_BOX } from '../components/adminUi';
 import { changelogCategoryMeta, formatChangelogStamp } from '../../_lib/changelogTokens';
 import {
   CHANGELOG_CATEGORIES,
@@ -59,13 +60,13 @@ export default function AdminChangelog() {
       <NewEntryForm onSaved={load} />
 
       {error ? (
-        <div className="rounded-xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700">{error}</div>
+        <div role="alert" className={ADMIN_ERROR_BOX}>{error}</div>
       ) : null}
 
       {loading ? (
         <p className="m-0 text-sm text-slate-400">Laddar…</p>
       ) : entries.length === 0 && !error ? (
-        <div className="rounded-2xl border border-dashed border-[#d5e0cf] bg-[#f4f8f1] px-4 py-8 text-center">
+        <div className={ADMIN_EMPTY_BOX}>
           <p className="m-0 text-sm text-slate-500">Inga egna poster ännu.</p>
         </div>
       ) : (

--- a/app/admin/components/AdminPromptDialog.tsx
+++ b/app/admin/components/AdminPromptDialog.tsx
@@ -78,7 +78,7 @@ export default function AdminPromptDialog({
                 ? 'border border-rose-600 bg-rose-600 hover:brightness-95'
                 : '',
             )}
-            style={danger ? undefined : { backgroundColor: 'var(--crm-primary)' }}
+            style={danger ? undefined : { backgroundColor: 'var(--crm-primary, #1a3f26)' }}
           >
             {busy ? '…' : confirmLabel}
           </button>

--- a/app/admin/components/adminUi.tsx
+++ b/app/admin/components/adminUi.tsx
@@ -22,6 +22,11 @@ export const ADMIN_NOTICE_BOX = 'rounded-xl border border-emerald-200 bg-emerald
 export const ADMIN_EMPTY_BOX = 'rounded-2xl border border-dashed border-[#d5e0cf] bg-[#f4f8f1] px-4 py-8 text-center';
 // Laddar: <p role="status" className="m-0 text-sm text-slate-400">Laddar…</p> (ingen hjälpare behövs)
 
+// Native kryssruta (dokumenterat undantag — ingen primitiv finns). Medvetet BARA
+// storlek + accentfärg: `rounded`/`border-*` är verkningslöst på en native checkbox
+// (preflight nollar border-width och globals.css återställer den bara för knappar).
+export const ADMIN_CHECKBOX = 'h-4 w-4 accent-emerald-600';
+
 // Innehållskort (vitt på flikkortets sage) respektive inre inset (sage på vitt).
 // Padding ägs av anropsplatsen (p-4 för kort, px-3 py-2.5/p-3.5 för inset).
 export const ADMIN_CARD = 'rounded-2xl border border-[#e0e8dc] bg-white';

--- a/app/admin/permissions/AdminPermissions.tsx
+++ b/app/admin/permissions/AdminPermissions.tsx
@@ -2,9 +2,8 @@
 import React from 'react';
 import { crm } from '../../crm/lib/crmTokens';
 import { cn } from '../../../lib/shared/cn';
-import { ADMIN_CARD, ADMIN_ERROR_BOX, ADMIN_LABEL, ADMIN_NOTICE_BOX, AdminFilterChip } from '../components/adminUi';
+import { ADMIN_CARD, ADMIN_CHECKBOX, ADMIN_ERROR_BOX, ADMIN_LABEL, ADMIN_NOTICE_BOX, AdminFilterChip } from '../components/adminUi';
 
-const CHECKBOX_CLASS = 'h-4 w-4 rounded border-slate-300 accent-emerald-600';
 
 type CatalogEntry = { key: string; description: string };
 type RoleBundles = Record<string, string[]>;
@@ -186,7 +185,7 @@ export default function AdminPermissions() {
                         checked={checked}
                         disabled={disabled}
                         onChange={(e) => toggleRole(entry.key, e.target.checked)}
-                        className={cn('mt-0.5', CHECKBOX_CLASS)}
+                        className={cn('mt-0.5', ADMIN_CHECKBOX)}
                       />
                       <span className="grid">
                         <span className="font-mono text-[12px] text-slate-800">{entry.key}</span>

--- a/app/admin/support/AdminSupportTickets.tsx
+++ b/app/admin/support/AdminSupportTickets.tsx
@@ -6,6 +6,7 @@ import { crm } from '../../crm/lib/crmTokens';
 import CrmModal from '../../crm/components/CrmModal';
 import Textarea from '../../../components/ui/Textarea';
 import Select from '../../../components/ui/Select';
+import { ADMIN_CHECKBOX, ADMIN_EMPTY_BOX, ADMIN_ERROR_BOX, AdminFilterChip } from '../components/adminUi';
 import { ticketKindGlyph, ticketKindGlyphClass, ticketStatusMeta } from '../../_lib/supportTokens';
 import {
   TICKET_KINDS,
@@ -103,29 +104,29 @@ export default function AdminSupportTickets() {
 
       <div className="flex flex-wrap items-center gap-2">
         {(['open', 'closed', 'any'] as StateFilter[]).map((s) => (
-          <FilterChip key={s} active={stateFilter === s} onClick={() => setStateFilter(s)}>
+          <AdminFilterChip key={s} active={stateFilter === s} onClick={() => setStateFilter(s)}>
             {STATE_LABEL[s]}
-          </FilterChip>
+          </AdminFilterChip>
         ))}
         <span className="mx-1 h-5 w-px shrink-0 bg-slate-200" aria-hidden />
-        <FilterChip active={kindFilter === 'all'} onClick={() => setKindFilter('all')}>
+        <AdminFilterChip active={kindFilter === 'all'} onClick={() => setKindFilter('all')}>
           Allt
-        </FilterChip>
+        </AdminFilterChip>
         {TICKET_KINDS.map((k) => (
-          <FilterChip key={k} active={kindFilter === k} onClick={() => setKindFilter(k)}>
+          <AdminFilterChip key={k} active={kindFilter === k} onClick={() => setKindFilter(k)}>
             {kindLabel[k]}
-          </FilterChip>
+          </AdminFilterChip>
         ))}
       </div>
 
       {error ? (
-        <div className="rounded-xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700">{error}</div>
+        <div role="alert" className={ADMIN_ERROR_BOX}>{error}</div>
       ) : null}
 
       {loading ? (
         <p className="m-0 text-sm text-slate-400">Laddar…</p>
       ) : items.length === 0 && !error ? (
-        <div className="rounded-2xl border border-dashed border-[#d5e0cf] bg-[#f4f8f1] px-4 py-8 text-center">
+        <div className={ADMIN_EMPTY_BOX}>
           <p className="m-0 text-sm text-slate-500">
             {stateFilter === 'open' ? 'Inget kvar att göra just nu.' : 'Inga ärenden att visa.'}
           </p>
@@ -152,23 +153,6 @@ export default function AdminSupportTickets() {
         />
       ) : null}
     </div>
-  );
-}
-
-function FilterChip({ active, onClick, children }: { active: boolean; onClick: () => void; children: React.ReactNode }) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      className={cn(
-        'rounded-full border px-2.5 py-1 text-[13px] font-semibold transition-colors',
-        active
-          ? 'border-emerald-200 bg-emerald-50 text-emerald-700'
-          : 'border-[#e0e8dc] bg-white text-slate-600 hover:border-emerald-200',
-      )}
-    >
-      {children}
-    </button>
   );
 }
 
@@ -378,7 +362,7 @@ function TicketModal({
                 onClick={save}
                 disabled={busy}
                 className={cn(crm.formButton, 'shrink-0')}
-                style={{ backgroundColor: 'var(--crm-primary)' }}
+                style={{ backgroundColor: 'var(--crm-primary, #1a3f26)' }}
               >
                 {saving ? 'Sparar…' : 'Spara'}
               </button>
@@ -465,7 +449,7 @@ function TicketModal({
               checked={publish}
               onChange={(e) => setPublish(e.target.checked)}
               disabled={busy}
-              className="w-4 shrink-0"
+              className={cn(ADMIN_CHECKBOX, 'shrink-0')}
             />
             Visa i changeloggen
           </label>

--- a/app/admin/tid/AdminTimeApprovals.tsx
+++ b/app/admin/tid/AdminTimeApprovals.tsx
@@ -3,6 +3,8 @@ import React from 'react';
 import CrmModal from '@/app/crm/components/CrmModal';
 import AdminTimeCorrectionModal, { type CorrectionReference } from './AdminTimeCorrectionModal';
 import Input from '../../../components/ui/Input';
+import { crm } from '../../crm/lib/crmTokens';
+import { ADMIN_ERROR_BOX, ADMIN_NOTICE_BOX } from '../components/adminUi';
 import { cn } from '../../../lib/shared/cn';
 import { minutesToHours } from '../../../lib/domains/time/hours';
 import {
@@ -423,7 +425,7 @@ export default function AdminTimeApprovals() {
           stora är summorna (underlaget). Förut låg båda som sex likadana badges i rad. */}
       {/* En rad, tre kolumner — inte tre fullbreddsblock under varandra. På en 1200 px-yta blir
           staplade block bara innehåll som klistras mot ytterkanterna med luft i mitten. */}
-      <section className="flex flex-wrap items-end gap-x-6 gap-y-3 rounded-2xl border border-solid border-[#e0e8dc] bg-[#f9fbf7] p-3.5">
+      <section className="flex flex-wrap items-end gap-x-6 gap-y-3 rounded-2xl border border-[#e0e8dc] bg-[#f9fbf7] p-3.5">
         <label className="grid gap-1">
           <span className={LABEL}>Period</span>
           <span className="inline-block w-40">
@@ -468,10 +470,10 @@ export default function AdminTimeApprovals() {
       </section>
 
       {error ? (
-        <div className="rounded-xl border border-solid border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700">{error}</div>
+        <div role="alert" className={ADMIN_ERROR_BOX}>{error}</div>
       ) : null}
       {notice ? (
-        <div className="rounded-xl border border-solid border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-800">{notice}</div>
+        <div role="status" className={ADMIN_NOTICE_BOX}>{notice}</div>
       ) : null}
 
       {/* Filtren är granskningens arbetsredskap: de tar en rakt till dem som inte lämnat in eller
@@ -486,7 +488,7 @@ export default function AdminTimeApprovals() {
               onClick={() => setFilter(key)}
               aria-pressed={filter === key}
               className={cn(
-                'px-3 py-1.5 rounded-full border border-solid text-sm font-semibold transition',
+                'px-3 py-1.5 rounded-full border text-sm font-semibold transition',
                 filter === key
                   ? 'border-transparent bg-slate-900 text-white'
                   : 'border-[#dbe4d6] bg-white text-slate-600 hover:border-slate-400',
@@ -504,7 +506,7 @@ export default function AdminTimeApprovals() {
             <select
               value={sort}
               onChange={(e) => setSort(e.target.value as Sort)}
-              className="rounded-lg border border-solid border-[#dbe4d6] bg-white px-2.5 py-1.5 text-sm"
+              className="rounded-lg border border-[#dbe4d6] bg-white px-2.5 py-1.5 text-sm"
             >
               <option value="name">Namn</option>
               <option value="hours_asc">Timmar, lägst först</option>
@@ -522,7 +524,7 @@ export default function AdminTimeApprovals() {
                 <button
                   type="button"
                   onClick={() => void approveAllSubmitted()}
-                  className="px-3 py-1.5 rounded-lg border border-solid border-emerald-300 bg-emerald-50 text-sm font-semibold text-emerald-800"
+                  className="px-3 py-1.5 rounded-lg border border-emerald-300 bg-emerald-50 text-sm font-semibold text-emerald-800"
                 >
                   Ja, attestera
                 </button>
@@ -539,7 +541,7 @@ export default function AdminTimeApprovals() {
                 type="button"
                 onClick={() => setConfirmBulk(true)}
                 disabled={bulkBusy}
-                className="px-3 py-1.5 rounded-lg border border-solid border-emerald-300 bg-emerald-50 text-sm font-semibold text-emerald-800 transition hover:border-emerald-400 disabled:opacity-60"
+                className="px-3 py-1.5 rounded-lg border border-emerald-300 bg-emerald-50 text-sm font-semibold text-emerald-800 transition hover:border-emerald-400 disabled:opacity-60"
               >
                 {bulkBusy ? 'Attesterar…' : `Attestera alla inlämnade (${submitted.length})`}
               </button>
@@ -643,7 +645,7 @@ function PersonRow({
     // Vit fyllning, inte sage. Fliken renderas i en `crm.card` som REDAN är #f9fbf7 — ett kort i
     // samma ton på samma ton skiljs bara av en hårlinje i #e0e8dc, och då läser raderna som en enda
     // yta. Samma grepp som tidraderna i /tid: vitt kort på sage-underlag.
-    <li className="overflow-hidden rounded-2xl border border-solid border-[#e0e8dc] bg-white">
+    <li className="overflow-hidden rounded-2xl border border-[#e0e8dc] bg-white">
       {/* EN rad med kolumner, inte tre band under varandra. Staplade fullbreddsblock på en yta som
           är över tusen pixlar bred ger innehåll klistrat mot ytterkanterna och luft i mitten — och
           en stapel som spänner hela bredden läser som en trasig avdelare, inte som ett mått.
@@ -699,7 +701,7 @@ function PersonRow({
             {/* Noll rader på en person som ska ha rapporterat är det attesten finns för att
                 upptäcka — därför en egen flagga och inte bara en siffra i en kolumn. */}
             {row.entry_count === 0 ? (
-              <span className="whitespace-nowrap rounded-full border border-solid border-amber-200 bg-amber-50 px-2.5 py-0.5 text-[11px] font-semibold text-amber-800">
+              <span className="whitespace-nowrap rounded-full border border-amber-200 bg-amber-50 px-2.5 py-0.5 text-[11px] font-semibold text-amber-800">
                 Inget rapporterat
               </span>
             ) : null}
@@ -714,7 +716,7 @@ function PersonRow({
                 type="button"
                 onClick={onApprove}
                 disabled={busy}
-                className="px-3 py-1.5 rounded-lg border border-solid border-emerald-300 bg-emerald-50 text-sm font-semibold text-emerald-800 transition hover:border-emerald-400 disabled:opacity-60"
+                className="px-3 py-1.5 rounded-lg border border-emerald-300 bg-emerald-50 text-sm font-semibold text-emerald-800 transition hover:border-emerald-400 disabled:opacity-60"
               >
                 Attestera
               </button>
@@ -724,7 +726,7 @@ function PersonRow({
                 type="button"
                 onClick={onReopen}
                 disabled={busy}
-                className="px-3 py-1.5 rounded-lg border border-solid border-[#dbe4d6] bg-white text-sm font-semibold text-slate-700 transition hover:border-slate-400 disabled:opacity-60"
+                className="px-3 py-1.5 rounded-lg border border-[#dbe4d6] bg-white text-sm font-semibold text-slate-700 transition hover:border-slate-400 disabled:opacity-60"
               >
                 Öppna igen
               </button>
@@ -734,7 +736,7 @@ function PersonRow({
       </div>
 
       {expanded ? (
-        <div className="border-x-0 border-b-0 border-t border-solid border-[#e4ebe0] bg-[#f9fbf7] px-4 py-3">
+        <div className="border-x-0 border-b-0 border-t border-[#e4ebe0] bg-[#f9fbf7] px-4 py-3">
           {/* Rättelse bara i en öppen period. Är månaden inlämnad eller attesterad avvisar databasen
               ändringen ändå — knappen döljs för att slippa be någon trycka på något som inte går. */}
           <PersonDays detail={detail} name={row.full_name} canCorrect={!locked} onEdit={onEdit} onDelete={onDelete} />
@@ -785,7 +787,7 @@ function ReopenModal({
           <button
             type="button"
             onClick={onClose}
-            className="py-2.5 flex-1 rounded-xl border border-solid border-[#dbe4d6] bg-white text-sm font-semibold text-slate-600 transition hover:border-slate-400 sm:flex-none sm:px-5"
+            className={cn(crm.ghostButton, 'h-auto flex-1 py-2.5 sm:flex-none sm:px-5')}
           >
             Avbryt
           </button>
@@ -799,8 +801,8 @@ function ReopenModal({
               if (result) { setFailure(result); setBusy(false); }
             }}
             disabled={busy}
-            className="py-2.5 flex-1 rounded-xl text-sm font-semibold text-white shadow-sm transition hover:brightness-95 disabled:opacity-60 sm:ml-auto sm:flex-none sm:px-5"
-            style={{ backgroundColor: 'var(--crm-primary)' }}
+            className={cn(crm.formButton, 'h-auto flex-1 py-2.5 sm:ml-auto sm:flex-none sm:px-5')}
+            style={{ backgroundColor: 'var(--crm-primary, #1a3f26)' }}
           >
             {busy ? 'Öppnar…' : 'Öppna igen'}
           </button>
@@ -808,7 +810,7 @@ function ReopenModal({
       }
     >
       {failure ? (
-        <div className="mb-3 rounded-xl border border-solid border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-700">{failure}</div>
+        <div className="mb-3 rounded-xl border border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-700">{failure}</div>
       ) : null}
 
       <label className="grid gap-1">
@@ -818,7 +820,7 @@ function ReopenModal({
           onChange={(e) => setNote(e.target.value)}
           rows={3}
           autoFocus
-          className="w-full rounded-xl border border-solid border-[#dbe4d6] bg-white px-3 py-2 text-sm text-slate-900"
+          className="w-full rounded-xl border border-[#dbe4d6] bg-white px-3 py-2 text-sm text-slate-900"
           placeholder="T.ex. Onsdag 12/8 saknar klockslag — fyll i och lämna in igen."
         />
         <span className="text-xs text-slate-500">Syns för {row.full_name || 'personen'} i Tidrapport.</span>
@@ -854,7 +856,7 @@ function PersonDays({
   if (!detail || detail.loading) return <p className="m-0 text-sm text-slate-400">Laddar dagar…</p>;
   if (detail.error) {
     return (
-      <div className="rounded-lg border border-solid border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-700">
+      <div className="rounded-lg border border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-700">
         {detail.error}
       </div>
     );
@@ -905,7 +907,7 @@ function PersonDays({
               ))}
             </tbody>
             <tfoot>
-              <tr className="border-x-0 border-b-0 border-t-2 border-solid border-slate-300 font-semibold text-slate-900">
+              <tr className="border-x-0 border-b-0 border-t-2 border-slate-300 font-semibold text-slate-900">
                 <td className="px-2 py-2" colSpan={2}>Totalt</td>
                 <td className="whitespace-nowrap px-2 py-2 text-right tabular-nums">{formatHours(summary.workMinutes)} h</td>
                 <td className="whitespace-nowrap px-2 py-2 text-right tabular-nums">
@@ -922,7 +924,7 @@ function PersonDays({
       {summary.absenceByReason.length > 0 ? (
         <div className="flex flex-wrap gap-2 text-xs text-slate-600">
           {summary.absenceByReason.map((item) => (
-            <span key={item.reason} className="rounded-lg border border-solid border-slate-200 bg-white px-2 py-1">
+            <span key={item.reason} className="rounded-lg border border-slate-200 bg-white px-2 py-1">
               {item.reason}: {formatHours(item.minutes)} h
             </span>
           ))}
@@ -987,7 +989,7 @@ function DayRowCells({
   const editable = canCorrect && !!day.entryId;
 
   return (
-    <tr className="border-x-0 border-b-0 border-t border-solid border-slate-200 align-top">
+    <tr className="border-x-0 border-b-0 border-t border-slate-200 align-top">
       <td className="whitespace-nowrap px-2 py-1.5 text-slate-700">{formatDay(day.date)}</td>
       <td className="whitespace-nowrap px-2 py-1.5 tabular-nums text-slate-700">
         {start && end ? (
@@ -1073,7 +1075,7 @@ function AuditTrail({ rows, failed }: { rows: TimeEntryAuditRow[]; failed: boole
           // Dagen först: utan den går raden inte att koppla till något i tabellen ovanför.
           const day = auditWorkDate(row);
           return (
-            <li key={row.id} className="rounded-xl border border-solid border-[#e4ebe0] bg-white px-3 py-2 text-sm">
+            <li key={row.id} className="rounded-xl border border-[#e4ebe0] bg-white px-3 py-2 text-sm">
               <div className="flex flex-wrap items-baseline gap-x-2 text-slate-700">
                 <span className="font-semibold">{day ? formatDay(day) : 'Okänd dag'}</span>
                 <span>{auditActionLabel(row.action).toLowerCase()}</span>

--- a/app/admin/tid/AdminTimeCorrectionModal.tsx
+++ b/app/admin/tid/AdminTimeCorrectionModal.tsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import CrmModal from '@/app/crm/components/CrmModal';
 import Input from '../../../components/ui/Input';
+import { crm } from '../../crm/lib/crmTokens';
 import { cn } from '../../../lib/shared/cn';
 import { minutesToHours, workedMinutes } from '../../../lib/domains/time/hours';
 import type { TimeReferenceItem } from '../../../lib/domains/time/reference';
@@ -37,7 +38,7 @@ const KINDS: Array<{ key: Kind; label: string }> = [
   { key: 'absence', label: 'Frånvaro' },
 ];
 
-const FIELD = 'w-full rounded-xl border border-solid border-[#dbe4d6] bg-white px-3 py-2 text-sm text-slate-900';
+const FIELD = 'w-full rounded-xl border border-[#dbe4d6] bg-white px-3 py-2 text-sm text-slate-900';
 const LABEL = 'text-[11px] font-bold uppercase tracking-[0.12em] text-slate-600';
 
 /**
@@ -195,7 +196,7 @@ export default function AdminTimeCorrectionModal({
           <button
             type="button"
             onClick={onClose}
-            className="py-2.5 flex-1 rounded-xl border border-solid border-[#dbe4d6] bg-white text-sm font-semibold text-slate-600 transition hover:border-slate-400 sm:flex-none sm:px-5"
+            className={cn(crm.ghostButton, 'h-auto flex-1 py-2.5 sm:flex-none sm:px-5')}
           >
             Avbryt
           </button>
@@ -203,8 +204,8 @@ export default function AdminTimeCorrectionModal({
             type="button"
             onClick={() => void save()}
             disabled={busy || previewMinutes <= 0 || needsTarget || sameClock || !date}
-            className="py-2.5 flex-1 rounded-xl text-sm font-semibold text-white shadow-sm transition hover:brightness-95 disabled:cursor-not-allowed disabled:opacity-60 sm:ml-auto sm:flex-none sm:px-5"
-            style={{ backgroundColor: 'var(--crm-primary)' }}
+            className={cn(crm.formButton, 'h-auto flex-1 py-2.5 sm:ml-auto sm:flex-none sm:px-5')}
+            style={{ backgroundColor: 'var(--crm-primary, #1a3f26)' }}
           >
             {busy ? 'Sparar…' : 'Spara rättelse'}
           </button>
@@ -213,7 +214,7 @@ export default function AdminTimeCorrectionModal({
     >
       <div className="grid gap-4">
         {failure ? (
-          <div className="rounded-xl border border-solid border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-700">{failure}</div>
+          <div className="rounded-xl border border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-700">{failure}</div>
         ) : null}
 
         <div className="flex gap-1 rounded-xl bg-[#eef3ea] p-1">
@@ -248,7 +249,7 @@ export default function AdminTimeCorrectionModal({
               Sök bara om raden ska flyttas till ett annat jobb.
             </p>
             {chosen ? (
-              <div className="flex flex-wrap items-center justify-between gap-2 rounded-xl border border-solid border-emerald-200 bg-emerald-50 px-3 py-2 text-sm">
+              <div className="flex flex-wrap items-center justify-between gap-2 rounded-xl border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm">
                 <span className="font-semibold text-emerald-900">Flyttas till {orderLabel(chosen)}</span>
                 <button
                   type="button"
@@ -270,12 +271,12 @@ export default function AdminTimeCorrectionModal({
                     onClick={() => { setWorkOrderId(order.id); setChosen(order); }}
                     aria-pressed={workOrderId === order.id}
                     className={cn(
-                      'px-3 py-2.5 justify-start text-left w-full rounded-xl border border-solid text-sm transition',
+                      'px-3 py-2.5 justify-start text-left w-full rounded-xl border text-sm transition',
                       workOrderId === order.id
                         ? 'border-transparent text-white shadow-sm'
                         : 'border-[#dbe4d6] bg-white text-slate-700 hover:border-slate-400',
                     )}
-                    style={workOrderId === order.id ? { backgroundColor: 'var(--crm-primary)' } : undefined}
+                    style={workOrderId === order.id ? { backgroundColor: 'var(--crm-primary, #1a3f26)' } : undefined}
                   >
                     {orderLabel(order)}
                   </button>
@@ -311,7 +312,7 @@ export default function AdminTimeCorrectionModal({
             <Input inputMode="decimal" value={absenceHours} onChange={(e) => setAbsenceHours(e.target.value)} />
           </label>
         ) : (
-          <div className="grid gap-3 rounded-2xl border border-solid border-[#e0e8dc] bg-[#f6f9f4] p-3">
+          <div className="grid gap-3 rounded-2xl border border-[#e0e8dc] bg-[#f6f9f4] p-3">
             <div className="grid grid-cols-2 gap-2">
               <label className="w-auto grid gap-1">
                 <span className={LABEL}>Start</span>

--- a/app/admin/tid/AdminTimeReference.tsx
+++ b/app/admin/tid/AdminTimeReference.tsx
@@ -2,10 +2,9 @@
 import React from 'react';
 import { crm } from '../../crm/lib/crmTokens';
 import { cn } from '../../../lib/shared/cn';
-import { ADMIN_CARD, ADMIN_COLHEAD, ADMIN_ERROR_BOX, ADMIN_NOTICE_BOX } from '../components/adminUi';
+import { ADMIN_CARD, ADMIN_CHECKBOX, ADMIN_COLHEAD, ADMIN_ERROR_BOX, ADMIN_NOTICE_BOX } from '../components/adminUi';
 import type { TimeReferenceItem, TimeReferenceKind } from '../../../lib/domains/time/reference';
 
-const CHECKBOX_CLASS = 'h-4 w-4 rounded border-slate-300 accent-emerald-600';
 
 // Admin → Tidkoder. Referensdatan för tidrapporteringen (fas 4.1).
 //
@@ -236,7 +235,7 @@ export default function AdminTimeReference() {
                             checked={item.requires_note}
                             disabled={busy}
                             onChange={(e) => void patchItem(section.kind, item, { requires_note: e.target.checked })}
-                            className={CHECKBOX_CLASS}
+                            className={ADMIN_CHECKBOX}
                             aria-label={`Kommentar krävs för ${item.name}`}
                           />
                         </td>
@@ -247,7 +246,7 @@ export default function AdminTimeReference() {
                               checked={item.billable === true}
                               disabled={busy}
                               onChange={(e) => void patchItem(section.kind, item, { billable: e.target.checked })}
-                              className={CHECKBOX_CLASS}
+                              className={ADMIN_CHECKBOX}
                               aria-label={`Debiterbar: ${item.name}`}
                             />
                           </td>
@@ -260,7 +259,7 @@ export default function AdminTimeReference() {
                             checked={item.is_active}
                             disabled={busy}
                             onChange={(e) => void patchItem(section.kind, item, { is_active: e.target.checked })}
-                            className={CHECKBOX_CLASS}
+                            className={ADMIN_CHECKBOX}
                             aria-label={`Aktiv: ${item.name}`}
                           />
                         </td>


### PR DESCRIPTION
## Sammanfattning

Sista vågen av admin-migreringen (#87–#90 mergade). Attest är i aktiv drift och rörs därför minimalt — resten är konvergens och verifiering.

- **Attest + rättelsemodalen — endast putsning enligt planens spärr**: de handskrivna footerknapparna → `crm.ghostButton`/`crm.formButton` med **byte-identiska** `disabled`-uttryck och async-handlers; alla döda `border-solid` bort; tillståndsrutorna → delade konstanter. Ingen struktur, inga lokala tokens (`LABEL`/`FIELD`/`STATUS_TONE`), inga kommentarer rörda.
- **Ärenden + Changelog** — fel/tom-literaler → `ADMIN_ERROR_BOX`/`ADMIN_EMPTY_BOX` med `role="alert"`; Ärendens lokala `FilterChip` → delade `AdminFilterChip` (aktivt läge går crm-primary i stället för emerald, konsekvent med övriga nio flikar)
- **`ADMIN_CHECKBOX`** — granskningen visade att receptet bar `rounded border-slate-300` som är **verkningslöst** på en native checkbox: preflight nollar `border-width` och globals.css återställer den bara för knappar. Nu bara storlek + accentfärg, med kommentar om varför. Konsumeras av Behörigheter, Tidkoder och Ärenden
- **`var(--crm-primary, #1a3f26)`** på de fyra kvarvarande ställena

## Dödkodssvep — noll träffar under `app/admin`

Exklusive `trucks/`, `jobtypes/` och `offert-kalkylator/` som ligger utanför scopet (jobtypes renderas i skyddade `app/plannering`):

| Mönster | Träffar |
|---|---|
| `components/ui/Button` | 0 |
| `EmptyState` / `ErrorState` / `LoadingState` | 0 |
| `border-ui-border` | 0 |
| `border-solid` | 0 |
| `✏️` / `🗑️` | 0 |
| `var(--crm-primary)` utan fallback | 0 |
| `rounded-[20px]` / `rounded-[24px]` | 0 |
| `text-[28px]` / `text-[30px]` | 0 |

## Migreringen i sin helhet (#87–#91)

Alla 10 flikar + `users/[id]` på CRM-standarden. Två dialekter → en. Delade recept i `app/admin/components/adminUi.tsx`. Ingen SQL i något steg, inga ändrade API-anrop, flik-id:n, djuplänkar eller localStorage-nycklar.

Buggar som granskningarna fångade på vägen: dialogen som såg avbruten ut men fullföljde raderingen, Blikk-filtret som gömde kort mid-edit, default-fliken som lazy-laddades, dinglande `aria-controls`, tomrutor som visades under laddning, och kategorirader som spillde över grannkortet.

## Verifiering

- `npm run type-check` ✅ · `npm run lint` ✅ · `npm run build` ✅ · `npm test` 1345/1345 ✅

### Manuell QA-checklista
- [ ] **Attest** (viktigast): godkänn period, återöppna (modalen behåller anteckningen vid fel), rättelsemodalen sparar — knapparna ska bara SE annorlunda ut
- [ ] Ärenden: `?tab=arenden&arende=<id>` öppnar modalen; filterchipsen filtrerar som förut
- [ ] Changelog: publicera + spara utkast
- [ ] Behörigheter/Tidkoder: kryssrutorna fungerar som förut (accentfärgen är enda synliga ändringen)

🤖 Generated with [Claude Code](https://claude.com/claude-code)