### PR TITLE
feat(crm): lägg upp uppgifter åt andra säljare, med notis

### DIFF
--- a/app/api/crm/tasks/_lib.ts
+++ b/app/api/crm/tasks/_lib.ts
@@ -1,4 +1,8 @@
 import { z } from 'zod';
+import { can, getEffectivePermissions } from '@/lib/auth/permissions';
+import { listCrmSellers } from '@/lib/domains/crm/customers';
+import { getSupabaseAdmin } from '@/lib/supabase/server';
+import { routeError } from '../_shared';
 export { ok, routeError, validationError, requireCrmUser, requireCrmWriter } from '../_shared';
 
 function normalizeOptionalText(value: unknown) {
@@ -17,6 +21,9 @@ export const listCrmTasksQuerySchema = z.object({
   status: statusSchema.optional(),
   prospect_id: z.string().uuid('Ogiltigt prospekt').optional(),
   customer_id: z.string().uuid('Ogiltig kund').optional(),
+  // 'delegated' = uppgifter den inloggade skapat ÅT ANDRA. Egen läsväg och inte ett filter på
+  // den vanliga listan: raderna tillhör mottagaren och ligger utanför anroparens RLS.
+  scope: z.enum(['own', 'delegated']).optional().default('own'),
 });
 
 export const createCrmTaskSchema = z.object({
@@ -31,6 +38,10 @@ export const createCrmTaskSchema = z.object({
   due_date: z.preprocess((value) => normalizeOptionalText(value), dueDateSchema.nullable()).optional().default(null),
   remind_at: z.preprocess((value) => normalizeOptionalText(value), z.string().datetime('Ogiltig påminnelsetid').nullable()).optional().default(null),
   source: z.preprocess((value) => normalizeOptionalText(value), z.string().nullable()).optional().default(null),
+  // Vem uppgiften ska ligga på. Utelämnad = den som skapar den, alltså dagens beteende.
+  // Optional UTAN default, så `undefined` betyder "mig själv" och inte ett skrivet värde.
+  // Att sätta någon annan kräver crm.admin — se authorizeTaskOwner.
+  user_id: z.string().uuid('Ogiltig mottagare').optional(),
 }).refine((data) => (data.related_id ? data.related_type != null : true), {
   message: 'Koppling kräver en typ',
   path: ['related_type'],
@@ -40,4 +51,50 @@ export const createCrmTaskSchema = z.object({
 });
 
 export const updateCrmTaskSchema = createCrmTaskSchema;
+
+/**
+ * Avgör om en uppgift får läggas på någon annan än den som skapar den.
+ *
+ * Att delegera kräver crm.admin — säljchefen lägger upp uppgifter åt sina säljare. Mottagaren
+ * valideras dessutom mot säljarkatalogen (sales/admin): utan den kontrollen går det att parkera
+ * en uppgift på en installatör, som varken når /crm eller ser uppgiftslistan, och uppgiften blir
+ * osynlig för alla utom den som skrev den.
+ *
+ * Returnerar `null` som ägare när uppgiften är till en själv — anroparen använder då sitt eget
+ * id och den vanliga sessionsvägen, precis som förut.
+ */
+export async function authorizeTaskOwner(
+  requested: string | undefined,
+  currentUserId: string
+): Promise<{ ownerId: string | null; response: null } | { ownerId: null; response: Response }> {
+  if (requested === undefined || requested === currentUserId) {
+    return { ownerId: null, response: null };
+  }
+
+  const permissions = await getEffectivePermissions();
+  if (!can(permissions, 'crm.admin')) {
+    return {
+      ownerId: null,
+      response: routeError(
+        403,
+        'crm_task_owner_forbidden',
+        'Bara en administratör kan lägga upp uppgifter åt någon annan.'
+      ),
+    };
+  }
+
+  const sellers = await listCrmSellers(getSupabaseAdmin());
+  if (!sellers.some((seller) => seller.id === requested)) {
+    return {
+      ownerId: null,
+      response: routeError(
+        422,
+        'crm_task_owner_invalid',
+        'Uppgiften kan bara läggas på en säljare eller administratör.'
+      ),
+    };
+  }
+
+  return { ownerId: requested, response: null };
+}
 

--- a/app/api/crm/tasks/route.ts
+++ b/app/api/crm/tasks/route.ts
@@ -1,7 +1,12 @@
 import { cookies } from 'next/headers';
 import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
-import { createCrmTask, listCrmTasks, mapCrmTaskRows } from '@/lib/domains/crm/tasks';
+import { getSupabaseAdmin } from '@/lib/supabase/server';
+import { createCrmTask, listCrmTasks, listCrmTasksDelegatedBy, mapCrmTaskRows } from '@/lib/domains/crm/tasks';
+import { buildCrmTaskAssignedNotification } from '@/lib/domains/notifications/payload';
+import { expandNotificationToRecipients } from '@/lib/domains/notifications/mutations';
+import { deliverNotifications } from '@/lib/domains/notifications/delivery';
 import {
+  authorizeTaskOwner,
   createCrmTaskSchema,
   listCrmTasksQuerySchema,
   ok,
@@ -14,7 +19,7 @@ import {
 export async function GET(req: Request) {
   try {
     const crmUser = await requireCrmUser();
-    if (crmUser.response) return crmUser.response;
+    if (crmUser.response || !crmUser.currentUser) return crmUser.response;
 
     const url = new URL(req.url);
     const parsedQuery = listCrmTasksQuerySchema.safeParse({
@@ -22,9 +27,18 @@ export async function GET(req: Request) {
       status: url.searchParams.get('status') || undefined,
       prospect_id: url.searchParams.get('prospect_id') || undefined,
       customer_id: url.searchParams.get('customer_id') || undefined,
+      scope: url.searchParams.get('scope') || undefined,
     });
 
     if (!parsedQuery.success) return validationError(parsedQuery.error);
+
+    // Uppgifter man delegerat tillhör mottagaren och ligger utanför den egna RLS-vyn. Skaparen
+    // kommer alltid från sessionen, aldrig från frågesträngen — filtret är slutet om anroparen.
+    if (parsedQuery.data.scope === 'delegated') {
+      const { data, error } = await listCrmTasksDelegatedBy(getSupabaseAdmin(), crmUser.currentUser.id);
+      if (error) return routeError(500, 'crm_tasks_delegated_failed', error.message);
+      return ok({ items: mapCrmTaskRows(data as any[] | null | undefined) });
+    }
 
     const supabase = createRouteHandlerClient({ cookies });
     const query = await listCrmTasks(supabase, {
@@ -45,6 +59,39 @@ export async function GET(req: Request) {
   }
 }
 
+/**
+ * Notis till den som fått en uppgift på sig.
+ *
+ * Avsändarens namn slås upp med elevated klient — profiles-RLS är self-only, så en säljare kan
+ * inte läsa chefens namn med sin egen session. Utan namnet vore notisen "du har fått en uppgift"
+ * utan avsändare, vilket är hälften av det man behöver veta.
+ *
+ * deliverNotifications skriver klockraden OCH skickar push till mottagarens opt-in-enheter.
+ */
+async function notifyTaskAssignee(input: {
+  taskId: string;
+  title: string;
+  dueDate: string | null;
+  assigneeId: string;
+  assignerId: string;
+}) {
+  const admin = getSupabaseAdmin();
+  const { data: assigner } = await admin
+    .from('profiles')
+    .select('full_name')
+    .eq('id', input.assignerId)
+    .maybeSingle();
+
+  const content = buildCrmTaskAssignedNotification({
+    taskId: input.taskId,
+    title: input.title,
+    assignerName: assigner?.full_name || 'En kollega',
+    dueDate: input.dueDate,
+  });
+
+  await deliverNotifications(admin, expandNotificationToRecipients(content, [input.assigneeId]));
+}
+
 export async function POST(req: Request) {
   try {
     const crmUser = await requireCrmWriter();
@@ -53,17 +100,39 @@ export async function POST(req: Request) {
     const parsedBody = createCrmTaskSchema.safeParse(await req.json().catch(() => null));
     if (!parsedBody.success) return validationError(parsedBody.error);
 
-    const supabase = createRouteHandlerClient({ cookies });
+    const owner = await authorizeTaskOwner(parsedBody.data.user_id, crmUser.currentUser.id);
+    if (owner.response) return owner.response;
+
     const payload = {
       ...parsedBody.data,
-      user_id: crmUser.currentUser.id,
+      user_id: owner.ownerId ?? crmUser.currentUser.id,
+      // Fylls i på ALLA uppgifter, inte bara delegerade — en halvfylld kolumn är svårare att
+      // lita på än en tom, och "vem skapade den här" är samma fråga oavsett mottagare.
+      created_by: crmUser.currentUser.id,
       completed_at: parsedBody.data.status === 'done' ? new Date().toISOString() : null,
     };
 
+    // Egen uppgift går den vanliga sessionsvägen. En uppgift åt någon ANNAN måste skrivas med
+    // elevated klient: dashboard_work_items WITH CHECK är egen-bara, och policyn lämnas
+    // medvetet orörd (se 20260817_dashboard_work_items_created_by.sql). Behörighetsbeslutet är
+    // redan fattat ovan — crm.admin plus en mottagare verifierad mot säljarkatalogen.
+    const supabase = owner.ownerId ? getSupabaseAdmin() : createRouteHandlerClient({ cookies });
     const { data, error } = await createCrmTask(supabase, payload);
 
     if (error) {
       return routeError(500, 'crm_task_create_failed', error.message);
+    }
+
+    // Notis till mottagaren. Best-effort: uppgiften är redan sparad, och en utebliven notis får
+    // aldrig fälla den. Bara vid delegering — ingen behöver en notis om sin egen uppgift.
+    if (data && owner.ownerId) {
+      await notifyTaskAssignee({
+        taskId: data.id,
+        title: data.title,
+        dueDate: data.due_date,
+        assigneeId: owner.ownerId,
+        assignerId: crmUser.currentUser.id,
+      }).catch((e) => console.error('[crm_task] notis-fan-out misslyckades', e));
     }
 
     return ok({ item: data }, 201);

--- a/app/api/crm/tasks/route.ts
+++ b/app/api/crm/tasks/route.ts
@@ -35,7 +35,9 @@ export async function GET(req: Request) {
     // Uppgifter man delegerat tillhör mottagaren och ligger utanför den egna RLS-vyn. Skaparen
     // kommer alltid från sessionen, aldrig från frågesträngen — filtret är slutet om anroparen.
     if (parsedQuery.data.scope === 'delegated') {
-      const { data, error } = await listCrmTasksDelegatedBy(getSupabaseAdmin(), crmUser.currentUser.id);
+      const { data, error } = await listCrmTasksDelegatedBy(getSupabaseAdmin(), crmUser.currentUser.id, {
+        search: parsedQuery.data.q,
+      });
       if (error) return routeError(500, 'crm_tasks_delegated_failed', error.message);
       return ok({ items: mapCrmTaskRows(data as any[] | null | undefined) });
     }

--- a/app/crm/uppgifter/TasksClient.tsx
+++ b/app/crm/uppgifter/TasksClient.tsx
@@ -359,17 +359,26 @@ export default function TasksClient({ canDelegate = false }: { canDelegate?: boo
       }
 
       const item = json?.data?.item as TaskItem | undefined;
+      // Den nya raden läggs bara till om den hör hemma i den lista som visas. En uppgift man
+      // lagt på någon annan tillhör MOTTAGAREN — hade den prependats i den egna listan skulle
+      // den räknats bland ens egna öppna uppgifter och märkts "Från: <sig själv>" tills nästa
+      // omladdning. Samma sak omvänt: en egen uppgift hör inte hemma i "Jag har lagt ut".
+      const belongsInView = item ? (filter === 'delegated' ? item.delegated : !item.delegated) : false;
       if (item) {
         setTasks((current) => {
           if (isEditing) return current.map((entry) => (entry.id === item.id ? item : entry));
-          return [item, ...current];
+          return belongsInView ? [item, ...current] : current;
         });
       }
 
       setModalOpen(false);
       setEditingTaskId(null);
       setDraft(initialDraft);
-      toast.success(isEditing ? 'Uppgift uppdaterad' : 'Uppgift skapad');
+      toast.success(
+        isEditing ? 'Uppgift uppdaterad'
+          : item?.delegated ? 'Uppgift skapad och notis skickad — finns under "Jag har lagt ut"'
+          : 'Uppgift skapad',
+      );
     } catch {
       toast.error('Fel vid sparande av uppgift');
     } finally {
@@ -605,8 +614,19 @@ export default function TasksClient({ canDelegate = false }: { canDelegate?: boo
                       )}
                     </div>
 
-                    {/* Actions */}
+                    {/* Actions.
+                        Den delegerade vyn är LÄSVY. Raderna tillhör mottagaren, och både PATCH
+                        och DELETE kör på sessionsklienten mot en tabell vars RLS är egen-bara —
+                        varje knapptryck här hade matchat noll rader och gett ett 500-fel. Att
+                        visa knappar som inte kan fungera är sämre än att inte visa dem: uppgiften
+                        är säljarens att göra klar, chefens att följa. */}
                     <div className="flex flex-wrap items-center gap-2 md:w-36 md:flex-col md:items-stretch">
+                      {filter === 'delegated' ? (
+                        <p className="text-[11px] leading-snug text-slate-400 md:text-right">
+                          {task.status === 'done' ? 'Avklarad av säljaren' : 'Väntar på säljaren'}
+                        </p>
+                      ) : (
+                      <>
                       <button
                         type="button"
                         onClick={() => toggleTaskStatus(task)}
@@ -628,6 +648,8 @@ export default function TasksClient({ canDelegate = false }: { canDelegate?: boo
                       >
                         Redigera
                       </button>
+                      </>
+                      )}
                     </div>
                   </div>
                 );

--- a/app/crm/uppgifter/TasksClient.tsx
+++ b/app/crm/uppgifter/TasksClient.tsx
@@ -36,6 +36,9 @@ type TaskItem = {
   related_label: string | null;
   prospect_id: string | null;
   user_id: string;
+  created_by: string | null;
+  // Härleds i domänlagret: skaparen är inte den som ska göra uppgiften.
+  delegated: boolean;
   title: string;
   details: string | null;
   status: 'open' | 'done';
@@ -59,9 +62,14 @@ type TaskDraft = {
   remind_at: string;
   source: string;
   status: TaskItem['status'];
+  // Vem uppgiften ska ligga på. Tom sträng = jag själv. Sätts bara vid skapandet — en befintlig
+  // uppgift flyttas inte mellan personer.
+  user_id: string;
 };
 
-type TaskFilter = 'all' | 'open' | 'overdue' | 'done';
+// 'delegated' är inte ett filter på samma lista utan en egen hämtning: uppgifterna tillhör
+// mottagaren och ligger utanför den inloggades RLS-vy.
+type TaskFilter = 'all' | 'open' | 'overdue' | 'done' | 'delegated';
 
 const priorityMeta: Record<TaskItem['priority'], { label: string; className: string }> = {
   low: { label: 'Låg', className: 'border-slate-200 bg-slate-100 text-slate-700' },
@@ -88,6 +96,7 @@ const initialDraft: TaskDraft = {
   remind_at: '',
   source: '',
   status: 'open',
+  user_id: '',
 };
 
 function formatDate(value: string | null | undefined) {
@@ -130,7 +139,7 @@ function isOverdue(task: TaskItem) {
   return task.due_date < todayIso;
 }
 
-export default function TasksClient() {
+export default function TasksClient({ canDelegate = false }: { canDelegate?: boolean }) {
   const toast = useToast();
   const searchParams = useSearchParams();
   const [tasks, setTasks] = useState<TaskItem[]>([]);
@@ -144,6 +153,30 @@ export default function TasksClient() {
   const [modalOpen, setModalOpen] = useState(false);
   const [editingTaskId, setEditingTaskId] = useState<string | null>(null);
   const [draft, setDraft] = useState<TaskDraft>(initialDraft);
+  // Säljarkatalogen bakom mottagarväljaren — och bakom "Från: X" på en uppgift man FÅTT.
+  // Hämtas därför av alla, inte bara den som får delegera: det är mottagaren som mest behöver
+  // veta vem som lagt uppgiften på hen, och utan katalogen hade hen bara sett ett uuid.
+  const [sellers, setSellers] = useState<{ id: string; full_name: string | null }[]>([]);
+  const [sellersLoaded, setSellersLoaded] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    fetch('/api/crm/sellers', { cache: 'no-store' })
+      .then((r) => r.json().catch(() => ({})))
+      .then((json) => {
+        if (!active) return;
+        setSellers(json?.ok ? json.data?.sellers || [] : []);
+        setSellersLoaded(Boolean(json?.ok));
+      })
+      .catch(() => { if (active) setSellers([]); });
+    return () => { active = false; };
+  }, []);
+
+  const sellerNameById = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const seller of sellers) if (seller.full_name) map.set(seller.id, seller.full_name);
+    return map;
+  }, [sellers]);
 
   // Debounced server-side search for the relation picker — scales to any table size
   // (vs. preloading every customer/quote into a <select>).
@@ -191,6 +224,9 @@ export default function TasksClient() {
       try {
         const query = new URLSearchParams();
         if (search.trim()) query.set('q', search.trim());
+        // Delegerade uppgifter är en EGEN hämtning, inte ett filter över den vanliga listan:
+        // de tillhör mottagaren och kommer aldrig med i den inloggades egna rader.
+        if (filter === 'delegated') query.set('scope', 'delegated');
 
         // Linked entities (customer/quote/prospect) are searched on demand in the
         // modal via EntityCombobox, so the list view only needs the tasks themselves.
@@ -220,7 +256,9 @@ export default function TasksClient() {
     return () => {
       active = false;
     };
-  }, [search]);
+    // filter är med som beroende BARA för att 'delegated' byter datakälla — de övriga filtren
+    // är rena klientfilter över samma hämtning och ska inte kosta en ny request.
+  }, [search, filter === 'delegated']); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Deep-link: open a specific task's edit modal when arriving with ?task_id=
   // (e.g. from a customer's related list). Handled once the task is loaded.
@@ -246,18 +284,22 @@ export default function TasksClient() {
   }, [modalOpen]);
 
   const visibleTasks = useMemo(() => {
-    if (filter === 'all') return tasks;
+    // 'delegated' har redan hämtat exakt de rader som ska visas — ett klientfilter här hade
+    // filtrerat bort dem allihop, eftersom de per definition inte är den inloggades egna.
+    if (filter === 'all' || filter === 'delegated') return tasks;
     if (filter === 'done') return tasks.filter((task) => task.status === 'done');
     if (filter === 'overdue') return tasks.filter((task) => isOverdue(task));
     return tasks.filter((task) => task.status === 'open');
   }, [filter, tasks]);
 
-  const filterCounts = useMemo(() => ({
+  // Räknarna beskriver den hämtade listan. I den delegerade vyn är det en annan lista, så de
+  // nollas hellre än visar siffror som gäller något annat.
+  const filterCounts = useMemo(() => (filter === 'delegated' ? { all: 0, open: 0, overdue: 0, done: 0 } : {
     all: tasks.length,
     open: tasks.filter((task) => task.status === 'open').length,
     overdue: tasks.filter((task) => isOverdue(task)).length,
     done: tasks.filter((task) => task.status === 'done').length,
-  }), [tasks]);
+  }), [tasks, filter]);
 
   // Active filter count — shown as a badge on the mobile filter toggle.
   const activeFilterCount = filter !== 'all' ? 1 : 0;
@@ -281,6 +323,9 @@ export default function TasksClient() {
       remind_at: toDateTimeLocalValue(task.remind_at),
       source: task.source || '',
       status: task.status,
+      // Ägaren är låst efter skapandet — väljaren visas inte i redigeringsläget, och fältet
+      // skickas inte med i PATCH:en. Bärs ändå med så draften speglar raden.
+      user_id: task.user_id,
     });
     setModalOpen(true);
   }
@@ -300,6 +345,10 @@ export default function TasksClient() {
         body: JSON.stringify({
           ...draft,
           remind_at: toIsoDateTime(draft.remind_at),
+          // Mottagaren sätts BARA när uppgiften skapas. En befintlig uppgift flyttas inte
+          // mellan personer, och att skicka fältet vid PATCH hade gett rutten ett värde den
+          // ändå ignorerar — bättre att inte påstå något.
+          user_id: !isEditing && canDelegate && draft.user_id ? draft.user_id : undefined,
         }),
       });
       const json = await res.json().catch(() => ({}));
@@ -436,6 +485,8 @@ export default function TasksClient() {
               ['open', 'Öppna'],
               ['overdue', 'Förfallna'],
               ['done', 'Klara'],
+              // Bara för den som kan delegera — för alla andra är listan alltid tom.
+              ...(canDelegate ? [['delegated', 'Jag har lagt ut'] as [TaskFilter, string]] : []),
             ] as Array<[TaskFilter, string]>).map(([value, label]) => {
               const isActive = filter === value;
               return (
@@ -452,12 +503,16 @@ export default function TasksClient() {
                   style={isActive ? { backgroundColor: 'var(--crm-primary)' } : undefined}
                 >
                   {label}
-                  <span className={cn(
-                    'rounded-full px-1.5 py-0.5 text-[10px] font-bold tabular-nums',
-                    isActive ? 'bg-white/20 text-white' : 'bg-slate-100 text-slate-500',
-                  )}>
-                    {filterCounts[value]}
-                  </span>
+                  {/* Den delegerade vyn är en egen hämtning — en siffra ur den vanliga listan
+                      hade beskrivit fel uppsättning rader. Hellre ingen siffra än en som ljuger. */}
+                  {value === 'delegated' ? null : (
+                    <span className={cn(
+                      'rounded-full px-1.5 py-0.5 text-[10px] font-bold tabular-nums',
+                      isActive ? 'bg-white/20 text-white' : 'bg-slate-100 text-slate-500',
+                    )}>
+                      {filterCounts[value as keyof typeof filterCounts]}
+                    </span>
+                  )}
                 </button>
               );
             })}
@@ -522,6 +577,20 @@ export default function TasksClient() {
                             Klar
                           </span>
                         )}
+                        {/* En delegerad uppgift måste säga varifrån den kommer. Samma rad dyker
+                            dessutom upp bland mottagarens egna dashboard-anteckningar (samma
+                            tabell, samma kind), och utan avsändare läses den som något hen själv
+                            skrivit och inte minns.
+
+                            Vilket namn som är intressant beror på vilken sida man står på: i den
+                            delegerade vyn är det MOTTAGAREN, i sin egen lista AVSÄNDAREN. */}
+                        {task.delegated ? (
+                          <span className={cn(crm.badge, 'border-sky-200 bg-sky-50 text-sky-700')}>
+                            {filter === 'delegated'
+                              ? `Åt: ${sellerNameById.get(task.user_id) ?? (sellersLoaded ? 'okänd' : '…')}`
+                              : `Från: ${(task.created_by && sellerNameById.get(task.created_by)) ?? (sellersLoaded ? 'en kollega' : '…')}`}
+                          </span>
+                        ) : null}
                       </div>
 
                       <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-0.5 text-[11px] text-slate-500">
@@ -652,6 +721,34 @@ export default function TasksClient() {
                   <option value="done">Klar</option>
                 </Select>
               </div>
+
+              {/* Mottagare — bara vid skapandet, och bara för den som får delegera. En befintlig
+                  uppgift flyttas inte mellan personer, så väljaren döljs i redigeringsläget i
+                  stället för att stå där utan verkan.
+
+                  Riktig <label> och inte crm.sectionTitle som fälten ovan: den är ett <p> och
+                  binder alltså inte till kontrollen, vilket bryter mot WCAG. De befintliga fälten
+                  har samma brist men rättas inte här — det är en egen städning. */}
+              {canDelegate && !editingTaskId ? (
+                <div className="rounded-xl border border-[#e3e9df] bg-[#f6f9f3] p-4">
+                  <label htmlFor="task-owner" className={cn('mb-1.5 block', crm.sectionTitle)}>Ansvarig</label>
+                  <Select
+                    id="task-owner"
+                    value={draft.user_id}
+                    onChange={(e) => setDraft((c) => ({ ...c, user_id: e.target.value }))}
+                  >
+                    <option value="">Jag själv</option>
+                    {sellers.map((seller) => (
+                      <option key={seller.id} value={seller.id}>{seller.full_name || seller.id}</option>
+                    ))}
+                  </Select>
+                  <p className="mt-1.5 text-xs text-slate-500">
+                    {draft.user_id
+                      ? 'Uppgiften hamnar hos säljaren, som får en notis. Du hittar den under "Jag har lagt ut".'
+                      : 'Lägg uppgiften på en säljare i stället för dig själv.'}
+                  </p>
+                </div>
+              ) : null}
 
               <div className="grid gap-4 rounded-xl border border-[#e3e9df] bg-[#f6f9f3] p-4 sm:grid-cols-3">
                 <div>

--- a/app/crm/uppgifter/page.tsx
+++ b/app/crm/uppgifter/page.tsx
@@ -1,7 +1,20 @@
+import { cookies } from 'next/headers';
+import { createServerComponentClient } from '@supabase/auth-helpers-nextjs';
 import TasksClient from './TasksClient';
 
 export const dynamic = 'force-dynamic';
 
-export default function CrmTasksPage() {
-  return <TasksClient />;
+// Behörigheten läses här och inte i klienten: sidan är rätt ställe för åtkomstbeslut, och en
+// klient som frågar själv hade blinkat till med fel formulär medan svaret var på väg.
+//
+// `createServerComponentClient` och inte getEffectivePermissions(): den senare bygger en
+// route-handler-klient, som försöker skriva cookies vid tokenförnyelse och därför inte hör hemma
+// i en server-komponent. Samma mönster som app/arbetsorder/[id]/page.tsx.
+export default async function CrmTasksPage() {
+  const supabase = createServerComponentClient({ cookies });
+  const { data: permissions } = await supabase.rpc('effective_permissions');
+  const canDelegate = Array.isArray(permissions)
+    && permissions.some((row) => (typeof row === 'string' ? row : String(row)) === 'crm.admin');
+
+  return <TasksClient canDelegate={canDelegate} />;
 }

--- a/lib/domains/crm/tasks.ts
+++ b/lib/domains/crm/tasks.ts
@@ -3,6 +3,7 @@ import type { SupabaseClient } from '@supabase/supabase-js';
 export const crmTaskSelect = `
   id,
   user_id,
+  created_by,
   kind,
   title,
   body,
@@ -28,6 +29,8 @@ type CreateCrmTaskInput = {
   related_id: string | null;
   related_label: string | null;
   user_id: string;
+  // Vem som skapade uppgiften. Skiljer sig från user_id när en chef lagt den på en säljare.
+  created_by: string;
   title: string;
   details: string | null;
   status: CrmTaskStatus;
@@ -38,7 +41,9 @@ type CreateCrmTaskInput = {
   completed_at: string | null;
 };
 
-type UpdateCrmTaskInput = Omit<CreateCrmTaskInput, 'user_id'>;
+// Varken ägare eller skapare ändras vid redigering: en uppgift flyttas inte mellan personer,
+// den skapas åt rätt person från början. Skaparen är dessutom ett historiskt faktum.
+type UpdateCrmTaskInput = Omit<CreateCrmTaskInput, 'user_id' | 'created_by'>;
 
 type ListCrmTasksOptions = {
   search?: string;
@@ -50,6 +55,7 @@ type ListCrmTasksOptions = {
 type RawCrmTaskRow = {
   id: string;
   user_id: string;
+  created_by: string | null;
   kind: string;
   title: string;
   body: string | null;
@@ -87,6 +93,11 @@ export function mapCrmTaskRow(row: RawCrmTaskRow) {
     // Back-compat: keep prospect_id populated when the relation is a prospect.
     prospect_id: relatedType === 'crm_prospect' ? row.related_id : null,
     user_id: row.user_id,
+    created_by: row.created_by ?? null,
+    // Uppgiften är delegerad när skaparen inte är den som ska göra den. Härleds här i stället
+    // för i varje vy — både uppgiftslistan och mottagarens rad behöver samma bedömning, och
+    // äldre rader (skapade före kolumnen fanns) har created_by null och är alltså inte delegerade.
+    delegated: Boolean(row.created_by && row.created_by !== row.user_id),
     title: row.title,
     details: row.body,
     status: row.status === 'done' ? 'done' : row.status === 'cancelled' ? 'cancelled' : 'open',
@@ -127,9 +138,35 @@ export async function listCrmTasks(supabase: SupabaseClient, options: ListCrmTas
   return query;
 }
 
+/**
+ * Uppgifter som `creatorUserId` skapat ÅT NÅGON ANNAN.
+ *
+ * Kräver en elevated klient: raderna tillhör mottagaren, och tabellens SELECT-policy är
+ * egen-bara. Policyn lämnas medvetet orörd — se huvudkommentaren i
+ * 20260817_dashboard_work_items_created_by.sql för varför en vidgad policy hade läckt in i
+ * den personliga dashboarden.
+ *
+ * Elevationen är ofarlig därför att filtret är slutet om anroparen själv: `created_by` måste
+ * vara hen, och `user_id` måste vara någon annan. Inget annat blir läsbart. Anropas ALDRIG med
+ * ett creatorUserId som kommer från klienten — bara från den inloggade sessionen.
+ */
+export async function listCrmTasksDelegatedBy(admin: SupabaseClient, creatorUserId: string) {
+  return admin
+    .from('dashboard_work_items')
+    .select(crmTaskSelect)
+    .eq('kind', 'note')
+    .eq('created_by', creatorUserId)
+    .neq('user_id', creatorUserId)
+    .order('status', { ascending: true })
+    .order('due_at', { ascending: true, nullsFirst: false })
+    .order('created_at', { ascending: false })
+    .limit(100);
+}
+
 export async function createCrmTask(supabase: SupabaseClient, input: CreateCrmTaskInput) {
   const result = await supabase.from('dashboard_work_items').insert({
     user_id: input.user_id,
+    created_by: input.created_by,
     kind: 'note',
     title: input.title,
     body: input.details,

--- a/lib/domains/crm/tasks.ts
+++ b/lib/domains/crm/tasks.ts
@@ -150,13 +150,25 @@ export async function listCrmTasks(supabase: SupabaseClient, options: ListCrmTas
  * vara hen, och `user_id` måste vara någon annan. Inget annat blir läsbart. Anropas ALDRIG med
  * ett creatorUserId som kommer från klienten — bara från den inloggade sessionen.
  */
-export async function listCrmTasksDelegatedBy(admin: SupabaseClient, creatorUserId: string) {
-  return admin
+export async function listCrmTasksDelegatedBy(
+  admin: SupabaseClient,
+  creatorUserId: string,
+  options: { search?: string } = {}
+) {
+  let query = admin
     .from('dashboard_work_items')
     .select(crmTaskSelect)
     .eq('kind', 'note')
     .eq('created_by', creatorUserId)
-    .neq('user_id', creatorUserId)
+    .neq('user_id', creatorUserId);
+
+  // Sökningen måste tillämpas här också. Klienten skickar samma `q` oavsett vy, och utan den
+  // här grenen hade en sökning i den delegerade vyn tyst gett hela listan tillbaka.
+  if (options.search) {
+    query = query.or(`title.ilike.%${options.search}%,body.ilike.%${options.search}%`);
+  }
+
+  return query
     .order('status', { ascending: true })
     .order('due_at', { ascending: true, nullsFirst: false })
     .order('created_at', { ascending: false })

--- a/lib/domains/notifications/payload.ts
+++ b/lib/domains/notifications/payload.ts
@@ -82,3 +82,30 @@ export function buildAppTicketCreatedNotification(input: {
     entity_id: input.ticketId,
   };
 }
+
+// Skickas till säljaren när någon annan lagt upp en CRM-uppgift åt hen.
+//
+// Vem som gett uppgiften är själva poängen med notisen och står därför i body:n — utan avsändare
+// blir det en uppgift man inte minns att man skrivit. Förfallodatumet följer med när det finns,
+// eftersom "gör det här" och "till när" är samma fråga för mottagaren.
+//
+// href går till uppgiftslistan med uppgiften öppnad. Mottagaren är alltid en säljare eller admin
+// (rutten validerar det mot säljarkatalogen), så /crm är en yta hen kan öppna — till skillnad
+// från arbetsorder-omnämnandena, som måste rollstyra sin länk.
+export function buildCrmTaskAssignedNotification(input: {
+  taskId: string;
+  title: string;
+  assignerName: string;
+  dueDate: string | null; // ISO-datum (YYYY-MM-DD)
+}): NotificationContent {
+  return {
+    type: 'crm_task.assigned',
+    title: `Ny uppgift: ${input.title}`,
+    body: input.dueDate
+      ? `${input.assignerName} har lagt en uppgift på dig · senast ${input.dueDate}`
+      : `${input.assignerName} har lagt en uppgift på dig`,
+    href: `/crm/uppgifter?task_id=${input.taskId}`,
+    entity_type: 'crm_task',
+    entity_id: input.taskId,
+  };
+}

--- a/supabase/sql/20260817_dashboard_work_items_created_by.sql
+++ b/supabase/sql/20260817_dashboard_work_items_created_by.sql
@@ -1,0 +1,39 @@
+-- Vem som skapade en uppgift, när det inte är den som ska göra den.
+--
+-- Säljchefen ska kunna lägga upp CRM-uppgifter åt sina säljare och se vad han delegerat.
+-- CRM-uppgifter är rader i den här tabellen (kind='note', metadata.crm=true), så kolumnen
+-- läggs där. Den fylls i på ALLA nya uppgifter, inte bara delegerade — en halvfylld kolumn är
+-- svårare att lita på än en tom.
+--
+-- ⚠️ KÖR FÖRE KODEN. Rutten skriver created_by på varje uppgift som skapas; utan kolumnen
+-- avvisar PostgREST insert:en och då går det inte att skapa NÅGON uppgift, inte bara de
+-- delegerade. Migrationen är rent additiv och påverkar ingenting som redan finns, så den är
+-- ofarlig att köra i förväg.
+--
+-- INGEN POLICYÄNDRING, och det är avsiktligt.
+--
+-- Det naturliga hade varit att lägga en gren i SELECT-policyn — `or auth.uid() = created_by` —
+-- så att skaparen kunde läsa sina delegerade rader direkt. Men tabellen är den PERSONLIGA
+-- dashboarden: den bär allas privata anteckningar och möten, och components/dashboard/
+-- DashboardNotes.tsx läser den UTAN user_id-filter och litar helt på RLS för avgränsningen.
+-- En vidgad policy hade därför omedelbart fyllt chefens egen dashboard med de uppgifter han
+-- lagt på andra — tyst, eftersom frågan inte har något filter som kan märka skillnaden, och på
+-- en icke-CRM-yta som ligger i den uppskjutna ombyggnaden.
+--
+-- Läsningen av "uppgifter jag delegerat" görs i stället i CRM-rutten med en elevated klient,
+-- hårt scopad till created_by = den inloggade. Auktoriseringen är trivial (det är hans egna
+-- rader) och inget annat blir läsbart.
+--
+-- on delete set null: en chef kan sluta utan att säljarens uppgift går sönder.
+-- Idempotent.
+
+alter table public.dashboard_work_items
+  add column if not exists created_by uuid references public.profiles(id) on delete set null;
+
+-- Partiellt index: bara delegerade rader frågas på created_by, och de är en minoritet.
+create index if not exists dashboard_work_items_created_by_idx
+  on public.dashboard_work_items (created_by, created_at desc)
+  where created_by is not null;
+
+comment on column public.dashboard_work_items.created_by is
+  'Vem som skapade raden. Skiljer sig från user_id när en uppgift delegerats (chef → säljare). RLS oförändrad — se huvudkommentaren i 20260817_dashboard_work_items_created_by.sql.';

--- a/tests/crm/tasks.test.ts
+++ b/tests/crm/tasks.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { salesUser, adminUser, effectivePermissionsForRole } from './helpers/supabase';
+
+// authorizeTaskOwner slår upp säljarkatalogen med elevated klient (profiles-RLS är self-only).
+vi.mock('@/lib/domains/crm/customers', () => ({ listCrmSellers: vi.fn() }));
+vi.mock('@/lib/supabase/server', () => ({ getSupabaseAdmin: vi.fn(() => ({})) }));
+vi.mock('@/lib/auth/route', () => ({ getCurrentUser: vi.fn() }));
+vi.mock('@/lib/auth/permissions', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/auth/permissions')>();
+  return { ...actual, getEffectivePermissions: vi.fn() };
+});
+
+import { getCurrentUser } from '@/lib/auth/route';
+import { getEffectivePermissions } from '@/lib/auth/permissions';
+import { listCrmSellers } from '@/lib/domains/crm/customers';
+import { mapCrmTaskRow } from '@/lib/domains/crm/tasks';
+import { authorizeTaskOwner } from '@/app/api/crm/tasks/_lib';
+
+const mockSellers = vi.mocked(listCrmSellers);
+
+const SALJARE = '44444444-4444-4444-4444-444444444444';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getEffectivePermissions).mockImplementation(async () =>
+    effectivePermissionsForRole((await vi.mocked(getCurrentUser)())?.role));
+});
+
+function rawTask(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 't1',
+    user_id: 'saljare-1',
+    created_by: 'chef-1',
+    kind: 'note',
+    title: 'Ring kunden',
+    body: null,
+    status: 'active',
+    due_at: null,
+    remind_at: null,
+    completed_at: null,
+    created_at: '2026-08-17T08:00:00Z',
+    updated_at: '2026-08-17T08:00:00Z',
+    related_type: null,
+    related_id: null,
+    metadata: null,
+    ...overrides,
+  } as any;
+}
+
+// ---------------------------------------------------------------------------
+// mapCrmTaskRow — delegated
+// ---------------------------------------------------------------------------
+
+describe('mapCrmTaskRow — delegated', () => {
+  it('flaggar uppgiften när skaparen inte är den som ska göra den', () => {
+    expect(mapCrmTaskRow(rawTask()).delegated).toBe(true);
+  });
+
+  it('flaggar INTE en uppgift man skapat åt sig själv', () => {
+    expect(mapCrmTaskRow(rawTask({ created_by: 'saljare-1' })).delegated).toBe(false);
+  });
+
+  // Rader skapade före created_by-kolumnen fanns har null. De är egna uppgifter, inte
+  // delegerade — utan den här grenen hade varje gammal uppgift fått en "Från:"-etikett.
+  it('behandlar en rad utan created_by som egen, inte delegerad', () => {
+    const mapped = mapCrmTaskRow(rawTask({ created_by: null }));
+    expect(mapped.delegated).toBe(false);
+    expect(mapped.created_by).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// authorizeTaskOwner
+// ---------------------------------------------------------------------------
+
+describe('authorizeTaskOwner', () => {
+  it('returnerar ingen ägare när uppgiften är till en själv', async () => {
+    vi.mocked(getCurrentUser).mockResolvedValue(salesUser);
+
+    const result = await authorizeTaskOwner(salesUser.id, salesUser.id);
+
+    expect(result.response).toBeNull();
+    expect(result.ownerId).toBeNull();
+    // Varken behörighet eller katalog ska slås upp för en uppgift till en själv.
+    expect(mockSellers).not.toHaveBeenCalled();
+  });
+
+  it('returnerar ingen ägare när fältet utelämnas helt', async () => {
+    vi.mocked(getCurrentUser).mockResolvedValue(salesUser);
+
+    const result = await authorizeTaskOwner(undefined, salesUser.id);
+
+    expect(result.ownerId).toBeNull();
+    expect(result.response).toBeNull();
+  });
+
+  it('nekar en vanlig säljare att lägga uppgiften på någon annan', async () => {
+    vi.mocked(getCurrentUser).mockResolvedValue(salesUser);
+
+    const result = await authorizeTaskOwner(SALJARE, salesUser.id);
+
+    expect(result.response?.status).toBe(403);
+    expect(mockSellers).not.toHaveBeenCalled();
+  });
+
+  it('låter en administratör lägga uppgiften på en säljare', async () => {
+    vi.mocked(getCurrentUser).mockResolvedValue(adminUser);
+    mockSellers.mockResolvedValue([{ id: SALJARE, full_name: 'Anna', role: 'sales' }]);
+
+    const result = await authorizeTaskOwner(SALJARE, adminUser.id);
+
+    expect(result.response).toBeNull();
+    expect(result.ownerId).toBe(SALJARE);
+  });
+
+  // Utan den här kontrollen går uppgiften att parkera på en installatör, som varken når /crm
+  // eller ser uppgiftslistan — den blir osynlig för alla utom den som skrev den.
+  it('avvisar en mottagare som inte finns i säljarkatalogen', async () => {
+    vi.mocked(getCurrentUser).mockResolvedValue(adminUser);
+    mockSellers.mockResolvedValue([]);
+
+    const result = await authorizeTaskOwner(SALJARE, adminUser.id);
+
+    expect(result.response?.status).toBe(422);
+    expect(result.ownerId).toBeNull();
+  });
+});

--- a/tests/notifications/notifications.test.ts
+++ b/tests/notifications/notifications.test.ts
@@ -6,6 +6,7 @@ import {
   buildFaultReportCreatedNotification,
   buildFaultReportUpdatedNotification,
   buildWorkOrderCommentMentionNotification,
+  buildCrmTaskAssignedNotification,
 } from '@/lib/domains/notifications/payload';
 import type { NotificationRow } from '@/lib/domains/notifications/types';
 
@@ -105,6 +106,37 @@ describe('buildWorkOrderCommentMentionNotification', () => {
   it('routes the crm audience to the CRM detail view', () => {
     const n = buildWorkOrderCommentMentionNotification({ workOrderId: 'wo4', audience: 'crm' });
     expect(n.href).toBe('/crm/arbetsorder/wo4');
+  });
+});
+
+describe('buildCrmTaskAssignedNotification', () => {
+  // Vem som gett uppgiften är hela poängen med notisen: samma rad dyker upp bland mottagarens
+  // egna dashboard-anteckningar, och utan avsändare läses den som något hen själv skrivit.
+  it('namnger avsändaren och länkar till uppgiften', () => {
+    const n = buildCrmTaskAssignedNotification({
+      taskId: 't1',
+      title: 'Ring Bygg AB om offerten',
+      assignerName: 'Marcus Chef',
+      dueDate: '2026-08-20',
+    });
+    expect(n.type).toBe('crm_task.assigned');
+    expect(n.entity_type).toBe('crm_task');
+    expect(n.entity_id).toBe('t1');
+    expect(n.href).toBe('/crm/uppgifter?task_id=t1');
+    expect(n.title).toContain('Ring Bygg AB om offerten');
+    expect(n.body).toContain('Marcus Chef');
+    expect(n.body).toContain('2026-08-20');
+  });
+
+  it('utelämnar deadline-delen när uppgiften saknar datum', () => {
+    const n = buildCrmTaskAssignedNotification({
+      taskId: 't2',
+      title: 'Följ upp',
+      assignerName: 'Marcus Chef',
+      dueDate: null,
+    });
+    expect(n.body).toContain('Marcus Chef');
+    expect(n.body).not.toContain('senast');
   });
 });
 


### PR DESCRIPTION
Säljchefen ska kunna lägga uppgifter på sina säljare och se vad han delegerat. Idag går bara den egna raden att skapa.

## ✅ SQL redan körd

`supabase/sql/20260817_dashboard_work_items_created_by.sql` är körd i prod före den här koden — vilket är rätt ordning här. Rutten skriver `created_by` på **varje** uppgift, så utan kolumnen hade insert:en avvisats och det inte gått att skapa någon uppgift alls, inte bara de delegerade.

## Det som styrde besluten

CRM-uppgifter är inte en egen tabell: de är rader i `dashboard_work_items` (`kind='note'`), alltså den **personliga dashboarden**, som också bär allas privata anteckningar och möten.

## Ändringen

- Ny kolumn `created_by`. Fylls på **alla** uppgifter, inte bara delegerade — en halvfylld kolumn är svårare att lita på än en tom.
- `POST /api/crm/tasks` tar emot `user_id`. Utelämnad = skaparen, som förut. Någon annan kräver `crm.admin` **och** att mottagaren finns i säljarkatalogen; utan den kontrollen går uppgiften att parkera på en installatör som varken når `/crm` eller ser listan, och den blir osynlig för alla utom den som skrev den.
- Insert:en görs då med elevated klient, eftersom tabellens `WITH CHECK` är egen-bara.
- `GET ?scope=delegated` läser det man lagt ut, hårt scopat till `created_by` = den inloggade. Skaparen kommer alltid från sessionen, aldrig från frågesträngen.
- Notis `crm_task.assigned` till mottagaren, best-effort. **Push följer med gratis** via `deliverNotifications`. Ingen migration — `type` är en öppen sträng.

## Ingen policyändring, och det är poängen

Det naturliga hade varit en gren `or auth.uid() = created_by` i SELECT-policyn. Men [DashboardNotes.tsx](components/dashboard/DashboardNotes.tsx#L131-L134) läser tabellen **utan `user_id`-filter** och litar helt på RLS. En vidgad policy hade därför omedelbart fyllt chefens egen dashboard med de uppgifter han lagt på andra — tyst, eftersom frågan inte har något filter som kan märka skillnaden, och på en icke-CRM-yta som ligger i den uppskjutna ombyggnaden.

## UI

"Ansvarig"-väljare i modalen (bara admin, bara vid skapandet), filtret "Jag har lagt ut", och en märkning som visar mottagare respektive avsändare beroende på vilken sida man står på. Säljarkatalogen hämtas av **alla** och inte bara den som får delegera: det är mottagaren som mest behöver se vem uppgiften kom från.

## Granskningsfynd åtgärdade

- **Den delegerade vyn visade knappar som omöjligt kunde fungera.** PATCH kör på sessionsklienten mot en egen-bara-RLS, så "Markera klar"/"Redigera" hade matchat noll rader och gett 500. Vyn är nu läsvy.
- Sökningen tillämpades inte i den delegerade vyn — samma `q` skickas oavsett vy, och utan grenen gav en sökning tyst hela listan.
- En nyss skapad uppgift åt någon annan prependades i skaparens egna lista, räknades bland hans öppna och märktes "Från: sig själv".

## Verifiering

`npm run type-check` · `npm run lint` · `npm test` (1381 gröna) · `npm run build` — alla gröna.

Nya tester: notis-byggaren (avsändarnamn + deadline-grenen), `authorizeTaskOwner`s fyra grenar, och `delegated`-härledningen inklusive back-compat för rader utan `created_by`.

UI:t renderat och granskat i 1100/390 px via en tillfällig sida som togs bort igen.

## Medvetna gränser

- Chefen kan **se** men inte redigera eller bocka av det han delegerat — det kräver skrivrätt i någon annans personliga dashboard.
- Ansvarig sätts bara vid skapandet; en uppgift flyttas inte mellan personer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)