### PR TITLE
feat(crm): visa ansvarigs namn i offert- och orderlistan

### DIFF
--- a/app/crm/arbetsorder/WorkOrdersClient.tsx
+++ b/app/crm/arbetsorder/WorkOrdersClient.tsx
@@ -331,7 +331,7 @@ export default function WorkOrdersClient({ currentUserId }: { currentUserId: str
               {workOrders.map((item) => {
                 const overdue = isWorkOrderOverdue(item.desired_installation_date, item.status);
                 const sellerName = item.assigned_to
-                  ? (assigneeNameById.get(item.assigned_to) || item.assignee?.full_name || 'Okänd')
+                  ? (assigneeNameById.get(item.assigned_to) ?? item.assignee?.full_name ?? null)
                   : null;
                 return (
                   <button
@@ -349,7 +349,7 @@ export default function WorkOrdersClient({ currentUserId }: { currentUserId: str
                     {/* Ansvarig-kolumnen är 116px och inte 48px: den rymmer namnet, inte bara en
                         initialbricka man måste hovra på. Utrymmet tas ur identitetskolumnen, som är
                         den flexibla — de två högerkolumnerna har fast innehåll. */}
-                    <div className="grid flex-1 grid-cols-[minmax(0,1fr)_auto] items-start gap-2 px-2.5 py-1.5 sm:grid-cols-[minmax(0,1fr)_116px_140px_128px] lg:grid-cols-[minmax(0,1fr)_150px_140px_128px] sm:items-center sm:gap-3">
+                    <div className="grid flex-1 grid-cols-[minmax(0,1fr)_auto] items-start gap-2 px-2.5 py-1.5 sm:grid-cols-[minmax(0,1fr)_48px_140px_128px] md:grid-cols-[minmax(0,1fr)_116px_140px_128px] lg:grid-cols-[minmax(0,1fr)_150px_140px_128px] sm:items-center sm:gap-3">
                       {/* Number badge + identity + chips */}
                       <div className="flex min-w-0 items-center gap-2">
                         <DocumentNumberBadge label="Order" value={documentRef(item.fortnox_order_number, item.order_number)} />
@@ -381,7 +381,7 @@ export default function WorkOrdersClient({ currentUserId }: { currentUserId: str
                       </div>
 
                       {/* Ansvarig, i en fast slot så den aldrig driver i sidled */}
-                      <RowAssignee name={sellerName} />
+                      <RowAssignee name={sellerName} assigned={Boolean(item.assigned_to)} />
 
                       {/* Date */}
                       <div className="hidden flex-col gap-0.5 sm:flex">

--- a/app/crm/arbetsorder/WorkOrdersClient.tsx
+++ b/app/crm/arbetsorder/WorkOrdersClient.tsx
@@ -8,6 +8,7 @@ import { crm, syncStatusLabel, syncStatusClass, workOrderStatusLabel, workOrderS
 import { formatDate, formatCurrency, isWorkOrderOverdue, documentRef } from '@/app/crm/lib/format';
 import AssigneeFilter, { MINE, type AssigneeFilterValue, type AssigneeOption } from '@/app/crm/components/AssigneeFilter';
 import DocumentNumberBadge from '@/app/crm/components/DocumentNumberBadge';
+import { RowAssignee, RowAssigneeChip } from '@/app/crm/components/RowAssignee';
 import CrmModal from '@/app/crm/components/CrmModal';
 import EntityCombobox, { type EntityResult } from '@/app/crm/components/EntityCombobox';
 import { formatPersonalNumber, isValidPersonalNumber, PERSONAL_NUMBER_ERROR } from '@/lib/domains/crm/personalNumber';
@@ -49,13 +50,6 @@ const FILTERS: Array<[WorkOrderFilter, string]> = [
 const PAGE_SIZE = 100;
 const EMPTY_COUNTS: Record<WorkOrderFilter, number> = { all: 0, draft: 0, scheduled: 0, active: 0, completed: 0, invoiced: 0 };
 
-function initialsOf(name: string | null | undefined) {
-  if (!name) return '–';
-  const parts = name.trim().split(/\s+/).filter(Boolean);
-  if (parts.length === 0) return '–';
-  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
-  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
-}
 
 
 export default function WorkOrdersClient({ currentUserId }: { currentUserId: string | null }) {
@@ -352,7 +346,10 @@ export default function WorkOrdersClient({ currentUserId }: { currentUserId: str
                     {/* Status accent rail */}
                     <span className={cn('w-1.5 shrink-0', workOrderStatusAccent[item.status])} aria-hidden="true" />
 
-                    <div className="grid flex-1 grid-cols-[minmax(0,1fr)_auto] items-start gap-2 px-2.5 py-1.5 sm:grid-cols-[minmax(0,1fr)_48px_140px_128px] sm:items-center sm:gap-3">
+                    {/* Ansvarig-kolumnen är 116px och inte 48px: den rymmer namnet, inte bara en
+                        initialbricka man måste hovra på. Utrymmet tas ur identitetskolumnen, som är
+                        den flexibla — de två högerkolumnerna har fast innehåll. */}
+                    <div className="grid flex-1 grid-cols-[minmax(0,1fr)_auto] items-start gap-2 px-2.5 py-1.5 sm:grid-cols-[minmax(0,1fr)_116px_140px_128px] lg:grid-cols-[minmax(0,1fr)_150px_140px_128px] sm:items-center sm:gap-3">
                       {/* Number badge + identity + chips */}
                       <div className="flex min-w-0 items-center gap-2">
                         <DocumentNumberBadge label="Order" value={documentRef(item.fortnox_order_number, item.order_number)} />
@@ -377,22 +374,14 @@ export default function WorkOrdersClient({ currentUserId }: { currentUserId: str
                             <span className={cn('inline-flex items-center rounded-md border px-1.5 py-0.5 text-[10px] font-semibold', syncStatusClass[item.fortnox_order_sync_status])}>
                               Fortnox: {syncStatusLabel[item.fortnox_order_sync_status]}
                             </span>
+                            {/* Ansvarig på mobil, där kolumnen till höger inte får plats */}
+                            <RowAssigneeChip name={sellerName} />
                           </div>
                         </div>
                       </div>
 
-                      {/* Responsible installer/seller — avatar pill only, in a fixed slot so it never drifts */}
-                      <div className="hidden items-center justify-center sm:flex">
-                        <span
-                          title={sellerName ?? 'Ej tilldelad'}
-                          className={cn(
-                            'flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-[10px] font-bold',
-                            sellerName ? 'bg-emerald-100 text-emerald-800' : 'bg-slate-100 text-slate-400',
-                          )}
-                        >
-                          {initialsOf(sellerName)}
-                        </span>
-                      </div>
+                      {/* Ansvarig, i en fast slot så den aldrig driver i sidled */}
+                      <RowAssignee name={sellerName} />
 
                       {/* Date */}
                       <div className="hidden flex-col gap-0.5 sm:flex">

--- a/app/crm/components/RowAssignee.tsx
+++ b/app/crm/components/RowAssignee.tsx
@@ -10,9 +10,20 @@ import { cn } from '@/lib/shared/cn';
  * Här står namnet skrivet. Brickan är kvar som visuellt ankare och som signalen för tilldelad
  * kontra otilldelad; det är den enda färgkodningen i cellen.
  *
+ * Tre tillstånd, för de är tre olika saker:
+ *   • otilldelad            → "Ej tilldelad"
+ *   • tilldelad, namn känt  → namnet
+ *   • tilldelad, namn okänt → dämpat streck
+ *
+ * Det tredje är inte en petitess. Namnen slås upp mot en katalog som hämtas i en EGEN request,
+ * så det finns alltid ett fönster där raderna är på plats men katalogen inte är det — och den
+ * kan dessutom fallera helt, eller sakna någon vars roll ändrats. Att då skriva "Okänd" vore
+ * att påstå något falskt om en rad som är korrekt tilldelad, och att skriva "Ej tilldelad" vore
+ * ännu värre. Strecket säger bara att vi inte vet ännu, och löses upp när katalogen landar.
+ *
  * Två renderingar, ömsesidigt uteslutande via brytpunkten: `RowAssignee` i den egna
- * rutnätskolumnen från `sm` och uppåt, `RowAssigneeChip` i radens chip-rad därunder. Samma
- * uppgift, olika plats — aldrig båda samtidigt.
+ * rutnätskolumnen, `RowAssigneeChip` i radens chip-rad därunder. Samma uppgift, olika plats —
+ * aldrig båda samtidigt.
  */
 
 export function initialsOf(name: string | null | undefined) {
@@ -23,11 +34,12 @@ export function initialsOf(name: string | null | undefined) {
   return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
 }
 
-export function RowAssignee({ name }: { name: string | null }) {
+export function RowAssignee({ name, assigned }: { name: string | null; assigned: boolean }) {
+  const label = name ?? (assigned ? '—' : 'Ej tilldelad');
+  const title = name ?? (assigned ? 'Ansvarig kunde inte hämtas' : 'Ej tilldelad');
+
   return (
-    // title bär hela namnet: kolumnen rymmer de flesta, men ett långt namn kapas och då ska
-    // hela finnas kvar att nå.
-    <div className="hidden min-w-0 items-center gap-1.5 sm:flex" title={name ?? 'Ej tilldelad'}>
+    <div className="hidden min-w-0 items-center gap-1.5 sm:flex" title={title}>
       <span
         className={cn(
           'flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-[10px] font-bold',
@@ -37,16 +49,24 @@ export function RowAssignee({ name }: { name: string | null }) {
       >
         {initialsOf(name)}
       </span>
-      <span className={cn('truncate text-[11px] font-medium', name ? 'text-slate-600' : 'text-slate-400')}>
-        {name ?? 'Ej tilldelad'}
+      {/* Namnet först från md. Mellan sm och md är raden som trängst — identitetskolumnen är den
+          som får betala för varje pixel här — så där står brickan ensam kvar precis som förut,
+          och title bär namnet. */}
+      <span
+        className={cn(
+          'hidden truncate text-[11px] font-medium md:inline',
+          name ? 'text-slate-600' : 'text-slate-400',
+        )}
+      >
+        {label}
       </span>
     </div>
   );
 }
 
 /**
- * Mobilvarianten. Renderas bara för en tilldelad rad — "Ej tilldelad" är en tom uppgift som inte
- * är värd en chip på den trängsta ytan, och kolumnen ovan säger det redan där det finns plats.
+ * Mobilvarianten. Renderas bara när namnet är känt: en chip som säger "—" är brus, och kolumnen
+ * ovan täcker de andra två tillstånden där det finns plats att förklara dem.
  *
  * Rund bricka + namn skiljer den från radens övriga chips, som alla är platta statusetiketter.
  */

--- a/app/crm/components/RowAssignee.tsx
+++ b/app/crm/components/RowAssignee.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import { cn } from '@/lib/shared/cn';
+
+/**
+ * Ansvarig person på en rad i offert- och orderlistan.
+ *
+ * Listorna visade tidigare bara en initialbricka med namnet i `title` — man fick hovra för att
+ * få svar på en fråga raden redan hade plats att besvara, och på mobil var kolumnen helt dold.
+ * Här står namnet skrivet. Brickan är kvar som visuellt ankare och som signalen för tilldelad
+ * kontra otilldelad; det är den enda färgkodningen i cellen.
+ *
+ * Två renderingar, ömsesidigt uteslutande via brytpunkten: `RowAssignee` i den egna
+ * rutnätskolumnen från `sm` och uppåt, `RowAssigneeChip` i radens chip-rad därunder. Samma
+ * uppgift, olika plats — aldrig båda samtidigt.
+ */
+
+export function initialsOf(name: string | null | undefined) {
+  if (!name) return '–';
+  const parts = name.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return '–';
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+}
+
+export function RowAssignee({ name }: { name: string | null }) {
+  return (
+    // title bär hela namnet: kolumnen rymmer de flesta, men ett långt namn kapas och då ska
+    // hela finnas kvar att nå.
+    <div className="hidden min-w-0 items-center gap-1.5 sm:flex" title={name ?? 'Ej tilldelad'}>
+      <span
+        className={cn(
+          'flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-[10px] font-bold',
+          name ? 'bg-emerald-100 text-emerald-800' : 'bg-slate-100 text-slate-400',
+        )}
+        aria-hidden="true"
+      >
+        {initialsOf(name)}
+      </span>
+      <span className={cn('truncate text-[11px] font-medium', name ? 'text-slate-600' : 'text-slate-400')}>
+        {name ?? 'Ej tilldelad'}
+      </span>
+    </div>
+  );
+}
+
+/**
+ * Mobilvarianten. Renderas bara för en tilldelad rad — "Ej tilldelad" är en tom uppgift som inte
+ * är värd en chip på den trängsta ytan, och kolumnen ovan säger det redan där det finns plats.
+ *
+ * Rund bricka + namn skiljer den från radens övriga chips, som alla är platta statusetiketter.
+ */
+export function RowAssigneeChip({ name }: { name: string | null }) {
+  if (!name) return null;
+  return (
+    <span className="inline-flex items-center gap-1 rounded-md border border-slate-200 bg-white px-1.5 py-0.5 text-[10px] font-medium text-slate-600 sm:hidden">
+      <span
+        className="flex h-3.5 w-3.5 items-center justify-center rounded-full bg-emerald-100 text-[8px] font-bold text-emerald-800"
+        aria-hidden="true"
+      >
+        {initialsOf(name)}
+      </span>
+      {name}
+    </span>
+  );
+}

--- a/app/crm/offerter/QuotesClient.tsx
+++ b/app/crm/offerter/QuotesClient.tsx
@@ -330,7 +330,10 @@ export default function QuotesClient({ currentUserId }: { currentUserId: string 
             {sortedVisibleQuotes.map((item) => {
               const overdue = isQuoteOverdue(item);
               const statusMeta = quoteStatusMeta[item.status];
-              const sellerName = item.assigned_to ? (assigneeNameById.get(item.assigned_to) || 'Okänd') : null;
+              // Inget 'Okänd'-fallback: katalogen hämtas i en egen request, så ett tomt uppslag
+              // betyder oftast "inte hämtad ännu" och inte "okänd person". RowAssignee skiljer
+              // de två tillstånden åt.
+              const sellerName = item.assigned_to ? (assigneeNameById.get(item.assigned_to) ?? null) : null;
               // Private → show price incl moms; business → show ex moms (with the basis tagged).
               const amountDisplay = quoteAmountDisplay(item.quote_type, resolveQuoteVatBreakdown(item));
 
@@ -350,7 +353,7 @@ export default function QuotesClient({ currentUserId }: { currentUserId: string 
                   {/* Ansvarig-kolumnen är 116px och inte 48px: den rymmer namnet, inte bara en
                       initialbricka man måste hovra på. Utrymmet tas ur identitetskolumnen, som är
                       den flexibla — de två högerkolumnerna har fast innehåll. */}
-                  <div className="grid flex-1 grid-cols-[minmax(0,1fr)_auto] items-start gap-2 px-2.5 py-1.5 sm:grid-cols-[minmax(0,1fr)_116px_140px_128px] lg:grid-cols-[minmax(0,1fr)_150px_140px_128px] sm:items-center sm:gap-3">
+                  <div className="grid flex-1 grid-cols-[minmax(0,1fr)_auto] items-start gap-2 px-2.5 py-1.5 sm:grid-cols-[minmax(0,1fr)_48px_140px_128px] md:grid-cols-[minmax(0,1fr)_116px_140px_128px] lg:grid-cols-[minmax(0,1fr)_150px_140px_128px] sm:items-center sm:gap-3">
                     {/* Number badge + identity + chips */}
                     <div className="flex min-w-0 items-center gap-2">
                       <DocumentNumberBadge label="Offert" value={documentRef(item.fortnox_offer_number, item.quote_number)} />
@@ -376,7 +379,7 @@ export default function QuotesClient({ currentUserId }: { currentUserId: string 
                     </div>
 
                     {/* Ansvarig säljare, i en fast slot så den aldrig driver i sidled */}
-                    <RowAssignee name={sellerName} />
+                    <RowAssignee name={sellerName} assigned={Boolean(item.assigned_to)} />
 
                     {/* Dates */}
                     <div className="hidden flex-col gap-0.5 sm:flex">

--- a/app/crm/offerter/QuotesClient.tsx
+++ b/app/crm/offerter/QuotesClient.tsx
@@ -4,6 +4,7 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import Input from '../../../components/ui/Input';
 import { cn } from '@/lib/shared/cn';
 import AssigneeFilter, { matchesAssignee, type AssigneeFilterValue, type AssigneeOption } from '@/app/crm/components/AssigneeFilter';
+import { RowAssignee, RowAssigneeChip } from '@/app/crm/components/RowAssignee';
 import { documentRef } from '@/app/crm/lib/format';
 import DocumentNumberBadge from '@/app/crm/components/DocumentNumberBadge';
 import { resolveQuoteVatBreakdown, quoteAmountDisplay } from '@/lib/domains/crm/pricing';
@@ -74,15 +75,6 @@ function formatDate(value: string | null | undefined) {
   if (Number.isNaN(date.getTime())) return '–';
   return new Intl.DateTimeFormat('sv-SE', { dateStyle: 'medium' }).format(date);
 }
-
-function initialsOf(name: string | null | undefined) {
-  if (!name) return '–';
-  const parts = name.trim().split(/\s+/).filter(Boolean);
-  if (parts.length === 0) return '–';
-  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
-  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
-}
-
 
 function compareQuotes(a: QuoteItem, b: QuoteItem) {
   const aOverdue = isQuoteOverdue(a);
@@ -355,7 +347,10 @@ export default function QuotesClient({ currentUserId }: { currentUserId: string 
                   {/* Status accent rail */}
                   <span className={cn('w-1.5 shrink-0', statusMeta.accent)} aria-hidden="true" />
 
-                  <div className="grid flex-1 grid-cols-[minmax(0,1fr)_auto] items-start gap-2 px-2.5 py-1.5 sm:grid-cols-[minmax(0,1fr)_48px_140px_128px] sm:items-center sm:gap-3">
+                  {/* Ansvarig-kolumnen är 116px och inte 48px: den rymmer namnet, inte bara en
+                      initialbricka man måste hovra på. Utrymmet tas ur identitetskolumnen, som är
+                      den flexibla — de två högerkolumnerna har fast innehåll. */}
+                  <div className="grid flex-1 grid-cols-[minmax(0,1fr)_auto] items-start gap-2 px-2.5 py-1.5 sm:grid-cols-[minmax(0,1fr)_116px_140px_128px] lg:grid-cols-[minmax(0,1fr)_150px_140px_128px] sm:items-center sm:gap-3">
                     {/* Number badge + identity + chips */}
                     <div className="flex min-w-0 items-center gap-2">
                       <DocumentNumberBadge label="Offert" value={documentRef(item.fortnox_offer_number, item.quote_number)} />
@@ -374,22 +369,14 @@ export default function QuotesClient({ currentUserId }: { currentUserId: string 
                               Order {documentRef(workOrderFortnoxById.get(item.work_order_id) ?? null, item.work_order_number)}
                             </span>
                           ) : null}
+                          {/* Ansvarig på mobil, där kolumnen till höger inte får plats */}
+                          <RowAssigneeChip name={sellerName} />
                         </div>
                       </div>
                     </div>
 
-                    {/* Responsible seller — avatar pill only, in a fixed slot so it never drifts */}
-                    <div className="hidden items-center justify-center sm:flex">
-                      <span
-                        title={sellerName ?? 'Ej tilldelad'}
-                        className={cn(
-                          'flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-[10px] font-bold',
-                          sellerName ? 'bg-emerald-100 text-emerald-800' : 'bg-slate-100 text-slate-400',
-                        )}
-                      >
-                        {initialsOf(sellerName)}
-                      </span>
-                    </div>
+                    {/* Ansvarig säljare, i en fast slot så den aldrig driver i sidled */}
+                    <RowAssignee name={sellerName} />
 
                     {/* Dates */}
                     <div className="hidden flex-col gap-0.5 sm:flex">


### PR DESCRIPTION
Båda listorna hade redan en ansvarig-slot, men den visade bara en initialbricka med namnet i `title`-attributet — man fick hovra för att få svar på en fråga raden hade plats att besvara. Under `sm` var kolumnen dessutom helt dold, så på mobil gick uppgiften inte att nå alls. Samtidigt går det att **filtrera** på ansvarig i båda listorna: informationen fanns, den syntes bara inte.

Ingen SQL.

## Ändringen

- Kolumnen växer från 48px till 116px (`md`) och 150px (`lg`), och visar namnet bredvid brickan. Utrymmet tas ur identitetskolumnen, som är den flexibla — de två högerkolumnerna har fast innehåll.
- **Mellan `sm` och `md` är kolumnen kvar på 48px.** Där är raden som trängst, och de extra pixlarna hade kapat projektnamnet till några tecken och staplat orderlistans fem chips. Brickan står ensam kvar däremellan, precis som förut.
- På mobil visas ansvarig som en chip i radens chip-rad, med rund initialbricka så den läses som en person och inte som ännu en statusetikett. Bara för en rad med känt namn.
- De två renderingarna är ömsesidigt uteslutande via brytpunkten — namnet renderas aldrig två gånger.

`initialsOf` och hela avatar-blocket låg ordagrant duplicerat i de två listorna och skulle ändrats likadant på båda ställena. Utbrutet till `app/crm/components/RowAssignee.tsx`.

## Tre tillstånd, inte två

Namnen slås upp mot en katalog som hämtas i en **egen** request, så det finns alltid ett fönster där raderna är på plats men katalogen inte är det. Det gamla `|| 'Okänd'`-fallbacket slog därför till som en blinkning i normalfallet, permanent om hämtningen fallerar, och permanent för den vars roll lämnat `sales/admin/konsult` (katalogen filtrerar på roll). Det satt där redan — men osynligt i en tvåbokstavsbricka; att skriva ut namnet är vad som gör det till ett fel.

Komponenten skiljer nu på tre saker som faktiskt är tre olika saker:

| Tillstånd | Visas som |
|---|---|
| Otilldelad | grå bricka + "Ej tilldelad" |
| Tilldelad, namn känt | grön bricka + namnet |
| Tilldelad, namn okänt | grå bricka + dämpat streck |

Det sista är inte en petitess: "Okänd" vore falskt om en korrekt tilldelad rad, och "Ej tilldelad" ännu värre.

## Verifiering

`npm run type-check` · `npm run lint` · `npm test` (1371 gröna) · `npm run build` — alla gröna.

Utöver det **renderat och granskat i 1280 / 700 / 390 px med båda radtyperna** (offertlistans två chips och orderlistans fem), via en tillfällig sida på en publik väg som togs bort igen. Det fångade två saker typkontrollen är blind för: att desktop kapade långa namn medan mobilen visade hela, och att bandet 640–768px blev trångt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)