### PR TITLE
feat(crm): ansvarig säljare på offerten, hela vägen till kunden och ordern

### DIFF
--- a/app/api/crm/quotes/[id]/route.ts
+++ b/app/api/crm/quotes/[id]/route.ts
@@ -1,9 +1,10 @@
 import { cookies } from 'next/headers';
 import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
-import { getCrmQuote, markCrmQuoteWon, updateCrmQuote, type UpdateCrmQuoteInput } from '@/lib/domains/crm/quotes';
+import { getCrmQuote, getCrmQuoteStatus, markCrmQuoteWon, updateCrmQuote, type UpdateCrmQuoteInput } from '@/lib/domains/crm/quotes';
 import { pushQuoteToFortnox } from '@/lib/domains/fortnox/offers';
 import { FortnoxNotConnectedError, friendlyFortnoxMessage } from '@/lib/domains/fortnox/client';
 import {
+  authorizeQuoteAssignee,
   isNoRowsError,
   ok,
   pickProvidedQuoteFields,
@@ -66,13 +67,34 @@ export async function PATCH(req: Request, context: RouteContext) {
       updateInput.currency_code = updateInput.currency_code || 'SEK';
     }
 
+    // Byte av ansvarig säljare kräver crm.admin. Nuvarande värde läses bara när fältet
+    // faktiskt skickas — en oförändrad ansvarig ska inte kosta en extra rundtur, och inte
+    // heller ge 403 för en klient som råkar eka tillbaka det den läste.
+    if (updateInput.assigned_to !== undefined) {
+      const { data: current } = await getCrmQuoteStatus(supabase, context.params.id);
+      if (!current) {
+        // Går offerten inte att läsa finns ingen nuvarande ansvarig att jämföra mot, och inget
+        // att skriva. Släpp fältet och låt den vanliga uppdateringen svara — annars hade en
+        // PATCH mot ett id som inte finns fått "bara en administratör kan ändra ansvarig"
+        // i stället för 404.
+        delete updateInput.assigned_to;
+      } else {
+        const assignee = await authorizeQuoteAssignee(updateInput.assigned_to, current.assigned_to ?? null);
+        if (assignee.response) return assignee.response;
+        if (assignee.assignedTo === undefined) {
+          delete updateInput.assigned_to;
+        } else {
+          updateInput.assigned_to = assignee.assignedTo;
+        }
+      }
+    }
+
     // markCrmQuoteWon / updateCrmQuote return loosely-typed mapped rows; treat as any.
     let data: any;
     if (parsedBody.data.status === 'won') {
       const result = await markCrmQuoteWon(
         supabase,
         context.params.id,
-        crmUser.currentUser.id,
         crmUser.currentUser.id,
         updateInput
       );
@@ -97,8 +119,14 @@ export async function PATCH(req: Request, context: RouteContext) {
     // Only on real content edits (line_items sent) — not quick status flips — and only
     // while the offer is unlocked (no work order has converted it to an order yet).
     // Best-effort: the save always succeeds; a failed sync is surfaced as fortnox_error.
+    //
+    // assigned_to räknas som en innehållsändring: offertens "Vår referens" i Fortnox härleds
+    // ur ansvarig säljare (resolveOurReference i fortnox/offers.ts). Utan den här grenen skulle
+    // ett ansvarigbyte — som inte skickar några rader — lämna kvar den gamla säljarens namn på
+    // det dokument kunden faktiskt får.
     let fortnoxError: string | null = null;
-    const isContentEdit = !!rawBody && typeof rawBody === 'object' && 'line_items' in rawBody;
+    const isContentEdit =
+      !!rawBody && typeof rawBody === 'object' && ('line_items' in rawBody || 'assigned_to' in rawBody);
     if (data && isContentEdit && !data.work_order_id) {
       try {
         await pushQuoteToFortnox(context.params.id);

--- a/app/api/crm/quotes/_lib.ts
+++ b/app/api/crm/quotes/_lib.ts
@@ -1,5 +1,9 @@
 import { z } from 'zod';
 import { ROT_HOUSE_WORK_TYPES } from '@/lib/domains/fortnox/types';
+import { can, getEffectivePermissions } from '@/lib/auth/permissions';
+import { listCrmSellers } from '@/lib/domains/crm/customers';
+import { getSupabaseAdmin } from '@/lib/supabase/server';
+import { routeError } from '../_shared';
 export { ok, routeError, validationError, invalidUuidParam, isNoRowsError, requireCrmUser, requireCrmWriter, requirePermission } from '../_shared';
 
 function normalizeOptionalText(value: unknown) {
@@ -147,6 +151,12 @@ export const createCrmQuoteSchema = z.object({
   quote_date: dateSchema,
   follow_up_date: z.preprocess((value) => normalizeOptionalText(value), dateSchema.nullable()).optional().default(null),
   notes: z.preprocess((value) => normalizeOptionalText(value), z.string().nullable()).optional().default(null),
+  // Ansvarig säljare. Optional UTAN default och INTE nullable: kolumnen är not null, och
+  // `undefined` måste betyda "rör inte" — ett default hade skrivit ett värde vid varje PATCH.
+  // Vem som får sätta fältet avgörs i rutterna (crm.admin); schemat bara släpper igenom det.
+  // MÅSTE stå här: ett fält utanför schemat strippas tyst av Zod vid varje sparning, samma
+  // fälla som is_rot_work, written_off och article_note gick i.
+  assigned_to: z.string().uuid('Ogiltig ansvarig säljare').optional(),
 }).superRefine((value, ctx) => {
   if (!value.prospect_id && !value.customer_id && !value.customer_name) {
     ctx.addIssue({
@@ -226,6 +236,57 @@ export const createCrmQuoteSchema = z.object({
 });
 
 export const updateCrmQuoteSchema = createCrmQuoteSchema;
+
+/**
+ * Avgör om en inkommande `assigned_to` får skrivas.
+ *
+ * Att byta ansvarig säljare kräver crm.admin — chefen som gör offerten åt en säljare. Det
+ * är också vad RLS förutsätter: offertens UPDATE-policy har `auth.uid() = assigned_to` i
+ * BÅDE using och with check, så en säljare som lämnade över sin egen offert hade skrivit sig
+ * själv ur policyn i samma operation och fått 0 rader tillbaka. Admin passerar båda grenarna.
+ *
+ * Oförändrat värde släpps igenom utan behörighetskrav: en klient som ekar tillbaka offertens
+ * nuvarande ansvariga i sin payload ska inte få 403 för att den råkade skicka med fältet.
+ * `undefined` tillbaka betyder "skriv inte kolumnen".
+ *
+ * Mottagaren valideras mot säljarlistan (sales/admin). Utan den kontrollen går det att parkera
+ * en offert på en installatör, som varken kan öppna eller redigera den — offerten blir låst
+ * för alla utom administratörer.
+ */
+export async function authorizeQuoteAssignee(
+  requested: string | undefined,
+  currentAssignee: string | null
+): Promise<{ assignedTo: string | undefined; response: null } | { assignedTo: null; response: Response }> {
+  if (requested === undefined || requested === currentAssignee) {
+    return { assignedTo: undefined, response: null };
+  }
+
+  const permissions = await getEffectivePermissions();
+  if (!can(permissions, 'crm.admin')) {
+    return {
+      assignedTo: null,
+      response: routeError(
+        403,
+        'crm_quote_assignee_forbidden',
+        'Bara en administratör kan ändra ansvarig säljare på en offert.'
+      ),
+    };
+  }
+
+  const sellers = await listCrmSellers(getSupabaseAdmin());
+  if (!sellers.some((seller) => seller.id === requested)) {
+    return {
+      assignedTo: null,
+      response: routeError(
+        422,
+        'crm_quote_assignee_invalid',
+        'Ansvarig säljare måste vara en säljare eller administratör.'
+      ),
+    };
+  }
+
+  return { assignedTo: requested, response: null };
+}
 
 // Persist only fields the client actually sent (shared helper, also used by work orders).
 // Prevents a partial PATCH — status change, "clear articles" save — from wiping untouched

--- a/app/api/crm/quotes/route.ts
+++ b/app/api/crm/quotes/route.ts
@@ -4,6 +4,7 @@ import { createCrmQuote, getCrmQuote, listCrmQuotesWithFilters } from '@/lib/dom
 import { pushQuoteToFortnox } from '@/lib/domains/fortnox/offers';
 import { FortnoxNotConnectedError, friendlyFortnoxMessage } from '@/lib/domains/fortnox/client';
 import {
+  authorizeQuoteAssignee,
   createCrmQuoteSchema,
   listCrmQuotesQuerySchema,
   ok,
@@ -57,11 +58,17 @@ export async function POST(req: Request) {
     const parsedBody = createCrmQuoteSchema.safeParse(await req.json().catch(() => null));
     if (!parsedBody.success) return validationError(parsedBody.error);
 
+    // Ansvarig säljare är normalt den som skapar offerten. En administratör får ange någon
+    // annan direkt vid skapandet — chefen som gör offerten åt en säljare slipper då skapa
+    // den i sitt eget namn och flytta den efteråt.
+    const assignee = await authorizeQuoteAssignee(parsedBody.data.assigned_to, crmUser.currentUser.id);
+    if (assignee.response) return assignee.response;
+
     const supabase = createRouteHandlerClient({ cookies });
     const payload = {
       ...parsedBody.data,
       created_by: crmUser.currentUser.id,
-      assigned_to: crmUser.currentUser.id,
+      assigned_to: assignee.assignedTo ?? crmUser.currentUser.id,
       currency_code: parsedBody.data.currency_code || 'SEK',
     };
 

--- a/app/crm/offerter/QuoteFormClient.tsx
+++ b/app/crm/offerter/QuoteFormClient.tsx
@@ -152,6 +152,7 @@ type QuoteItem = {
   quote_date: string;
   follow_up_date: string | null;
   notes: string | null;
+  assigned_to: string | null;
 };
 
 type QuoteDraft = {
@@ -203,6 +204,9 @@ type QuoteDraft = {
   follow_up_date: string;
   notes: string;
   create_follow_up_task: boolean;
+  // Ansvarig säljare. Tom sträng = "den som skapar offerten" (servern fyller i vid POST).
+  // Bara en administratör kan ändra fältet; för alla andra visas det som text.
+  assigned_to: string;
 };
 
 type EffectiveRow = QuoteLineItem & {
@@ -469,6 +473,7 @@ const initialDraft: QuoteDraft = {
   follow_up_date: '',
   notes: '',
   create_follow_up_task: true,
+  assigned_to: '',
 };
 
 // ─── ArticlePicker ────────────────────────────────────────────────────────────
@@ -1107,7 +1112,7 @@ const DRAFT_RECOVERY_TTL_MS = 24 * 60 * 60 * 1000;
 // Debounce before an edited draft is written to localStorage (a keystroke shouldn't hit storage).
 const DRAFT_AUTOSAVE_DEBOUNCE_MS = 800;
 
-export default function QuoteFormClient({ quoteId }: { quoteId?: string }) {
+export default function QuoteFormClient({ quoteId, canReassign = false }: { quoteId?: string; canReassign?: boolean }) {
   const router = useRouter();
   const searchParams = useSearchParams();
   // Offertformuläret nås både från offertlistan och från säljtavlan. Utan det här landade
@@ -1159,6 +1164,14 @@ export default function QuoteFormClient({ quoteId }: { quoteId?: string }) {
   const [customWorkAddress, setCustomWorkAddress] = useState(false);
   // Separate on-site contact (slutkund) outside the customer card, mirrors the work-address toggle.
   const [customEndContact, setCustomEndContact] = useState(false);
+  // Säljarkatalogen bakom ansvarig-väljaren. Hämtas även utan bytesrätt: läsvyn visar namnet,
+  // och utan listan hade en vanlig säljare bara sett ett uuid.
+  //
+  // sellersLoaded skiljer "listan är hämtad och tom" från "svaret är på väg". Utan den läser en
+  // tom lista som att offertens ansvariga inte finns i katalogen — och då blinkar "inte längre
+  // säljare" förbi vid varje öppning, och blir permanent om hämtningen fallerar.
+  const [sellers, setSellers] = useState<{ id: string; full_name: string | null }[]>([]);
+  const [sellersLoaded, setSellersLoaded] = useState(false);
 
   // Drag-and-drop reordering of the article rows. Pointer for mouse (small distance so a click
   // still selects), Touch with a short press-delay so scrolling the form on mobile isn't hijacked.
@@ -1194,6 +1207,19 @@ export default function QuoteFormClient({ quoteId }: { quoteId?: string }) {
   // JSON snapshot of the current draft — the single comparison key for dirty detection + autosave.
   const draftJson = useMemo(() => JSON.stringify(draft), [draft]);
   useEffect(() => { draftRef.current = draft; }, [draft]);
+
+  useEffect(() => {
+    let active = true;
+    fetch('/api/crm/sellers', { cache: 'no-store' })
+      .then((r) => r.json().catch(() => ({})))
+      .then((json) => {
+        if (!active) return;
+        setSellers(json?.ok ? json.data?.sellers || [] : []);
+        setSellersLoaded(Boolean(json?.ok));
+      })
+      .catch(() => { if (active) setSellers([]); });
+    return () => { active = false; };
+  }, []);
   // Unsaved work: the draft differs from the captured clean baseline (null until it's captured).
   const isDirty = baselineRef.current !== null && draftJson !== baselineRef.current;
 
@@ -1239,7 +1265,15 @@ export default function QuoteFormClient({ quoteId }: { quoteId?: string }) {
     // Backfill any fields absent from an older-shaped stash (e.g. saved before `labor_cost` existed)
     // from the initial draft / an empty line item, so every field/Input stays controlled.
     const items = (restored.items ?? []).map((line) => ({ ...createEmptyLineItem(), ...line }));
-    setDraft({ ...initialDraft, ...restored, items: items.length ? items : [createEmptyLineItem()] });
+    setDraft({
+      ...initialDraft,
+      ...restored,
+      items: items.length ? items : [createEmptyLineItem()],
+      // En stash sparad före ansvarig-fältet saknar det, och initialDraft bidrar med tom
+      // sträng — i redigeringsläget finns inget tomt alternativ, så rullgardinen hade fallit
+      // till det första namnet i listan och visat fel ansvarig på en offert man inte rört.
+      assigned_to: restored.assigned_to || loadedQuote?.assigned_to || '',
+    });
     // Måttblocket i den återställda texten är redan insatt — annars lägger automatiken en dubblett.
     adoptExistingMeasurementBlock(items, restored.handoff_notes ?? '');
     setCustomWorkAddress(Boolean(restored.delivery_address));
@@ -1439,6 +1473,10 @@ export default function QuoteFormClient({ quoteId }: { quoteId?: string }) {
           follow_up_date: item.follow_up_date || '',
           notes: item.notes || '',
           create_follow_up_task: false,
+          // Ligger med i loadedDraft och därmed i baslinjen nedan. Sätts den i stället av en
+          // effekt efteråt blir en nyss öppnad offert omedelbart "ändrad", och det river
+          // sönder utkastskyddet — samma fälla som måttblocket gick i (se kommentaren nedan).
+          assigned_to: item.assigned_to || '',
         };
         // Måttblocket sätts in HÄR, före baslinjen — inte av automatik-effekten efteråt.
         //
@@ -1912,6 +1950,10 @@ export default function QuoteFormClient({ quoteId }: { quoteId?: string }) {
       quote_date: draft.quote_date,
       follow_up_date: draft.follow_up_date || null,
       notes: draft.notes,
+      // Skickas BARA av den som får ändra fältet. En vanlig säljare som ekade tillbaka värdet
+      // hade fått rutten att läsa upp offertens nuvarande ansvariga för att jämföra — en extra
+      // rundtur i varje sparning för ett fält som ändå inte fick ändras.
+      ...(canReassign && draft.assigned_to ? { assigned_to: draft.assigned_to } : {}),
     };
   }
 
@@ -3009,6 +3051,48 @@ export default function QuoteFormClient({ quoteId }: { quoteId?: string }) {
               <Field label="Följ upp senast" plain>
                 <DatePicker value={draft.follow_up_date} onChange={(v) => setDraft((d) => ({ ...d, follow_up_date: v }))} placeholder="Inget datum" aria-label="Följ upp senast" />
               </Field>
+
+              {/* Ansvarig säljare. Läsvy för alla, väljare bara för administratörer — se
+                  authorizeQuoteAssignee för varför spärren också måste sitta i rutten.
+                  Fältet visas ÄVEN utan bytesrätt: vem som äger offerten avgör vem som får
+                  redigera den, och den som just fått "du kan bara redigera offerter du är
+                  ansvarig för" ska kunna se vem hen ska fråga. */}
+              {canReassign ? (
+                <Field label="Ansvarig säljare">
+                  <Select
+                    value={draft.assigned_to}
+                    onChange={(e) => setDraft((d) => ({ ...d, assigned_to: e.target.value }))}
+                  >
+                    {!isEditing ? <option value="">Jag själv</option> : null}
+                    {/* Offertens nuvarande ansvariga kan saknas i katalogen — hen har slutat
+                        eller bytt roll (listan är sales/admin). Utan den här raden har
+                        rullgardinen inget alternativ som matchar värdet, och webbläsaren
+                        visar då det FÖRSTA i listan: fel namn, utan att något ändrats. */}
+                    {draft.assigned_to && sellersLoaded && !sellers.some((seller) => seller.id === draft.assigned_to) ? (
+                      <option value={draft.assigned_to}>Nuvarande ansvarig (inte längre säljare)</option>
+                    ) : null}
+                    {/* Medan katalogen är på väg finns inga alternativ alls. Ett värdebärande
+                        alternativ håller rullgardinen på rätt rad i stället för att låta
+                        webbläsaren falla till det första namnet som dyker upp. */}
+                    {draft.assigned_to && !sellersLoaded ? (
+                      <option value={draft.assigned_to}>Laddar…</option>
+                    ) : null}
+                    {sellers.map((seller) => (
+                      <option key={seller.id} value={seller.id}>{seller.full_name || seller.id}</option>
+                    ))}
+                  </Select>
+                  <p className="mt-1.5 text-xs text-slate-500">
+                    Säljaren offerten tillhör. Blir kundansvarig när offerten vinns, och står som
+                    Vår referens på offerten i Fortnox.
+                  </p>
+                </Field>
+              ) : draft.assigned_to && sellersLoaded ? (
+                <Field label="Ansvarig säljare" plain>
+                  <p className="text-sm text-slate-700">
+                    {sellers.find((seller) => seller.id === draft.assigned_to)?.full_name || 'Okänd säljare'}
+                  </p>
+                </Field>
+              ) : null}
             </div>
 
             {/* Divider */}

--- a/app/crm/offerter/[id]/redigera/page.tsx
+++ b/app/crm/offerter/[id]/redigera/page.tsx
@@ -1,13 +1,16 @@
 import { Suspense } from 'react';
 import QuoteFormClient from '../../QuoteFormClient';
+import { canReassignQuote } from '../../quotePermissions';
 
 export const dynamic = 'force-dynamic';
 
 export default async function RedigeraOffertPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
+  const canReassign = await canReassignQuote();
+
   return (
     <Suspense>
-      <QuoteFormClient quoteId={id} />
+      <QuoteFormClient quoteId={id} canReassign={canReassign} />
     </Suspense>
   );
 }

--- a/app/crm/offerter/ny/page.tsx
+++ b/app/crm/offerter/ny/page.tsx
@@ -1,12 +1,15 @@
 import { Suspense } from 'react';
 import QuoteFormClient from '../QuoteFormClient';
+import { canReassignQuote } from '../quotePermissions';
 
 export const dynamic = 'force-dynamic';
 
-export default function NyOffertPage() {
+export default async function NyOffertPage() {
+  const canReassign = await canReassignQuote();
+
   return (
     <Suspense>
-      <QuoteFormClient />
+      <QuoteFormClient canReassign={canReassign} />
     </Suspense>
   );
 }

--- a/app/crm/offerter/quotePermissions.ts
+++ b/app/crm/offerter/quotePermissions.ts
@@ -1,0 +1,22 @@
+import { cookies } from 'next/headers';
+import { createServerComponentClient } from '@supabase/auth-helpers-nextjs';
+
+/**
+ * Får den inloggade byta ansvarig säljare på en offert?
+ *
+ * Behörigheten läses i sidan och inte i klienten: sidan är rätt ställe för åtkomstbeslut, och
+ * en klient som frågar själv hade blinkat till med fel sidopanel medan svaret var på väg.
+ *
+ * `createServerComponentClient` och INTE getEffectivePermissions(): den senare bygger en
+ * route-handler-klient, som försöker skriva cookies vid tokenförnyelse och därför inte hör
+ * hemma i en server-komponent. Samma mönster (och samma skäl) som app/arbetsorder/[id]/page.tsx.
+ *
+ * Ligger i en egen modul och inte i page.tsx: Next.js App Router tillåter bara ett känt
+ * urval exporter ur en sidfil.
+ */
+export async function canReassignQuote(): Promise<boolean> {
+  const supabase = createServerComponentClient({ cookies });
+  const { data: permissions } = await supabase.rpc('effective_permissions');
+  return Array.isArray(permissions)
+    && permissions.some((row) => (typeof row === 'string' ? row : String(row)) === 'crm.admin');
+}

--- a/lib/domains/crm/customers.ts
+++ b/lib/domains/crm/customers.ts
@@ -450,6 +450,57 @@ export async function convertProspectToCustomer(
   return { customerId: updated.id, error: null };
 }
 
+/**
+ * Sätter kundansvarig på en kund — men BARA om fältet är tomt.
+ *
+ * Anropas när en offert markeras vunnen, så att offertens ansvariga säljare också blir
+ * ansvarig för kunden. Fyll-om-tomt och inte skriv-över: en säljare som vinner en enskild
+ * offert hos någon annans etablerade kund ska inte tyst ta över hela kundrelationen (den
+ * styr både kundregistret och vem topplistan räknar). Ett medvetet byte görs i kundformuläret.
+ *
+ * Returnerar `changed` så anroparen kan logga skillnaden mellan "satte den" och "fanns redan".
+ * RLS: crm_customers UPDATE släpper igenom alla med crm.customer.write
+ * (20260629_crm_customers_shared_register.sql), så ingen elevated klient behövs.
+ */
+export async function setAccountManagerIfUnset(
+  supabase: SupabaseClient,
+  customerId: string,
+  sellerId: string
+): Promise<{ changed: boolean; error: string | null }> {
+  const { data: existing, error: readError } = await supabase
+    .from('crm_customers')
+    .select('id, account_manager_id')
+    .eq('id', customerId)
+    .maybeSingle();
+
+  if (readError) return { changed: false, error: readError.message };
+  if (!existing) return { changed: false, error: 'Kunden hittades inte' };
+  if (existing.account_manager_id) return { changed: false, error: null };
+
+  // is null-villkoret är med i UPDATE:en och inte bara i läsningen ovan: två samtidiga
+  // vunna offerter på samma kund skulle annars låta den sista skriva över den första.
+  //
+  // .select('id') är inte kosmetik. En UPDATE som träffar noll rader svarar `error: null` —
+  // en RLS-nekad skrivning ser exakt ut som en lyckad. Utan radräkningen hade anroparens
+  // felloggning aldrig gått igång och kundansvarig tyst uteblivit. Samma felklass som
+  // planeringen tappade segment på.
+  const { data: updated, error: updateError } = await supabase
+    .from('crm_customers')
+    .update({ account_manager_id: sellerId })
+    .eq('id', customerId)
+    .is('account_manager_id', null)
+    .select('id');
+
+  if (updateError) return { changed: false, error: updateError.message };
+  if (!updated || updated.length === 0) {
+    return {
+      changed: false,
+      error: 'Skrivningen träffade noll rader — antingen nekad av RLS eller så hann en annan sparning före.',
+    };
+  }
+  return { changed: true, error: null };
+}
+
 // Säljare som kan vara kundansvarig: profiles med role sales/admin. konsult är
 // READONLY och utesluts. Läs-modell över hela teamet → kör med en elevated klient
 // (profiles-RLS är self-only), samma mönster som reports.ts/ringlists.ts.

--- a/lib/domains/crm/quotes.ts
+++ b/lib/domains/crm/quotes.ts
@@ -1,5 +1,5 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
-import { convertProspectToCustomer } from './customers';
+import { convertProspectToCustomer, setAccountManagerIfUnset } from './customers';
 
 export const crmQuoteSelect = `
   id,
@@ -134,7 +134,11 @@ type CreateCrmQuoteInput = {
   assigned_to: string;
 };
 
-export type UpdateCrmQuoteInput = Omit<CreateCrmQuoteInput, 'created_by' | 'assigned_to'>;
+// created_by är oföränderligt (vem som skrev offerten är ett historiskt faktum), men
+// assigned_to går att ändra: ansvarig säljare kan lämnas över, t.ex. när en chef gör
+// offerten åt en säljare. Vem som FÅR göra det avgörs i rutten (crm.admin) — kolumnen
+// öppnas här bara typmässigt.
+export type UpdateCrmQuoteInput = Omit<CreateCrmQuoteInput, 'created_by'>;
 
 type ListCrmQuotesOptions = {
   search?: string;
@@ -185,7 +189,7 @@ export async function getCrmQuote(supabase: SupabaseClient, id: string) {
 export async function getCrmQuoteStatus(supabase: SupabaseClient, id: string) {
   return supabase
     .from('crm_quotes')
-    .select('id, status, prospect_id')
+    .select('id, status, prospect_id, customer_id, assigned_to')
     .eq('id', id)
     .single();
 }
@@ -201,6 +205,31 @@ export async function updateCrmQuote(supabase: SupabaseClient, id: string, input
 type WonResult = { data: unknown; error: { code: string; message: string } | null };
 
 /**
+ * Låter offertens ansvariga säljare bli kundansvarig när offerten vinns.
+ *
+ * Best-effort med flit: att offerten blir vunnen är den viktiga händelsen, och den ska inte
+ * falla på att kundansvarig inte gick att sätta. Fyller bara ett TOMT fält — se
+ * setAccountManagerIfUnset för varför övertagande inte sker tyst.
+ *
+ * Kundraden: prospekt och kund är samma rad i crm_customers (convertProspectToCustomer flippar
+ * bara customer_stage), så prospect_id duger som kund-id när customer_id ännu inte hunnit sättas.
+ */
+async function applyQuoteAssigneeAsAccountManager(
+  supabase: SupabaseClient,
+  quoteId: string,
+  customerId: string | null,
+  sellerId: string | null
+) {
+  if (!customerId || !sellerId) return;
+  const { error } = await setAccountManagerIfUnset(supabase, customerId, sellerId);
+  if (error) {
+    console.error(
+      `[markCrmQuoteWon] Offert ${quoteId} vanns men kundansvarig kunde inte sättas på kund ${customerId}: ${error}`
+    );
+  }
+}
+
+/**
  * Handles the 'won' status transition for a quote.
  *
  * Separates the orchestration from the HTTP layer: if the quote has a prospect_id
@@ -208,12 +237,13 @@ type WonResult = { data: unknown; error: { code: string; message: string } | nul
  * updated. The two operations are sequential without a true DB transaction — if the
  * quote update fails after conversion, the error message identifies the partial state
  * so it can be reconciled manually.
+ *
+ * Efter en lyckad uppdatering får kunden offertens ansvariga som kundansvarig (om den saknas).
  */
 export async function markCrmQuoteWon(
   supabase: SupabaseClient,
   quoteId: string,
-  assignedTo: string,
-  createdBy: string,
+  actorUserId: string,
   updateInput: Partial<UpdateCrmQuoteInput>
 ): Promise<WonResult> {
   const { data: current, error: fetchError } = await getCrmQuoteStatus(supabase, quoteId);
@@ -221,12 +251,28 @@ export async function markCrmQuoteWon(
     return { data: null, error: { code: 'crm_quote_not_found', message: fetchError?.message ?? 'Offert hittades inte' } };
   }
 
+  // Ansvarig kan bytas i SAMMA sparning som offerten vinns — chefen sätter säljaren och
+  // markerar vunnen på en gång. Den inkommande ändringen måste därför vinna över den sparade
+  // raden, annars ärver kunden den ansvariga som just byttes bort.
+  const effectiveAssignee = updateInput.assigned_to ?? current.assigned_to ?? null;
+
   // Already won, or no prospect to convert — just update
   if (current.status === 'won' || !current.prospect_id) {
     const { data, error } = await updateCrmQuote(supabase, quoteId, updateInput);
     // Preserve PGRST116 (0 rows) so the route can answer 403/404 for a non-owner instead of a
     // raw 500 (RLS scopes the UPDATE to the owner while SELECT is open) — mirrors the plain path.
     if (error) return { data: null, error: { code: error.code === 'PGRST116' ? 'PGRST116' : 'crm_quote_update_failed', message: error.message } };
+    // Bara vid ÖVERGÅNGEN till vunnen, inte vid varje sparning av en redan vunnen offert.
+    // Att medvetet sätta kundansvarig till "— Ingen —" på kundkortet är ett uttryckt val, och
+    // en refill vid nästa beröring av offerten hade tagit tillbaka det utan att någon bad om det.
+    if (current.status !== 'won') {
+      await applyQuoteAssigneeAsAccountManager(
+        supabase,
+        quoteId,
+        current.customer_id ?? current.prospect_id ?? null,
+        effectiveAssignee
+      );
+    }
     return { data, error: null };
   }
 
@@ -234,8 +280,8 @@ export async function markCrmQuoteWon(
   const { customerId, error: conversionError } = await convertProspectToCustomer(
     supabase,
     current.prospect_id,
-    assignedTo,
-    createdBy
+    actorUserId,
+    actorUserId
   );
 
   if (conversionError || !customerId) {
@@ -258,6 +304,8 @@ export async function markCrmQuoteWon(
       },
     };
   }
+
+  await applyQuoteAssigneeAsAccountManager(supabase, quoteId, customerId, effectiveAssignee);
 
   return { data, error: null };
 }

--- a/lib/domains/crm/work-orders.ts
+++ b/lib/domains/crm/work-orders.ts
@@ -1,4 +1,5 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
+import { getSupabaseAdmin } from '@/lib/supabase/server';
 import { crmQuoteSelect } from './quotes';
 import { resolveCrmContact, type CrmContactSource } from './contacts';
 import { computePricing, type PricingLineItem } from './pricing';
@@ -377,7 +378,18 @@ export async function createCrmWorkOrderFromQuote(supabase: SupabaseClient, quot
 
   const workOrder = createResult.data;
 
-  const quoteUpdateResult = await supabase
+  // Återlänkningen körs med elevated klient, INTE sessionsklienten. Sedan
+  // 20260817_crm_work_orders_insert_from_won_quote.sql får vilken säljare som helst skapa
+  // ordern på en vunnen offert (så att ett jobb inte står still när säljaren är borta), men
+  // offertens UPDATE-policy är fortfarande ägarscopad — och den ska den vara, annars blir
+  // allas offerter redigerbara för alla. Utan elevationen skulle raden ovan skapas och den här
+  // skrivningen falla: föräldralös order, offert som ser okonverterad ut, och nästa försök
+  // smäller på unikhetsindexet på quote_id.
+  //
+  // Avgränsningen är medveten: fyra kolumner som är systemets bokföring över att
+  // konverteringen skett, inget av användarens innehåll. Behörighetsbeslutet är redan fattat
+  // (crm.workorder.write + vunnen offert) och ordern är redan skapad när vi kommer hit.
+  const quoteUpdateResult = await getSupabaseAdmin()
     .from('crm_quotes')
     .update({
       work_order_id: workOrder.id,

--- a/supabase/sql/20260817_crm_work_orders_insert_from_won_quote.sql
+++ b/supabase/sql/20260817_crm_work_orders_insert_from_won_quote.sql
@@ -1,0 +1,57 @@
+-- Arbetsorder från VUNNEN offert: låt vilken säljare som helst skapa ordern, även när
+-- offerten är någon annans.
+--
+-- Bakgrund. Ordern ärver offertens säljare (`assigned_to: quote.assigned_to`, se
+-- createCrmWorkOrderFromQuote) så att offert → order → Fortnox "Vår referens" → topplistan
+-- pekar på samma person hela vägen. Den gamla INSERT-policyn krävde samtidigt
+-- `assigned_to = auth.uid()`, vilket gjorde de två kraven oförenliga: säljare B som tryckte
+-- "Skapa arbetsorder" på säljare A:s vunna offert blockerades av RLS och fick en rå 500:a.
+-- Är A sjukskriven stod ordern still tills en administratör hann göra den.
+--
+-- Ändringen. `assigned_to = auth.uid()` blir en av två grenar i stället för ett ovillkorligt
+-- krav. Den andra grenen släpper igenom en order åt någon annan BARA när:
+--   * ordern kommer från en offert (quote_id is not null),
+--   * den offerten är vunnen, och
+--   * ordern hamnar på exakt den offertens säljare.
+-- Ingen kan alltså lägga en order på en godtycklig kollega — bara följa en vunnen offert dit
+-- den redan pekar. `created_by = auth.uid()` och `crm.workorder.write` står kvar orörda.
+--
+-- Standalone-ordrar (quote_id null, 20260607_crm_work_orders_standalone.sql) matchar aldrig
+-- exists-grenen och lyder därför fortfarande under `assigned_to = auth.uid()`. Oförändrat.
+--
+-- ⚠️ KÖR INTE FÖRE KODEN. Orderskapandet är två steg: raden skapas här, sedan skrivs
+-- work_order_id tillbaka på offerten. Återlänkningen låg på sessionsklienten och stoppades av
+-- offertens UPDATE-policy (assigned_to eller crm.admin) — idag onåbart eftersom INSERT:en faller
+-- först. Öppnas INSERT:en medan återlänkningen fortfarande är sessionsscopad skapas ordern men
+-- länkas aldrig: föräldralös order, offert som ser okonverterad ut, och nästa försök smäller på
+-- unikhetsindexet på quote_id. Koden som flyttar återlänkningen till en elevated klient måste
+-- vara ute först (eller i samma deploy).
+--
+-- Idempotent.
+
+drop policy if exists crm_work_orders_insert_sales_or_admin on public.crm_work_orders;
+create policy crm_work_orders_insert_sales_or_admin
+  on public.crm_work_orders
+  for insert
+  to authenticated
+  with check (
+    created_by = auth.uid()
+    and public.has_permission('crm.workorder.write')
+    and (
+      assigned_to = auth.uid()
+      or exists (
+        select 1 from public.crm_quotes q
+        where q.id = crm_work_orders.quote_id
+          and q.status = 'won'
+          -- Kvalificeringen är INTE kosmetisk: oskrivet binder `assigned_to` till q:s egen
+          -- kolumn (inre scope vinner) och villkoret blir q.assigned_to = q.assigned_to — en
+          -- tautologi som hade släppt igenom en order åt vem som helst.
+          and q.assigned_to = crm_work_orders.assigned_to
+      )
+    )
+  );
+
+-- Not: exists-satsen läser crm_quotes som den anropande användaren, alltså genom offertens
+-- egen SELECT-policy (`assigned_to = auth.uid() or crm.offer.read`). Varje roll som har
+-- crm.workorder.write har också crm.offer.read i rollpaketet (20260608_permissions_model.sql),
+-- så uppslaget är aldrig blint. Ingen security definer behövs.

--- a/tests/crm/customers.domain.test.ts
+++ b/tests/crm/customers.domain.test.ts
@@ -6,6 +6,7 @@ import {
   getCrmCustomer,
   updateCrmCustomer,
   convertProspectToCustomer,
+  setAccountManagerIfUnset,
   getCrmCustomerDisplayName,
   privateCustomerContactName,
   createCrmCustomerContact,
@@ -383,5 +384,103 @@ describe('convertProspectToCustomer', () => {
     const result = await convertProspectToCustomer(sb as any, 'c1', 'u1', 'u1');
 
     expect(result.error).toBe('db error');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// setAccountManagerIfUnset
+//
+// Anropas när en offert vinns, så att offertens ansvariga säljare också blir kundansvarig.
+// makeSupabaseMock duger inte här: kedjan använder .is() för is-null-villkoret, och den
+// metoden finns inte i hjälparen.
+// ---------------------------------------------------------------------------
+
+function makeAccountManagerMock(
+  customer: Record<string, unknown> | null,
+  updateError: { message: string } | null = null,
+  updatedRows: { id: string }[] = [{ id: 'c1' }],
+) {
+  const captured: { update: Record<string, unknown> | null; isFilter: [string, unknown] | null } = {
+    update: null,
+    isFilter: null,
+  };
+
+  const supabase: any = {
+    from: vi.fn(() => {
+      const builder: any = {
+        select: vi.fn(() => builder),
+        eq: vi.fn(() => builder),
+        maybeSingle: vi.fn(() => Promise.resolve({ data: customer, error: null })),
+        update: vi.fn((payload: Record<string, unknown>) => { captured.update = payload; return builder; }),
+        is: vi.fn((column: string, value: unknown) => {
+          captured.isFilter = [column, value];
+          // .select('id') efter is-filtret: skrivningen räknar rader, eftersom en UPDATE som
+          // träffar noll rader svarar error: null och annars ser lyckad ut.
+          return { select: vi.fn(() => Promise.resolve({ data: updatedRows, error: updateError })) };
+        }),
+      };
+      return builder;
+    }),
+  };
+
+  return { supabase, captured };
+}
+
+describe('setAccountManagerIfUnset', () => {
+  it('sätter kundansvarig när fältet är tomt', async () => {
+    const { supabase, captured } = makeAccountManagerMock({ id: 'c1', account_manager_id: null });
+
+    const result = await setAccountManagerIfUnset(supabase, 'c1', 'saljare-1');
+
+    expect(result).toEqual({ changed: true, error: null });
+    expect(captured.update).toEqual({ account_manager_id: 'saljare-1' });
+  });
+
+  // Kärnregeln: en säljare som vinner EN offert hos någon annans etablerade kund ska inte
+  // tyst ta över kundrelationen. Ett medvetet byte görs i kundformuläret.
+  it('rör inte en kund som redan har en kundansvarig', async () => {
+    const { supabase, captured } = makeAccountManagerMock({ id: 'c1', account_manager_id: 'nagon-annan' });
+
+    const result = await setAccountManagerIfUnset(supabase, 'c1', 'saljare-1');
+
+    expect(result).toEqual({ changed: false, error: null });
+    expect(captured.update).toBeNull();
+  });
+
+  // is-null-villkoret måste ligga i SKRIVNINGEN och inte bara i läsningen ovan: två offerter
+  // som vinns samtidigt på samma kund skulle annars låta den sista skriva över den första.
+  it('bär is-null-villkoret i själva uppdateringen', async () => {
+    const { supabase, captured } = makeAccountManagerMock({ id: 'c1', account_manager_id: null });
+
+    await setAccountManagerIfUnset(supabase, 'c1', 'saljare-1');
+
+    expect(captured.isFilter).toEqual(['account_manager_id', null]);
+  });
+
+  it('rapporterar fel från skrivningen', async () => {
+    const { supabase } = makeAccountManagerMock({ id: 'c1', account_manager_id: null }, { message: 'RLS' });
+
+    expect(await setAccountManagerIfUnset(supabase, 'c1', 'saljare-1')).toEqual({ changed: false, error: 'RLS' });
+  });
+
+  // En UPDATE som träffar noll rader svarar `error: null` — en RLS-nekad skrivning ser exakt
+  // ut som en lyckad. Utan radräkningen rapporteras "satt" fast ingenting skrevs, och
+  // anroparens felloggning går aldrig igång. Samma felklass som planeringen tappade segment på.
+  it('rapporterar noll skrivna rader som ett fel, inte som en lyckad skrivning', async () => {
+    const { supabase } = makeAccountManagerMock({ id: 'c1', account_manager_id: null }, null, []);
+
+    const result = await setAccountManagerIfUnset(supabase, 'c1', 'saljare-1');
+
+    expect(result.changed).toBe(false);
+    expect(result.error).toMatch(/noll rader/);
+  });
+
+  it('rapporterar när kunden inte finns', async () => {
+    const { supabase } = makeAccountManagerMock(null);
+
+    expect(await setAccountManagerIfUnset(supabase, 'saknas', 'saljare-1')).toEqual({
+      changed: false,
+      error: 'Kunden hittades inte',
+    });
   });
 });

--- a/tests/crm/quotes.domain.test.ts
+++ b/tests/crm/quotes.domain.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Domänlagret kring markCrmQuoteWon: att offertens ansvariga säljare också blir kundansvarig
+// när offerten vinns. Konverteringen och kundskrivningen mockas — det som testas här är
+// ORKESTRERINGEN, alltså vilken kund och vilken säljare som skickas vidare.
+vi.mock('@/lib/domains/crm/customers', () => ({
+  convertProspectToCustomer: vi.fn(),
+  setAccountManagerIfUnset: vi.fn(),
+}));
+
+import { markCrmQuoteWon } from '@/lib/domains/crm/quotes';
+import { convertProspectToCustomer, setAccountManagerIfUnset } from '@/lib/domains/crm/customers';
+
+const mockConvert = vi.mocked(convertProspectToCustomer);
+const mockSetAccountManager = vi.mocked(setAccountManagerIfUnset);
+
+const SALJARE = 'saljare-1';
+const CHEFEN = 'chef-1';
+const KUND = 'kund-1';
+const PROSPEKT = 'prospekt-1';
+
+/**
+ * markCrmQuoteWon rör crm_quotes två gånger: en select (getCrmQuoteStatus) och en update
+ * (updateCrmQuote). Builder som svarar olika beroende på operation.
+ */
+function makeSupabase(quote: Record<string, unknown>, updateError: { code?: string; message: string } | null = null) {
+  return {
+    from() {
+      const state: { op: 'select' | 'update' } = { op: 'select' };
+      const builder: any = {
+        select: vi.fn(() => builder),
+        eq: vi.fn(() => builder),
+        update: vi.fn(() => { state.op = 'update'; return builder; }),
+        single: vi.fn(() => (state.op === 'select'
+          ? Promise.resolve({ data: quote, error: null })
+          : Promise.resolve({ data: updateError ? null : { id: quote.id, status: 'won' }, error: updateError }))),
+      };
+      return builder;
+    },
+  } as any;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockSetAccountManager.mockResolvedValue({ changed: true, error: null });
+});
+
+describe('markCrmQuoteWon — offertens ansvariga blir kundansvarig', () => {
+  it('sätter kundansvarig på den befintliga kunden när offerten redan pekar på en', async () => {
+    const supabase = makeSupabase({ id: 'q1', status: 'sent', prospect_id: null, customer_id: KUND, assigned_to: SALJARE });
+
+    const result = await markCrmQuoteWon(supabase, 'q1', CHEFEN, { status: 'won' } as any);
+
+    expect(result.error).toBeNull();
+    expect(mockSetAccountManager).toHaveBeenCalledWith(expect.anything(), KUND, SALJARE);
+  });
+
+  it('sätter kundansvarig på den nykonverterade kunden', async () => {
+    mockConvert.mockResolvedValue({ customerId: KUND, error: null });
+    const supabase = makeSupabase({ id: 'q1', status: 'sent', prospect_id: PROSPEKT, customer_id: null, assigned_to: SALJARE });
+
+    const result = await markCrmQuoteWon(supabase, 'q1', CHEFEN, { status: 'won' } as any);
+
+    expect(result.error).toBeNull();
+    expect(mockConvert).toHaveBeenCalled();
+    expect(mockSetAccountManager).toHaveBeenCalledWith(expect.anything(), KUND, SALJARE);
+  });
+
+  // Kärnfallet: chefen sätter ansvarig säljare OCH markerar vunnen i samma sparning. Läser
+  // koden bara den lagrade raden får kunden den ansvariga som just byttes bort.
+  it('använder den ansvariga som byts i samma sparning, inte den sparade', async () => {
+    const supabase = makeSupabase({ id: 'q1', status: 'sent', prospect_id: null, customer_id: KUND, assigned_to: CHEFEN });
+
+    await markCrmQuoteWon(supabase, 'q1', CHEFEN, { status: 'won', assigned_to: SALJARE } as any);
+
+    expect(mockSetAccountManager).toHaveBeenCalledWith(expect.anything(), KUND, SALJARE);
+  });
+
+  // Prospekt och kund är samma rad i crm_customers — prospect_id duger som kund-id innan
+  // customer_id hunnit sättas.
+  it('faller tillbaka på prospect_id när customer_id saknas', async () => {
+    const supabase = makeSupabase({ id: 'q1', status: 'sent', prospect_id: PROSPEKT, customer_id: null, assigned_to: SALJARE });
+    mockConvert.mockResolvedValue({ customerId: PROSPEKT, error: null });
+
+    await markCrmQuoteWon(supabase, 'q1', CHEFEN, { status: 'won' } as any);
+
+    expect(mockSetAccountManager).toHaveBeenCalledWith(expect.anything(), PROSPEKT, SALJARE);
+  });
+
+  it('rör ingen kund när offerten varken har prospekt eller kund', async () => {
+    const supabase = makeSupabase({ id: 'q1', status: 'sent', prospect_id: null, customer_id: null, assigned_to: SALJARE });
+
+    await markCrmQuoteWon(supabase, 'q1', CHEFEN, { status: 'won' } as any);
+
+    expect(mockSetAccountManager).not.toHaveBeenCalled();
+  });
+
+  // Bara vid ÖVERGÅNGEN. Att sätta kundansvarig till "— Ingen —" på kundkortet är ett uttryckt
+  // val — en refill vid nästa sparning av en redan vunnen offert hade tagit tillbaka det.
+  it('rör inte kundansvarig när offerten redan var vunnen', async () => {
+    const supabase = makeSupabase({ id: 'q1', status: 'won', prospect_id: null, customer_id: KUND, assigned_to: SALJARE });
+
+    const result = await markCrmQuoteWon(supabase, 'q1', CHEFEN, { status: 'won', notes: 'rättstavning' } as any);
+
+    expect(result.error).toBeNull();
+    expect(mockSetAccountManager).not.toHaveBeenCalled();
+  });
+
+  // Att offerten blir vunnen är den viktiga händelsen. Den får inte falla på att kundansvarig
+  // inte gick att sätta — kunden går att rätta i efterhand, en tappad vinstmarkering syns inte.
+  it('låter sparningen lyckas även när kundansvarig inte kunde sättas', async () => {
+    mockSetAccountManager.mockResolvedValue({ changed: false, error: 'RLS' });
+    const supabase = makeSupabase({ id: 'q1', status: 'sent', prospect_id: null, customer_id: KUND, assigned_to: SALJARE });
+
+    const result = await markCrmQuoteWon(supabase, 'q1', CHEFEN, { status: 'won' } as any);
+
+    expect(result.error).toBeNull();
+    expect(result.data).not.toBeNull();
+  });
+
+  // 0 rader = RLS nekade (offerten är någon annans). Koden måste behålla PGRST116 så rutten
+  // kan svara 403/404 i stället för en rå 500.
+  it('behåller PGRST116 så rutten kan skilja "inte din" från "borta"', async () => {
+    const supabase = makeSupabase(
+      { id: 'q1', status: 'won', prospect_id: null, customer_id: KUND, assigned_to: SALJARE },
+      { code: 'PGRST116', message: 'no rows' },
+    );
+
+    const result = await markCrmQuoteWon(supabase, 'q1', CHEFEN, { status: 'won' } as any);
+
+    expect(result.error?.code).toBe('PGRST116');
+    expect(mockSetAccountManager).not.toHaveBeenCalled();
+  });
+});

--- a/tests/crm/quotes.test.ts
+++ b/tests/crm/quotes.test.ts
@@ -11,9 +11,15 @@ vi.mock('@/lib/domains/crm/quotes', () => ({
   listCrmQuotesWithFilters: vi.fn(),
   createCrmQuote: vi.fn(),
   getCrmQuote: vi.fn(),
+  getCrmQuoteStatus: vi.fn(),
   updateCrmQuote: vi.fn(),
   markCrmQuoteWon: vi.fn(),
 }));
+
+// authorizeQuoteAssignee validerar mottagaren mot säljarkatalogen med elevated klient
+// (profiles-RLS är self-only). Mockas här så testet slipper env-beroenden.
+vi.mock('@/lib/domains/crm/customers', () => ({ listCrmSellers: vi.fn() }));
+vi.mock('@/lib/supabase/server', () => ({ getSupabaseAdmin: vi.fn(() => ({})) }));
 
 vi.mock('@supabase/auth-helpers-nextjs', () => ({
   createRouteHandlerClient: vi.fn(() => ({})),
@@ -36,9 +42,11 @@ import {
   listCrmQuotesWithFilters,
   createCrmQuote,
   getCrmQuote,
+  getCrmQuoteStatus,
   updateCrmQuote,
   markCrmQuoteWon,
 } from '@/lib/domains/crm/quotes';
+import { listCrmSellers } from '@/lib/domains/crm/customers';
 import { createCrmQuoteSchema, listCrmQuotesQuerySchema } from '@/app/api/crm/quotes/_lib';
 
 const { GET: collectionGET, POST } = await import('@/app/api/crm/quotes/route');
@@ -50,6 +58,8 @@ const mockCreate = vi.mocked(createCrmQuote);
 const mockGet = vi.mocked(getCrmQuote);
 const mockUpdate = vi.mocked(updateCrmQuote);
 const mockMarkWon = vi.mocked(markCrmQuoteWon);
+const mockQuoteStatus = vi.mocked(getCrmQuoteStatus);
+const mockSellers = vi.mocked(listCrmSellers);
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -553,6 +563,161 @@ describe('PATCH /api/crm/quotes/[id] — status won', () => {
 
     expect(res.status).toBe(500);
     expect((await res.json()).errorDetails.code).toBe('crm_quote_won_failed');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Ansvarig säljare (assigned_to)
+//
+// Chefen gör offerten åt en säljare, men säljaren ska stå som ansvarig: det styr vem som får
+// redigera offerten (RLS), vem som blir kundansvarig när den vinns, vem topplistan räknar och
+// vems namn som hamnar som "Vår referens" på Fortnox-offerten.
+// ---------------------------------------------------------------------------
+
+const ANNAN_SALJARE = '22222222-2222-2222-2222-222222222222';
+// Delade fixturen salesUser har ett läsbart id ('user-sales-1'), inte ett uuid. Schemat kräver
+// uuid — profiles.id ÄR uuid — så de fall som ekar tillbaka det egna id:t behöver en användare
+// med ett riktigt formaterat id för att testa behörigheten och inte valideringen.
+const saljareUuid = { id: '33333333-3333-3333-3333-333333333333', role: 'sales' as const };
+
+describe('assigned_to i offertschemat', () => {
+  // Ett fält utanför schemat strippas TYST av Zod vid varje sparning. Samma felklass som
+  // is_rot_work, written_off och article_note gick i — utan den här vakten hade ansvarig
+  // säljare tappats vid nästa sparning utan ett enda felmeddelande.
+  it('överlever valideringen', () => {
+    const parsed = createCrmQuoteSchema.safeParse({ ...validQuoteBase, assigned_to: ANNAN_SALJARE });
+    expect(parsed.success).toBe(true);
+    expect(parsed.success && parsed.data.assigned_to).toBe(ANNAN_SALJARE);
+  });
+
+  // Optional UTAN default: `undefined` måste betyda "rör inte kolumnen". Ett default hade
+  // skrivit ett värde vid varje PATCH, även när fältet aldrig skickades.
+  it('lämnas undefined när det inte skickas', () => {
+    const parsed = createCrmQuoteSchema.safeParse(validQuoteBase);
+    expect(parsed.success && parsed.data.assigned_to).toBeUndefined();
+  });
+
+  it('avvisar ett värde som inte är ett uuid', () => {
+    expect(createCrmQuoteSchema.safeParse({ ...validQuoteBase, assigned_to: 'anna' }).success).toBe(false);
+  });
+});
+
+describe('POST /api/crm/quotes — ansvarig säljare', () => {
+  it('låter en administratör skapa offerten direkt i säljarens namn', async () => {
+    mockGetUser.mockResolvedValue(adminUser);
+    mockSellers.mockResolvedValue([{ id: ANNAN_SALJARE, full_name: 'Anna', role: 'sales' }]);
+    mockCreate.mockResolvedValue({ data: {}, error: null } as any);
+
+    await POST(req('/api/crm/quotes', {
+      method: 'POST',
+      body: JSON.stringify({ ...validQuoteBase, assigned_to: ANNAN_SALJARE }),
+    }));
+
+    expect(mockCreate).toHaveBeenCalledWith(
+      expect.anything(),
+      // created_by står kvar på den som faktiskt skrev offerten — vem som gjorde jobbet är
+      // ett historiskt faktum, bara ansvaret flyttas.
+      expect.objectContaining({ assigned_to: ANNAN_SALJARE, created_by: adminUser.id })
+    );
+  });
+
+  it('nekar en vanlig säljare att lägga offerten på någon annan', async () => {
+    mockGetUser.mockResolvedValue(salesUser);
+    mockCreate.mockResolvedValue({ data: {}, error: null } as any);
+
+    const res = await POST(req('/api/crm/quotes', {
+      method: 'POST',
+      body: JSON.stringify({ ...validQuoteBase, assigned_to: ANNAN_SALJARE }),
+    }));
+
+    expect(res.status).toBe(403);
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  // Ett eko av det egna id:t är ingen behörighetsfråga — det är exakt vad servern hade satt ändå.
+  it('släpper igenom en säljare som anger sig själv', async () => {
+    mockGetUser.mockResolvedValue(saljareUuid);
+    mockCreate.mockResolvedValue({ data: {}, error: null } as any);
+
+    const res = await POST(req('/api/crm/quotes', {
+      method: 'POST',
+      body: JSON.stringify({ ...validQuoteBase, assigned_to: saljareUuid.id }),
+    }));
+
+    expect(res.status).toBe(201);
+    expect(mockCreate).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ assigned_to: saljareUuid.id })
+    );
+    // Säljarkatalogen ska inte ens slås upp för ett oförändrat värde.
+    expect(mockSellers).not.toHaveBeenCalled();
+  });
+
+  // Utan den här kontrollen går det att parkera offerten på en installatör, som varken kan
+  // öppna eller redigera den — offerten blir låst för alla utom administratörer.
+  it('avvisar en mottagare som inte är säljare', async () => {
+    mockGetUser.mockResolvedValue(adminUser);
+    mockSellers.mockResolvedValue([]);
+    mockCreate.mockResolvedValue({ data: {}, error: null } as any);
+
+    const res = await POST(req('/api/crm/quotes', {
+      method: 'POST',
+      body: JSON.stringify({ ...validQuoteBase, assigned_to: ANNAN_SALJARE }),
+    }));
+
+    expect(res.status).toBe(422);
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+});
+
+describe('PATCH /api/crm/quotes/[id] — ansvarig säljare', () => {
+  const ctx = { params: { id: 'q1' } };
+
+  it('låter en administratör flytta ansvaret till säljaren', async () => {
+    mockGetUser.mockResolvedValue(adminUser);
+    mockQuoteStatus.mockResolvedValue({ data: { assigned_to: adminUser.id }, error: null } as any);
+    mockSellers.mockResolvedValue([{ id: ANNAN_SALJARE, full_name: 'Anna', role: 'sales' }]);
+    mockUpdate.mockResolvedValue({ data: { id: 'q1' }, error: null } as any);
+
+    await PATCH(req('/api/crm/quotes/q1', {
+      method: 'PATCH',
+      body: JSON.stringify({ ...validQuoteBase, assigned_to: ANNAN_SALJARE }),
+    }), ctx);
+
+    expect(mockUpdate).toHaveBeenCalledWith(
+      expect.anything(),
+      'q1',
+      expect.objectContaining({ assigned_to: ANNAN_SALJARE })
+    );
+  });
+
+  it('nekar en vanlig säljare att lämna över sin offert', async () => {
+    mockGetUser.mockResolvedValue(salesUser);
+    mockQuoteStatus.mockResolvedValue({ data: { assigned_to: salesUser.id }, error: null } as any);
+
+    const res = await PATCH(req('/api/crm/quotes/q1', {
+      method: 'PATCH',
+      body: JSON.stringify({ ...validQuoteBase, assigned_to: ANNAN_SALJARE }),
+    }), ctx);
+
+    expect(res.status).toBe(403);
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  // En klient som ekar tillbaka offertens nuvarande ansvariga ska inte få 403 — och kolumnen
+  // ska inte skrivas i onödan.
+  it('skriver inte kolumnen när ansvarig är oförändrad', async () => {
+    mockGetUser.mockResolvedValue(saljareUuid);
+    mockQuoteStatus.mockResolvedValue({ data: { assigned_to: saljareUuid.id }, error: null } as any);
+    mockUpdate.mockResolvedValue({ data: { id: 'q1' }, error: null } as any);
+
+    const res = await PATCH(req('/api/crm/quotes/q1', {
+      method: 'PATCH',
+      body: JSON.stringify({ ...validQuoteBase, assigned_to: saljareUuid.id }),
+    }), ctx);
+
+    expect(res.status).toBe(200);
+    expect(mockUpdate.mock.calls[0][2]).not.toHaveProperty('assigned_to');
   });
 });
 

--- a/tests/crm/work-orders.test.ts
+++ b/tests/crm/work-orders.test.ts
@@ -1,42 +1,93 @@
 import { describe, it, expect, vi } from 'vitest';
 import { createCrmWorkOrderFromQuote } from '@/lib/domains/crm/work-orders';
 
+// Återlänkningen (steg 3 nedan) körs med elevated klient, inte sessionsklienten — se
+// kommentaren i work-orders.ts. vi.hoisted: mock-fabriken körs före modulens toppnivå, så
+// hållaren måste finnas innan dess.
+const elevated = vi.hoisted(() => ({ client: null as any }));
+vi.mock('@/lib/supabase/server', () => ({ getSupabaseAdmin: () => elevated.client }));
+
 // ---------------------------------------------------------------------------
 // Supabase-mock
 //
 // createCrmWorkOrderFromQuote gör tre anrop i tur och ordning:
-//   1. crm_quotes   .select().eq().single()           → hämtar offerten
-//   2. crm_work_orders .insert(payload).select().single() → skapar ordern
-//   3. crm_quotes   .update().eq().select().single()   → länkar tillbaka
+//   1. crm_quotes   .select().eq().single()           → hämtar offerten      (session)
+//   2. crm_work_orders .insert(payload).select().single() → skapar ordern    (session)
+//   3. crm_quotes   .update().eq().select().single()   → länkar tillbaka     (elevated)
 // Mocken är en chainable builder per .from(table); .single() löser olika
 // beroende på tabell + operation. insert-payloaden fångas så vi kan asserta
 // fält-mappningen.
+//
+// De två klienterna är SKILDA fakes och `quoteUpdateVia` noterar vilken som fick
+// återlänkningen. Går den på sessionsklienten stoppas den av offertens ägarscopade
+// UPDATE-policy så fort en annan säljare än offertens skapar ordern — då finns ordern men
+// offerten är olänkad, och nästa försök smäller på unikhetsindexet på quote_id.
 // ---------------------------------------------------------------------------
 
 function makeSupabase(quote: Record<string, unknown>) {
-  const captured: { insert: Record<string, any> | null } = { insert: null };
+  const captured: {
+    insert: Record<string, any> | null;
+    quoteUpdateVia: 'session' | 'elevated' | null;
+  } = { insert: null, quoteUpdateVia: null };
 
-  const supabase = {
-    from(table: string) {
-      const state: { op: 'select' | 'insert' | 'update' } = { op: 'select' };
-      const builder: any = {
-        select: vi.fn(() => builder),
-        eq: vi.fn(() => builder),
-        update: vi.fn(() => { state.op = 'update'; return builder; }),
-        insert: vi.fn((payload: Record<string, any>) => { state.op = 'insert'; captured.insert = payload; return builder; }),
-        single: vi.fn(() => {
-          if (table === 'crm_quotes' && state.op === 'select') return Promise.resolve({ data: quote, error: null });
-          if (table === 'crm_work_orders' && state.op === 'insert') return Promise.resolve({ data: { id: 'wo1', order_number: 'AO-TEST' }, error: null });
-          if (table === 'crm_quotes' && state.op === 'update') return Promise.resolve({ data: { id: quote.id }, error: null });
-          return Promise.resolve({ data: null, error: { message: `oväntat anrop: ${table}/${state.op}` } });
-        }),
-      };
-      return builder;
-    },
-  };
+  function makeClient(via: 'session' | 'elevated') {
+    return {
+      from(table: string) {
+        const state: { op: 'select' | 'insert' | 'update' } = { op: 'select' };
+        const builder: any = {
+          select: vi.fn(() => builder),
+          eq: vi.fn(() => builder),
+          update: vi.fn(() => {
+            state.op = 'update';
+            if (table === 'crm_quotes') captured.quoteUpdateVia = via;
+            return builder;
+          }),
+          insert: vi.fn((payload: Record<string, any>) => { state.op = 'insert'; captured.insert = payload; return builder; }),
+          single: vi.fn(() => {
+            if (table === 'crm_quotes' && state.op === 'select') return Promise.resolve({ data: quote, error: null });
+            if (table === 'crm_work_orders' && state.op === 'insert') return Promise.resolve({ data: { id: 'wo1', order_number: 'AO-TEST' }, error: null });
+            if (table === 'crm_quotes' && state.op === 'update') return Promise.resolve({ data: { id: quote.id }, error: null });
+            return Promise.resolve({ data: null, error: { message: `oväntat anrop: ${table}/${state.op}` } });
+          }),
+        };
+        return builder;
+      },
+    };
+  }
+
+  const supabase = makeClient('session');
+  elevated.client = makeClient('elevated');
 
   return { supabase, captured };
 }
+
+describe('createCrmWorkOrderFromQuote — återlänkningen till offerten', () => {
+  // Regressionsvakt för en tyst partiell skrivning. Ordern ärver offertens säljare
+  // (assigned_to), och sedan RLS öppnades för att vilken säljare som helst ska kunna skapa
+  // ordern på en vunnen offert är sessionsklienten inte längre garanterad skrivrätt på just
+  // den offerten. Flyttas den här skrivningen tillbaka till sessionsklienten skapas ordern
+  // men länkas aldrig — offerten ser okonverterad ut och nästa försök smäller på
+  // unikhetsindexet på quote_id.
+  it('skriver work_order_id med elevated klient, inte sessionsklienten', async () => {
+    const { supabase, captured } = makeSupabase(wonQuote({ assigned_to: 'annan-saljare' }));
+
+    const result = await createCrmWorkOrderFromQuote(supabase as any, 'q1', 'user-1');
+
+    expect(result.error).toBeNull();
+    expect(captured.quoteUpdateVia).toBe('elevated');
+  });
+
+  // Kedjan offert → order → Fortnox "Vår referens" → topplistan ska peka på samma person.
+  // Ordern får INTE hamna på den som råkade trycka på knappen.
+  it('lägger ordern på offertens säljare, inte på den som skapar den', async () => {
+    const { supabase, captured } = makeSupabase(wonQuote({ assigned_to: 'annan-saljare' }));
+
+    await createCrmWorkOrderFromQuote(supabase as any, 'q1', 'user-1');
+
+    expect(captured.insert!.assigned_to).toBe('annan-saljare');
+    expect(captured.insert!.created_by).toBe('user-1');
+  });
+});
 
 const MEASUREMENT_BLOCK = 'EKOVILLA\nVägg – 100 m² × 195 mm @ 52 kg/m³ – 73 säck\n\nTotalt: 73 säck';
 


### PR DESCRIPTION
Chefen kan göra offerten åt en säljare utan att stå som ansvarig för den. `crm_quotes.assigned_to` fanns redan och driver säljtavlan, topplistan, rapporteringen och "Vår referens" på Fortnox-offerten — det som saknades var att den gick att sätta.

## ⚠️ Körordning: KODEN FÖRST

Migrationen `supabase/sql/20260817_crm_work_orders_insert_from_won_quote.sql` får **inte** köras före den här koden är live.

Orderskapandet är två steg: raden skapas, sedan skrivs `work_order_id` tillbaka på offerten. Öppnas INSERT:en medan återlänkningen fortfarande är sessionsscopad skapas ordern men länkas aldrig — föräldralös order, offert som ser okonverterad ut, och nästa försök smäller på unikhetsindexet på `quote_id`. Idag är det tillståndet onåbart bara för att INSERT:en faller först.

## Ansvarig säljare på offerten

- `assigned_to` öppnas i `UpdateCrmQuoteInput` och i offertschemat — optional **utan** default, eftersom `undefined` måste betyda "rör inte kolumnen".
- Byte kräver `crm.admin`, kontrollerat på servern i både POST och PATCH. Det är också vad RLS förutsätter: offertens UPDATE-policy har `auth.uid() = assigned_to` i **både** `using` och `with check`, så en säljare som lämnade över sin egen offert hade skrivit sig själv ur policyn i samma operation och fått 0 rader tillbaka.
- Mottagaren valideras mot säljarkatalogen (sales/admin). Utan det går offerten att parkera på en installatör, som varken kan öppna eller redigera den.
- Ett **oförändrat** värde släpps igenom utan behörighetskrav — ett eko är ingen behörighetsfråga.
- Ansvarigbyte räknas som innehållsändring mot Fortnox. Annars hade den gamla säljarens namn stått kvar som Vår referens på det dokument kunden faktiskt får.
- Väljaren visas bara för administratörer; alla andra ser namnet som text, så den som möter "du kan bara redigera offerter du är ansvarig för" vet vem hen ska fråga.

## Kundansvarig följer offerten

- Vid **övergången** till vunnen får kunden offertens ansvariga som kundansvarig — om fältet är tomt. Aldrig övertagande: en säljare som vinner EN offert hos någon annans etablerade kund ska inte tyst ta över kundrelationen.
- Bara vid övergången, inte vid varje sparning av en redan vunnen offert — annars hade ett medvetet "— Ingen —" på kundkortet tagits tillbaka.
- Byts ansvarig i **samma** sparning som offerten vinns vinner den inkommande ändringen; annars ärvde kunden den ansvariga som just byttes bort.
- Noterbart: `convertProspectToCustomer` ignorerar sina två sista argument, så `account_manager_id` fylldes tidigare **aldrig** automatiskt, av någon.

## Arbetsorder när säljaren är borta

- Vilken säljare som helst kan skapa ordern på en vunnen offert. Tidigare blockerade RLS det med en **rå 500** — knappen är bara spärrad på status och befintlig order, inte på ägarskap, så det var nåbart redan idag: ordern ärver offertens säljare, men INSERT-policyn krävde samtidigt `assigned_to = auth.uid()`.
- Den nya policyn släpper igenom en order åt någon annan **bara** från en vunnen offert och **bara** på exakt den offertens säljare. Ingen kan lägga en order på en godtycklig kollega.
- Återlänkningen körs med elevated klient, avgränsat till fyra bokföringskolumner. Alternativet — att vidga offertens UPDATE-policy — hade gjort alla säljares offerter redigerbara för alla.

## Granskningsfynd åtgärdade

Fem fynd, alla verifierade mot koden:

- Kundansvarig fylldes i på nytt vid **varje** sparning av en redan vunnen offert.
- Skrivningen rapporterade framgång på **noll rader** — en RLS-nekad UPDATE svarar `error: null`. Samma felklass som planeringens tyst tappade segment. Nu `.select('id')` med radräkning.
- 403 "bara en administratör…" i stället för 404 när offerten inte gick att läsa.
- Rullgardinen visade fel säljare medan säljarkatalogen var på väg (och permanent om hämtningen fallerade).
- Ett utkast sparat **före** fältet fanns fick tom ansvarig och lät webbläsaren falla till första namnet i listan.

## Verifiering

`npm run type-check` · `npm run lint` · `npm test` (1371 gröna) · `npm run build` — alla gröna.

Nya regressionsvakter: att `assigned_to` överlever Zod (samma fälla som `is_rot_work`, `written_off` och `article_note` gick i), behörighetsgrenarna i POST/PATCH, kundansvarig-kedjan i `markCrmQuoteWon`, noll-rader-skrivningen, och att återlänkningen går via elevated klient.

## Kvar utanför

- Säljare B kan skapa A:s order men inte redigera den efteråt (`crm_work_orders_update_visible` är ägarscopad). Praktiska vägen när A är borta längre är att chefen flyttar ansvaret.
- Arbetsordern har ingen egen ansvarig-väljare.
- Förutsättning i drift: cheferna måste ha `crm.admin` (rollen `admin`, eller ett grant per användare i /admin → Behörigheter) — annars syns ingen väljare.

🤖 Generated with [Claude Code](https://claude.com/claude-code)