### PR TITLE
Översikten och offertlistan räknar på servern, plus småfixar i sidomenyn

### DIFF
--- a/app/api/crm/overview/route.ts
+++ b/app/api/crm/overview/route.ts
@@ -1,0 +1,56 @@
+import { cookies } from 'next/headers';
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
+import { z } from 'zod';
+import { ok, routeError, validationError, requireCrmUser } from '@/app/api/crm/_shared';
+import { fetchCrmOverviewSummary, type CrmOverviewWindow } from '@/lib/domains/crm/overviewSummary';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+const dateSchema = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Ogiltigt datum (ÅÅÅÅ-MM-DD)');
+const querySchema = z.object({
+  today: dateSchema,
+  since: dateSchema,
+  week_start: dateSchema,
+  week_end: dateSchema,
+});
+
+// The window comes from the client, the way the reports route takes its range. The reader's own
+// clock is the one that decides what "this week" and "the last 7 days" mean, and the server runs on
+// UTC — computing the boundaries here would quietly move them for anyone whose calendar day differs
+// from the server's. Passing them in also keeps the figures identical to what the page showed when
+// it did this arithmetic in the browser.
+export async function GET(req: Request) {
+  try {
+    // Same gate as the rest of the CRM reads: every seller may see the team's figures.
+    const crmUser = await requireCrmUser();
+    if (crmUser.response) return crmUser.response;
+
+    const url = new URL(req.url);
+    const parsed = querySchema.safeParse({
+      today: url.searchParams.get('today') || undefined,
+      since: url.searchParams.get('since') || undefined,
+      week_start: url.searchParams.get('week_start') || undefined,
+      week_end: url.searchParams.get('week_end') || undefined,
+    });
+    if (!parsed.success) return validationError(parsed.error);
+
+    const window: CrmOverviewWindow = {
+      today: parsed.data.today,
+      since: parsed.data.since,
+      weekStart: parsed.data.week_start,
+      weekEnd: parsed.data.week_end,
+    };
+    if (window.since > window.today) return routeError(400, 'invalid_window', 'Fönstrets start måste ligga före idag.');
+    if (window.weekStart >= window.weekEnd) return routeError(400, 'invalid_window', 'Veckans start måste ligga före dess slut.');
+
+    // Session client on purpose: RLS decides what the reader may count, exactly as it did when the
+    // page counted list rows. The task figures are personal precisely because of that policy.
+    const supabase = createRouteHandlerClient({ cookies });
+    const summary = await fetchCrmOverviewSummary(supabase, window);
+
+    return ok({ summary });
+  } catch (e: any) {
+    return routeError(500, 'crm_overview_summary_failed', e?.message || 'Kunde inte räkna översiktens siffror.');
+  }
+}

--- a/app/api/crm/overview/route.ts
+++ b/app/api/crm/overview/route.ts
@@ -8,6 +8,17 @@ export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
 
 const dateSchema = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Ogiltigt datum (ÅÅÅÅ-MM-DD)');
+
+// The overview asks for eight days at most (today plus the rolling seven). The margin is for a
+// reader whose calendar day differs from the server's, not for arbitrary history.
+const MAX_WINDOW_DAYS = 31;
+
+function daysBetween(fromDay: string, toDay: string) {
+  const from = Date.parse(`${fromDay}T00:00:00Z`);
+  const to = Date.parse(`${toDay}T00:00:00Z`);
+  return Math.round((to - from) / 86_400_000);
+}
+
 const querySchema = z.object({
   today: dateSchema,
   since: dateSchema,
@@ -43,6 +54,12 @@ export async function GET(req: Request) {
     };
     if (window.since > window.today) return routeError(400, 'invalid_window', 'Fönstrets start måste ligga före idag.');
     if (window.weekStart >= window.weekEnd) return routeError(400, 'invalid_window', 'Veckans start måste ligga före dess slut.');
+    // A ceiling on the width, not just the direction. The window is client-supplied, and
+    // `since=1970-01-01` would turn three bounded reads into full-table scans on demand — for any
+    // authenticated CRM user, konsult included. The page never asks for more than eight days.
+    if (daysBetween(window.since, window.today) > MAX_WINDOW_DAYS) {
+      return routeError(400, 'invalid_window', `Fönstret får vara högst ${MAX_WINDOW_DAYS} dagar.`);
+    }
 
     // Session client on purpose: RLS decides what the reader may count, exactly as it did when the
     // page counted list rows. The task figures are personal precisely because of that policy.

--- a/app/api/crm/quotes/_lib.ts
+++ b/app/api/crm/quotes/_lib.ts
@@ -126,9 +126,17 @@ export const listCrmQuotesQuerySchema = z.object({
   // group ALL of a seller's quotes client-side pass a higher value so won/lost
   // quotes aren't truncated. Bounded to keep the query safe.
   limit: z.coerce.number().int().min(1).max(2000).optional(),
-  // Row order. Default (status_asc) is the offer list's working order; 'updated_desc' is for
-  // callers that want the most recently touched quotes rather than the open ones.
-  sort: z.enum(['status_asc', 'updated_desc']).optional(),
+  // Pagination offset for the offer list's "Visa fler".
+  offset: z.coerce.number().int().min(0).optional(),
+  // Tab filter (status group). Server-side so the paginated list is correct.
+  filter: z.enum(['all', 'active', 'follow_up', 'won', 'lost']).optional(),
+  // Assignee scope — comma-separated user ids ('mine' is resolved to the current user id on the
+  // client before sending). Empty/absent = everyone.
+  assignee: z.string().trim().optional(),
+  // Row order. Default (status_asc) is the historical working order; the offer list asks for
+  // 'created_desc' (newest first) or 'follow_up_asc' (most urgent first), the overview for
+  // 'updated_desc'.
+  sort: z.enum(['status_asc', 'updated_desc', 'created_desc', 'follow_up_asc']).optional(),
 });
 
 export const createCrmQuoteSchema = z.object({

--- a/app/api/crm/quotes/_lib.ts
+++ b/app/api/crm/quotes/_lib.ts
@@ -126,6 +126,9 @@ export const listCrmQuotesQuerySchema = z.object({
   // group ALL of a seller's quotes client-side pass a higher value so won/lost
   // quotes aren't truncated. Bounded to keep the query safe.
   limit: z.coerce.number().int().min(1).max(2000).optional(),
+  // Row order. Default (status_asc) is the offer list's working order; 'updated_desc' is for
+  // callers that want the most recently touched quotes rather than the open ones.
+  sort: z.enum(['status_asc', 'updated_desc']).optional(),
 });
 
 export const createCrmQuoteSchema = z.object({

--- a/app/api/crm/quotes/route.ts
+++ b/app/api/crm/quotes/route.ts
@@ -26,6 +26,7 @@ export async function GET(req: Request) {
       prospect_id: url.searchParams.get('prospect_id') || undefined,
       customer_id: url.searchParams.get('customer_id') || undefined,
       limit: url.searchParams.get('limit') || undefined,
+      sort: url.searchParams.get('sort') || undefined,
     });
 
     if (!parsedQuery.success) return validationError(parsedQuery.error);
@@ -37,6 +38,7 @@ export async function GET(req: Request) {
       prospectId: parsedQuery.data.prospect_id,
       customerId: parsedQuery.data.customer_id,
       limit: parsedQuery.data.limit,
+      sort: parsedQuery.data.sort,
     });
     const { data, error } = await query;
 

--- a/app/api/crm/quotes/route.ts
+++ b/app/api/crm/quotes/route.ts
@@ -1,6 +1,6 @@
 import { cookies } from 'next/headers';
 import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
-import { createCrmQuote, getCrmQuote, listCrmQuotesWithFilters } from '@/lib/domains/crm/quotes';
+import { createCrmQuote, getCrmQuote, getCrmQuoteFilterCounts, listCrmQuotesWithFilters, CRM_QUOTES_PAGE_SIZE } from '@/lib/domains/crm/quotes';
 import { pushQuoteToFortnox } from '@/lib/domains/fortnox/offers';
 import { FortnoxNotConnectedError, friendlyFortnoxMessage } from '@/lib/domains/fortnox/client';
 import {
@@ -26,27 +26,51 @@ export async function GET(req: Request) {
       prospect_id: url.searchParams.get('prospect_id') || undefined,
       customer_id: url.searchParams.get('customer_id') || undefined,
       limit: url.searchParams.get('limit') || undefined,
+      offset: url.searchParams.get('offset') || undefined,
+      filter: url.searchParams.get('filter') || undefined,
+      assignee: url.searchParams.get('assignee') || undefined,
       sort: url.searchParams.get('sort') || undefined,
     });
 
     if (!parsedQuery.success) return validationError(parsedQuery.error);
 
-    const supabase = createRouteHandlerClient({ cookies });
-    const query = await listCrmQuotesWithFilters(supabase, {
+    // Assignee scope: a comma-separated list of user ids (the client resolves 'mine' to the
+    // current user id before sending). Empty = everyone.
+    const assignedToIn = (parsedQuery.data.assignee || '')
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean);
+    const offset = parsedQuery.data.offset ?? 0;
+    const limit = parsedQuery.data.limit ?? CRM_QUOTES_PAGE_SIZE;
+    const scope = {
       search: parsedQuery.data.q,
-      status: parsedQuery.data.status,
+      assignedToIn,
       prospectId: parsedQuery.data.prospect_id,
       customerId: parsedQuery.data.customer_id,
-      limit: parsedQuery.data.limit,
+    };
+
+    const supabase = createRouteHandlerClient({ cookies });
+    const query = await listCrmQuotesWithFilters(supabase, {
+      ...scope,
+      status: parsedQuery.data.status,
+      filter: parsedQuery.data.filter,
+      limit,
+      offset,
       sort: parsedQuery.data.sort,
     });
-    const { data, error } = await query;
+    const { data, error, count } = await query;
 
     if (error) {
       return routeError(500, 'crm_quotes_list_failed', error.message);
     }
 
-    return ok({ items: data || [] });
+    // Per-tab counts (scoped to the same search + assignee filter). Only the offer list asks for
+    // them (counts=1, first page); the board, the customer detail and the overview skip the extra
+    // count queries. Same contract as the work-orders route.
+    const wantCounts = url.searchParams.get('counts') === '1' && offset === 0;
+    const counts = wantCounts ? await getCrmQuoteFilterCounts(supabase, scope) : undefined;
+
+    return ok({ items: data || [], total: count ?? 0, offset, limit, counts });
   } catch (e: any) {
     return routeError(500, 'crm_quotes_unexpected', e?.message || 'Failed to list quotes');
   }

--- a/app/api/crm/work-orders/_lib.ts
+++ b/app/api/crm/work-orders/_lib.ts
@@ -116,6 +116,9 @@ export const listCrmWorkOrdersQuerySchema = z.object({
   limit: z.coerce.number().int().min(1).max(2000).optional(),
   // Pagination offset for the "Visa fler" board.
   offset: z.coerce.number().int().min(0).optional(),
+  // Row order. Default (installation_asc) is the board's work queue; 'created_desc' is for
+  // callers that want the newest orders, which the default sort puts LAST in the table.
+  sort: z.enum(['installation_asc', 'created_desc']).optional(),
 });
 
 export const updateCrmWorkOrderSchema = z.object({

--- a/app/api/crm/work-orders/route.ts
+++ b/app/api/crm/work-orders/route.ts
@@ -18,6 +18,7 @@ export async function GET(req: Request) {
       customer_id: url.searchParams.get('customer_id') || undefined,
       limit: url.searchParams.get('limit') || undefined,
       offset: url.searchParams.get('offset') || undefined,
+      sort: url.searchParams.get('sort') || undefined,
     });
 
     if (!parsedQuery.success) return validationError(parsedQuery.error);
@@ -43,6 +44,7 @@ export async function GET(req: Request) {
       customerId: parsedQuery.data.customer_id,
       limit,
       offset,
+      sort: parsedQuery.data.sort,
     });
     const { data, error, count } = await query;
 

--- a/app/components/AppSidebar.tsx
+++ b/app/components/AppSidebar.tsx
@@ -406,7 +406,9 @@ export default function AppSidebar({
         onMouseEnter={(e) => { if (!active) (e.currentTarget as HTMLElement).style.backgroundColor = 'var(--crm-sidebar-hover)'; }}
         onMouseLeave={(e) => { if (!active) (e.currentTarget as HTMLElement).style.backgroundColor = ''; }}
       >
-        {!isChild && <span className={cn('shrink-0', active ? 'text-emerald-300' : '')}>{icon}</span>}
+        {/* h-5 is the label's line box: the icon, not the hidden text, sets the row height
+            on the rail, so a row measures the same open as closed. */}
+        {!isChild && <span className={cn('flex h-5 shrink-0 items-center', active ? 'text-emerald-300' : '')}>{icon}</span>}
         <span className={cn('truncate crm-fade-in', rail && 'lg:hidden')}>{node.label}</span>
       </Link>
     );
@@ -481,8 +483,11 @@ export default function AppSidebar({
         )}
         style={{ backgroundColor: 'var(--crm-sidebar-bg)' }}
       >
-        {/* Logo + collapse toggle */}
-        <div className={cn('flex items-center justify-between px-4 pb-3 [padding-top:calc(1.25rem+env(safe-area-inset-top))] lg:pt-5', rail && 'lg:flex-col lg:items-center lg:gap-2 lg:px-3')}>
+        {/* Logo + collapse toggle. The band holds one height across rail and peek — 20px
+            top padding + 24px logo + 8px gap + 32px control + 12px bottom padding = 96px,
+            the rail's stack measured exactly — so everything below it keeps its line and
+            nothing walks upward under the cursor when the panel opens. */}
+        <div className={cn('flex items-center justify-between px-4 pb-3 [padding-top:calc(1.25rem+env(safe-area-inset-top))] lg:min-h-24 lg:pt-5', rail && 'lg:flex-col lg:items-center lg:gap-2 lg:px-3')}>
           <Link
             href="/"
             title="Till start"
@@ -503,25 +508,34 @@ export default function AppSidebar({
             <img src="/brand/Ekovilla_logga_vit.png" alt="Ekovilla" className="h-6 w-6 object-contain" />
           </Link>
           {/* Desktop: notification bell + pin toggle, grouped top-right (mobile has the bell in the top bar). */}
-          <div className={cn('ml-auto hidden items-center gap-1 lg:flex', rail ? 'lg:ml-0 lg:flex-col' : 'lg:self-start')}>
+          {/* Centred rather than top-aligned: the band is now taller than the brand block,
+              and self-start would float the controls above the logo instead of beside it. */}
+          <div className={cn('ml-auto hidden items-center gap-1 lg:flex', rail && 'lg:ml-0 lg:flex-col')}>
             {/* The sheet is anchored to the sidebar's layout column, so the peek has to be
                 gone before it opens. It can't be left to the mouse: the overlay is inserted
                 under a stationary cursor, and no mouseleave fires until the pointer moves. */}
             <span onClickCapture={endPeek} className="contents">
               <NotificationBell collapsed={!pinned} className="h-8 w-8 rounded-lg border border-white/20 bg-transparent p-0 text-white/80 hover:border-white/30 hover:bg-white/10 hover:text-white" />
             </span>
-            <button
-              type="button"
-              onClick={togglePinned}
-              aria-pressed={pinned}
-              aria-label={pinned ? 'Lossa menyn' : 'Fäst menyn öppen'}
-              title={pinned ? 'Lossa menyn — den visas då vid hover' : 'Fäst menyn öppen'}
-              className="grid h-8 w-8 shrink-0 place-items-center rounded-lg text-white/80 transition-colors hover:bg-white/10 hover:text-white"
-            >
-              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.9" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true" className={cn('transition-transform', !pinned && 'rotate-180')}>
-                <polyline points="15 18 9 12 15 6" />
-              </svg>
-            </button>
+            {/* 68px of rail fits the logo and one control, and the bell is the one carrying
+                information (the unread badge). A pointer that can click this button has
+                already opened the panel by reaching it, so the rail loses nothing by leaving
+                it out. Devices without hover never peek — there the rail keeps the button,
+                since it is their only way back to a pinned sidebar. */}
+            {(!rail || hoverCapable === false) && (
+              <button
+                type="button"
+                onClick={togglePinned}
+                aria-pressed={pinned}
+                aria-label={pinned ? 'Lossa menyn' : 'Fäst menyn öppen'}
+                title={pinned ? 'Lossa menyn — den visas då vid hover' : 'Fäst menyn öppen'}
+                className="grid h-8 w-8 shrink-0 place-items-center rounded-lg text-white/80 transition-colors hover:bg-white/10 hover:text-white"
+              >
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.9" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true" className={cn('transition-transform', !pinned && 'rotate-180')}>
+                  <polyline points="15 18 9 12 15 6" />
+                </svg>
+              </button>
+            )}
           </div>
           <button
             type="button"
@@ -549,7 +563,7 @@ export default function AppSidebar({
               onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.backgroundColor = 'var(--crm-sidebar-hover)'; }}
               onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.backgroundColor = ''; }}
             >
-              <span className="shrink-0">
+              <span className="flex h-5 shrink-0 items-center">
                 <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
                   <path d="M15 18l-6-6 6-6" />
                 </svg>
@@ -585,7 +599,7 @@ export default function AppSidebar({
                       onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.backgroundColor = 'var(--crm-sidebar-hover)'; }}
                       onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.backgroundColor = ''; }}
                     >
-                      <span className={cn('shrink-0', groupActive ? 'text-emerald-300' : '')}>{navIcons[item.href] ?? fallbackIcon}</span>
+                      <span className={cn('flex h-5 shrink-0 items-center', groupActive ? 'text-emerald-300' : '')}>{navIcons[item.href] ?? fallbackIcon}</span>
                       <span className={cn('flex-1 truncate text-left crm-fade-in', rail && 'lg:hidden')}>{item.label}</span>
                       <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true" className={cn('shrink-0 transition-transform', open && 'rotate-180', rail && 'lg:hidden')}>
                         <polyline points="6 9 12 15 18 9" />
@@ -608,7 +622,9 @@ export default function AppSidebar({
 
         {/* User + account menu */}
         <div className="mx-3 mt-2 mb-3 h-px" style={{ backgroundColor: 'var(--crm-sidebar-border)' }} />
-        <div className={cn('flex items-center gap-2.5 px-4 pb-5', rail && 'lg:justify-center lg:px-2')}>
+        {/* min-h-10 is the profile button's height (22px icon + padding + border): without it
+            the footer row shrinks to the avatar on the rail and the avatar hops on hover. */}
+        <div className={cn('flex items-center gap-2.5 px-4 pb-5 lg:min-h-10', rail && 'lg:justify-center lg:px-2')}>
           <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-emerald-700 text-xs font-bold text-white">
             {userInitial}
           </div>

--- a/app/components/AppSidebar.tsx
+++ b/app/components/AppSidebar.tsx
@@ -622,9 +622,11 @@ export default function AppSidebar({
 
         {/* User + account menu */}
         <div className="mx-3 mt-2 mb-3 h-px" style={{ backgroundColor: 'var(--crm-sidebar-border)' }} />
-        {/* min-h-10 is the profile button's height (22px icon + padding + border): without it
-            the footer row shrinks to the avatar on the rail and the avatar hops on hover. */}
-        <div className={cn('flex items-center gap-2.5 px-4 pb-5 lg:min-h-10', rail && 'lg:justify-center lg:px-2')}>
+        {/* 3.75rem = the profile button's 40px (22px icon + 8px padding + 1px border, twice) PLUS
+            pb-5's 20px. Preflight makes this a border box, so min-height has to include the
+            padding — a 40px floor would sit under the rail's own 52px and do nothing at all, and
+            the avatar would keep hopping on hover. */}
+        <div className={cn('flex items-center gap-2.5 px-4 pb-5 lg:min-h-[3.75rem]', rail && 'lg:justify-center lg:px-2')}>
           <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-emerald-700 text-xs font-bold text-white">
             {userInitial}
           </div>

--- a/app/crm/components/CrmOverview.tsx
+++ b/app/crm/components/CrmOverview.tsx
@@ -8,7 +8,7 @@ import ChangelogCard from './ChangelogCard';
 import type { UserRole } from '@/lib/roles';
 import { getVisibleCrmNavItems } from '../_lib/nav';
 import { cn } from '@/lib/shared/cn';
-import { crm } from '@/app/crm/lib/crmTokens';
+import { crm, workOrderStatusClass, workOrderStatusLabel, type WorkOrderStatus } from '@/app/crm/lib/crmTokens';
 import { weeklyFromMonthly } from '@/lib/domains/crm/goals';
 
 type ProspectItem = {
@@ -85,9 +85,12 @@ type QuoteItem = {
 
 type WorkOrderItem = {
   id: string;
+  order_number: string;
+  project_name: string;
+  client_name: string;
   amount: number | string;
   currency_code: string;
-  status: string;
+  status: WorkOrderStatus;
   assigned_to: string;
   created_at: string;
   fortnox_invoiced_at: string | null;
@@ -148,15 +151,6 @@ const quoteStatusLabel: Record<QuoteItem['status'], string> = {
   lost: 'Förlorad',
 };
 
-const prospectStatusLabel: Record<ProspectItem['status'], string> = {
-  new: 'Ny',
-  contacted: 'Kontaktad',
-  qualified: 'Kvalificerad',
-  quoted: 'Offert',
-  won: 'Vunnen',
-  lost: 'Förlorad',
-};
-
 function getProspectFromCall(item: CallItem) {
   if (Array.isArray(item.prospect)) return item.prospect[0] || null;
   return item.prospect || null;
@@ -194,8 +188,12 @@ function isPipelineProspect(prospect: ProspectItem) {
 // 'in_progress' is out on the job — both are open work — while 'completed' and
 // 'partially_invoiced' are the invoicing stage the board's chip calls "Fakturera".
 // 'invoiced' and 'cancelled' are deliberately in neither: they have left the flow.
-const OPEN_WORK_ORDER_STATUSES = ['draft', 'scheduled', 'ready', 'in_progress'];
-const TO_INVOICE_WORK_ORDER_STATUSES = ['completed', 'partially_invoiced'];
+const OPEN_WORK_ORDER_STATUSES: WorkOrderStatus[] = ['draft', 'scheduled', 'ready', 'in_progress'];
+const TO_INVOICE_WORK_ORDER_STATUSES: WorkOrderStatus[] = ['completed', 'partially_invoiced'];
+
+// Rows per "senaste …" card. Five fills the column next to the status panel and the leaderboard
+// without turning the overview into a list page — the cards' own "Visa alla" leads there.
+const RECENT_ITEM_LIMIT = 5;
 
 function toAmount(value: number | string) {
   const numeric = typeof value === 'number' ? value : Number(String(value));
@@ -452,10 +450,12 @@ export default function CrmOverview({ role }: { role: UserRole | null }) {
     };
   }, [state.calls, state.goals, state.prospects, state.quotes, state.tasks, state.workOrders]);
 
-  const recentProspects = useMemo(() => [...state.prospects].sort((a, b) => b.updated_at.localeCompare(a.updated_at)).slice(0, 3), [state.prospects]);
-  const recentCalls = useMemo(() => [...state.calls].sort((a, b) => b.call_at.localeCompare(a.call_at)).slice(0, 3), [state.calls]);
-  const recentQuotes = useMemo(() => [...state.quotes].sort((a, b) => b.updated_at.localeCompare(a.updated_at)).slice(0, 3), [state.quotes]);
-  const nextTasks = useMemo(() => [...state.tasks].filter((task) => task.status === 'open').sort(sortTasks).slice(0, 3), [state.tasks]);
+  const recentCalls = useMemo(() => [...state.calls].sort((a, b) => b.call_at.localeCompare(a.call_at)).slice(0, RECENT_ITEM_LIMIT), [state.calls]);
+  const recentQuotes = useMemo(() => [...state.quotes].sort((a, b) => b.updated_at.localeCompare(a.updated_at)).slice(0, RECENT_ITEM_LIMIT), [state.quotes]);
+  // Newest orders first, on creation date — "senaste" means the ones that just came in, not the
+  // ones somebody last touched.
+  const recentWorkOrders = useMemo(() => [...state.workOrders].sort((a, b) => b.created_at.localeCompare(a.created_at)).slice(0, RECENT_ITEM_LIMIT), [state.workOrders]);
+  const nextTasks = useMemo(() => [...state.tasks].filter((task) => task.status === 'open').sort(sortTasks).slice(0, RECENT_ITEM_LIMIT), [state.tasks]);
   const nextActions = buildOverviewActions({ overdueTasks: summary.overdueTasks, followUpCalls: summary.followUpCalls, newProspects: summary.newProspects, standaloneCalls: summary.standaloneCalls, quoteFollowUps: summary.quoteFollowUps });
   const teamLeaderboard = useMemo(() => {
     // Goals are MONTHLY budgets; the leaderboard shows the weekly target (budget ÷ 4) against
@@ -666,34 +666,36 @@ export default function CrmOverview({ role }: { role: UserRole | null }) {
             ) : null}
           </div>
 
-          {/* Recent items grid */}
+          {/* Recent items grid. Order follows the flow the sellers work in: offert → order on the
+              first row, then the two activity lists. Prospects had their own card here until
+              2026-08-17 and were dropped — that stage isn't in use right now. */}
           <div className="grid gap-4 xl:grid-cols-2">
-            <RecentCard title="Senaste prospekt" href="/crm/prospekt" loading={loading}>
-              {recentProspects.length === 0 ? <EmptyState description="Inga prospekt ännu." /> : (
+            <RecentCard title="Senaste offertlägen" href="/crm/offerter" loading={loading}>
+              {recentQuotes.length === 0 ? <EmptyState description="Inga offertsteg registrerade ännu." /> : (
                 <div className="grid gap-2">
-                  {recentProspects.map((prospect) => (
-                    <Link key={prospect.id} href="/crm/prospekt" className="flex items-start justify-between gap-3 rounded-xl border border-slate-100 p-3 no-underline transition hover:border-slate-200 hover:bg-slate-50">
+                  {recentQuotes.map((quote) => (
+                    <Link key={quote.id} href="/crm/offerter" className="flex items-start justify-between gap-3 rounded-xl border border-slate-100 p-3 no-underline transition hover:border-slate-200 hover:bg-slate-50">
                       <div className="min-w-0">
-                        <strong className="block truncate text-sm font-semibold text-slate-900">{prospect.company_name}</strong>
-                        <p className="m-0 truncate text-xs text-slate-500">{[prospect.contact_name, prospect.city, prospect.source].filter(Boolean).join(' · ') || 'Ingen extra info'}</p>
+                        <strong className="block truncate text-sm font-semibold text-slate-900">{quote.project_name}</strong>
+                        <p className="m-0 truncate text-xs text-slate-500">{getQuoteCustomerName(quote)} · {formatCurrency(quote.amount, quote.currency_code)}</p>
                       </div>
-                      <span className="shrink-0 rounded-full border border-slate-200 bg-slate-100 px-2.5 py-0.5 text-[11px] font-semibold text-slate-600">{prospectStatusLabel[prospect.status]}</span>
+                      <span className="shrink-0 rounded-full border border-amber-200 bg-amber-50 px-2.5 py-0.5 text-[11px] font-semibold text-amber-700">{quoteStatusLabel[quote.status]}</span>
                     </Link>
                   ))}
                 </div>
               )}
             </RecentCard>
 
-            <RecentCard title="Senaste samtal" href="/crm/samtal" loading={loading}>
-              {recentCalls.length === 0 ? <EmptyState description="Inga samtal loggade ännu." /> : (
+            <RecentCard title="Senaste ordrar" href="/crm/arbetsorder" loading={loading}>
+              {recentWorkOrders.length === 0 ? <EmptyState description="Inga arbetsordrar ännu." /> : (
                 <div className="grid gap-2">
-                  {recentCalls.map((call) => (
-                    <Link key={call.id} href="/crm/samtal" className="flex items-start justify-between gap-3 rounded-xl border border-slate-100 p-3 no-underline transition hover:border-slate-200 hover:bg-slate-50">
+                  {recentWorkOrders.map((order) => (
+                    <Link key={order.id} href={`/crm/arbetsorder/${order.id}`} className="flex items-start justify-between gap-3 rounded-xl border border-slate-100 p-3 no-underline transition hover:border-slate-200 hover:bg-slate-50">
                       <div className="min-w-0">
-                        <strong className="block truncate text-sm font-semibold text-slate-900">{getCallCompanyName(call)}</strong>
-                        <p className="m-0 truncate text-xs text-slate-500">{formatDateTime(call.call_at)}</p>
+                        <strong className="block truncate text-sm font-semibold text-slate-900">{order.project_name}</strong>
+                        <p className="m-0 truncate text-xs text-slate-500">{order.client_name} · {formatCurrency(order.amount, order.currency_code)}</p>
                       </div>
-                      <span className="shrink-0 rounded-full border border-slate-200 bg-slate-100 px-2.5 py-0.5 text-[11px] font-semibold text-slate-600">{outcomeLabel[call.outcome]}</span>
+                      <span className={cn('shrink-0 rounded-full border px-2.5 py-0.5 text-[11px] font-semibold', workOrderStatusClass[order.status])}>{workOrderStatusLabel[order.status]}</span>
                     </Link>
                   ))}
                 </div>
@@ -716,16 +718,16 @@ export default function CrmOverview({ role }: { role: UserRole | null }) {
               )}
             </RecentCard>
 
-            <RecentCard title="Senaste offertlägen" href="/crm/offerter" loading={loading}>
-              {recentQuotes.length === 0 ? <EmptyState description="Inga offertsteg registrerade ännu." /> : (
+            <RecentCard title="Senaste samtal" href="/crm/samtal" loading={loading}>
+              {recentCalls.length === 0 ? <EmptyState description="Inga samtal loggade ännu." /> : (
                 <div className="grid gap-2">
-                  {recentQuotes.map((quote) => (
-                    <Link key={quote.id} href="/crm/offerter" className="flex items-start justify-between gap-3 rounded-xl border border-slate-100 p-3 no-underline transition hover:border-slate-200 hover:bg-slate-50">
+                  {recentCalls.map((call) => (
+                    <Link key={call.id} href="/crm/samtal" className="flex items-start justify-between gap-3 rounded-xl border border-slate-100 p-3 no-underline transition hover:border-slate-200 hover:bg-slate-50">
                       <div className="min-w-0">
-                        <strong className="block truncate text-sm font-semibold text-slate-900">{quote.project_name}</strong>
-                        <p className="m-0 truncate text-xs text-slate-500">{getQuoteCustomerName(quote)} · {formatCurrency(quote.amount, quote.currency_code)}</p>
+                        <strong className="block truncate text-sm font-semibold text-slate-900">{getCallCompanyName(call)}</strong>
+                        <p className="m-0 truncate text-xs text-slate-500">{formatDateTime(call.call_at)}</p>
                       </div>
-                      <span className="shrink-0 rounded-full border border-amber-200 bg-amber-50 px-2.5 py-0.5 text-[11px] font-semibold text-amber-700">{quoteStatusLabel[quote.status]}</span>
+                      <span className="shrink-0 rounded-full border border-slate-200 bg-slate-100 px-2.5 py-0.5 text-[11px] font-semibold text-slate-600">{outcomeLabel[call.outcome]}</span>
                     </Link>
                   ))}
                 </div>
@@ -795,15 +797,17 @@ function RecentCard({ title, href, loading, children }: { title: string; href: s
         <strong className="text-sm font-bold text-slate-900">{title}</strong>
         <Link href={href} className="text-xs font-semibold text-emerald-700 no-underline hover:text-emerald-800">Visa alla</Link>
       </div>
-      {loading ? <OverviewLoadingRows /> : children}
+      {loading ? <OverviewLoadingRows rows={RECENT_ITEM_LIMIT} /> : children}
     </div>
   );
 }
 
-function OverviewLoadingRows() {
+// Skeleton row count is per caller: the recent lists settle on five rows, so a three-row skeleton
+// would make the whole column jump when the data lands.
+function OverviewLoadingRows({ rows = 3 }: { rows?: number }) {
   return (
     <div className="grid gap-2">
-      {Array.from({ length: 3 }).map((_, i) => (
+      {Array.from({ length: rows }).map((_, i) => (
         <div key={i} className="h-14 animate-pulse rounded-xl border border-[#e0e8dc] bg-[#dfe6da]" />
       ))}
     </div>

--- a/app/crm/components/CrmOverview.tsx
+++ b/app/crm/components/CrmOverview.tsx
@@ -324,9 +324,15 @@ export default function CrmOverview({ role }: { role: UserRole | null }) {
           fetch('/api/crm/prospects', { cache: 'no-store' }),
           fetch('/api/crm/calls', { cache: 'no-store' }),
           fetch('/api/crm/tasks', { cache: 'no-store' }),
-          fetch('/api/crm/quotes', { cache: 'no-store' }),
+          // Newest first, both of them. Every list here is capped at 100 rows server-side, and
+          // the two default sorts put exactly what this page needs last: the offer list leads
+          // with drafts and lost quotes, the order board with the earliest installation date —
+          // so a new order is the final row in the table. Sorting in the browser cannot repair
+          // that; the cut happens first. With recency leading, the "senaste"-cards are right at
+          // any table size and the windowed figures (7 days) can never fall outside the page.
+          fetch('/api/crm/quotes?sort=updated_desc', { cache: 'no-store' }),
           fetch('/api/crm/goals?period_type=month', { cache: 'no-store' }),
-          fetch('/api/crm/work-orders', { cache: 'no-store' }),
+          fetch('/api/crm/work-orders?sort=created_desc', { cache: 'no-store' }),
         ]);
 
         const [prospectsJson, callsJson, tasksJson, quotesJson, goalsJson, workOrdersJson] = await Promise.all([

--- a/app/crm/components/CrmOverview.tsx
+++ b/app/crm/components/CrmOverview.tsx
@@ -9,8 +9,8 @@ import type { UserRole } from '@/lib/roles';
 import { getVisibleCrmNavItems } from '../_lib/nav';
 import { cn } from '@/lib/shared/cn';
 import { crm, workOrderStatusClass, workOrderStatusLabel, type WorkOrderStatus } from '@/app/crm/lib/crmTokens';
-import { formatLocalDateOnly, getCurrentWeekStartDate, weeklyFromMonthly } from '@/lib/domains/crm/goals';
-import type { CrmOverviewSummary, CrmOverviewWindow } from '@/lib/domains/crm/overviewSummary';
+import { getCrmOverviewWindow, weeklyFromMonthly } from '@/lib/domains/crm/goals';
+import type { CrmOverviewSummary } from '@/lib/domains/crm/overviewSummary';
 
 type ProspectStatus = 'new' | 'contacted' | 'qualified' | 'quoted' | 'won' | 'lost';
 
@@ -78,7 +78,6 @@ type QuoteItem = {
 
 type WorkOrderItem = {
   id: string;
-  order_number: string;
   project_name: string;
   client_name: string;
   amount: number | string;
@@ -183,11 +182,11 @@ const RECENT_ITEM_LIMIT = 5;
 // rather than blanking. Matches what the empty lists produced before the server did the counting.
 const EMPTY_SUMMARY: CrmOverviewSummary = {
   pipelineProspects: 0, newProspects: 0, quotedProspects: 0, qualifiedProspects: 0,
-  activeQuotes: 0, activeQuoteValue: 0, quoteFollowUps: 0, quotesLast7Days: 0, quoteValueLast7Days: 0,
+  activeQuotes: 0, activeQuoteValue: 0, quoteFollowUps: 0,
   openWorkOrders: 0, openOrderValue: 0, workOrdersToInvoice: 0, toInvoiceOrderValue: 0,
-  orderValueLast7Days: 0, invoicedValueLast7Days: 0,
   callsLast7Days: 0, followUpCalls: 0, standaloneCalls: 0,
   openTasks: 0, overdueTasks: 0, todayTasks: 0,
+  weekTeam: { calls: 0, quotes: 0, quoteValue: 0, orderCount: 0, orderValue: 0, invoicedValue: 0 },
   weekByUser: {},
   truncated: [],
 };
@@ -210,34 +209,6 @@ function formatCurrency(value: number | string, currencyCode: string) {
   const numeric = typeof value === 'number' ? value : Number(String(value));
   if (!Number.isFinite(numeric)) return '–';
   return new Intl.NumberFormat('sv-SE', { style: 'currency', currency: currencyCode || 'SEK', maximumFractionDigits: 0 }).format(numeric);
-}
-
-function startOfToday() {
-  const now = new Date();
-  return new Date(now.getFullYear(), now.getMonth(), now.getDate());
-}
-
-function addDays(date: Date, days: number) {
-  const next = new Date(date);
-  next.setDate(next.getDate() + days);
-  return next;
-}
-
-// The window the server counts inside, built from the READER's clock — the route runs on UTC, so
-// deciding "this week" there would move the boundary for anyone whose calendar day differs from the
-// server's. The Monday comes from goals.ts, the same definition the weekly targets are keyed on, so
-// the actuals and the budget can't disagree about which week it is.
-function currentOverviewWindow(): CrmOverviewWindow {
-  const today = startOfToday();
-  const weekStart = getCurrentWeekStartDate();
-  // Noon anchor: adding days to a midnight Date can land on 23:00 the same day across a DST shift.
-  const weekEndDate = addDays(new Date(`${weekStart}T12:00:00`), 7);
-  return {
-    today: formatLocalDateOnly(today),
-    since: formatLocalDateOnly(addDays(today, -7)),
-    weekStart,
-    weekEnd: formatLocalDateOnly(weekEndDate),
-  };
 }
 
 function sortTasks(taskA: TaskItem, taskB: TaskItem) {
@@ -283,7 +254,7 @@ export default function CrmOverview({ role }: { role: UserRole | null }) {
       setError(null);
 
       try {
-        const overviewWindow = currentOverviewWindow();
+        const overviewWindow = getCrmOverviewWindow();
         const summaryQuery = new URLSearchParams({
           today: overviewWindow.today,
           since: overviewWindow.since,
@@ -365,11 +336,12 @@ export default function CrmOverview({ role }: { role: UserRole | null }) {
     };
   }, [state.summary, state.goals]);
 
-  const recentCalls = useMemo(() => [...state.calls].sort((a, b) => b.call_at.localeCompare(a.call_at)).slice(0, RECENT_ITEM_LIMIT), [state.calls]);
-  const recentQuotes = useMemo(() => [...state.quotes].sort((a, b) => b.updated_at.localeCompare(a.updated_at)).slice(0, RECENT_ITEM_LIMIT), [state.quotes]);
-  // Newest orders first, on creation date — "senaste" means the ones that just came in, not the
-  // ones somebody last touched.
-  const recentWorkOrders = useMemo(() => [...state.workOrders].sort((a, b) => b.created_at.localeCompare(a.created_at)).slice(0, RECENT_ITEM_LIMIT), [state.workOrders]);
+  // Quotes and orders arrive already ordered and already five rows long — the fetches ask for
+  // sort=updated_desc / sort=created_desc with limit=5, and re-sorting them here would leave two
+  // competing definitions of the same card's order, with the query's parameter looking
+  // authoritative. Calls and tasks come from routes without those parameters, so they are shaped
+  // here: calls arrive newest-first (call_at desc) and only need the slice; tasks need both.
+  const recentCalls = useMemo(() => state.calls.slice(0, RECENT_ITEM_LIMIT), [state.calls]);
   const nextTasks = useMemo(() => [...state.tasks].filter((task) => task.status === 'open').sort(sortTasks).slice(0, RECENT_ITEM_LIMIT), [state.tasks]);
   const nextActions = buildOverviewActions({ overdueTasks: summary.overdueTasks, followUpCalls: summary.followUpCalls, newProspects: summary.newProspects, standaloneCalls: summary.standaloneCalls, quoteFollowUps: summary.quoteFollowUps });
   const teamLeaderboard = useMemo(() => {
@@ -554,9 +526,9 @@ export default function CrmOverview({ role }: { role: UserRole | null }) {
               2026-08-17 and were dropped — that stage isn't in use right now. */}
           <div className="grid gap-4 xl:grid-cols-2">
             <RecentCard title="Senaste offertlägen" href="/crm/offerter" loading={loading}>
-              {recentQuotes.length === 0 ? <EmptyState description="Inga offertsteg registrerade ännu." /> : (
+              {state.quotes.length === 0 ? <EmptyState description="Inga offertsteg registrerade ännu." /> : (
                 <div className="grid gap-2">
-                  {recentQuotes.map((quote) => (
+                  {state.quotes.map((quote) => (
                     <Link key={quote.id} href="/crm/offerter" className="flex items-start justify-between gap-3 rounded-xl border border-slate-100 p-3 no-underline transition hover:border-slate-200 hover:bg-slate-50">
                       <div className="min-w-0">
                         <strong className="block truncate text-sm font-semibold text-slate-900">{quote.project_name}</strong>
@@ -570,9 +542,9 @@ export default function CrmOverview({ role }: { role: UserRole | null }) {
             </RecentCard>
 
             <RecentCard title="Senaste ordrar" href="/crm/arbetsorder" loading={loading}>
-              {recentWorkOrders.length === 0 ? <EmptyState description="Inga arbetsordrar ännu." /> : (
+              {state.workOrders.length === 0 ? <EmptyState description="Inga arbetsordrar ännu." /> : (
                 <div className="grid gap-2">
-                  {recentWorkOrders.map((order) => (
+                  {state.workOrders.map((order) => (
                     <Link key={order.id} href={`/crm/arbetsorder/${order.id}`} className="flex items-start justify-between gap-3 rounded-xl border border-slate-100 p-3 no-underline transition hover:border-slate-200 hover:bg-slate-50">
                       <div className="min-w-0">
                         <strong className="block truncate text-sm font-semibold text-slate-900">{order.project_name}</strong>
@@ -634,11 +606,15 @@ export default function CrmOverview({ role }: { role: UserRole | null }) {
                 <StatusStrip label="Aktiva offerter" value={summary.activeQuoteValue} scale={summary.flowScale} tone="emerald" currency helper={`${summary.activeQuotes} st`} />
                 <StatusStrip label="Öppna ordrar" value={summary.openOrderValue} scale={summary.flowScale} tone="teal" currency helper={`${summary.openWorkOrders} st`} />
                 <StatusStrip label="Att fakturera" value={summary.toInvoiceOrderValue} scale={summary.flowScale} tone="amber" currency helper={`${summary.workOrdersToInvoice} st`} />
-                <StatusStrip label="Fakturerat, 7 dagar" value={summary.invoicedValueLast7Days} tone="violet" currency />
+                <StatusStrip label="Fakturerat i veckan" value={summary.weekTeam.invoicedValue} tone="violet" currency />
                 <div className="my-1 h-px bg-slate-100" />
-                <StatusStrip label="Offerter mot mål" value={summary.quotesLast7Days} goal={summary.quotesTarget} tone="emerald" />
-                <StatusStrip label="Ordervärde mot mål" value={summary.orderValueLast7Days} goal={summary.orderValueTarget} tone="teal" currency />
-                <StatusStrip label="Samtal mot mål" value={summary.callsLast7Days} goal={summary.callsTarget} tone="sky" />
+                {/* Everything below is measured against a WEEKLY target, so the actuals are the
+                    week's — the same window the topplista under this card uses per säljare. With a
+                    rolling 7 days the team row could never equal the sum of the seller rows beside
+                    it, and one of the two would have to be read as broken. */}
+                <StatusStrip label="Offerter mot mål" value={summary.weekTeam.quotes} goal={summary.quotesTarget} tone="emerald" />
+                <StatusStrip label="Ordervärde mot mål" value={summary.weekTeam.orderValue} goal={summary.orderValueTarget} tone="teal" currency />
+                <StatusStrip label="Samtal mot mål" value={summary.weekTeam.calls} goal={summary.callsTarget} tone="sky" />
                 <StatusStrip label="Sena uppgifter" value={summary.overdueTasks} tone="rose" />
                 {/* Only ever shows if a query hit its row cap. The point of counting server-side
                     was that a truncated read stops being silent — so it says so. */}

--- a/app/crm/components/CrmOverview.tsx
+++ b/app/crm/components/CrmOverview.tsx
@@ -9,17 +9,10 @@ import type { UserRole } from '@/lib/roles';
 import { getVisibleCrmNavItems } from '../_lib/nav';
 import { cn } from '@/lib/shared/cn';
 import { crm, workOrderStatusClass, workOrderStatusLabel, type WorkOrderStatus } from '@/app/crm/lib/crmTokens';
-import { weeklyFromMonthly } from '@/lib/domains/crm/goals';
+import { formatLocalDateOnly, getCurrentWeekStartDate, weeklyFromMonthly } from '@/lib/domains/crm/goals';
+import type { CrmOverviewSummary, CrmOverviewWindow } from '@/lib/domains/crm/overviewSummary';
 
-type ProspectItem = {
-  id: string;
-  company_name: string;
-  contact_name: string | null;
-  city: string | null;
-  status: 'new' | 'contacted' | 'qualified' | 'quoted' | 'won' | 'lost';
-  source: string | null;
-  updated_at: string;
-};
+type ProspectStatus = 'new' | 'contacted' | 'qualified' | 'quoted' | 'won' | 'lost';
 
 type CallProspect = {
   id: string;
@@ -27,7 +20,7 @@ type CallProspect = {
   contact_name: string | null;
   city: string | null;
   source: string | null;
-  status: ProspectItem['status'];
+  status: ProspectStatus;
 };
 
 type CallItem = {
@@ -65,7 +58,7 @@ type QuoteProspect = {
   company_name: string;
   contact_name: string | null;
   city: string | null;
-  status: ProspectItem['status'];
+  status: ProspectStatus;
 };
 
 type QuoteItem = {
@@ -96,8 +89,11 @@ type WorkOrderItem = {
   fortnox_invoiced_at: string | null;
 };
 
+// The page's numbers come pre-counted from /api/crm/overview; the lists are only what the four
+// "senaste …"-cards render, five rows each. Counting list rows in the browser is what this
+// replaced — see lib/domains/crm/overviewSummary.ts for why that could not hold.
 type LoadState = {
-  prospects: ProspectItem[];
+  summary: CrmOverviewSummary | null;
   calls: CallItem[];
   tasks: TaskItem[];
   quotes: QuoteItem[];
@@ -179,26 +175,22 @@ function hasActiveGoalTarget(goal: GoalItem) {
     || goal.order_count_target > 0 || Number(goal.order_value_target) > 0;
 }
 
-function isPipelineProspect(prospect: ProspectItem) {
-  return prospect.status === 'new' || prospect.status === 'contacted' || prospect.status === 'qualified' || prospect.status === 'quoted';
-}
-
-// Where an order sits in the flow, split the same way the order board splits it (see
-// BOARD_FILTER_STATUSES in lib/domains/crm/work-orders.ts): 'draft' is not planned yet and
-// 'in_progress' is out on the job — both are open work — while 'completed' and
-// 'partially_invoiced' are the invoicing stage the board's chip calls "Fakturera".
-// 'invoiced' and 'cancelled' are deliberately in neither: they have left the flow.
-const OPEN_WORK_ORDER_STATUSES: WorkOrderStatus[] = ['draft', 'scheduled', 'ready', 'in_progress'];
-const TO_INVOICE_WORK_ORDER_STATUSES: WorkOrderStatus[] = ['completed', 'partially_invoiced'];
-
 // Rows per "senaste …" card. Five fills the column next to the status panel and the leaderboard
 // without turning the overview into a list page — the cards' own "Visa alla" leads there.
 const RECENT_ITEM_LIMIT = 5;
 
-function toAmount(value: number | string) {
-  const numeric = typeof value === 'number' ? value : Number(String(value));
-  return Number.isFinite(numeric) ? numeric : 0;
-}
+// Zeros while the summary is in flight or after a failed load, so the panels render their shape
+// rather than blanking. Matches what the empty lists produced before the server did the counting.
+const EMPTY_SUMMARY: CrmOverviewSummary = {
+  pipelineProspects: 0, newProspects: 0, quotedProspects: 0, qualifiedProspects: 0,
+  activeQuotes: 0, activeQuoteValue: 0, quoteFollowUps: 0, quotesLast7Days: 0, quoteValueLast7Days: 0,
+  openWorkOrders: 0, openOrderValue: 0, workOrdersToInvoice: 0, toInvoiceOrderValue: 0,
+  orderValueLast7Days: 0, invoicedValueLast7Days: 0,
+  callsLast7Days: 0, followUpCalls: 0, standaloneCalls: 0,
+  openTasks: 0, overdueTasks: 0, todayTasks: 0,
+  weekByUser: {},
+  truncated: [],
+};
 
 function formatDateTime(value: string | null | undefined) {
   if (!value) return '–';
@@ -231,50 +223,21 @@ function addDays(date: Date, days: number) {
   return next;
 }
 
-function isWithinLastDays(value: string, days: number) {
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return false;
-  const from = addDays(startOfToday(), -days);
-  return date >= from;
-}
-
-// Current ISO week range [Monday 00:00, next Monday 00:00) in local time. The leaderboard
-// scopes its actuals to this so weekly targets compare against the current week's activity.
-function currentWeekRange() {
-  const start = startOfToday();
-  const mondayOffset = (start.getDay() + 6) % 7;
-  start.setDate(start.getDate() - mondayOffset);
-  return { start, end: addDays(start, 7) };
-}
-
-// Parse a call_at/created_at timestamp OR a quote_date (date-only) consistently in local time.
-function parseActivityDate(value: string | null | undefined): Date | null {
-  if (!value) return null;
-  const iso = value.length === 10 ? `${value}T12:00:00` : value;
-  const date = new Date(iso);
-  return Number.isNaN(date.getTime()) ? null : date;
-}
-
-function isWithin(value: string | null | undefined, range: { start: Date; end: Date }) {
-  const date = parseActivityDate(value);
-  return date != null && date >= range.start && date < range.end;
-}
-
-function isOverdue(task: TaskItem) {
-  if (task.status === 'done' || !task.due_date) return false;
+// The window the server counts inside, built from the READER's clock — the route runs on UTC, so
+// deciding "this week" there would move the boundary for anyone whose calendar day differs from the
+// server's. The Monday comes from goals.ts, the same definition the weekly targets are keyed on, so
+// the actuals and the budget can't disagree about which week it is.
+function currentOverviewWindow(): CrmOverviewWindow {
   const today = startOfToday();
-  const dueDate = new Date(`${task.due_date}T00:00:00`);
-  if (Number.isNaN(dueDate.getTime())) return false;
-  return dueDate < today;
-}
-
-function isDueToday(task: TaskItem) {
-  if (task.status === 'done' || !task.due_date) return false;
-  const today = startOfToday();
-  const dueDate = new Date(`${task.due_date}T00:00:00`);
-  return dueDate.getFullYear() === today.getFullYear()
-    && dueDate.getMonth() === today.getMonth()
-    && dueDate.getDate() === today.getDate();
+  const weekStart = getCurrentWeekStartDate();
+  // Noon anchor: adding days to a midnight Date can land on 23:00 the same day across a DST shift.
+  const weekEndDate = addDays(new Date(`${weekStart}T12:00:00`), 7);
+  return {
+    today: formatLocalDateOnly(today),
+    since: formatLocalDateOnly(addDays(today, -7)),
+    weekStart,
+    weekEnd: formatLocalDateOnly(weekEndDate),
+  };
 }
 
 function sortTasks(taskA: TaskItem, taskB: TaskItem) {
@@ -308,7 +271,7 @@ function buildOverviewActions(args: { overdueTasks: number; followUpCalls: numbe
 
 export default function CrmOverview({ role }: { role: UserRole | null }) {
   const items = getVisibleCrmNavItems(role).filter((item) => item.href !== '/crm');
-  const [state, setState] = useState<LoadState>({ prospects: [], calls: [], tasks: [], quotes: [], goals: [], workOrders: [] });
+  const [state, setState] = useState<LoadState>({ summary: null, calls: [], tasks: [], quotes: [], goals: [], workOrders: [] });
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -320,23 +283,27 @@ export default function CrmOverview({ role }: { role: UserRole | null }) {
       setError(null);
 
       try {
-        const [prospectsRes, callsRes, tasksRes, quotesRes, goalsRes, workOrdersRes] = await Promise.all([
-          fetch('/api/crm/prospects', { cache: 'no-store' }),
+        const overviewWindow = currentOverviewWindow();
+        const summaryQuery = new URLSearchParams({
+          today: overviewWindow.today,
+          since: overviewWindow.since,
+          week_start: overviewWindow.weekStart,
+          week_end: overviewWindow.weekEnd,
+        });
+        const [summaryRes, callsRes, tasksRes, quotesRes, goalsRes, workOrdersRes] = await Promise.all([
+          fetch(`/api/crm/overview?${summaryQuery}`, { cache: 'no-store' }),
           fetch('/api/crm/calls', { cache: 'no-store' }),
           fetch('/api/crm/tasks', { cache: 'no-store' }),
-          // Newest first, both of them. Every list here is capped at 100 rows server-side, and
-          // the two default sorts put exactly what this page needs last: the offer list leads
-          // with drafts and lost quotes, the order board with the earliest installation date —
-          // so a new order is the final row in the table. Sorting in the browser cannot repair
-          // that; the cut happens first. With recency leading, the "senaste"-cards are right at
-          // any table size and the windowed figures (7 days) can never fall outside the page.
-          fetch('/api/crm/quotes?sort=updated_desc', { cache: 'no-store' }),
+          // These two lists are now only the cards' five rows. Both sorts have to be asked for:
+          // the offer list's default order leads with drafts and lost quotes, the order board's
+          // with the earliest installation date — so a brand new order is the table's last row.
+          fetch(`/api/crm/quotes?sort=updated_desc&limit=${RECENT_ITEM_LIMIT}`, { cache: 'no-store' }),
           fetch('/api/crm/goals?period_type=month', { cache: 'no-store' }),
-          fetch('/api/crm/work-orders?sort=created_desc', { cache: 'no-store' }),
+          fetch(`/api/crm/work-orders?sort=created_desc&limit=${RECENT_ITEM_LIMIT}`, { cache: 'no-store' }),
         ]);
 
-        const [prospectsJson, callsJson, tasksJson, quotesJson, goalsJson, workOrdersJson] = await Promise.all([
-          prospectsRes.json().catch(() => ({})),
+        const [summaryJson, callsJson, tasksJson, quotesJson, goalsJson, workOrdersJson] = await Promise.all([
+          summaryRes.json().catch(() => ({})),
           callsRes.json().catch(() => ({})),
           tasksRes.json().catch(() => ({})),
           quotesRes.json().catch(() => ({})),
@@ -344,18 +311,18 @@ export default function CrmOverview({ role }: { role: UserRole | null }) {
           workOrdersRes.json().catch(() => ({})),
         ]);
 
-        if (!prospectsRes.ok) throw new Error(prospectsJson?.error || 'Kunde inte läsa prospekt.');
+        if (!summaryRes.ok) throw new Error(summaryJson?.error || 'Kunde inte räkna översiktens siffror.');
         if (!callsRes.ok) throw new Error(callsJson?.error || 'Kunde inte läsa samtal.');
         if (!tasksRes.ok) throw new Error(tasksJson?.error || 'Kunde inte läsa uppgifter.');
         if (!quotesRes.ok) throw new Error(quotesJson?.error || 'Kunde inte läsa offerter.');
         if (!goalsRes.ok) throw new Error(goalsJson?.error || 'Kunde inte läsa mål.');
-        // Work orders feed the leaderboard's order-value rows; a failure there shouldn't
-        // blank the whole overview, so we tolerate it and fall back to an empty list.
+        // Work orders only feed the "senaste ordrar"-card now — the numbers come from the summary
+        // — so a failure there shouldn't blank the whole overview. Same tolerance as before.
 
         if (!active) return;
 
         setState({
-          prospects: Array.isArray(prospectsJson?.data?.items) ? prospectsJson.data.items : [],
+          summary: (summaryJson?.data?.summary as CrmOverviewSummary | undefined) ?? null,
           calls: Array.isArray(callsJson?.data?.items) ? callsJson.data.items : [],
           tasks: Array.isArray(tasksJson?.data?.items) ? tasksJson.data.items : [],
           quotes: Array.isArray(quotesJson?.data?.items) ? quotesJson.data.items : [],
@@ -365,7 +332,7 @@ export default function CrmOverview({ role }: { role: UserRole | null }) {
       } catch (loadError: any) {
         if (!active) return;
         setError(loadError?.message || 'Kunde inte ladda CRM-översikten.');
-        setState({ prospects: [], calls: [], tasks: [], quotes: [], goals: [], workOrders: [] });
+        setState({ summary: null, calls: [], tasks: [], quotes: [], goals: [], workOrders: [] });
       } finally {
         if (active) setLoading(false);
       }
@@ -378,83 +345,25 @@ export default function CrmOverview({ role }: { role: UserRole | null }) {
     };
   }, []);
 
+  // The figures are counted by /api/crm/overview; what's left here is the team's targets, which
+  // come from the goals list, and the flow bars' shared scale.
   const summary = useMemo(() => {
-    const openTasks = state.tasks.filter((task) => task.status === 'open');
-    const overdueTasks = openTasks.filter(isOverdue);
-    const todayTasks = openTasks.filter(isDueToday);
-    const recentCalls = state.calls.filter((call) => isWithinLastDays(call.call_at, 7));
-    const followUpCalls = state.calls.filter((call) => call.outcome === 'follow_up');
-    const standaloneCalls = state.calls.filter((call) => !getProspectFromCall(call));
-    const activeQuotes = state.quotes.filter((quote) => quote.status === 'draft' || quote.status === 'sent' || quote.status === 'follow_up');
-    const quoteFollowUps = state.quotes.filter((quote) => quote.status === 'follow_up');
-    const wonQuotes = state.quotes.filter((quote) => quote.status === 'won');
-    const recentQuotes = state.quotes.filter((quote) => isWithinLastDays(quote.quote_date, 7));
-    const quoteValueLast7Days = recentQuotes.reduce((total, quote) => total + toAmount(quote.amount), 0);
-    const activeQuoteValue = activeQuotes.reduce((total, quote) => total + toAmount(quote.amount), 0);
-    // The order side of the flow. The two stocks are current state; the two windowed figures use
-    // the same rolling 7 days as the quote and call rows above so the card keeps one clock.
-    // "Fakturerat" is bucketed on the invoice date, never on creation: the lag from order to
-    // invoice runs about a month, so created_at would drop most of what was actually invoiced
-    // in the window — the error PR #70 fixed in reporting. Unlike reports.ts's invoicedAt()
-    // there is deliberately no created_at fallback for rows predating the column: this row has
-    // to sum to the leaderboard's "Fakturerat ordervärde" sitting right below it, and that one
-    // requires the stamp. Two invoiced figures that disagree on one screen is worse than
-    // dropping legacy rows that are far outside a 7-day window anyway.
-    const openWorkOrders = state.workOrders.filter((order) => OPEN_WORK_ORDER_STATUSES.includes(order.status));
-    const workOrdersToInvoice = state.workOrders.filter((order) => TO_INVOICE_WORK_ORDER_STATUSES.includes(order.status));
-    const openOrderValue = openWorkOrders.reduce((total, order) => total + toAmount(order.amount), 0);
-    // Full order value, not what remains: a partially invoiced order carries no remaining-amount
-    // field on this payload, so the row is the value sitting in the invoicing stage.
-    const toInvoiceOrderValue = workOrdersToInvoice.reduce((total, order) => total + toAmount(order.amount), 0);
-    const orderValueLast7Days = state.workOrders
-      .filter((order) => isWithinLastDays(order.created_at, 7))
-      .reduce((total, order) => total + toAmount(order.amount), 0);
-    const invoicedValueLast7Days = state.workOrders
-      .filter((order) => order.status === 'invoiced' && order.fortnox_invoiced_at != null && isWithinLastDays(order.fortnox_invoiced_at, 7))
-      .reduce((total, order) => total + toAmount(order.amount), 0);
-    const pipelineProspects = state.prospects.filter(isPipelineProspect);
-    const newProspects = state.prospects.filter((prospect) => prospect.status === 'new');
-    const quotedProspects = state.prospects.filter((prospect) => prospect.status === 'quoted');
-    const qualifiedProspects = state.prospects.filter((prospect) => prospect.status === 'qualified' || prospect.status === 'quoted');
+    const counted = state.summary ?? EMPTY_SUMMARY;
     // Monthly budgets → weekly targets (÷4) so the team summary compares against ~one week.
     const callsTarget = Math.round(weeklyFromMonthly(state.goals.reduce((total, goal) => total + goal.calls_target, 0)));
     const quotesTarget = Math.round(weeklyFromMonthly(state.goals.reduce((total, goal) => total + goal.quotes_target, 0)));
-    const quoteValueTarget = weeklyFromMonthly(state.goals.reduce((total, goal) => total + Number(goal.quote_value_target || 0), 0));
     const orderValueTarget = weeklyFromMonthly(state.goals.reduce((total, goal) => total + Number(goal.order_value_target || 0), 0));
 
     return {
-      prospectsTotal: state.prospects.length,
-      pipelineProspects: pipelineProspects.length,
-      newProspects: newProspects.length,
-      quotedProspects: quotedProspects.length,
-      qualifiedProspects: qualifiedProspects.length,
-      callsLast7Days: recentCalls.length,
-      followUpCalls: followUpCalls.length,
-      standaloneCalls: standaloneCalls.length,
-      activeQuotes: activeQuotes.length,
-      activeQuoteValue,
-      quoteFollowUps: quoteFollowUps.length,
-      wonQuotes: wonQuotes.length,
-      quotesLast7Days: recentQuotes.length,
-      quoteValueLast7Days,
-      openWorkOrders: openWorkOrders.length,
-      workOrdersToInvoice: workOrdersToInvoice.length,
-      openOrderValue,
-      toInvoiceOrderValue,
+      ...counted,
       // Shared denominator for the three flow bars: the largest stock, so nothing can exceed
       // the track and the bars stay proportional to each other.
-      flowScale: Math.max(activeQuoteValue, openOrderValue, toInvoiceOrderValue),
-      orderValueLast7Days,
-      invoicedValueLast7Days,
-      openTasks: openTasks.length,
-      overdueTasks: overdueTasks.length,
-      todayTasks: todayTasks.length,
+      flowScale: Math.max(counted.activeQuoteValue, counted.openOrderValue, counted.toInvoiceOrderValue),
       callsTarget,
       quotesTarget,
-      quoteValueTarget,
       orderValueTarget,
     };
-  }, [state.calls, state.goals, state.prospects, state.quotes, state.tasks, state.workOrders]);
+  }, [state.summary, state.goals]);
 
   const recentCalls = useMemo(() => [...state.calls].sort((a, b) => b.call_at.localeCompare(a.call_at)).slice(0, RECENT_ITEM_LIMIT), [state.calls]);
   const recentQuotes = useMemo(() => [...state.quotes].sort((a, b) => b.updated_at.localeCompare(a.updated_at)).slice(0, RECENT_ITEM_LIMIT), [state.quotes]);
@@ -464,43 +373,10 @@ export default function CrmOverview({ role }: { role: UserRole | null }) {
   const nextTasks = useMemo(() => [...state.tasks].filter((task) => task.status === 'open').sort(sortTasks).slice(0, RECENT_ITEM_LIMIT), [state.tasks]);
   const nextActions = buildOverviewActions({ overdueTasks: summary.overdueTasks, followUpCalls: summary.followUpCalls, newProspects: summary.newProspects, standaloneCalls: summary.standaloneCalls, quoteFollowUps: summary.quoteFollowUps });
   const teamLeaderboard = useMemo(() => {
-    // Goals are MONTHLY budgets; the leaderboard shows the weekly target (budget ÷ 4) against
-    // THIS WEEK's actuals — so every actual is scoped to the current ISO week.
-    const week = currentWeekRange();
-    const callsByUser = new Map<string, number>();
-    const quotesByUser = new Map<string, number>();
-    const quoteValueByUser = new Map<string, number>();
-    const orderCountByUser = new Map<string, number>();
-    const orderValueByUser = new Map<string, number>();
-    const invoicedValueByUser = new Map<string, number>();
-    const add = (map: Map<string, number>, key: string, value: number) => map.set(key, (map.get(key) || 0) + value);
-    const numeric = (value: number | string) => {
-      const n = typeof value === 'number' ? value : Number(String(value));
-      return Number.isFinite(n) ? n : 0;
-    };
-
-    for (const call of state.calls) {
-      if (isWithin(call.call_at, week)) add(callsByUser, call.user_id, 1);
-    }
-
-    for (const quote of state.quotes) {
-      if (!isWithin(quote.quote_date, week)) continue;
-      add(quotesByUser, quote.assigned_to, 1);
-      add(quoteValueByUser, quote.assigned_to, numeric(quote.amount));
-    }
-
-    for (const workOrder of state.workOrders) {
-      const amount = numeric(workOrder.amount);
-      // Order count + value: orders created this week.
-      if (isWithin(workOrder.created_at, week)) {
-        add(orderCountByUser, workOrder.assigned_to, 1);
-        add(orderValueByUser, workOrder.assigned_to, amount);
-      }
-      // "Fakturerat": value of orders invoiced this week (by the Fortnox invoice date).
-      if (workOrder.status === 'invoiced' && isWithin(workOrder.fortnox_invoiced_at, week)) {
-        add(invoicedValueByUser, workOrder.assigned_to, amount);
-      }
-    }
+    // Goals are MONTHLY budgets; the leaderboard shows the weekly target (budget ÷ 4) against THIS
+    // WEEK's actuals. The actuals are counted per user by /api/crm/overview — summing them here
+    // meant reading them out of a capped list, which is exactly what stopped being trustworthy.
+    const week = state.summary?.weekByUser ?? {};
 
     return state.goals
       .filter(hasActiveGoalTarget)
@@ -514,12 +390,13 @@ export default function CrmOverview({ role }: { role: UserRole | null }) {
         const orderCountTarget = Math.round(weeklyFromMonthly(goal.order_count_target));
         const orderValueTarget = weeklyFromMonthly(goal.order_value_target);
 
-        const callsDone = callsByUser.get(goal.user_id) || 0;
-        const quotesDone = quotesByUser.get(goal.user_id) || 0;
-        const quoteValueDone = quoteValueByUser.get(goal.user_id) || 0;
-        const orderCountDone = orderCountByUser.get(goal.user_id) || 0;
-        const orderValueDone = orderValueByUser.get(goal.user_id) || 0;
-        const invoicedValueDone = invoicedValueByUser.get(goal.user_id) || 0;
+        const actuals = week[goal.user_id];
+        const callsDone = actuals?.calls ?? 0;
+        const quotesDone = actuals?.quotes ?? 0;
+        const quoteValueDone = actuals?.quoteValue ?? 0;
+        const orderCountDone = actuals?.orderCount ?? 0;
+        const orderValueDone = actuals?.orderValue ?? 0;
+        const invoicedValueDone = actuals?.invoicedValue ?? 0;
         const progressValues = [
           callsTarget > 0 ? callsDone / callsTarget : null,
           quotesTarget > 0 ? quotesDone / quotesTarget : null,
@@ -555,7 +432,7 @@ export default function CrmOverview({ role }: { role: UserRole | null }) {
         if (right.callsDone !== left.callsDone) return right.callsDone - left.callsDone;
         return left.userName.localeCompare(right.userName, 'sv');
       });
-  }, [state.calls, state.goals, state.quotes, state.workOrders]);
+  }, [state.goals, state.summary]);
 
   return (
     <div className="grid grid-cols-1 gap-6">
@@ -763,6 +640,13 @@ export default function CrmOverview({ role }: { role: UserRole | null }) {
                 <StatusStrip label="Ordervärde mot mål" value={summary.orderValueLast7Days} goal={summary.orderValueTarget} tone="teal" currency />
                 <StatusStrip label="Samtal mot mål" value={summary.callsLast7Days} goal={summary.callsTarget} tone="sky" />
                 <StatusStrip label="Sena uppgifter" value={summary.overdueTasks} tone="rose" />
+                {/* Only ever shows if a query hit its row cap. The point of counting server-side
+                    was that a truncated read stops being silent — so it says so. */}
+                {summary.truncated.length > 0 ? (
+                  <p className="m-0 text-[11px] leading-4 text-amber-700">
+                    Räknat på ett kapat urval ({summary.truncated.join(', ')}) — siffrorna kan vara för låga.
+                  </p>
+                ) : null}
               </div>
             )}
           </div>

--- a/app/crm/components/CrmOverview.tsx
+++ b/app/crm/components/CrmOverview.tsx
@@ -189,6 +189,19 @@ function isPipelineProspect(prospect: ProspectItem) {
   return prospect.status === 'new' || prospect.status === 'contacted' || prospect.status === 'qualified' || prospect.status === 'quoted';
 }
 
+// Where an order sits in the flow, split the same way the order board splits it (see
+// BOARD_FILTER_STATUSES in lib/domains/crm/work-orders.ts): 'draft' is not planned yet and
+// 'in_progress' is out on the job — both are open work — while 'completed' and
+// 'partially_invoiced' are the invoicing stage the board's chip calls "Fakturera".
+// 'invoiced' and 'cancelled' are deliberately in neither: they have left the flow.
+const OPEN_WORK_ORDER_STATUSES = ['draft', 'scheduled', 'ready', 'in_progress'];
+const TO_INVOICE_WORK_ORDER_STATUSES = ['completed', 'partially_invoiced'];
+
+function toAmount(value: number | string) {
+  const numeric = typeof value === 'number' ? value : Number(String(value));
+  return Number.isFinite(numeric) ? numeric : 0;
+}
+
 function formatDateTime(value: string | null | undefined) {
   if (!value) return '–';
   const date = new Date(value);
@@ -372,19 +385,38 @@ export default function CrmOverview({ role }: { role: UserRole | null }) {
     const quoteFollowUps = state.quotes.filter((quote) => quote.status === 'follow_up');
     const wonQuotes = state.quotes.filter((quote) => quote.status === 'won');
     const recentQuotes = state.quotes.filter((quote) => isWithinLastDays(quote.quote_date, 7));
-    const quoteValueLast7Days = recentQuotes.reduce((total, quote) => {
-      const numeric = typeof quote.amount === 'number' ? quote.amount : Number(String(quote.amount));
-      return total + (Number.isFinite(numeric) ? numeric : 0);
-    }, 0);
+    const quoteValueLast7Days = recentQuotes.reduce((total, quote) => total + toAmount(quote.amount), 0);
+    const activeQuoteValue = activeQuotes.reduce((total, quote) => total + toAmount(quote.amount), 0);
+    // The order side of the flow. The two stocks are current state; the two windowed figures use
+    // the same rolling 7 days as the quote and call rows above so the card keeps one clock.
+    // "Fakturerat" is bucketed on the invoice date, never on creation: the lag from order to
+    // invoice runs about a month, so created_at would drop most of what was actually invoiced
+    // in the window — the error PR #70 fixed in reporting. Unlike reports.ts's invoicedAt()
+    // there is deliberately no created_at fallback for rows predating the column: this row has
+    // to sum to the leaderboard's "Fakturerat ordervärde" sitting right below it, and that one
+    // requires the stamp. Two invoiced figures that disagree on one screen is worse than
+    // dropping legacy rows that are far outside a 7-day window anyway.
+    const openWorkOrders = state.workOrders.filter((order) => OPEN_WORK_ORDER_STATUSES.includes(order.status));
+    const workOrdersToInvoice = state.workOrders.filter((order) => TO_INVOICE_WORK_ORDER_STATUSES.includes(order.status));
+    const openOrderValue = openWorkOrders.reduce((total, order) => total + toAmount(order.amount), 0);
+    // Full order value, not what remains: a partially invoiced order carries no remaining-amount
+    // field on this payload, so the row is the value sitting in the invoicing stage.
+    const toInvoiceOrderValue = workOrdersToInvoice.reduce((total, order) => total + toAmount(order.amount), 0);
+    const orderValueLast7Days = state.workOrders
+      .filter((order) => isWithinLastDays(order.created_at, 7))
+      .reduce((total, order) => total + toAmount(order.amount), 0);
+    const invoicedValueLast7Days = state.workOrders
+      .filter((order) => order.status === 'invoiced' && order.fortnox_invoiced_at != null && isWithinLastDays(order.fortnox_invoiced_at, 7))
+      .reduce((total, order) => total + toAmount(order.amount), 0);
     const pipelineProspects = state.prospects.filter(isPipelineProspect);
     const newProspects = state.prospects.filter((prospect) => prospect.status === 'new');
     const quotedProspects = state.prospects.filter((prospect) => prospect.status === 'quoted');
     const qualifiedProspects = state.prospects.filter((prospect) => prospect.status === 'qualified' || prospect.status === 'quoted');
-    const wonProspects = state.prospects.filter((prospect) => prospect.status === 'won');
     // Monthly budgets → weekly targets (÷4) so the team summary compares against ~one week.
     const callsTarget = Math.round(weeklyFromMonthly(state.goals.reduce((total, goal) => total + goal.calls_target, 0)));
     const quotesTarget = Math.round(weeklyFromMonthly(state.goals.reduce((total, goal) => total + goal.quotes_target, 0)));
     const quoteValueTarget = weeklyFromMonthly(state.goals.reduce((total, goal) => total + Number(goal.quote_value_target || 0), 0));
+    const orderValueTarget = weeklyFromMonthly(state.goals.reduce((total, goal) => total + Number(goal.order_value_target || 0), 0));
 
     return {
       prospectsTotal: state.prospects.length,
@@ -392,23 +424,33 @@ export default function CrmOverview({ role }: { role: UserRole | null }) {
       newProspects: newProspects.length,
       quotedProspects: quotedProspects.length,
       qualifiedProspects: qualifiedProspects.length,
-      wonProspects: wonProspects.length,
       callsLast7Days: recentCalls.length,
       followUpCalls: followUpCalls.length,
       standaloneCalls: standaloneCalls.length,
       activeQuotes: activeQuotes.length,
+      activeQuoteValue,
       quoteFollowUps: quoteFollowUps.length,
       wonQuotes: wonQuotes.length,
       quotesLast7Days: recentQuotes.length,
       quoteValueLast7Days,
+      openWorkOrders: openWorkOrders.length,
+      workOrdersToInvoice: workOrdersToInvoice.length,
+      openOrderValue,
+      toInvoiceOrderValue,
+      // Shared denominator for the three flow bars: the largest stock, so nothing can exceed
+      // the track and the bars stay proportional to each other.
+      flowScale: Math.max(activeQuoteValue, openOrderValue, toInvoiceOrderValue),
+      orderValueLast7Days,
+      invoicedValueLast7Days,
       openTasks: openTasks.length,
       overdueTasks: overdueTasks.length,
       todayTasks: todayTasks.length,
       callsTarget,
       quotesTarget,
       quoteValueTarget,
+      orderValueTarget,
     };
-  }, [state.calls, state.goals, state.prospects, state.quotes, state.tasks]);
+  }, [state.calls, state.goals, state.prospects, state.quotes, state.tasks, state.workOrders]);
 
   const recentProspects = useMemo(() => [...state.prospects].sort((a, b) => b.updated_at.localeCompare(a.updated_at)).slice(0, 3), [state.prospects]);
   const recentCalls = useMemo(() => [...state.calls].sort((a, b) => b.call_at.localeCompare(a.call_at)).slice(0, 3), [state.calls]);
@@ -700,12 +742,18 @@ export default function CrmOverview({ role }: { role: UserRole | null }) {
             <h2 className="m-0 mb-4 text-lg font-bold tracking-tight text-slate-900">Fördelning och mål</h2>
             {loading ? <OverviewLoadingRows /> : (
               <div className="grid gap-3">
-                <StatusStrip label="Öppna prospekt" value={summary.pipelineProspects} tone="teal" />
-                <StatusStrip label="Nya prospekt" value={summary.newProspects} tone="slate" />
-                <StatusStrip label="Prospekt i offertläge" value={summary.quotedProspects} tone="amber" />
-                <StatusStrip label="Vunna prospekt" value={summary.wonProspects} tone="emerald" />
-                <StatusStrip label="Samtal mot mål" value={summary.callsLast7Days} goal={summary.callsTarget} tone="sky" />
+                {/* The three stocks in the flow share one scale, so the bars read as an actual
+                    distribution — where the money is sitting right now — instead of three
+                    unrelated bars. Fakturerat is a 7-day flow with no target to measure against,
+                    so it stays a plain figure (same convention as the leaderboard's value rows). */}
+                <StatusStrip label="Aktiva offerter" value={summary.activeQuoteValue} scale={summary.flowScale} tone="emerald" currency helper={`${summary.activeQuotes} st`} />
+                <StatusStrip label="Öppna ordrar" value={summary.openOrderValue} scale={summary.flowScale} tone="teal" currency helper={`${summary.openWorkOrders} st`} />
+                <StatusStrip label="Att fakturera" value={summary.toInvoiceOrderValue} scale={summary.flowScale} tone="amber" currency helper={`${summary.workOrdersToInvoice} st`} />
+                <StatusStrip label="Fakturerat, 7 dagar" value={summary.invoicedValueLast7Days} tone="violet" currency />
+                <div className="my-1 h-px bg-slate-100" />
                 <StatusStrip label="Offerter mot mål" value={summary.quotesLast7Days} goal={summary.quotesTarget} tone="emerald" />
+                <StatusStrip label="Ordervärde mot mål" value={summary.orderValueLast7Days} goal={summary.orderValueTarget} tone="teal" currency />
+                <StatusStrip label="Samtal mot mål" value={summary.callsLast7Days} goal={summary.callsTarget} tone="sky" />
                 <StatusStrip label="Sena uppgifter" value={summary.overdueTasks} tone="rose" />
               </div>
             )}
@@ -762,7 +810,7 @@ function OverviewLoadingRows() {
   );
 }
 
-function StatusStrip({ label, value, tone, goal, currency = false }: { label: string; value: number; tone: 'slate' | 'sky' | 'amber' | 'rose' | 'emerald' | 'teal'; goal?: number; currency?: boolean }) {
+function StatusStrip({ label, value, tone, goal, scale, helper, currency = false }: { label: string; value: number; tone: 'slate' | 'sky' | 'amber' | 'rose' | 'emerald' | 'teal' | 'violet'; goal?: number; scale?: number; helper?: string; currency?: boolean }) {
   const toneClass = {
     slate: 'bg-slate-900',
     sky: 'bg-sky-500',
@@ -770,24 +818,37 @@ function StatusStrip({ label, value, tone, goal, currency = false }: { label: st
     rose: 'bg-rose-500',
     emerald: 'bg-emerald-500',
     teal: 'bg-teal-500',
+    violet: 'bg-violet-500',
   }[tone];
 
-  const width = goal && goal > 0
-    ? value <= 0 ? 0 : Math.min(100, (value / goal) * 100)
-    : value <= 0 ? 0 : Math.min(100, value * 16);
+  // The bar needs something to measure against: a goal, or an explicit scale shared with the
+  // sibling rows. Without either, a count keeps the old rough 16-%-per-unit fill and a money row
+  // shows a damped full bar — the same convention the leaderboard uses for a figure with no
+  // target, since a krona amount has no natural scale of its own.
+  const hasGoal = goal != null && goal > 0;
+  const hasScale = !hasGoal && scale != null && scale > 0;
+  const denominator = hasGoal ? goal! : hasScale ? scale! : null;
+  const width = denominator != null
+    ? value <= 0 ? 0 : Math.min(100, (value / denominator) * 100)
+    : currency
+      ? value > 0 ? 100 : 0
+      : value <= 0 ? 0 : Math.min(100, value * 16);
   const displayValue = currency ? formatCurrency(value, 'SEK') : value;
-  const displayGoal = goal != null && goal > 0
-    ? currency ? formatCurrency(goal, 'SEK') : String(goal)
+  const displayGoal = hasGoal
+    ? currency ? formatCurrency(goal!, 'SEK') : String(goal)
     : null;
 
   return (
     <div className="grid gap-1">
       <div className="flex items-center justify-between gap-3 text-xs text-slate-600">
-        <span>{label}</span>
-        <strong className="text-slate-800">{displayGoal ? `${displayValue} / ${displayGoal}` : displayValue}</strong>
+        <span className="min-w-0 truncate">
+          {label}
+          {helper ? <span className="text-slate-400"> · {helper}</span> : null}
+        </span>
+        <strong className="shrink-0 text-slate-800">{displayGoal ? `${displayValue} / ${displayGoal}` : displayValue}</strong>
       </div>
       <div className="h-1.5 rounded-full bg-slate-100">
-        <div className={`h-1.5 rounded-full transition-all ${toneClass}`} style={{ width: `${width}%` }} />
+        <div className={cn('h-1.5 rounded-full transition-all', toneClass, denominator == null && currency && 'opacity-40')} style={{ width: `${width}%` }} />
       </div>
     </div>
   );

--- a/app/crm/offerter/QuotesClient.tsx
+++ b/app/crm/offerter/QuotesClient.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import Input from '../../../components/ui/Input';
 import { cn } from '@/lib/shared/cn';
@@ -114,7 +114,20 @@ export default function QuotesClient({ currentUserId }: { currentUserId: string 
     [assigneeFilter, currentUserId],
   );
 
-  function buildListQuery(nextOffset: number) {
+  const presetProspectId = searchParams.get('prospect_id') || '';
+  const presetQuoteId = searchParams.get('quote_id') || '';
+  const shouldOpenCreate = searchParams.get('new') === '1';
+
+  // What the tab counts are computed over. They don't depend on the tab (every tab is counted) nor
+  // on the sort (order can't change a count), so re-requesting five exact COUNTs on a sort toggle
+  // would be five O(n) scans for a number that cannot move.
+  const countScope = `${search.trim()}|${assigneeParam}|${presetProspectId}`;
+  const countedScope = useRef<string | null>(null);
+
+  // Bumped when something happens that can move a row between tabs, to force a reload.
+  const [reloadKey, setReloadKey] = useState(0);
+
+  function buildListQuery(nextOffset: number, withCounts: boolean) {
     const query = new URLSearchParams();
     if (search.trim()) query.set('q', search.trim());
     if (presetProspectId) query.set('prospect_id', presetProspectId);
@@ -123,17 +136,21 @@ export default function QuotesClient({ currentUserId }: { currentUserId: string 
     if (assigneeParam) query.set('assignee', assigneeParam);
     query.set('offset', String(nextOffset));
     query.set('limit', String(PAGE_SIZE));
-    // Tab counts only need recomputing on a fresh first page, not on "Visa fler".
-    if (nextOffset === 0) query.set('counts', '1');
+    if (withCounts) query.set('counts', '1');
     return query.toString();
   }
 
   async function loadMore() {
     if (loadingMore || quotes.length >= total) return;
     setLoadingMore(true);
+    // The page being appended belongs to the query it was asked for. Change the sort mid-flight and
+    // the first-page effect replaces the list under it; appending then mixes two orderings and
+    // duplicates rows, so a response whose request no longer describes the visible list is dropped.
+    const requestedFor = `${countScope}|${filter}|${sort}`;
     try {
-      const res = await fetch(`/api/crm/quotes?${buildListQuery(quotes.length)}`, { cache: 'no-store' });
+      const res = await fetch(`/api/crm/quotes?${buildListQuery(quotes.length, false)}`, { cache: 'no-store' });
       const json = await res.json().catch(() => ({}));
+      if (requestedFor !== `${countScope}|${filter}|${sort}`) return;
       if (!res.ok || !json.ok) { setError(json?.error || 'Kunde inte ladda fler offerter.'); return; }
       const items = Array.isArray(json?.data?.items) ? json.data.items : [];
       setQuotes((prev) => [...prev, ...items]);
@@ -168,9 +185,6 @@ export default function QuotesClient({ currentUserId }: { currentUserId: string 
   const [linkedQuote, setLinkedQuote] = useState<QuoteItem | null>(null);
   const [hasHandledPreset, setHasHandledPreset] = useState(false);
 
-  const presetProspectId = searchParams.get('prospect_id') || '';
-  const presetQuoteId = searchParams.get('quote_id') || '';
-  const shouldOpenCreate = searchParams.get('new') === '1';
   const [hasHandledQuotePreset, setHasHandledQuotePreset] = useState(false);
 
   // Redirect preset "new=1" links to the form page
@@ -190,23 +204,24 @@ export default function QuotesClient({ currentUserId }: { currentUserId: string 
   // starts a fresh page rather than re-filtering what happens to be in the browser.
   useEffect(() => {
     let active = true;
+    const wantCounts = countedScope.current !== countScope;
     async function load() {
       setLoading(true); setError(null);
       try {
-        const res = await fetch(`/api/crm/quotes?${buildListQuery(0)}`, { cache: 'no-store' });
+        const res = await fetch(`/api/crm/quotes?${buildListQuery(0, wantCounts)}`, { cache: 'no-store' });
         const json = await res.json().catch(() => ({}));
         if (!active) return;
         if (!res.ok || !json.ok) { setError(json?.error || 'Kunde inte ladda offerter.'); setQuotes([]); setTotal(0); return; }
         setQuotes(Array.isArray(json?.data?.items) ? json.data.items : []);
         setTotal(json?.data?.total ?? 0);
-        if (json?.data?.counts) setCounts(json.data.counts);
+        if (json?.data?.counts) { setCounts(json.data.counts); countedScope.current = countScope; }
       } catch { if (active) { setError('Kunde inte ladda offerter.'); setQuotes([]); setTotal(0); } }
       finally { if (active) setLoading(false); }
     }
     void load();
     return () => { active = false; };
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [presetProspectId, search, filter, sort, assigneeParam]);
+  }, [presetProspectId, search, filter, sort, assigneeParam, reloadKey]);
 
   // Deep-link: open a specific quote's detail panel when arriving with ?quote_id= (e.g. from a
   // customer's related list). Handled once the matching quote is loaded so a manual close isn't
@@ -490,9 +505,18 @@ export default function QuotesClient({ currentUserId }: { currentUserId: string 
           onClose={() => setDetailPanelOpen(false)}
           onQuoteChanged={(patch) => {
             setQuotes((current) => current.map((q) => (q.id === patch.id ? { ...q, ...patch } : q)));
-            // The deep-linked quote lives outside the list, so it needs the same patch — otherwise
-            // an edit made in the panel wouldn't show in the panel it was made in.
-            setLinkedQuote((current) => (current && current.id === patch.id ? { ...current, ...patch } : current));
+            // Keep the open panel alive across a reload that may drop its row from the page: hold
+            // the patched quote outside the list. Without this, marking a draft "Vunnen" from the
+            // "Aktiva" tab would reload the list, lose the row, and unmount the panel mid-click.
+            const patched = quotes.find((q) => q.id === patch.id) ?? linkedQuote;
+            if (patched && patched.id === patch.id) setLinkedQuote({ ...patched, ...patch });
+            // A status change moves the row between tabs and moves two counters. The tabs are
+            // server-side now, so the browser can no longer make that happen by re-filtering an
+            // array — it has to ask again, counts included.
+            if (patch.status && patch.status !== patched?.status) {
+              countedScope.current = null;
+              setReloadKey((key) => key + 1);
+            }
           }}
         />
       ) : null}

--- a/app/crm/offerter/QuotesClient.tsx
+++ b/app/crm/offerter/QuotesClient.tsx
@@ -3,7 +3,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import Input from '../../../components/ui/Input';
 import { cn } from '@/lib/shared/cn';
-import AssigneeFilter, { matchesAssignee, type AssigneeFilterValue, type AssigneeOption } from '@/app/crm/components/AssigneeFilter';
+import AssigneeFilter, { MINE, type AssigneeFilterValue, type AssigneeOption } from '@/app/crm/components/AssigneeFilter';
 import { RowAssignee, RowAssigneeChip } from '@/app/crm/components/RowAssignee';
 import { documentRef } from '@/app/crm/lib/format';
 import DocumentNumberBadge from '@/app/crm/components/DocumentNumberBadge';
@@ -52,6 +52,7 @@ type QuoteItem = {
 };
 
 type QuoteFilter = 'all' | 'active' | 'follow_up' | 'won' | 'lost';
+type QuoteSort = 'created_desc' | 'follow_up_asc';
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -62,6 +63,17 @@ const quoteFilterMeta: Record<QuoteFilter, { label: string }> = {
   won: { label: 'Vunna' },
   lost: { label: 'Förlorade' },
 };
+
+const quoteSortMeta: Record<QuoteSort, { label: string }> = {
+  created_desc: { label: 'Senast skapad' },
+  follow_up_asc: { label: 'Följ upp först' },
+};
+
+// The list pages the same way the order board does: one page per filter, accumulated with
+// "Visa fler". Filtering, counting and ordering all happen server-side — the row cap cuts before
+// the browser sees anything, so a client-side tab would have been counting a truncated set.
+const PAGE_SIZE = 100;
+const EMPTY_COUNTS: Record<QuoteFilter, number> = { all: 0, active: 0, follow_up: 0, won: 0, lost: 0 };
 
 function formatCurrency(value: number | string, currencyCode: string) {
   const numeric = typeof value === 'number' ? value : Number(String(value));
@@ -76,17 +88,6 @@ function formatDate(value: string | null | undefined) {
   return new Intl.DateTimeFormat('sv-SE', { dateStyle: 'medium' }).format(date);
 }
 
-function compareQuotes(a: QuoteItem, b: QuoteItem) {
-  const aOverdue = isQuoteOverdue(a);
-  const bOverdue = isQuoteOverdue(b);
-  if (aOverdue !== bOverdue) return aOverdue ? -1 : 1;
-  if (a.follow_up_date && b.follow_up_date && a.follow_up_date !== b.follow_up_date) {
-    return a.follow_up_date.localeCompare(b.follow_up_date);
-  }
-  if (a.quote_date !== b.quote_date) return b.quote_date.localeCompare(a.quote_date);
-  return b.updated_at.localeCompare(a.updated_at);
-}
-
 // ─── QuotesClient ─────────────────────────────────────────────────────────────
 
 export default function QuotesClient({ currentUserId }: { currentUserId: string | null }) {
@@ -94,13 +95,55 @@ export default function QuotesClient({ currentUserId }: { currentUserId: string 
   const searchParams = useSearchParams();
 
   const [quotes, setQuotes] = useState<QuoteItem[]>([]);
+  const [total, setTotal] = useState(0);
+  const [counts, setCounts] = useState<Record<QuoteFilter, number>>(EMPTY_COUNTS);
   const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [search, setSearch] = useState('');
   const [filter, setFilter] = useState<QuoteFilter>('all');
+  const [sort, setSort] = useState<QuoteSort>('created_desc');
   const [filtersOpen, setFiltersOpen] = useState(false);
   const [assigneeFilter, setAssigneeFilter] = useState<AssigneeFilterValue>([]);
   const [assignees, setAssignees] = useState<AssigneeOption[]>([]);
+
+  // 'mine' resolves to the current user before it goes to the server, the same way the order board
+  // does it — the filter is server-side now, so the browser can't be the one deciding who's who.
+  const assigneeParam = useMemo(
+    () => assigneeFilter.map((v) => (v === MINE ? (currentUserId ?? '') : v)).filter(Boolean).join(','),
+    [assigneeFilter, currentUserId],
+  );
+
+  function buildListQuery(nextOffset: number) {
+    const query = new URLSearchParams();
+    if (search.trim()) query.set('q', search.trim());
+    if (presetProspectId) query.set('prospect_id', presetProspectId);
+    query.set('filter', filter);
+    query.set('sort', sort);
+    if (assigneeParam) query.set('assignee', assigneeParam);
+    query.set('offset', String(nextOffset));
+    query.set('limit', String(PAGE_SIZE));
+    // Tab counts only need recomputing on a fresh first page, not on "Visa fler".
+    if (nextOffset === 0) query.set('counts', '1');
+    return query.toString();
+  }
+
+  async function loadMore() {
+    if (loadingMore || quotes.length >= total) return;
+    setLoadingMore(true);
+    try {
+      const res = await fetch(`/api/crm/quotes?${buildListQuery(quotes.length)}`, { cache: 'no-store' });
+      const json = await res.json().catch(() => ({}));
+      if (!res.ok || !json.ok) { setError(json?.error || 'Kunde inte ladda fler offerter.'); return; }
+      const items = Array.isArray(json?.data?.items) ? json.data.items : [];
+      setQuotes((prev) => [...prev, ...items]);
+      setTotal(json?.data?.total ?? total);
+    } catch {
+      setError('Kunde inte ladda fler offerter.');
+    } finally {
+      setLoadingMore(false);
+    }
+  }
 
   useEffect(() => {
     let active = true;
@@ -121,6 +164,8 @@ export default function QuotesClient({ currentUserId }: { currentUserId: string 
   const documentEmail = useDocumentEmail();
   const [detailPanelOpen, setDetailPanelOpen] = useState(false);
   const [detailQuoteId, setDetailQuoteId] = useState<string | null>(null);
+  // A quote reached by ?quote_id= that isn't on the loaded page. Feeds the panel only.
+  const [linkedQuote, setLinkedQuote] = useState<QuoteItem | null>(null);
   const [hasHandledPreset, setHasHandledPreset] = useState(false);
 
   const presetProspectId = searchParams.get('prospect_id') || '';
@@ -141,60 +186,59 @@ export default function QuotesClient({ currentUserId }: { currentUserId: string 
     setHasHandledPreset(false);
   }, [presetProspectId, shouldOpenCreate]);
 
-  // Load quotes
+  // Load the first page. Search, tab, sort and assignee are all server-side, so every one of them
+  // starts a fresh page rather than re-filtering what happens to be in the browser.
   useEffect(() => {
     let active = true;
-    setLoading(true);
-    setError(null);
-
-    const query = new URLSearchParams();
-    if (search.trim()) query.set('q', search.trim());
-    if (presetProspectId) query.set('prospect_id', presetProspectId);
-
-    fetch(`/api/crm/quotes${query.size > 0 ? `?${query}` : ''}`, { cache: 'no-store' })
-      .then((r) => r.json().catch(() => ({})))
-      .then((json) => {
+    async function load() {
+      setLoading(true); setError(null);
+      try {
+        const res = await fetch(`/api/crm/quotes?${buildListQuery(0)}`, { cache: 'no-store' });
+        const json = await res.json().catch(() => ({}));
         if (!active) return;
-        if (!json.ok) { setError(json?.error || 'Kunne inte ladda offerter.'); setQuotes([]); return; }
+        if (!res.ok || !json.ok) { setError(json?.error || 'Kunde inte ladda offerter.'); setQuotes([]); setTotal(0); return; }
         setQuotes(Array.isArray(json?.data?.items) ? json.data.items : []);
-      })
-      .catch(() => { if (active) { setError('Kunde inte ladda offerter.'); setQuotes([]); } })
-      .finally(() => { if (active) setLoading(false); });
-
+        setTotal(json?.data?.total ?? 0);
+        if (json?.data?.counts) setCounts(json.data.counts);
+      } catch { if (active) { setError('Kunde inte ladda offerter.'); setQuotes([]); setTotal(0); } }
+      finally { if (active) setLoading(false); }
+    }
+    void load();
     return () => { active = false; };
-  }, [presetProspectId, search]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [presetProspectId, search, filter, sort, assigneeParam]);
 
-  // Deep-link: open a specific quote's detail panel when arriving with
-  // ?quote_id= (e.g. from a customer's related list). Handled once the matching
-  // quote is loaded so a manual close isn't re-triggered.
+  // Deep-link: open a specific quote's detail panel when arriving with ?quote_id= (e.g. from a
+  // customer's related list). Handled once the matching quote is loaded so a manual close isn't
+  // re-triggered.
   useEffect(() => { setHasHandledQuotePreset(false); }, [presetQuoteId]);
+
+  // The linked quote need not be on the loaded page any more: it may be won while the tab shows
+  // "Aktiva", or simply sit past the first page. Fetch that one row so the link opens the panel it
+  // promised — but keep it OUT of the list, which stays exactly the page the server returned. A
+  // prepended row would sit at the top in defiance of the chosen sort once the panel closes.
+  useEffect(() => {
+    if (!presetQuoteId || hasHandledQuotePreset || loading) return;
+    if (quotes.some((q) => q.id === presetQuoteId) || linkedQuote?.id === presetQuoteId) return;
+    let active = true;
+    fetch(`/api/crm/quotes/${presetQuoteId}`, { cache: 'no-store' })
+      .then((r) => r.json().catch(() => ({})))
+      .then((json) => { if (active && json?.ok && json?.data?.item) setLinkedQuote(json.data.item); })
+      .catch(() => { /* the panel simply won't open — the list is still usable */ });
+    return () => { active = false; };
+  }, [presetQuoteId, hasHandledQuotePreset, loading, quotes, linkedQuote]);
 
   useEffect(() => {
     if (!presetQuoteId || hasHandledQuotePreset || loading) return;
-    if (!quotes.some((q) => q.id === presetQuoteId)) return;
+    if (!quotes.some((q) => q.id === presetQuoteId) && linkedQuote?.id !== presetQuoteId) return;
     setDetailQuoteId(presetQuoteId);
     setDetailPanelOpen(true);
     setHasHandledQuotePreset(true);
-  }, [presetQuoteId, hasHandledQuotePreset, loading, quotes]);
+  }, [presetQuoteId, hasHandledQuotePreset, loading, quotes, linkedQuote]);
 
   // Count of active filters (status + assignee) — shown as a badge on the mobile toggle.
   const activeFilterCount = (filter !== 'all' ? 1 : 0) + (assigneeFilter.length > 0 ? 1 : 0);
-
-  // Scope the whole page (list, stats, chip counts) to the chosen "Ansvarig" filter.
-  const assigneeScopedQuotes = useMemo(
-    () => quotes.filter((q) => matchesAssignee(q.assigned_to, assigneeFilter, currentUserId)),
-    [quotes, assigneeFilter, currentUserId],
-  );
-
-  const visibleQuotes = useMemo(() => {
-    if (filter === 'all') return assigneeScopedQuotes;
-    if (filter === 'active') return assigneeScopedQuotes.filter((q) => q.status === 'draft' || q.status === 'sent' || q.status === 'follow_up');
-    if (filter === 'follow_up') return assigneeScopedQuotes.filter((q) => q.status === 'follow_up');
-    if (filter === 'won') return assigneeScopedQuotes.filter((q) => q.status === 'won');
-    return assigneeScopedQuotes.filter((q) => q.status === 'lost');
-  }, [filter, assigneeScopedQuotes]);
-
-  const sortedVisibleQuotes = useMemo(() => [...visibleQuotes].sort(compareQuotes), [visibleQuotes]);
+  const hasMore = quotes.length < total;
 
   const assigneeNameById = useMemo(() => {
     const map = new Map<string, string>();
@@ -202,18 +246,11 @@ export default function QuotesClient({ currentUserId }: { currentUserId: string 
     return map;
   }, [assignees]);
 
-  const filterCounts = useMemo<Record<QuoteFilter, number>>(() => ({
-    all: assigneeScopedQuotes.length,
-    active: assigneeScopedQuotes.filter((q) => q.status === 'draft' || q.status === 'sent' || q.status === 'follow_up').length,
-    follow_up: assigneeScopedQuotes.filter((q) => q.status === 'follow_up').length,
-    won: assigneeScopedQuotes.filter((q) => q.status === 'won').length,
-    lost: assigneeScopedQuotes.filter((q) => q.status === 'lost').length,
-  }), [assigneeScopedQuotes]);
-
-  const detailQuote = useMemo(
-    () => (detailQuoteId ? quotes.find((q) => q.id === detailQuoteId) || null : null),
-    [detailQuoteId, quotes],
-  );
+  const detailQuote = useMemo(() => {
+    if (!detailQuoteId) return null;
+    return quotes.find((q) => q.id === detailQuoteId)
+      ?? (linkedQuote?.id === detailQuoteId ? linkedQuote : null);
+  }, [detailQuoteId, quotes, linkedQuote]);
 
   // The offer is locked in Fortnox only once it's been converted to an order (a work
   // order exists) AND its sync didn't fail. If the sync failed we must NOT show "Låst"
@@ -308,26 +345,40 @@ export default function QuotesClient({ currentUserId }: { currentUserId: string 
                 >
                   {quoteFilterMeta[value].label}
                   <span className={cn('rounded-full px-1.5 py-0.5 text-[10px] font-bold', active ? 'bg-white/20 text-white' : 'bg-slate-100 text-slate-600')}>
-                    {filterCounts[value]}
+                    {counts[value]}
                   </span>
                 </button>
               );
             })}
           </div>
+          {/* Sort: newest first by default, nearest follow-up as the other view. Server-side, since
+              the list is paginated — ordering the loaded page would only sort the first hundred. */}
+          <label className="flex items-center gap-1.5 text-[13px] text-slate-500">
+            <span className="shrink-0">Sortera</span>
+            <select
+              value={sort}
+              onChange={(e) => setSort(e.target.value as QuoteSort)}
+              className="rounded-lg border border-[#dce4d8] bg-white px-2 py-1 text-[13px] font-semibold text-slate-700"
+            >
+              {(Object.keys(quoteSortMeta) as QuoteSort[]).map((value) => (
+                <option key={value} value={value}>{quoteSortMeta[value].label}</option>
+              ))}
+            </select>
+          </label>
           <AssigneeFilter value={assigneeFilter} onChange={setAssigneeFilter} users={assignees} className="w-full sm:ml-auto sm:w-[200px]" />
         </div>
 
         {error ? <div className="rounded-xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700">{error}</div> : null}
         {loading ? <div className="text-sm text-slate-400">Laddar offerter…</div> : null}
-        {!loading && visibleQuotes.length === 0 ? (
+        {!loading && quotes.length === 0 ? (
           <div className="rounded-xl border border-dashed border-slate-200 px-4 py-10 text-center text-sm text-slate-400">
             Inga offerter matchar just nu.
           </div>
         ) : null}
 
-        {!loading && visibleQuotes.length > 0 ? (
+        {!loading && quotes.length > 0 ? (
           <div className="grid gap-1">
-            {sortedVisibleQuotes.map((item) => {
+            {quotes.map((item) => {
               const overdue = isQuoteOverdue(item);
               const statusMeta = quoteStatusMeta[item.status];
               // Inget 'Okänd'-fallback: katalogen hämtas i en egen request, så ett tomt uppslag
@@ -411,6 +462,22 @@ export default function QuotesClient({ currentUserId }: { currentUserId: string 
             })}
           </div>
         ) : null}
+
+        {/* Visa fler — server-side pagination so the list never silently truncates. Without it the
+            row cap cut from the tail of the sort, which meant won and sent quotes vanished first. */}
+        {!loading && hasMore ? (
+          <div className="flex flex-col items-center gap-1 pt-1">
+            <button
+              type="button"
+              onClick={() => void loadMore()}
+              disabled={loadingMore}
+              className="rounded-full border border-[#dce4d8] bg-white px-4 py-1.5 text-[13px] font-semibold text-slate-600 transition hover:border-[#c8d4c3] disabled:opacity-60"
+            >
+              {loadingMore ? 'Laddar…' : 'Visa fler'}
+            </button>
+            <span className="text-[11px] text-slate-400">Visar {quotes.length} av {total}</span>
+          </div>
+        ) : null}
       </div>
 
       {/* ── Detail panel ── */}
@@ -421,7 +488,12 @@ export default function QuotesClient({ currentUserId }: { currentUserId: string 
           returnTo={`/crm/offerter?quote_id=${detailQuote.id}`}
           documentEmail={documentEmail}
           onClose={() => setDetailPanelOpen(false)}
-          onQuoteChanged={(patch) => setQuotes((current) => current.map((q) => (q.id === patch.id ? { ...q, ...patch } : q)))}
+          onQuoteChanged={(patch) => {
+            setQuotes((current) => current.map((q) => (q.id === patch.id ? { ...q, ...patch } : q)));
+            // The deep-linked quote lives outside the list, so it needs the same patch — otherwise
+            // an edit made in the panel wouldn't show in the panel it was made in.
+            setLinkedQuote((current) => (current && current.id === patch.id ? { ...current, ...patch } : current));
+          }}
         />
       ) : null}
 

--- a/lib/domains/crm/goals.ts
+++ b/lib/domains/crm/goals.ts
@@ -90,6 +90,37 @@ export function getCurrentMonthStartDate() {
   return formatLocalDateOnly(new Date(now.getFullYear(), now.getMonth(), 1));
 }
 
+/**
+ * The window the CRM overview asks the server to count inside, built from the READER's clock: the
+ * route runs on UTC, so deciding "this week" there would move the boundary for anyone whose
+ * calendar day differs from the server's. Lives here, next to getCurrentWeekStartDate, so the
+ * actuals and the weekly budget can never disagree about which week it is — and so the arithmetic
+ * is reachable from a test, which it was not inside the client component.
+ *
+ * `now` is injectable for exactly that reason; production passes nothing.
+ */
+export function getCrmOverviewWindow(now: Date = new Date()) {
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const weekStart = new Date(today);
+  weekStart.setDate(weekStart.getDate() - ((weekStart.getDay() + 6) % 7));
+  // Noon anchors: adding days to a midnight Date can land on 23:00 the previous day across a DST
+  // shift, which would move the boundary by a day.
+  const noon = (date: Date, offsetDays: number) => {
+    const shifted = new Date(date.getFullYear(), date.getMonth(), date.getDate(), 12);
+    shifted.setDate(shifted.getDate() + offsetDays);
+    return shifted;
+  };
+  return {
+    today: formatLocalDateOnly(today),
+    /** Inclusive first day of the rolling 7-day window. */
+    since: formatLocalDateOnly(noon(today, -7)),
+    /** Inclusive Monday of the current week. */
+    weekStart: formatLocalDateOnly(weekStart),
+    /** Exclusive Monday after the current week. */
+    weekEnd: formatLocalDateOnly(noon(weekStart, 7)),
+  };
+}
+
 // Derive the displayed weekly target from a monthly budget (budget ÷ 4, fixed).
 export function weeklyFromMonthly(monthly: number | string): number {
   const numeric = typeof monthly === 'number' ? monthly : Number(String(monthly));

--- a/lib/domains/crm/overviewSummary.ts
+++ b/lib/domains/crm/overviewSummary.ts
@@ -1,0 +1,351 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { BOARD_FILTER_STATUSES, type CrmWorkOrderStatus } from './work-orders';
+
+// ── The CRM overview's read model ──
+//
+// One number per figure the overview shows, counted where the rows are instead of in the browser.
+//
+// The page used to download the quote, order, call, prospect and task lists and count them client
+// side. Every one of those lists is capped before the browser sees it — PostgREST answers with at
+// most 1000 rows here and the CRM list routes cap lower still — and a cap cuts BEFORE anything can
+// be counted, so the totals silently shrank as the tables grew. They were close: measured
+// 2026-08-17 the tables held 778 prospects (cap 1000), 69 quotes (cap 100, growing ~52/month) and
+// 29 orders (cap 100, ~22/month), so the quote figures were weeks from starting to lie.
+//
+// Each number is read with the WHERE clause that belongs to it, which is what makes this safe at
+// any table size:
+//   · a STOCK ("aktiva offerter", "öppna ordrar") is filtered on the statuses that define it, so
+//     the result set is bounded by open work — tens of rows — and not by the table.
+//   · a WINDOWED figure is filtered on its window, so it is bounded by the window.
+//   · a count with no natural bound (prospect buckets, follow-up calls) is a head-only count:
+//     exact at any size and no rows transferred.
+// Every row-returning query still carries an explicit cap and reports hitting it in `truncated`,
+// because the one thing worse than a wrong number is a wrong number that says nothing.
+
+/** A quote is "active" while it is still in play: not won, not lost. */
+export const ACTIVE_QUOTE_STATUSES = ['draft', 'sent', 'follow_up'];
+
+// ⚠️ These four buckets are structurally empty today, and were before the counting moved here.
+// Prospects are `crm_customers` rows with customer_stage='prospect', and `status` on that table is
+// the CUSTOMER status: createCrmProspect writes 'active', and measured 2026-08-17 all 778 prospect
+// rows carry exactly that. The pipeline statuses below are a leftover from the standalone prospect
+// table — only updateCrmProspect can even write them, and nothing does. So the overview's two
+// prospect metric cards read 0 for 778 prospects. Kept as-is deliberately: reproducing today's
+// numbers is the job here, and deciding what "öppna prospekt" should mean instead is a product
+// decision, not a refactor.
+export const PIPELINE_PROSPECT_STATUSES = ['new', 'contacted', 'qualified', 'quoted'];
+
+// Single-sourced from the order board's chip definitions, so a status added to a board group
+// cannot silently fall out of the overview's stocks. 'all' is the only filter without a status
+// list, and it is not used here.
+function boardStatuses(...filters: Array<'draft' | 'scheduled' | 'active' | 'completed' | 'invoiced'>): CrmWorkOrderStatus[] {
+  return filters.flatMap((filter) => BOARD_FILTER_STATUSES[filter] ?? []);
+}
+
+/** Ordered but not yet in the invoicing stage: not planned, planned, or out on the job. */
+export const OPEN_WORK_ORDER_STATUSES = boardStatuses('draft', 'scheduled', 'active');
+
+/** Sitting in the invoicing stage — the board's "Fakturera" chip, including mid-delfakturering. */
+export const TO_INVOICE_WORK_ORDER_STATUSES = boardStatuses('completed');
+
+// A plain PostgREST select answers with at most 1000 rows in this project. The queries below are
+// filtered to sets that stay far below it; the cap is the backstop, not the plan.
+const ROW_CAP = 1000;
+
+export type CrmOverviewWindow = {
+  /** Today, local to the reader (YYYY-MM-DD). Buckets the task due dates. */
+  today: string;
+  /** First day of the rolling 7-day window, inclusive (YYYY-MM-DD). */
+  since: string;
+  /** Monday of the current week, inclusive (YYYY-MM-DD). */
+  weekStart: string;
+  /** The Monday after the current week, exclusive (YYYY-MM-DD). */
+  weekEnd: string;
+};
+
+export type CrmOverviewWeekActuals = {
+  calls: number;
+  quotes: number;
+  quoteValue: number;
+  orderCount: number;
+  orderValue: number;
+  invoicedValue: number;
+};
+
+export type CrmOverviewSummary = {
+  // Prospects (metric cards)
+  pipelineProspects: number;
+  newProspects: number;
+  quotedProspects: number;
+  qualifiedProspects: number;
+  // Quotes
+  activeQuotes: number;
+  activeQuoteValue: number;
+  quoteFollowUps: number;
+  quotesLast7Days: number;
+  quoteValueLast7Days: number;
+  // Work orders
+  openWorkOrders: number;
+  openOrderValue: number;
+  workOrdersToInvoice: number;
+  toInvoiceOrderValue: number;
+  orderValueLast7Days: number;
+  invoicedValueLast7Days: number;
+  // Calls
+  callsLast7Days: number;
+  followUpCalls: number;
+  standaloneCalls: number;
+  // Tasks (personal — RLS scopes dashboard_work_items to the reader)
+  openTasks: number;
+  overdueTasks: number;
+  todayTasks: number;
+  /** Current week's actuals per user id — the leaderboard joins these with each user's goal. */
+  weekByUser: Record<string, CrmOverviewWeekActuals>;
+  /** Names of queries that hit ROW_CAP. Empty is the normal case; non-empty means read low. */
+  truncated: string[];
+};
+
+export type QuoteStockRow = { status: string; amount: number | string };
+export type QuoteWindowRow = { amount: number | string; quote_date: string; assigned_to: string | null };
+export type OrderStockRow = { status: string; amount: number | string };
+export type OrderWindowRow = {
+  status: string;
+  amount: number | string;
+  created_at: string;
+  fortnox_invoiced_at: string | null;
+  assigned_to: string | null;
+};
+export type CallWindowRow = { user_id: string; call_at: string };
+export type TaskDueRow = { due_at: string | null };
+
+export type CrmOverviewRows = {
+  quoteStocks: QuoteStockRow[];
+  quoteWindow: QuoteWindowRow[];
+  orderStocks: OrderStockRow[];
+  orderWindow: OrderWindowRow[];
+  callWindow: CallWindowRow[];
+  openTasks: TaskDueRow[];
+  counts: {
+    pipelineProspects: number;
+    newProspects: number;
+    quotedProspects: number;
+    qualifiedProspects: number;
+    followUpCalls: number;
+    standaloneCalls: number;
+  };
+  truncated: string[];
+};
+
+export function toAmount(value: number | string | null | undefined): number {
+  if (value == null) return 0;
+  const numeric = typeof value === 'number' ? value : Number(String(value));
+  return Number.isFinite(numeric) ? numeric : 0;
+}
+
+// Day-resolution comparison, the same rule reports.ts uses: take the date part and compare as a
+// string. For a `date` column that is exact. For a timestamptz the day is the UTC one, so a row
+// written between 00:00 and 02:00 Swedish time counts towards the previous day — measured to be
+// empty in this data (the crews work 07–16) and deliberately not chased, see reports.ts.
+function dayOf(value: string | null | undefined): string | null {
+  return value ? String(value).slice(0, 10) : null;
+}
+
+function inWindow(value: string | null | undefined, from: string, toExclusive?: string): boolean {
+  const day = dayOf(value);
+  if (day == null) return false;
+  return day >= from && (toExclusive == null || day < toExclusive);
+}
+
+function addToUser(map: Record<string, CrmOverviewWeekActuals>, userId: string | null, patch: Partial<CrmOverviewWeekActuals>) {
+  if (!userId) return;
+  const current = map[userId] ?? { calls: 0, quotes: 0, quoteValue: 0, orderCount: 0, orderValue: 0, invoicedValue: 0 };
+  map[userId] = {
+    calls: current.calls + (patch.calls ?? 0),
+    quotes: current.quotes + (patch.quotes ?? 0),
+    quoteValue: current.quoteValue + (patch.quoteValue ?? 0),
+    orderCount: current.orderCount + (patch.orderCount ?? 0),
+    orderValue: current.orderValue + (patch.orderValue ?? 0),
+    invoicedValue: current.invoicedValue + (patch.invoicedValue ?? 0),
+  };
+}
+
+/**
+ * Pure: rows in, read model out. The queries are the impure half (fetchCrmOverviewSummary).
+ */
+export function composeCrmOverviewSummary(rows: CrmOverviewRows, window: CrmOverviewWindow): CrmOverviewSummary {
+  const activeQuotes = rows.quoteStocks.filter((quote) => ACTIVE_QUOTE_STATUSES.includes(quote.status));
+  const openOrders = rows.orderStocks.filter((order) => OPEN_WORK_ORDER_STATUSES.includes(order.status as CrmWorkOrderStatus));
+  const toInvoiceOrders = rows.orderStocks.filter((order) => TO_INVOICE_WORK_ORDER_STATUSES.includes(order.status as CrmWorkOrderStatus));
+
+  const sum = (list: Array<{ amount: number | string }>) => list.reduce((total, row) => total + toAmount(row.amount), 0);
+
+  // Order value is attributed to when the order was won, invoiced revenue to when it was billed.
+  // Bucketing invoiced revenue on created_at was the biggest data error the reports have had (it
+  // hid 371 323 kr of 450 101 kr in one month, PR #70) — the lag from order to invoice runs about
+  // a month, so the two dates are not interchangeable.
+  const invoicedInWindow = rows.orderWindow.filter(
+    (order) => order.status === 'invoiced' && inWindow(order.fortnox_invoiced_at, window.since),
+  );
+  const createdInWindow = rows.orderWindow.filter((order) => inWindow(order.created_at, window.since));
+
+  const weekByUser: Record<string, CrmOverviewWeekActuals> = {};
+  for (const call of rows.callWindow) {
+    if (inWindow(call.call_at, window.weekStart, window.weekEnd)) addToUser(weekByUser, call.user_id, { calls: 1 });
+  }
+  for (const quote of rows.quoteWindow) {
+    if (!inWindow(quote.quote_date, window.weekStart, window.weekEnd)) continue;
+    addToUser(weekByUser, quote.assigned_to, { quotes: 1, quoteValue: toAmount(quote.amount) });
+  }
+  for (const order of rows.orderWindow) {
+    if (inWindow(order.created_at, window.weekStart, window.weekEnd)) {
+      addToUser(weekByUser, order.assigned_to, { orderCount: 1, orderValue: toAmount(order.amount) });
+    }
+    if (order.status === 'invoiced' && inWindow(order.fortnox_invoiced_at, window.weekStart, window.weekEnd)) {
+      addToUser(weekByUser, order.assigned_to, { invoicedValue: toAmount(order.amount) });
+    }
+  }
+
+  const quotesInWindow = rows.quoteWindow.filter((quote) => inWindow(quote.quote_date, window.since));
+  const openTaskDays = rows.openTasks.map((task) => dayOf(task.due_at));
+
+  return {
+    pipelineProspects: rows.counts.pipelineProspects,
+    newProspects: rows.counts.newProspects,
+    quotedProspects: rows.counts.quotedProspects,
+    qualifiedProspects: rows.counts.qualifiedProspects,
+
+    activeQuotes: activeQuotes.length,
+    activeQuoteValue: sum(activeQuotes),
+    quoteFollowUps: rows.quoteStocks.filter((quote) => quote.status === 'follow_up').length,
+    quotesLast7Days: quotesInWindow.length,
+    quoteValueLast7Days: sum(quotesInWindow),
+
+    openWorkOrders: openOrders.length,
+    openOrderValue: sum(openOrders),
+    workOrdersToInvoice: toInvoiceOrders.length,
+    toInvoiceOrderValue: sum(toInvoiceOrders),
+    orderValueLast7Days: sum(createdInWindow),
+    invoicedValueLast7Days: sum(invoicedInWindow),
+
+    // Re-filtered rather than taken as the query's row count, so the numbers are a function of the
+    // rows and the window alone — that is what makes them testable without a database.
+    callsLast7Days: rows.callWindow.filter((call) => inWindow(call.call_at, window.since)).length,
+    followUpCalls: rows.counts.followUpCalls,
+    standaloneCalls: rows.counts.standaloneCalls,
+
+    openTasks: rows.openTasks.length,
+    overdueTasks: openTaskDays.filter((day) => day != null && day < window.today).length,
+    todayTasks: openTaskDays.filter((day) => day === window.today).length,
+
+    weekByUser,
+    truncated: rows.truncated,
+  };
+}
+
+type CountableQuery = PromiseLike<{ count: number | null; error: { message: string } | null }>;
+type RowQuery<T> = PromiseLike<{ data: T[] | null; error: { message: string } | null }>;
+
+async function readRows<T>(name: string, query: RowQuery<T>, truncated: string[]): Promise<T[]> {
+  const { data, error } = await query;
+  if (error) throw new Error(`${name}: ${error.message}`);
+  const rows = data ?? [];
+  if (rows.length >= ROW_CAP) truncated.push(name);
+  return rows;
+}
+
+async function readCount(name: string, query: CountableQuery): Promise<number> {
+  const { count, error } = await query;
+  if (error) throw new Error(`${name}: ${error.message}`);
+  return count ?? 0;
+}
+
+/**
+ * Reads the overview's numbers with the caller's Supabase client, so RLS decides what counts —
+ * the same scoping the page had when it counted list rows in the browser. That matters most for
+ * the tasks: dashboard_work_items is the reader's PERSONAL board, and its row policy is what keeps
+ * these three numbers personal.
+ */
+export async function fetchCrmOverviewSummary(
+  supabase: SupabaseClient,
+  window: CrmOverviewWindow,
+): Promise<CrmOverviewSummary> {
+  const truncated: string[] = [];
+  const prospectCount = (build: (q: any) => any, name: string) =>
+    readCount(name, build(supabase.from('crm_customers').select('id', { count: 'exact', head: true }).eq('customer_stage', 'prospect')));
+
+  const [
+    quoteStocks,
+    quoteWindow,
+    orderStocks,
+    orderWindow,
+    callWindow,
+    openTasks,
+    pipelineProspects,
+    newProspects,
+    quotedProspects,
+    qualifiedProspects,
+    followUpCalls,
+    standaloneCalls,
+  ] = await Promise.all([
+    readRows<QuoteStockRow>('quote_stocks', supabase
+      .from('crm_quotes')
+      .select('status, amount')
+      .in('status', ACTIVE_QUOTE_STATUSES)
+      .limit(ROW_CAP), truncated),
+    readRows<QuoteWindowRow>('quote_window', supabase
+      .from('crm_quotes')
+      .select('amount, quote_date, assigned_to')
+      .gte('quote_date', window.since)
+      .limit(ROW_CAP), truncated),
+    readRows<OrderStockRow>('order_stocks', supabase
+      .from('crm_work_orders')
+      .select('status, amount')
+      .in('status', [...OPEN_WORK_ORDER_STATUSES, ...TO_INVOICE_WORK_ORDER_STATUSES])
+      .limit(ROW_CAP), truncated),
+    // Superset: created in the window OR invoiced in it. An order created in June and invoiced in
+    // August belongs to both figures but to neither date alone, so it has to be fetched on either.
+    readRows<OrderWindowRow>('order_window', supabase
+      .from('crm_work_orders')
+      .select('status, amount, created_at, fortnox_invoiced_at, assigned_to')
+      .or(`created_at.gte.${window.since},fortnox_invoiced_at.gte.${window.since}`)
+      .limit(ROW_CAP), truncated),
+    readRows<CallWindowRow>('call_window', supabase
+      .from('crm_calls')
+      .select('user_id, call_at')
+      .gte('call_at', window.since)
+      .limit(ROW_CAP), truncated),
+    // 'active' is the stored value the task domain maps to 'open'; 'done' and 'cancelled' are out.
+    readRows<TaskDueRow>('open_tasks', supabase
+      .from('dashboard_work_items')
+      .select('due_at')
+      .eq('kind', 'note')
+      .eq('status', 'active')
+      .limit(ROW_CAP), truncated),
+    prospectCount((q) => q.in('status', PIPELINE_PROSPECT_STATUSES), 'prospects_pipeline'),
+    prospectCount((q) => q.eq('status', 'new'), 'prospects_new'),
+    prospectCount((q) => q.eq('status', 'quoted'), 'prospects_quoted'),
+    prospectCount((q) => q.in('status', ['qualified', 'quoted']), 'prospects_qualified'),
+    readCount('calls_follow_up', supabase
+      .from('crm_calls')
+      .select('id', { count: 'exact', head: true })
+      .eq('outcome', 'follow_up')),
+    readCount('calls_standalone', supabase
+      .from('crm_calls')
+      .select('id', { count: 'exact', head: true })
+      .is('prospect_id', null)),
+  ]);
+
+  return composeCrmOverviewSummary(
+    {
+      quoteStocks,
+      quoteWindow,
+      orderStocks,
+      orderWindow,
+      callWindow,
+      openTasks,
+      counts: { pipelineProspects, newProspects, quotedProspects, qualifiedProspects, followUpCalls, standaloneCalls },
+      truncated,
+    },
+    window,
+  );
+}

--- a/lib/domains/crm/overviewSummary.ts
+++ b/lib/domains/crm/overviewSummary.ts
@@ -1,5 +1,6 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { BOARD_FILTER_STATUSES, type CrmWorkOrderStatus } from './work-orders';
+import { QUOTE_FILTER_STATUSES, type CrmQuoteStatus } from './quotes';
 
 // ── The CRM overview's read model ──
 //
@@ -22,8 +23,10 @@ import { BOARD_FILTER_STATUSES, type CrmWorkOrderStatus } from './work-orders';
 // Every row-returning query still carries an explicit cap and reports hitting it in `truncated`,
 // because the one thing worse than a wrong number is a wrong number that says nothing.
 
-/** A quote is "active" while it is still in play: not won, not lost. */
-export const ACTIVE_QUOTE_STATUSES = ['draft', 'sent', 'follow_up'];
+// A quote is "active" while it is still in play. Read from the offer list's own tab definition
+// rather than copied: "Aktiva offerter" here and the "Aktiva" tab there must mean the same thing,
+// and a fourth in-play status added to one of them would otherwise fall silently out of the other.
+export const ACTIVE_QUOTE_STATUSES = QUOTE_FILTER_STATUSES.active ?? [];
 
 // ⚠️ These four buckets are structurally empty today, and were before the counting moved here.
 // Prospects are `crm_customers` rows with customer_stage='prospect', and `status` on that table is
@@ -78,20 +81,18 @@ export type CrmOverviewSummary = {
   newProspects: number;
   quotedProspects: number;
   qualifiedProspects: number;
-  // Quotes
+  // Quotes — stocks
   activeQuotes: number;
   activeQuoteValue: number;
   quoteFollowUps: number;
-  quotesLast7Days: number;
-  quoteValueLast7Days: number;
-  // Work orders
+  // Work orders — stocks
   openWorkOrders: number;
   openOrderValue: number;
   workOrdersToInvoice: number;
   toInvoiceOrderValue: number;
-  orderValueLast7Days: number;
-  invoicedValueLast7Days: number;
-  // Calls
+  // Calls over the rolling 7 days. The only figure on the page still keyed to that window, because
+  // it is the only one whose label says so ("Samtal senaste 7 dagar"). Everything measured against
+  // a target is keyed to the week instead — see weekTeam.
   callsLast7Days: number;
   followUpCalls: number;
   standaloneCalls: number;
@@ -99,6 +100,15 @@ export type CrmOverviewSummary = {
   openTasks: number;
   overdueTasks: number;
   todayTasks: number;
+  /**
+   * The whole team's actuals for the CURRENT WEEK — the window the weekly targets are set in, and
+   * the same window the leaderboard uses per seller. The two must be able to reconcile: a team
+   * figure over a rolling 7 days could not equal the sum of per-seller figures over the week, and
+   * on any screen showing both, one of them then reads as broken.
+   *
+   * Unlike weekByUser this includes rows with no assignee, which belong to the team but to nobody.
+   */
+  weekTeam: CrmOverviewWeekActuals;
   /** Current week's actuals per user id — the leaderboard joins these with each user's goal. */
   weekByUser: Record<string, CrmOverviewWeekActuals>;
   /** Names of queries that hit ROW_CAP. Empty is the normal case; non-empty means read low. */
@@ -115,7 +125,13 @@ export type OrderWindowRow = {
   fortnox_invoiced_at: string | null;
   assigned_to: string | null;
 };
-export type CallWindowRow = { user_id: string; call_at: string };
+export type CallWindowRow = {
+  user_id: string;
+  call_at: string;
+  outcome: string;
+  /** Null = a call logged without a prospect behind it. */
+  prospect_id: string | null;
+};
 export type TaskDueRow = { due_at: string | null };
 
 export type CrmOverviewRows = {
@@ -130,8 +146,6 @@ export type CrmOverviewRows = {
     newProspects: number;
     quotedProspects: number;
     qualifiedProspects: number;
-    followUpCalls: number;
-    standaloneCalls: number;
   };
   truncated: string[];
 };
@@ -156,16 +170,16 @@ function inWindow(value: string | null | undefined, from: string, toExclusive?: 
   return day >= from && (toExclusive == null || day < toExclusive);
 }
 
-function addToUser(map: Record<string, CrmOverviewWeekActuals>, userId: string | null, patch: Partial<CrmOverviewWeekActuals>) {
-  if (!userId) return;
-  const current = map[userId] ?? { calls: 0, quotes: 0, quoteValue: 0, orderCount: 0, orderValue: 0, invoicedValue: 0 };
-  map[userId] = {
-    calls: current.calls + (patch.calls ?? 0),
-    quotes: current.quotes + (patch.quotes ?? 0),
-    quoteValue: current.quoteValue + (patch.quoteValue ?? 0),
-    orderCount: current.orderCount + (patch.orderCount ?? 0),
-    orderValue: current.orderValue + (patch.orderValue ?? 0),
-    invoicedValue: current.invoicedValue + (patch.invoicedValue ?? 0),
+const NO_ACTUALS: CrmOverviewWeekActuals = { calls: 0, quotes: 0, quoteValue: 0, orderCount: 0, orderValue: 0, invoicedValue: 0 };
+
+function addActuals(base: CrmOverviewWeekActuals, patch: Partial<CrmOverviewWeekActuals>): CrmOverviewWeekActuals {
+  return {
+    calls: base.calls + (patch.calls ?? 0),
+    quotes: base.quotes + (patch.quotes ?? 0),
+    quoteValue: base.quoteValue + (patch.quoteValue ?? 0),
+    orderCount: base.orderCount + (patch.orderCount ?? 0),
+    orderValue: base.orderValue + (patch.orderValue ?? 0),
+    invoicedValue: base.invoicedValue + (patch.invoicedValue ?? 0),
   };
 }
 
@@ -173,39 +187,45 @@ function addToUser(map: Record<string, CrmOverviewWeekActuals>, userId: string |
  * Pure: rows in, read model out. The queries are the impure half (fetchCrmOverviewSummary).
  */
 export function composeCrmOverviewSummary(rows: CrmOverviewRows, window: CrmOverviewWindow): CrmOverviewSummary {
-  const activeQuotes = rows.quoteStocks.filter((quote) => ACTIVE_QUOTE_STATUSES.includes(quote.status));
+  const activeQuotes = rows.quoteStocks.filter((quote) => ACTIVE_QUOTE_STATUSES.includes(quote.status as CrmQuoteStatus));
   const openOrders = rows.orderStocks.filter((order) => OPEN_WORK_ORDER_STATUSES.includes(order.status as CrmWorkOrderStatus));
   const toInvoiceOrders = rows.orderStocks.filter((order) => TO_INVOICE_WORK_ORDER_STATUSES.includes(order.status as CrmWorkOrderStatus));
 
   const sum = (list: Array<{ amount: number | string }>) => list.reduce((total, row) => total + toAmount(row.amount), 0);
 
-  // Order value is attributed to when the order was won, invoiced revenue to when it was billed.
+  // Every figure measured against a target is scoped to the current week, for the team and per
+  // seller in the same pass — so the team row and the leaderboard row for the same metric are the
+  // same arithmetic and can be checked against each other.
+  //
+  // Order value is attributed to when the order was won, invoiced revenue to when it was BILLED.
   // Bucketing invoiced revenue on created_at was the biggest data error the reports have had (it
   // hid 371 323 kr of 450 101 kr in one month, PR #70) — the lag from order to invoice runs about
   // a month, so the two dates are not interchangeable.
-  const invoicedInWindow = rows.orderWindow.filter(
-    (order) => order.status === 'invoiced' && inWindow(order.fortnox_invoiced_at, window.since),
-  );
-  const createdInWindow = rows.orderWindow.filter((order) => inWindow(order.created_at, window.since));
-
+  let weekTeam = NO_ACTUALS;
   const weekByUser: Record<string, CrmOverviewWeekActuals> = {};
+  const addWeek = (userId: string | null, patch: Partial<CrmOverviewWeekActuals>) => {
+    weekTeam = addActuals(weekTeam, patch);
+    // A row with no assignee still belongs to the team; it just belongs to nobody in the list.
+    if (userId) weekByUser[userId] = addActuals(weekByUser[userId] ?? NO_ACTUALS, patch);
+  };
+
   for (const call of rows.callWindow) {
-    if (inWindow(call.call_at, window.weekStart, window.weekEnd)) addToUser(weekByUser, call.user_id, { calls: 1 });
+    if (inWindow(call.call_at, window.weekStart, window.weekEnd)) addWeek(call.user_id, { calls: 1 });
   }
   for (const quote of rows.quoteWindow) {
     if (!inWindow(quote.quote_date, window.weekStart, window.weekEnd)) continue;
-    addToUser(weekByUser, quote.assigned_to, { quotes: 1, quoteValue: toAmount(quote.amount) });
+    addWeek(quote.assigned_to, { quotes: 1, quoteValue: toAmount(quote.amount) });
   }
   for (const order of rows.orderWindow) {
     if (inWindow(order.created_at, window.weekStart, window.weekEnd)) {
-      addToUser(weekByUser, order.assigned_to, { orderCount: 1, orderValue: toAmount(order.amount) });
+      addWeek(order.assigned_to, { orderCount: 1, orderValue: toAmount(order.amount) });
     }
     if (order.status === 'invoiced' && inWindow(order.fortnox_invoiced_at, window.weekStart, window.weekEnd)) {
-      addToUser(weekByUser, order.assigned_to, { invoicedValue: toAmount(order.amount) });
+      addWeek(order.assigned_to, { invoicedValue: toAmount(order.amount) });
     }
   }
 
-  const quotesInWindow = rows.quoteWindow.filter((quote) => inWindow(quote.quote_date, window.since));
+  const callsInWindow = rows.callWindow.filter((call) => inWindow(call.call_at, window.since));
   const openTaskDays = rows.openTasks.map((task) => dayOf(task.due_at));
 
   return {
@@ -217,26 +237,27 @@ export function composeCrmOverviewSummary(rows: CrmOverviewRows, window: CrmOver
     activeQuotes: activeQuotes.length,
     activeQuoteValue: sum(activeQuotes),
     quoteFollowUps: rows.quoteStocks.filter((quote) => quote.status === 'follow_up').length,
-    quotesLast7Days: quotesInWindow.length,
-    quoteValueLast7Days: sum(quotesInWindow),
 
     openWorkOrders: openOrders.length,
     openOrderValue: sum(openOrders),
     workOrdersToInvoice: toInvoiceOrders.length,
     toInvoiceOrderValue: sum(toInvoiceOrders),
-    orderValueLast7Days: sum(createdInWindow),
-    invoicedValueLast7Days: sum(invoicedInWindow),
 
-    // Re-filtered rather than taken as the query's row count, so the numbers are a function of the
-    // rows and the window alone — that is what makes them testable without a database.
-    callsLast7Days: rows.callWindow.filter((call) => inWindow(call.call_at, window.since)).length,
-    followUpCalls: rows.counts.followUpCalls,
-    standaloneCalls: rows.counts.standaloneCalls,
+    // All three read from the rows and the window alone — no query row-count is trusted, which is
+    // what makes them testable without a database. The two follow-up figures are WINDOWED on
+    // purpose: they drive "Att agera på", so they have to describe a workload you can still act on.
+    // Counted over all time they would only ever grow — `outcome` is a permanent historical fact
+    // with no resolution flag, so a call marked "följ upp" in June would still be demanding
+    // attention in December.
+    callsLast7Days: callsInWindow.length,
+    followUpCalls: callsInWindow.filter((call) => call.outcome === 'follow_up').length,
+    standaloneCalls: callsInWindow.filter((call) => call.prospect_id == null).length,
 
     openTasks: rows.openTasks.length,
     overdueTasks: openTaskDays.filter((day) => day != null && day < window.today).length,
     todayTasks: openTaskDays.filter((day) => day === window.today).length,
 
+    weekTeam,
     weekByUser,
     truncated: rows.truncated,
   };
@@ -284,34 +305,37 @@ export async function fetchCrmOverviewSummary(
     newProspects,
     quotedProspects,
     qualifiedProspects,
-    followUpCalls,
-    standaloneCalls,
   ] = await Promise.all([
     readRows<QuoteStockRow>('quote_stocks', supabase
       .from('crm_quotes')
       .select('status, amount')
       .in('status', ACTIVE_QUOTE_STATUSES)
       .limit(ROW_CAP), truncated),
+    // Only the week is read: every quote figure on the page is either a stock (above) or measured
+    // against the weekly target. `since` would fetch days nothing reads.
     readRows<QuoteWindowRow>('quote_window', supabase
       .from('crm_quotes')
       .select('amount, quote_date, assigned_to')
-      .gte('quote_date', window.since)
+      .gte('quote_date', window.weekStart)
       .limit(ROW_CAP), truncated),
     readRows<OrderStockRow>('order_stocks', supabase
       .from('crm_work_orders')
       .select('status, amount')
       .in('status', [...OPEN_WORK_ORDER_STATUSES, ...TO_INVOICE_WORK_ORDER_STATUSES])
       .limit(ROW_CAP), truncated),
-    // Superset: created in the window OR invoiced in it. An order created in June and invoiced in
-    // August belongs to both figures but to neither date alone, so it has to be fetched on either.
+    // Superset: created in the week OR invoiced in it. An order created in June and invoiced this
+    // week belongs to one figure each, and to neither date alone, so it must be fetched on either.
     readRows<OrderWindowRow>('order_window', supabase
       .from('crm_work_orders')
       .select('status, amount, created_at, fortnox_invoiced_at, assigned_to')
-      .or(`created_at.gte.${window.since},fortnox_invoiced_at.gte.${window.since}`)
+      .or(`created_at.gte.${window.weekStart},fortnox_invoiced_at.gte.${window.weekStart}`)
       .limit(ROW_CAP), truncated),
+    // The widest window on the page: the calls metric card is explicitly the rolling 7 days, and the
+    // week is a subset of it, so one read serves both. outcome + prospect_id come along because the
+    // two follow-up figures are counted from these same rows instead of by their own scans.
     readRows<CallWindowRow>('call_window', supabase
       .from('crm_calls')
-      .select('user_id, call_at')
+      .select('user_id, call_at, outcome, prospect_id')
       .gte('call_at', window.since)
       .limit(ROW_CAP), truncated),
     // 'active' is the stored value the task domain maps to 'open'; 'done' and 'cancelled' are out.
@@ -325,14 +349,6 @@ export async function fetchCrmOverviewSummary(
     prospectCount((q) => q.eq('status', 'new'), 'prospects_new'),
     prospectCount((q) => q.eq('status', 'quoted'), 'prospects_quoted'),
     prospectCount((q) => q.in('status', ['qualified', 'quoted']), 'prospects_qualified'),
-    readCount('calls_follow_up', supabase
-      .from('crm_calls')
-      .select('id', { count: 'exact', head: true })
-      .eq('outcome', 'follow_up')),
-    readCount('calls_standalone', supabase
-      .from('crm_calls')
-      .select('id', { count: 'exact', head: true })
-      .is('prospect_id', null)),
   ]);
 
   return composeCrmOverviewSummary(
@@ -343,7 +359,7 @@ export async function fetchCrmOverviewSummary(
       orderWindow,
       callWindow,
       openTasks,
-      counts: { pipelineProspects, newProspects, quotedProspects, qualifiedProspects, followUpCalls, standaloneCalls },
+      counts: { pipelineProspects, newProspects, quotedProspects, qualifiedProspects },
       truncated,
     },
     window,

--- a/lib/domains/crm/quotes.ts
+++ b/lib/domains/crm/quotes.ts
@@ -140,22 +140,31 @@ type CreateCrmQuoteInput = {
 // öppnas här bara typmässigt.
 export type UpdateCrmQuoteInput = Omit<CreateCrmQuoteInput, 'created_by'>;
 
+// Sort orders, named after the leading key. Default is the offer list's working order: open
+// statuses first (status sorts draft → follow_up → lost → sent → won), then the nearest
+// follow-up. 'updated_desc' is for callers that want the most recently touched quotes — the
+// default sort would hand them drafts and lost quotes first and truncate won/sent ones at the
+// row cap, since the cap cuts server-side before the browser can reorder anything.
+export type CrmQuoteSort = 'status_asc' | 'updated_desc';
+
 type ListCrmQuotesOptions = {
   search?: string;
   status?: CrmQuoteStatus;
   prospectId?: string;
   customerId?: string;
   limit?: number;
+  sort?: CrmQuoteSort;
 };
 
 export async function listCrmQuotesWithFilters(supabase: SupabaseClient, options: ListCrmQuotesOptions) {
-  let query = supabase
-    .from('crm_quotes')
-    .select(crmQuoteSelect)
-    .order('status', { ascending: true })
-    .order('follow_up_date', { ascending: true, nullsFirst: false })
-    .order('quote_date', { ascending: false })
-    .limit(options.limit ?? 100);
+  const selected = supabase.from('crm_quotes').select(crmQuoteSelect);
+  let query = (options.sort === 'updated_desc'
+    ? selected.order('updated_at', { ascending: false })
+    : selected
+      .order('status', { ascending: true })
+      .order('follow_up_date', { ascending: true, nullsFirst: false })
+      .order('quote_date', { ascending: false })
+  ).limit(options.limit ?? 100);
 
   if (options.search) {
     query = query.or(

--- a/lib/domains/crm/quotes.ts
+++ b/lib/domains/crm/quotes.ts
@@ -41,7 +41,7 @@ export const crmQuoteSelect = `
   )
 `;
 
-type CrmQuoteStatus = 'draft' | 'sent' | 'follow_up' | 'won' | 'lost';
+export type CrmQuoteStatus = 'draft' | 'sent' | 'follow_up' | 'won' | 'lost';
 type CrmQuoteType = 'private' | 'business';
 
 type CustomerSource = {
@@ -160,7 +160,7 @@ export type CrmQuoteSort = 'status_asc' | 'updated_desc' | 'created_desc' | 'fol
 // BOARD_FILTER_STATUSES for work orders.
 export type CrmQuoteListFilter = 'all' | 'active' | 'follow_up' | 'won' | 'lost';
 export const CRM_QUOTE_LIST_FILTERS: CrmQuoteListFilter[] = ['all', 'active', 'follow_up', 'won', 'lost'];
-const QUOTE_FILTER_STATUSES: Record<CrmQuoteListFilter, CrmQuoteStatus[] | null> = {
+export const QUOTE_FILTER_STATUSES: Record<CrmQuoteListFilter, CrmQuoteStatus[] | null> = {
   all: null,
   // "Aktiva" = still in play: not won, not lost.
   active: ['draft', 'sent', 'follow_up'],
@@ -238,7 +238,11 @@ export async function getCrmQuoteFilterCounts(
         supabase.from('crm_quotes').select('id', { count: 'exact', head: true }),
         { ...options, filter },
       );
-      const { count } = await query;
+      // Throw rather than fall back to 0: a failed count would otherwise render as "Alla 0" beside
+      // a hundred visible rows, with nothing telling the reader the number is wrong. Silent zeros
+      // are the failure mode this whole change exists to remove.
+      const { count, error } = await query;
+      if (error) throw new Error(`quote_counts:${filter}: ${error.message}`);
       return [filter, count ?? 0] as const;
     }),
   );

--- a/lib/domains/crm/quotes.ts
+++ b/lib/domains/crm/quotes.ts
@@ -140,51 +140,109 @@ type CreateCrmQuoteInput = {
 // öppnas här bara typmässigt.
 export type UpdateCrmQuoteInput = Omit<CreateCrmQuoteInput, 'created_by'>;
 
-// Sort orders, named after the leading key. Default is the offer list's working order: open
-// statuses first (status sorts draft → follow_up → lost → sent → won), then the nearest
-// follow-up. 'updated_desc' is for callers that want the most recently touched quotes — the
-// default sort would hand them drafts and lost quotes first and truncate won/sent ones at the
-// row cap, since the cap cuts server-side before the browser can reorder anything.
-export type CrmQuoteSort = 'status_asc' | 'updated_desc';
+// PostgREST row cap once the company accumulates quotes (see SUPABASE_CONVENTIONS.md). Mirrors
+// CRM_WORK_ORDERS_PAGE_SIZE — the offer list pages the same way the order board does.
+export const CRM_QUOTES_PAGE_SIZE = 100;
+
+// Sort orders, named after the leading key.
+//
+// 'created_desc' is what the offer list asks for: newest first, so the quote you just wrote is at
+// the top. 'follow_up_asc' is the same list's other view — the nearest follow-up first, most
+// urgent at the top. 'updated_desc' serves the overview's "senaste offertlägen". The historical
+// default, 'status_asc', is the old working order (status sorts draft → follow_up → lost → sent →
+// won, then nearest follow-up); it stays the default so every other caller is untouched, but note
+// what it does at the row cap: the cut happens server-side, from the tail, so WON quotes go first
+// and SENT ones next — the two groups the money figures are built on.
+export type CrmQuoteSort = 'status_asc' | 'updated_desc' | 'created_desc' | 'follow_up_asc';
+
+// The offer list's tabs → the concrete statuses each one covers, so the page filter and its chip
+// counts can never diverge from each other. 'all' = no status filter. Mirrors
+// BOARD_FILTER_STATUSES for work orders.
+export type CrmQuoteListFilter = 'all' | 'active' | 'follow_up' | 'won' | 'lost';
+export const CRM_QUOTE_LIST_FILTERS: CrmQuoteListFilter[] = ['all', 'active', 'follow_up', 'won', 'lost'];
+const QUOTE_FILTER_STATUSES: Record<CrmQuoteListFilter, CrmQuoteStatus[] | null> = {
+  all: null,
+  // "Aktiva" = still in play: not won, not lost.
+  active: ['draft', 'sent', 'follow_up'],
+  follow_up: ['follow_up'],
+  won: ['won'],
+  lost: ['lost'],
+};
 
 type ListCrmQuotesOptions = {
   search?: string;
   status?: CrmQuoteStatus;
+  filter?: CrmQuoteListFilter;
+  assignedToIn?: string[];
   prospectId?: string;
   customerId?: string;
   limit?: number;
+  offset?: number;
   sort?: CrmQuoteSort;
 };
 
-export async function listCrmQuotesWithFilters(supabase: SupabaseClient, options: ListCrmQuotesOptions) {
-  const selected = supabase.from('crm_quotes').select(crmQuoteSelect);
-  let query = (options.sort === 'updated_desc'
-    ? selected.order('updated_at', { ascending: false })
-    : selected
-      .order('status', { ascending: true })
-      .order('follow_up_date', { ascending: true, nullsFirst: false })
-      .order('quote_date', { ascending: false })
-  ).limit(options.limit ?? 100);
-
+// Apply the shared WHERE clauses so the paginated list and the per-filter counts always use the
+// exact same predicates. Same shape — and the same comma/parenthesis hazard — as
+// applyWorkOrderListFilters: PostgREST reads `or=(...)` as a comma-separated condition list, so a
+// customer name like "Ekbergs Bygg, AB" would split the expression and answer 400.
+function applyQuoteListFilters<Q extends {
+  or: (f: string) => Q; eq: (c: string, v: string) => Q; in: (c: string, v: string[]) => Q;
+}>(query: Q, options: ListCrmQuotesOptions): Q {
   if (options.search) {
+    const term = options.search.replace(/[,()]/g, ' ').trim();
+    if (!term) return query;
     query = query.or(
-      `project_name.ilike.%${options.search}%,customer_name.ilike.%${options.search}%,description.ilike.%${options.search}%,notes.ilike.%${options.search}%`
+      `quote_number.ilike.%${term}%,fortnox_offer_number.ilike.%${term}%,project_name.ilike.%${term}%,customer_name.ilike.%${term}%,description.ilike.%${term}%,notes.ilike.%${term}%`,
     );
   }
-
-  if (options.status) {
-    query = query.eq('status', options.status);
-  }
-
-  if (options.prospectId) {
-    query = query.eq('prospect_id', options.prospectId);
-  }
-
-  if (options.customerId) {
-    query = query.eq('customer_id', options.customerId);
-  }
-
+  const statuses = options.filter ? QUOTE_FILTER_STATUSES[options.filter] : null;
+  if (statuses) query = query.in('status', statuses);
+  if (options.status) query = query.eq('status', options.status);
+  if (options.assignedToIn && options.assignedToIn.length > 0) query = query.in('assigned_to', options.assignedToIn);
+  if (options.prospectId) query = query.eq('prospect_id', options.prospectId);
+  if (options.customerId) query = query.eq('customer_id', options.customerId);
   return query;
+}
+
+export async function listCrmQuotesWithFilters(supabase: SupabaseClient, options: ListCrmQuotesOptions) {
+  const limit = options.limit ?? CRM_QUOTES_PAGE_SIZE;
+  const offset = options.offset ?? 0;
+  const selected = supabase.from('crm_quotes').select(crmQuoteSelect, { count: 'exact' });
+  const ordered = options.sort === 'updated_desc'
+    ? selected.order('updated_at', { ascending: false })
+    : options.sort === 'created_desc'
+      ? selected.order('created_at', { ascending: false })
+      : options.sort === 'follow_up_asc'
+        // Nulls last: a quote with no follow-up date set is not more urgent than one that has one.
+        ? selected
+          .order('follow_up_date', { ascending: true, nullsFirst: false })
+          .order('created_at', { ascending: false })
+        : selected
+          .order('status', { ascending: true })
+          .order('follow_up_date', { ascending: true, nullsFirst: false })
+          .order('quote_date', { ascending: false });
+
+  return applyQuoteListFilters(ordered.range(offset, offset + limit - 1), options);
+}
+
+// Per-filter counts for the offer list's tabs. One head-count query per tab (count only, no rows
+// transferred) so the numbers stay exact at any table size. The search and assignee scope is
+// applied so the counts describe the same set the list is showing.
+export async function getCrmQuoteFilterCounts(
+  supabase: SupabaseClient,
+  options: { search?: string; assignedToIn?: string[]; prospectId?: string; customerId?: string },
+): Promise<Record<CrmQuoteListFilter, number>> {
+  const entries = await Promise.all(
+    CRM_QUOTE_LIST_FILTERS.map(async (filter) => {
+      const query = applyQuoteListFilters(
+        supabase.from('crm_quotes').select('id', { count: 'exact', head: true }),
+        { ...options, filter },
+      );
+      const { count } = await query;
+      return [filter, count ?? 0] as const;
+    }),
+  );
+  return Object.fromEntries(entries) as Record<CrmQuoteListFilter, number>;
 }
 
 export async function getCrmQuote(supabase: SupabaseClient, id: string) {

--- a/lib/domains/crm/work-orders.ts
+++ b/lib/domains/crm/work-orders.ts
@@ -515,7 +515,10 @@ export async function getCrmWorkOrderFilterCounts(
         supabase.from('crm_work_orders').select('id', { count: 'exact', head: true }),
         { search: options.search, filter, assignedToIn: options.assignedToIn },
       );
-      const { count } = await query;
+      // Throw rather than fall back to 0 — a failed count would render as a chip reading 0 next to
+      // a list full of rows, with nothing saying the number is wrong. Same rule as the quote counts.
+      const { count, error } = await query;
+      if (error) throw new Error(`work_order_counts:${filter}: ${error.message}`);
       return [filter, count ?? 0] as const;
     }),
   );

--- a/lib/domains/crm/work-orders.ts
+++ b/lib/domains/crm/work-orders.ts
@@ -426,7 +426,7 @@ export const CRM_WORK_ORDERS_PAGE_SIZE = 100;
 // query and the per-filter counts can never diverge.
 export type CrmWorkOrderBoardFilter = 'all' | 'draft' | 'scheduled' | 'active' | 'completed' | 'invoiced';
 export const CRM_WORK_ORDER_BOARD_FILTERS: CrmWorkOrderBoardFilter[] = ['all', 'draft', 'scheduled', 'active', 'completed', 'invoiced'];
-const BOARD_FILTER_STATUSES: Record<CrmWorkOrderBoardFilter, CrmWorkOrderStatus[] | null> = {
+export const BOARD_FILTER_STATUSES: Record<CrmWorkOrderBoardFilter, CrmWorkOrderStatus[] | null> = {
   all: null,
   draft: ['draft'],
   scheduled: ['scheduled', 'ready'],

--- a/lib/domains/crm/work-orders.ts
+++ b/lib/domains/crm/work-orders.ts
@@ -475,20 +475,31 @@ function applyWorkOrderListFilters<Q extends {
   return query;
 }
 
+// Sort orders, named after the leading key. The board is a work queue — earliest installation
+// date first — but a "senaste ordrar" list needs the other end of the table, and the order MUST
+// be chosen server-side: the page cap cuts the rows before the browser sees them, so sorting in
+// the client only reorders whatever survived the cut. With the default sort a newly created
+// order (installation date in the future) is the LAST row in the table, so once the company
+// passes CRM_WORK_ORDERS_PAGE_SIZE orders a client-sorted "latest" list would quietly show the
+// oldest jobs instead.
+export type CrmWorkOrderSort = 'installation_asc' | 'created_desc';
+
 export async function listCrmWorkOrdersWithFilters(
   supabase: SupabaseClient,
-  options: WorkOrderListFilters & { limit?: number; offset?: number },
+  options: WorkOrderListFilters & { limit?: number; offset?: number; sort?: CrmWorkOrderSort },
 ) {
   const limit = options.limit ?? CRM_WORK_ORDERS_PAGE_SIZE;
   const offset = options.offset ?? 0;
-  const query = supabase
+  const selected = supabase
     .from('crm_work_orders')
-    .select(crmWorkOrderSelect, { count: 'exact' })
-    .order('desired_installation_date', { ascending: true, nullsFirst: false })
-    .order('created_at', { ascending: false })
-    .range(offset, offset + limit - 1);
+    .select(crmWorkOrderSelect, { count: 'exact' });
+  const ordered = options.sort === 'created_desc'
+    ? selected.order('created_at', { ascending: false })
+    : selected
+      .order('desired_installation_date', { ascending: true, nullsFirst: false })
+      .order('created_at', { ascending: false });
 
-  return applyWorkOrderListFilters(query, options);
+  return applyWorkOrderListFilters(ordered.range(offset, offset + limit - 1), options);
 }
 
 // Per-filter counts for the board chips. One head-count query per filter (count-only, no rows

--- a/tests/crm/goals.test.ts
+++ b/tests/crm/goals.test.ts
@@ -29,3 +29,52 @@ describe('formatLocalDateOnly', () => {
     expect(formatLocalDateOnly(new Date(2026, 11, 9))).toBe('2026-12-09');
   });
 });
+
+// ---------------------------------------------------------------------------
+// getCrmOverviewWindow — fönstret CRM-översikten ber servern räkna inuti
+//
+// Låg tidigare i CrmOverview.tsx ("use client") och gick därför inte att testa alls, vilket är
+// precis den kod man minst vill ha otestad: kalenderaritmetik med DST-fällor. Kör den här filen
+// under BÅDE TZ=UTC och TZ=Europe/Stockholm — en förankring som bara håller i den ena är fel.
+// ---------------------------------------------------------------------------
+
+import { getCrmOverviewWindow } from '@/lib/domains/crm/goals';
+
+describe('getCrmOverviewWindow', () => {
+  it('en måndag är veckans start samma dag, och slutet nästa måndag', () => {
+    // 2026-08-17 är en måndag.
+    const w = getCrmOverviewWindow(new Date(2026, 7, 17, 9, 30));
+    expect(w).toEqual({ today: '2026-08-17', since: '2026-08-10', weekStart: '2026-08-17', weekEnd: '2026-08-24' });
+  });
+
+  it('en söndag hör till veckan som började föregående måndag', () => {
+    // 2026-08-23 är en söndag — ISO-veckan, inte den amerikanska.
+    const w = getCrmOverviewWindow(new Date(2026, 7, 23, 23, 59));
+    expect(w).toEqual({ today: '2026-08-23', since: '2026-08-16', weekStart: '2026-08-17', weekEnd: '2026-08-24' });
+  });
+
+  it('fönstret är sju dagar bakåt och håller över ett månadsskifte', () => {
+    const w = getCrmOverviewWindow(new Date(2026, 8, 3, 12));
+    expect(w.today).toBe('2026-09-03');
+    expect(w.since).toBe('2026-08-27');
+  });
+
+  it('vintertid: sommartidens slut flyttar inte gränserna', () => {
+    // Sverige ställer om natten till söndag 2026-10-25. Onsdagen efter ska landa på veckan som
+    // började måndagen den 26:e, och `since` sju dagar bak trots att dygnet däremellan var 25 timmar.
+    const w = getCrmOverviewWindow(new Date(2026, 9, 28, 8));
+    expect(w).toEqual({ today: '2026-10-28', since: '2026-10-21', weekStart: '2026-10-26', weekEnd: '2026-11-02' });
+  });
+
+  it('sommartid: omställningen in i sommartid flyttar inte heller gränserna', () => {
+    // 2026-03-29 ställer klockan fram. Måndagen den 30:e ska ge weekEnd 2026-04-06 (23-timmarsdygn
+    // i intervallet), och en midnatt-baserad addering hade kunnat landa en dag fel.
+    const w = getCrmOverviewWindow(new Date(2026, 2, 30, 7));
+    expect(w).toEqual({ today: '2026-03-30', since: '2026-03-23', weekStart: '2026-03-30', weekEnd: '2026-04-06' });
+  });
+
+  it('runt midnatt tar den dagen läsaren har, inte serverns', () => {
+    const w = getCrmOverviewWindow(new Date(2026, 7, 17, 0, 15));
+    expect(w.today).toBe('2026-08-17');
+  });
+});

--- a/tests/crm/helpers/supabase.ts
+++ b/tests/crm/helpers/supabase.ts
@@ -13,6 +13,9 @@ export function makeQueryChain(result: { data: unknown; error: unknown }) {
   const methods = [
     'select', 'insert', 'update', 'delete', 'upsert',
     'eq', 'neq', 'or', 'ilike', 'like', 'filter', 'match',
+    // Filter verbs the CRM list queries use: status groups and assignee scopes go through .in(),
+    // "no prospect" through .is(), and the windowed reads through .gte()/.lte().
+    'in', 'is', 'gte', 'lte',
     'order', 'limit', 'range',
   ] as const;
 

--- a/tests/crm/overview.route.test.ts
+++ b/tests/crm/overview.route.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { salesUser, memberUser, effectivePermissionsForRole } from './helpers/supabase';
+
+// Mockar före modulimporter.
+vi.mock('@/lib/auth/route', () => ({ getCurrentUser: vi.fn() }));
+vi.mock('@/lib/domains/crm/overviewSummary', () => ({ fetchCrmOverviewSummary: vi.fn() }));
+vi.mock('@supabase/auth-helpers-nextjs', () => ({ createRouteHandlerClient: vi.fn(() => ({})) }));
+vi.mock('next/headers', () => ({ cookies: vi.fn() }));
+vi.mock('@/lib/auth/permissions', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/auth/permissions')>();
+  return { ...actual, getEffectivePermissions: vi.fn() };
+});
+
+import { getCurrentUser } from '@/lib/auth/route';
+import { getEffectivePermissions } from '@/lib/auth/permissions';
+import { fetchCrmOverviewSummary } from '@/lib/domains/crm/overviewSummary';
+import { GET } from '@/app/api/crm/overview/route';
+
+const mockGetUser = vi.mocked(getCurrentUser);
+const mockPermissions = vi.mocked(getEffectivePermissions);
+const mockFetch = vi.mocked(fetchCrmOverviewSummary);
+
+const WINDOW = 'today=2026-08-17&since=2026-08-10&week_start=2026-08-17&week_end=2026-08-24';
+
+function req(query: string) {
+  return new Request(`http://localhost/api/crm/overview?${query}`);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetUser.mockResolvedValue(salesUser as any);
+  // Samma koppling som de andra rutt-testerna: rollen läses ur getCurrentUser-mocken, inte ur
+  // argumentet (guarden skickar in ett användar-id).
+  mockPermissions.mockImplementation(async () => effectivePermissionsForRole((await mockGetUser())?.role) as any);
+  mockFetch.mockResolvedValue({ truncated: [] } as any);
+});
+
+describe('GET /api/crm/overview — auth', () => {
+  it('nekar utan session', async () => {
+    mockGetUser.mockResolvedValue(null as any);
+    expect((await GET(req(WINDOW))).status).toBe(401);
+  });
+
+  it('nekar member', async () => {
+    mockGetUser.mockResolvedValue(memberUser as any);
+    expect((await GET(req(WINDOW))).status).toBe(403);
+  });
+
+  it('tillåter sales', async () => {
+    expect((await GET(req(WINDOW))).status).toBe(200);
+  });
+});
+
+describe('GET /api/crm/overview — fönstret', () => {
+  it('kräver alla fyra datumen', async () => {
+    expect((await GET(req('today=2026-08-17'))).status).toBe(400);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('avvisar datum som inte är datum', async () => {
+    expect((await GET(req(`today=igår&since=2026-08-10&week_start=2026-08-17&week_end=2026-08-24`))).status).toBe(400);
+  });
+
+  it('avvisar en start som ligger efter idag', async () => {
+    expect((await GET(req('today=2026-08-17&since=2026-08-20&week_start=2026-08-17&week_end=2026-08-24'))).status).toBe(400);
+  });
+
+  it('avvisar en vecka som slutar före den börjar', async () => {
+    expect((await GET(req('today=2026-08-17&since=2026-08-10&week_start=2026-08-24&week_end=2026-08-17'))).status).toBe(400);
+  });
+
+  // Fönstret kommer från klienten, så det behöver ett TAK och inte bara en riktning: since=1970-01-01
+  // hade förvandlat tre avgränsade läsningar till fulltabellsskanningar på begäran, för vilken
+  // inloggad CRM-användare som helst (konsult inräknad). Sidan ber aldrig om mer än åtta dagar.
+  it('avvisar ett fönster som är bredare än en månad', async () => {
+    const res = await GET(req('today=2026-08-17&since=1970-01-01&week_start=2026-08-17&week_end=2026-08-24'));
+    expect(res.status).toBe(400);
+    expect((await res.json()).errorDetails.code).toBe('invalid_window');
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('släpper igenom sidans eget fönster och skickar det vidare oförändrat', async () => {
+    await GET(req(WINDOW));
+    expect(mockFetch).toHaveBeenCalledWith(expect.anything(), {
+      today: '2026-08-17', since: '2026-08-10', weekStart: '2026-08-17', weekEnd: '2026-08-24',
+    });
+  });
+
+  it('svarar 500 med kod när räkningen fallerar', async () => {
+    mockFetch.mockRejectedValue(new Error('quote_stocks: db error'));
+    const res = await GET(req(WINDOW));
+    expect(res.status).toBe(500);
+    expect((await res.json()).errorDetails.code).toBe('crm_overview_summary_failed');
+  });
+});

--- a/tests/crm/overviewSummary.test.ts
+++ b/tests/crm/overviewSummary.test.ts
@@ -1,0 +1,248 @@
+import { describe, it, expect } from 'vitest';
+import {
+  composeCrmOverviewSummary,
+  OPEN_WORK_ORDER_STATUSES,
+  TO_INVOICE_WORK_ORDER_STATUSES,
+  type CrmOverviewRows,
+  type CrmOverviewWindow,
+} from '@/lib/domains/crm/overviewSummary';
+
+// CRM-översiktens siffror räknas på servern sedan 2026-08-17, för att listorna kapas innan
+// webbläsaren ser dem (PostgREST svarar med max 1000 rader, CRM-rutterna kapar lägre) — en siffra
+// räknad ur en kapad lista krymper tyst när tabellen växer. Det som testas här är den rena halvan:
+// rader in, läsmodell ut. Ingen databas, inga mockar.
+
+const WINDOW: CrmOverviewWindow = {
+  today: '2026-08-17',      // en måndag
+  since: '2026-08-10',      // rullande 7 dagar bakåt, inklusive
+  weekStart: '2026-08-17',  // veckans måndag, inklusive
+  weekEnd: '2026-08-24',    // nästa måndag, EXKLUSIVE
+};
+
+const ANNA = 'user-anna';
+const BOSSE = 'user-bosse';
+
+function rows(overrides: Partial<CrmOverviewRows> = {}): CrmOverviewRows {
+  return {
+    quoteStocks: [],
+    quoteWindow: [],
+    orderStocks: [],
+    orderWindow: [],
+    callWindow: [],
+    openTasks: [],
+    counts: {
+      pipelineProspects: 0,
+      newProspects: 0,
+      quotedProspects: 0,
+      qualifiedProspects: 0,
+      followUpCalls: 0,
+      standaloneCalls: 0,
+    },
+    truncated: [],
+    ...overrides,
+  };
+}
+
+describe('composeCrmOverviewSummary — lagren', () => {
+  it('räknar och summerar aktiva offerter, och håller vunna och förlorade utanför', () => {
+    const summary = composeCrmOverviewSummary(rows({
+      quoteStocks: [
+        { status: 'draft', amount: 10_000 },
+        { status: 'sent', amount: '25000.50' },
+        { status: 'follow_up', amount: 5_000 },
+        // Frågan filtrerar redan på status, men den rena funktionen litar inte på det: den som
+        // skickar in en vunnen offert ska inte kunna blåsa upp "aktivt offertvärde".
+        { status: 'won', amount: 999_999 },
+        { status: 'lost', amount: 888_888 },
+      ],
+    }), WINDOW);
+
+    expect(summary.activeQuotes).toBe(3);
+    expect(summary.activeQuoteValue).toBe(40_000.5);
+    expect(summary.quoteFollowUps).toBe(1);
+  });
+
+  it('delar ordrarna i öppet arbete och faktureringssteget, och lämnar avslutade och avbrutna utanför', () => {
+    const summary = composeCrmOverviewSummary(rows({
+      orderStocks: [
+        { status: 'draft', amount: 1_000 },
+        { status: 'scheduled', amount: 2_000 },
+        { status: 'ready', amount: 4_000 },        // pensionerad status, lever kvar i gamla rader
+        { status: 'in_progress', amount: 8_000 },
+        { status: 'completed', amount: 16_000 },
+        { status: 'partially_invoiced', amount: 32_000 },
+        { status: 'invoiced', amount: 64_000 },
+        { status: 'cancelled', amount: 128_000 },
+      ],
+    }), WINDOW);
+
+    expect(summary.openWorkOrders).toBe(4);
+    expect(summary.openOrderValue).toBe(15_000);
+    expect(summary.workOrdersToInvoice).toBe(2);
+    expect(summary.toInvoiceOrderValue).toBe(48_000);
+  });
+
+  it('statusgrupperna kommer från orderbrädans egna definitioner', () => {
+    // Grupperna får inte drifta ifrån brädans chip-filter — då hade en ny status kunnat falla ur
+    // både "Öppna ordrar" och "Att fakturera" utan att någon märkte det.
+    expect(OPEN_WORK_ORDER_STATUSES).toEqual(['draft', 'scheduled', 'ready', 'in_progress']);
+    expect(TO_INVOICE_WORK_ORDER_STATUSES).toEqual(['completed', 'partially_invoiced']);
+  });
+});
+
+describe('composeCrmOverviewSummary — fakturerat bucketas på fakturadatumet', () => {
+  // Det här är felklassen PR #70 rättade i rapporten: ordrar hämtade och bucketade på created_at
+  // dolde 371 323 kr av 450 101 kr i en månad, eftersom eftersläpningen order→faktura är ungefär
+  // en månad. De två datumen är alltså inte utbytbara.
+  it('räknar en gammal order som fakturerades i fönstret', () => {
+    const summary = composeCrmOverviewSummary(rows({
+      orderWindow: [
+        { status: 'invoiced', amount: 100_000, created_at: '2026-06-01T08:00:00+00:00', fortnox_invoiced_at: '2026-08-14T09:00:00+00:00', assigned_to: ANNA },
+      ],
+    }), WINDOW);
+
+    expect(summary.invoicedValueLast7Days).toBe(100_000);
+    // Ordern skapades långt utanför fönstret, så ordervärdet ska INTE räknas.
+    expect(summary.orderValueLast7Days).toBe(0);
+  });
+
+  it('räknar inte en order som skapades i fönstret men faktureras senare', () => {
+    const summary = composeCrmOverviewSummary(rows({
+      orderWindow: [
+        { status: 'in_progress', amount: 70_000, created_at: '2026-08-12T08:00:00+00:00', fortnox_invoiced_at: null, assigned_to: ANNA },
+      ],
+    }), WINDOW);
+
+    expect(summary.orderValueLast7Days).toBe(70_000);
+    expect(summary.invoicedValueLast7Days).toBe(0);
+  });
+
+  it('kräver både statusen och stämpeln', () => {
+    const summary = composeCrmOverviewSummary(rows({
+      orderWindow: [
+        // Status invoiced men ingen stämpel: en gammal rad från före kolumnen fanns. Ingen
+        // created_at-fallback här — raden ska summera till topplistans fakturerat, och den
+        // kräver stämpeln.
+        { status: 'invoiced', amount: 50_000, created_at: '2026-08-12T08:00:00+00:00', fortnox_invoiced_at: null, assigned_to: ANNA },
+        // Stämpel men inte fakturerad status: ska inte kunna hända, och räknas inte.
+        { status: 'completed', amount: 60_000, created_at: '2026-06-01T08:00:00+00:00', fortnox_invoiced_at: '2026-08-13T08:00:00+00:00', assigned_to: ANNA },
+      ],
+    }), WINDOW);
+
+    expect(summary.invoicedValueLast7Days).toBe(0);
+  });
+
+  it('tar med randdagen (since är inklusive) men inte dagen före', () => {
+    const summary = composeCrmOverviewSummary(rows({
+      orderWindow: [
+        { status: 'draft', amount: 1_000, created_at: '2026-08-10T23:30:00+00:00', fortnox_invoiced_at: null, assigned_to: ANNA },
+        { status: 'draft', amount: 2_000, created_at: '2026-08-09T23:30:00+00:00', fortnox_invoiced_at: null, assigned_to: ANNA },
+      ],
+    }), WINDOW);
+
+    expect(summary.orderValueLast7Days).toBe(1_000);
+  });
+});
+
+describe('composeCrmOverviewSummary — veckans utfall per säljare', () => {
+  it('fördelar samtal, offerter, ordrar och fakturerat på rätt användare', () => {
+    const summary = composeCrmOverviewSummary(rows({
+      callWindow: [
+        { user_id: ANNA, call_at: '2026-08-17T09:00:00+00:00' },
+        { user_id: ANNA, call_at: '2026-08-18T09:00:00+00:00' },
+        { user_id: BOSSE, call_at: '2026-08-19T09:00:00+00:00' },
+      ],
+      quoteWindow: [
+        { amount: '12000', quote_date: '2026-08-17', assigned_to: ANNA },
+        { amount: 8_000, quote_date: '2026-08-20', assigned_to: BOSSE },
+      ],
+      orderWindow: [
+        { status: 'scheduled', amount: 40_000, created_at: '2026-08-18T10:00:00+00:00', fortnox_invoiced_at: null, assigned_to: ANNA },
+        { status: 'invoiced', amount: 30_000, created_at: '2026-07-01T10:00:00+00:00', fortnox_invoiced_at: '2026-08-19T10:00:00+00:00', assigned_to: BOSSE },
+      ],
+    }), WINDOW);
+
+    expect(summary.weekByUser[ANNA]).toEqual({
+      calls: 2, quotes: 1, quoteValue: 12_000, orderCount: 1, orderValue: 40_000, invoicedValue: 0,
+    });
+    expect(summary.weekByUser[BOSSE]).toEqual({
+      calls: 1, quotes: 1, quoteValue: 8_000, orderCount: 0, orderValue: 0, invoicedValue: 30_000,
+    });
+  });
+
+  it('veckans slut är exklusive, och förra veckans rader hör inte hit', () => {
+    const summary = composeCrmOverviewSummary(rows({
+      callWindow: [
+        { user_id: ANNA, call_at: '2026-08-24T08:00:00+00:00' }, // nästa måndag — utanför
+        { user_id: ANNA, call_at: '2026-08-16T08:00:00+00:00' }, // söndagen före — utanför
+        { user_id: ANNA, call_at: '2026-08-23T08:00:00+00:00' }, // veckans söndag — inne
+      ],
+    }), WINDOW);
+
+    expect(summary.weekByUser[ANNA]).toMatchObject({ calls: 1 });
+    // Samtalsfönstret är de rullande 7 dagarna, alltså vidare än veckan: söndagen den 16:e är kvar.
+    expect(summary.callsLast7Days).toBe(3);
+  });
+
+  it('en order utan ansvarig hamnar inte på någon säljare', () => {
+    const summary = composeCrmOverviewSummary(rows({
+      orderWindow: [
+        { status: 'scheduled', amount: 5_000, created_at: '2026-08-18T10:00:00+00:00', fortnox_invoiced_at: null, assigned_to: null },
+      ],
+    }), WINDOW);
+
+    expect(summary.weekByUser).toEqual({});
+    // Lagsiffran ska däremot inte tappa ordern bara för att ingen är utsedd.
+    expect(summary.orderValueLast7Days).toBe(5_000);
+  });
+});
+
+describe('composeCrmOverviewSummary — uppgifter och genomsläpp', () => {
+  it('delar öppna uppgifter i sena, dagens och resten', () => {
+    const summary = composeCrmOverviewSummary(rows({
+      openTasks: [
+        { due_at: '2026-08-10T12:00:00+00:00' }, // sen
+        { due_at: '2026-08-16T12:00:00+00:00' }, // sen
+        { due_at: '2026-08-17T12:00:00+00:00' }, // idag
+        { due_at: '2026-08-20T12:00:00+00:00' }, // framåt
+        { due_at: null },                        // ingen deadline
+      ],
+    }), WINDOW);
+
+    expect(summary.openTasks).toBe(5);
+    expect(summary.overdueTasks).toBe(2);
+    expect(summary.todayTasks).toBe(1);
+  });
+
+  it('släpper igenom head-räkningarna och kapningsflaggan orörda', () => {
+    const summary = composeCrmOverviewSummary(rows({
+      counts: {
+        pipelineProspects: 778, newProspects: 12, quotedProspects: 3, qualifiedProspects: 9,
+        followUpCalls: 4, standaloneCalls: 2,
+      },
+      truncated: ['quote_window'],
+    }), WINDOW);
+
+    expect(summary.pipelineProspects).toBe(778);
+    expect(summary.newProspects).toBe(12);
+    expect(summary.quotedProspects).toBe(3);
+    expect(summary.qualifiedProspects).toBe(9);
+    expect(summary.followUpCalls).toBe(4);
+    expect(summary.standaloneCalls).toBe(2);
+    expect(summary.truncated).toEqual(['quote_window']);
+  });
+
+  it('tål belopp som strängar och skräp', () => {
+    // Supabase svarar med numeric som sträng, och en tom kolumn som null.
+    const summary = composeCrmOverviewSummary(rows({
+      quoteStocks: [
+        { status: 'draft', amount: '1234.56' },
+        { status: 'sent', amount: 'inte ett tal' },
+        { status: 'follow_up', amount: '' },
+      ],
+    }), WINDOW);
+
+    expect(summary.activeQuotes).toBe(3);
+    expect(summary.activeQuoteValue).toBe(1234.56);
+  });
+});

--- a/tests/crm/overviewSummary.test.ts
+++ b/tests/crm/overviewSummary.test.ts
@@ -3,6 +3,7 @@ import {
   composeCrmOverviewSummary,
   OPEN_WORK_ORDER_STATUSES,
   TO_INVOICE_WORK_ORDER_STATUSES,
+  ACTIVE_QUOTE_STATUSES,
   type CrmOverviewRows,
   type CrmOverviewWindow,
 } from '@/lib/domains/crm/overviewSummary';
@@ -11,6 +12,12 @@ import {
 // webbläsaren ser dem (PostgREST svarar med max 1000 rader, CRM-rutterna kapar lägre) — en siffra
 // räknad ur en kapad lista krymper tyst när tabellen växer. Det som testas här är den rena halvan:
 // rader in, läsmodell ut. Ingen databas, inga mockar.
+//
+// TVÅ FÖNSTER, med flit:
+//  · veckan — allt som mäts mot ett veckomål, för laget och per säljare i samma svep, så att
+//    lagraden och topplistans rader för samma mått går att stämma av mot varandra.
+//  · rullande 7 dagar — bara samtalen, för det är det enda talet vars etikett säger det
+//    ("Samtal senaste 7 dagar").
 
 const WINDOW: CrmOverviewWindow = {
   today: '2026-08-17',      // en måndag
@@ -22,6 +29,16 @@ const WINDOW: CrmOverviewWindow = {
 const ANNA = 'user-anna';
 const BOSSE = 'user-bosse';
 
+function call(userId: string | null, callAt: string, extra: { outcome?: string; prospect_id?: string | null } = {}) {
+  return {
+    user_id: userId as string,
+    call_at: callAt,
+    outcome: extra.outcome ?? 'positive',
+    // Not `?? 'p1'`: null is the value under test (a call without a prospect), and ?? would swallow it.
+    prospect_id: 'prospect_id' in extra ? extra.prospect_id ?? null : 'p1',
+  };
+}
+
 function rows(overrides: Partial<CrmOverviewRows> = {}): CrmOverviewRows {
   return {
     quoteStocks: [],
@@ -30,14 +47,7 @@ function rows(overrides: Partial<CrmOverviewRows> = {}): CrmOverviewRows {
     orderWindow: [],
     callWindow: [],
     openTasks: [],
-    counts: {
-      pipelineProspects: 0,
-      newProspects: 0,
-      quotedProspects: 0,
-      qualifiedProspects: 0,
-      followUpCalls: 0,
-      standaloneCalls: 0,
-    },
+    counts: { pipelineProspects: 0, newProspects: 0, quotedProspects: 0, qualifiedProspects: 0 },
     truncated: [],
     ...overrides,
   };
@@ -82,39 +92,41 @@ describe('composeCrmOverviewSummary — lagren', () => {
     expect(summary.toInvoiceOrderValue).toBe(48_000);
   });
 
-  it('statusgrupperna kommer från orderbrädans egna definitioner', () => {
-    // Grupperna får inte drifta ifrån brädans chip-filter — då hade en ny status kunnat falla ur
-    // både "Öppna ordrar" och "Att fakturera" utan att någon märkte det.
+  it('statusgrupperna kommer från vyernas egna definitioner, inte från kopior', () => {
+    // Grupperna får inte drifta ifrån orderbrädans chip-filter och offertlistans flikar — då hade
+    // en ny status kunnat falla ur översiktens lager utan att något test gick sönder.
     expect(OPEN_WORK_ORDER_STATUSES).toEqual(['draft', 'scheduled', 'ready', 'in_progress']);
     expect(TO_INVOICE_WORK_ORDER_STATUSES).toEqual(['completed', 'partially_invoiced']);
+    expect(ACTIVE_QUOTE_STATUSES).toEqual(['draft', 'sent', 'follow_up']);
   });
 });
 
 describe('composeCrmOverviewSummary — fakturerat bucketas på fakturadatumet', () => {
-  // Det här är felklassen PR #70 rättade i rapporten: ordrar hämtade och bucketade på created_at
-  // dolde 371 323 kr av 450 101 kr i en månad, eftersom eftersläpningen order→faktura är ungefär
-  // en månad. De två datumen är alltså inte utbytbara.
-  it('räknar en gammal order som fakturerades i fönstret', () => {
+  // Det här är felklassen PR #70 rättade i rapporten: ordrar bucketade på created_at dolde
+  // 371 323 kr av 450 101 kr i en månad, eftersom eftersläpningen order→faktura är ungefär en
+  // månad. De två datumen är alltså inte utbytbara.
+  it('räknar en gammal order som fakturerades i veckan', () => {
     const summary = composeCrmOverviewSummary(rows({
       orderWindow: [
-        { status: 'invoiced', amount: 100_000, created_at: '2026-06-01T08:00:00+00:00', fortnox_invoiced_at: '2026-08-14T09:00:00+00:00', assigned_to: ANNA },
+        { status: 'invoiced', amount: 100_000, created_at: '2026-06-01T08:00:00+00:00', fortnox_invoiced_at: '2026-08-19T09:00:00+00:00', assigned_to: ANNA },
       ],
     }), WINDOW);
 
-    expect(summary.invoicedValueLast7Days).toBe(100_000);
-    // Ordern skapades långt utanför fönstret, så ordervärdet ska INTE räknas.
-    expect(summary.orderValueLast7Days).toBe(0);
+    expect(summary.weekTeam.invoicedValue).toBe(100_000);
+    // Ordern skapades långt utanför veckan, så ordervärdet ska INTE räknas.
+    expect(summary.weekTeam.orderValue).toBe(0);
+    expect(summary.weekTeam.orderCount).toBe(0);
   });
 
-  it('räknar inte en order som skapades i fönstret men faktureras senare', () => {
+  it('räknar inte en order som skapades i veckan men faktureras senare', () => {
     const summary = composeCrmOverviewSummary(rows({
       orderWindow: [
-        { status: 'in_progress', amount: 70_000, created_at: '2026-08-12T08:00:00+00:00', fortnox_invoiced_at: null, assigned_to: ANNA },
+        { status: 'in_progress', amount: 70_000, created_at: '2026-08-18T08:00:00+00:00', fortnox_invoiced_at: null, assigned_to: ANNA },
       ],
     }), WINDOW);
 
-    expect(summary.orderValueLast7Days).toBe(70_000);
-    expect(summary.invoicedValueLast7Days).toBe(0);
+    expect(summary.weekTeam.orderValue).toBe(70_000);
+    expect(summary.weekTeam.invoicedValue).toBe(0);
   });
 
   it('kräver både statusen och stämpeln', () => {
@@ -123,34 +135,35 @@ describe('composeCrmOverviewSummary — fakturerat bucketas på fakturadatumet',
         // Status invoiced men ingen stämpel: en gammal rad från före kolumnen fanns. Ingen
         // created_at-fallback här — raden ska summera till topplistans fakturerat, och den
         // kräver stämpeln.
-        { status: 'invoiced', amount: 50_000, created_at: '2026-08-12T08:00:00+00:00', fortnox_invoiced_at: null, assigned_to: ANNA },
+        { status: 'invoiced', amount: 50_000, created_at: '2026-08-18T08:00:00+00:00', fortnox_invoiced_at: null, assigned_to: ANNA },
         // Stämpel men inte fakturerad status: ska inte kunna hända, och räknas inte.
-        { status: 'completed', amount: 60_000, created_at: '2026-06-01T08:00:00+00:00', fortnox_invoiced_at: '2026-08-13T08:00:00+00:00', assigned_to: ANNA },
+        { status: 'completed', amount: 60_000, created_at: '2026-06-01T08:00:00+00:00', fortnox_invoiced_at: '2026-08-19T08:00:00+00:00', assigned_to: ANNA },
       ],
     }), WINDOW);
 
-    expect(summary.invoicedValueLast7Days).toBe(0);
+    expect(summary.weekTeam.invoicedValue).toBe(0);
   });
 
-  it('tar med randdagen (since är inklusive) men inte dagen före', () => {
+  it('veckans start är inklusive och dess slut exklusive', () => {
     const summary = composeCrmOverviewSummary(rows({
       orderWindow: [
-        { status: 'draft', amount: 1_000, created_at: '2026-08-10T23:30:00+00:00', fortnox_invoiced_at: null, assigned_to: ANNA },
-        { status: 'draft', amount: 2_000, created_at: '2026-08-09T23:30:00+00:00', fortnox_invoiced_at: null, assigned_to: ANNA },
+        { status: 'draft', amount: 1_000, created_at: '2026-08-17T23:30:00+00:00', fortnox_invoiced_at: null, assigned_to: ANNA }, // måndag — inne
+        { status: 'draft', amount: 2_000, created_at: '2026-08-16T23:30:00+00:00', fortnox_invoiced_at: null, assigned_to: ANNA }, // söndagen före — ute
+        { status: 'draft', amount: 4_000, created_at: '2026-08-24T00:30:00+00:00', fortnox_invoiced_at: null, assigned_to: ANNA }, // nästa måndag — ute
       ],
     }), WINDOW);
 
-    expect(summary.orderValueLast7Days).toBe(1_000);
+    expect(summary.weekTeam.orderValue).toBe(1_000);
   });
 });
 
-describe('composeCrmOverviewSummary — veckans utfall per säljare', () => {
-  it('fördelar samtal, offerter, ordrar och fakturerat på rätt användare', () => {
+describe('composeCrmOverviewSummary — laget och säljarna räknas i samma svep', () => {
+  it('fördelar samtal, offerter, ordrar och fakturerat på rätt säljare — och summerar laget', () => {
     const summary = composeCrmOverviewSummary(rows({
       callWindow: [
-        { user_id: ANNA, call_at: '2026-08-17T09:00:00+00:00' },
-        { user_id: ANNA, call_at: '2026-08-18T09:00:00+00:00' },
-        { user_id: BOSSE, call_at: '2026-08-19T09:00:00+00:00' },
+        call(ANNA, '2026-08-17T09:00:00+00:00'),
+        call(ANNA, '2026-08-18T09:00:00+00:00'),
+        call(BOSSE, '2026-08-19T09:00:00+00:00'),
       ],
       quoteWindow: [
         { amount: '12000', quote_date: '2026-08-17', assigned_to: ANNA },
@@ -168,23 +181,13 @@ describe('composeCrmOverviewSummary — veckans utfall per säljare', () => {
     expect(summary.weekByUser[BOSSE]).toEqual({
       calls: 1, quotes: 1, quoteValue: 8_000, orderCount: 0, orderValue: 0, invoicedValue: 30_000,
     });
+    // Lagraden MÅSTE vara summan av säljarraderna — statusbilden visar den ovanför topplistan.
+    expect(summary.weekTeam).toEqual({
+      calls: 3, quotes: 2, quoteValue: 20_000, orderCount: 1, orderValue: 40_000, invoicedValue: 30_000,
+    });
   });
 
-  it('veckans slut är exklusive, och förra veckans rader hör inte hit', () => {
-    const summary = composeCrmOverviewSummary(rows({
-      callWindow: [
-        { user_id: ANNA, call_at: '2026-08-24T08:00:00+00:00' }, // nästa måndag — utanför
-        { user_id: ANNA, call_at: '2026-08-16T08:00:00+00:00' }, // söndagen före — utanför
-        { user_id: ANNA, call_at: '2026-08-23T08:00:00+00:00' }, // veckans söndag — inne
-      ],
-    }), WINDOW);
-
-    expect(summary.weekByUser[ANNA]).toMatchObject({ calls: 1 });
-    // Samtalsfönstret är de rullande 7 dagarna, alltså vidare än veckan: söndagen den 16:e är kvar.
-    expect(summary.callsLast7Days).toBe(3);
-  });
-
-  it('en order utan ansvarig hamnar inte på någon säljare', () => {
+  it('en order utan ansvarig hör till laget men till ingen säljare', () => {
     const summary = composeCrmOverviewSummary(rows({
       orderWindow: [
         { status: 'scheduled', amount: 5_000, created_at: '2026-08-18T10:00:00+00:00', fortnox_invoiced_at: null, assigned_to: null },
@@ -192,8 +195,45 @@ describe('composeCrmOverviewSummary — veckans utfall per säljare', () => {
     }), WINDOW);
 
     expect(summary.weekByUser).toEqual({});
-    // Lagsiffran ska däremot inte tappa ordern bara för att ingen är utsedd.
-    expect(summary.orderValueLast7Days).toBe(5_000);
+    expect(summary.weekTeam.orderValue).toBe(5_000);
+  });
+
+  it('förra veckans rader hör inte till veckan, men kan ligga i samtalens 7 dagar', () => {
+    const summary = composeCrmOverviewSummary(rows({
+      callWindow: [
+        call(ANNA, '2026-08-24T08:00:00+00:00'), // nästa måndag — utanför VECKAN (slutet är exklusive)
+        call(ANNA, '2026-08-16T08:00:00+00:00'), // söndagen före — utanför veckan, inne i 7 dagar
+        call(ANNA, '2026-08-23T08:00:00+00:00'), // veckans söndag — inne i båda
+        call(ANNA, '2026-08-09T08:00:00+00:00'), // åtta dagar bak — utanför båda
+      ],
+    }), WINDOW);
+
+    expect(summary.weekTeam.calls).toBe(1);
+    // 3, inte 2: de rullande 7 dagarna har en undre gräns men INGEN övre, precis som klientkoden
+    // hade före flytten. Ett samtal med framtidsdatum räknas alltså med. Det är inte en olycka som
+    // ska tystas här — vill man ha ett tak är det en ändring av vad siffran betyder.
+    expect(summary.callsLast7Days).toBe(3);
+  });
+});
+
+describe('composeCrmOverviewSummary — samtalen som driver "Att agera på"', () => {
+  it('räknar uppföljning och fristående samtal INOM fönstret, inte över all tid', () => {
+    // `outcome` är ett permanent historiskt faktum utan kvitteringsflagga. Räknat över all tid
+    // hade siffran bara vuxit, och ett samtal märkt "följ upp" i juni hade fortsatt kräva
+    // uppmärksamhet i december.
+    const summary = composeCrmOverviewSummary(rows({
+      callWindow: [
+        call(ANNA, '2026-08-15T09:00:00+00:00', { outcome: 'follow_up' }),
+        call(ANNA, '2026-08-16T09:00:00+00:00', { outcome: 'follow_up', prospect_id: null }),
+        call(ANNA, '2026-08-11T09:00:00+00:00', { outcome: 'positive', prospect_id: null }),
+        // Utanför de rullande 7 dagarna — ska inte räknas alls.
+        call(ANNA, '2026-06-01T09:00:00+00:00', { outcome: 'follow_up', prospect_id: null }),
+      ],
+    }), WINDOW);
+
+    expect(summary.callsLast7Days).toBe(3);
+    expect(summary.followUpCalls).toBe(2);
+    expect(summary.standaloneCalls).toBe(2);
   });
 });
 
@@ -216,10 +256,7 @@ describe('composeCrmOverviewSummary — uppgifter och genomsläpp', () => {
 
   it('släpper igenom head-räkningarna och kapningsflaggan orörda', () => {
     const summary = composeCrmOverviewSummary(rows({
-      counts: {
-        pipelineProspects: 778, newProspects: 12, quotedProspects: 3, qualifiedProspects: 9,
-        followUpCalls: 4, standaloneCalls: 2,
-      },
+      counts: { pipelineProspects: 778, newProspects: 12, quotedProspects: 3, qualifiedProspects: 9 },
       truncated: ['quote_window'],
     }), WINDOW);
 
@@ -227,8 +264,6 @@ describe('composeCrmOverviewSummary — uppgifter och genomsläpp', () => {
     expect(summary.newProspects).toBe(12);
     expect(summary.quotedProspects).toBe(3);
     expect(summary.qualifiedProspects).toBe(9);
-    expect(summary.followUpCalls).toBe(4);
-    expect(summary.standaloneCalls).toBe(2);
     expect(summary.truncated).toEqual(['quote_window']);
   });
 

--- a/tests/crm/quotes.domain.test.ts
+++ b/tests/crm/quotes.domain.test.ts
@@ -132,3 +132,34 @@ describe('markCrmQuoteWon — offertens ansvariga blir kundansvarig', () => {
     expect(mockSetAccountManager).not.toHaveBeenCalled();
   });
 });
+
+// ---------------------------------------------------------------------------
+// listCrmQuotesWithFilters — radordningen
+//
+// Standardordningen är offertlistans arbetsordning: status stigande, alltså draft → follow_up →
+// lost → sent → won. Den ordningen kapar bort vunna och skickade offerter FÖRST vid radtaket,
+// vilket är precis de som pengarsiffrorna på översikten bygger på. Därför finns 'updated_desc'
+// för de anropare som vill ha det senast rörda — och kapningen sker på servern, så ordningen
+// kan inte lagas i webbläsaren.
+// ---------------------------------------------------------------------------
+
+import { listCrmQuotesWithFilters } from '@/lib/domains/crm/quotes';
+import { makeSupabaseMock } from './helpers/supabase';
+
+describe('listCrmQuotesWithFilters — radordningen', () => {
+  it('sorterar som offertlistan som standard: status, närmaste uppföljning, senaste offertdatum', async () => {
+    const supabase = makeSupabaseMock({ data: [], error: null });
+    await listCrmQuotesWithFilters(supabase as any, {});
+    expect((supabase._query.order as any).mock.calls).toEqual([
+      ['status', { ascending: true }],
+      ['follow_up_date', { ascending: true, nullsFirst: false }],
+      ['quote_date', { ascending: false }],
+    ]);
+  });
+
+  it('sort=updated_desc sorterar på senast rörd och rör inte statusordningen', async () => {
+    const supabase = makeSupabaseMock({ data: [], error: null });
+    await listCrmQuotesWithFilters(supabase as any, { sort: 'updated_desc' });
+    expect((supabase._query.order as any).mock.calls).toEqual([['updated_at', { ascending: false }]]);
+  });
+});

--- a/tests/crm/quotes.domain.test.ts
+++ b/tests/crm/quotes.domain.test.ts
@@ -143,7 +143,7 @@ describe('markCrmQuoteWon — offertens ansvariga blir kundansvarig', () => {
 // kan inte lagas i webbläsaren.
 // ---------------------------------------------------------------------------
 
-import { listCrmQuotesWithFilters } from '@/lib/domains/crm/quotes';
+import { listCrmQuotesWithFilters, getCrmQuoteFilterCounts, CRM_QUOTES_PAGE_SIZE } from '@/lib/domains/crm/quotes';
 import { makeSupabaseMock } from './helpers/supabase';
 
 describe('listCrmQuotesWithFilters — radordningen', () => {
@@ -161,5 +161,87 @@ describe('listCrmQuotesWithFilters — radordningen', () => {
     const supabase = makeSupabaseMock({ data: [], error: null });
     await listCrmQuotesWithFilters(supabase as any, { sort: 'updated_desc' });
     expect((supabase._query.order as any).mock.calls).toEqual([['updated_at', { ascending: false }]]);
+  });
+
+  it('sort=created_desc sorterar nyast först — offertlistans standard', async () => {
+    const supabase = makeSupabaseMock({ data: [], error: null });
+    await listCrmQuotesWithFilters(supabase as any, { sort: 'created_desc' });
+    expect((supabase._query.order as any).mock.calls).toEqual([['created_at', { ascending: false }]]);
+  });
+
+  it('sort=follow_up_asc sorterar närmaste uppföljning först, och offerter utan datum sist', async () => {
+    // nullsFirst: false — en offert utan uppföljningsdatum är inte mer brådskande än en med.
+    const supabase = makeSupabaseMock({ data: [], error: null });
+    await listCrmQuotesWithFilters(supabase as any, { sort: 'follow_up_asc' });
+    expect((supabase._query.order as any).mock.calls).toEqual([
+      ['follow_up_date', { ascending: true, nullsFirst: false }],
+      ['created_at', { ascending: false }],
+    ]);
+  });
+});
+
+describe('listCrmQuotesWithFilters — sidindelning och flikfilter', () => {
+  // Flikarna och deras räknare låg i webbläsaren och filtrerade den hämtade arrayen. Radtaket kapar
+  // på servern, från sorteringens SVANS, så med statusordningen försvann vunna offerter först och
+  // skickade därefter — precis de grupper pengarsiffrorna byggs på. Filtret måste vara server-side.
+  it('sidindelar med range och begär ett exakt antal', async () => {
+    const supabase = makeSupabaseMock({ data: [], error: null });
+    await listCrmQuotesWithFilters(supabase as any, { offset: 100 });
+    expect((supabase._query.select as any).mock.calls[0][1]).toEqual({ count: 'exact' });
+    expect((supabase._query.range as any).mock.calls).toEqual([[100, 199]]);
+  });
+
+  it('första sidan är CRM_QUOTES_PAGE_SIZE rader', async () => {
+    const supabase = makeSupabaseMock({ data: [], error: null });
+    await listCrmQuotesWithFilters(supabase as any, {});
+    expect((supabase._query.range as any).mock.calls).toEqual([[0, CRM_QUOTES_PAGE_SIZE - 1]]);
+  });
+
+  it('"Aktiva" är de tre statusar som fortfarande är i spel', async () => {
+    const supabase = makeSupabaseMock({ data: [], error: null });
+    await listCrmQuotesWithFilters(supabase as any, { filter: 'active' });
+    expect((supabase._query.in as any).mock.calls).toEqual([['status', ['draft', 'sent', 'follow_up']]]);
+  });
+
+  it('"Alla" sätter inget statusfilter', async () => {
+    const supabase = makeSupabaseMock({ data: [], error: null });
+    await listCrmQuotesWithFilters(supabase as any, { filter: 'all' });
+    expect((supabase._query.in as any).mock.calls).toEqual([]);
+  });
+
+  it('ansvarig-filtret går till servern', async () => {
+    const supabase = makeSupabaseMock({ data: [], error: null });
+    await listCrmQuotesWithFilters(supabase as any, { filter: 'won', assignedToIn: ['anna', 'bosse'] });
+    expect((supabase._query.in as any).mock.calls).toEqual([
+      ['status', ['won']],
+      ['assigned_to', ['anna', 'bosse']],
+    ]);
+  });
+
+  it('söktermen städas på kommatecken och parenteser', async () => {
+    // PostgREST läser or=(...) som en kommaseparerad villkorslista, så "Ekbergs Bygg, AB" hade
+    // delat uttrycket mitt itu och hela frågan svarat 400 — vilket listan visar som "inga träffar".
+    const supabase = makeSupabaseMock({ data: [], error: null });
+    await listCrmQuotesWithFilters(supabase as any, { search: 'Ekbergs Bygg, AB (nya)' });
+    const filter = (supabase._query.or as any).mock.calls[0][0] as string;
+    expect(filter).not.toMatch(/[,()]Ekbergs|Bygg,|\(nya\)/);
+    expect(filter).toContain('Ekbergs Bygg  AB  nya');
+    // Numret som appen visar överallt måste gå att söka på — samma läxa som orderlistan fick.
+    expect(filter).toContain('quote_number.ilike');
+    expect(filter).toContain('fortnox_offer_number.ilike');
+  });
+});
+
+describe('getCrmQuoteFilterCounts', () => {
+  it('räknar varje flik med head-frågor i samma sök- och ansvarig-skop', async () => {
+    const supabase = makeSupabaseMock({ data: null, error: null, count: 7 } as any);
+    const counts = await getCrmQuoteFilterCounts(supabase as any, { search: 'tak', assignedToIn: ['anna'] });
+
+    expect(counts).toEqual({ all: 7, active: 7, follow_up: 7, won: 7, lost: 7 });
+    // head: true — räkningen ska inte dra över några rader.
+    expect((supabase._query.select as any).mock.calls[0]).toEqual(['id', { count: 'exact', head: true }]);
+    // Skopet appliceras på varje flik, annars beskriver räknarna en annan mängd än listan visar.
+    expect((supabase._query.or as any).mock.calls.length).toBe(5);
+    expect((supabase._query.in as any).mock.calls).toContainEqual(['assigned_to', ['anna']]);
   });
 });

--- a/tests/crm/quotes.test.ts
+++ b/tests/crm/quotes.test.ts
@@ -9,6 +9,10 @@ vi.mock('@/lib/auth/route', () => ({ getCurrentUser: vi.fn() }));
 
 vi.mock('@/lib/domains/crm/quotes', () => ({
   listCrmQuotesWithFilters: vi.fn(),
+  // Flikräknarna körs bara när routen får counts=1, men exporten måste finnas i mocken: routen
+  // importerar den, och en saknad namngiven export kastar vid import och blir ett 500 i stället.
+  getCrmQuoteFilterCounts: vi.fn(async () => ({ all: 0, active: 0, follow_up: 0, won: 0, lost: 0 })),
+  CRM_QUOTES_PAGE_SIZE: 100,
   createCrmQuote: vi.fn(),
   getCrmQuote: vi.fn(),
   getCrmQuoteStatus: vi.fn(),

--- a/tests/crm/work-orders.test.ts
+++ b/tests/crm/work-orders.test.ts
@@ -308,3 +308,32 @@ describe('updateCrmWorkOrderTimeEntry', () => {
     expect((supabase._query.eq as any).mock.calls).toEqual([['id', 'e1'], ['user_id', 'anna']]);
   });
 });
+
+// ---------------------------------------------------------------------------
+// listCrmWorkOrdersWithFilters — radordningen
+//
+// Ordningen måste väljas på servern. Sidtaket (CRM_WORK_ORDERS_PAGE_SIZE) kapar raderna innan
+// webbläsaren ser dem, så en klientsortering ordnar bara det som råkade överleva kapningen. Med
+// standardsorteringen ligger en nyskapad order SIST i tabellen — installationsdatumet ligger i
+// framtiden — så en klientsorterad "senaste ordrar"-lista hade tyst visat de äldsta jobben så
+// fort bolaget passerar taket. Testet vaktar att de två sorteringarna inte glider ihop igen.
+// ---------------------------------------------------------------------------
+
+import { listCrmWorkOrdersWithFilters } from '@/lib/domains/crm/work-orders';
+
+describe('listCrmWorkOrdersWithFilters — radordningen', () => {
+  it('sorterar som arbetskö som standard: tidigast installationsdatum först', async () => {
+    const supabase = makeSupabaseMock({ data: [], error: null });
+    await listCrmWorkOrdersWithFilters(supabase as any, {});
+    expect((supabase._query.order as any).mock.calls).toEqual([
+      ['desired_installation_date', { ascending: true, nullsFirst: false }],
+      ['created_at', { ascending: false }],
+    ]);
+  });
+
+  it('sort=created_desc sorterar nyast först och rör inte installationsdatumet', async () => {
+    const supabase = makeSupabaseMock({ data: [], error: null });
+    await listCrmWorkOrdersWithFilters(supabase as any, { sort: 'created_desc' });
+    expect((supabase._query.order as any).mock.calls).toEqual([['created_at', { ascending: false }]]);
+  });
+});


### PR DESCRIPTION
Började som små justeringar i sidomenyn och CRM-översikten, och växte till att laga hur de läser data. Sju commits, **ingen SQL**.

## Varför det växte

Listorna kapas innan webbläsaren ser dem — PostgREST svarar med max 1000 rader och CRM-rutterna kapar lägre — och **en kapning sker före räkningen**, så varje siffra som räknades ur en hämtad lista krympte tyst när tabellen växte. Mätt 2026-08-17: 778 prospekt (tak 1000), 69 offerter (tak 100), 29 ordrar (tak 100), och sex offerter skapade på en förmiddag. Offertlistan var dagar från kanten, inte veckor.

## Vad som ändrats

**Sidomenyn** — länkarna låg inte still mellan skena och hover. Rubrikbandet bytte höjd (staplad kolumn mot rad) och varje rad krympte 2 px eftersom radhöjden sattes av etiketten och inte av ikonen. Bandet är låst till 96 px i båda lägena och ikonrutorna har etikettens radbox.

**CRM-översikten**
- Statusbilden visar pengarnas väg — aktiva offerter → öppna ordrar → att fakturera → fakturerat — i stället för fyra prospektrader. De tre lagren delar en skala, så staplarna blir en verklig fördelning.
- Nytt kort "Senaste ordrar", prospektkortet borta, korten i flödets ordning, fem rader per kort.
- Siffrorna räknas nu på servern (`GET /api/crm/overview`): varje tal läses med sitt eget `WHERE` — ett lager på sina statusar, ett fönstrat tal på sitt fönster, och tal utan naturlig gräns som head-räkningar utan rader. Sessionsklient med flit, så RLS avgör vad läsaren får räkna; det är också det som håller uppgiftssiffrorna personliga. Nedladdningen gick från **717 kB till 38 kB**.
- Målraderna mäter veckan, samma fönster som topplistan under dem, så lagraden är summan av säljarraderna.

**Offertlistan** — sidindelad som orderbrädan: `offset` + exakt `count`, flikfilter och ansvarig-skop på servern, head-räknade flikar, "Visa fler" med "Visar X av Y". Sorteringen är skapandedatum nyast först som standard, närmaste uppföljning som alternativ. Sökningen städar komma och parentes (PostgREST svarade annars 400 på "Ekbergs Bygg, AB") och letar nu även i offertnummer.

**Sorteringsparametrar** på båda listrutterna, med standarden orörd — säljtavlan, orderbrädan, kundkortet och tidkorrigeringen får exakt samma rader som förut.

## Verifiering

- Gammal klientregel mot ny serverregel över samma rader: **identiska tal** (ordervärde 558 140,71 · fakturerat 466 780,70 · offertvärde 1 702 618,66), och noll rader i tidszonsgränsen 00:00–02:00.
- Domänmodulerna körda direkt mot skarp databas, inte bara kompilerade. Flikräknarna 69/41/7/26/2 stämmer med statusfördelningen; sida 1 → 2 är strikt fallande över sidgränsen; laget = summan av säljarna.
- Granskning per gren: 13 fynd, 12 stämde och är åtgärdade (tre riktiga regressioner: statusändring som inte flyttade raden ur fliken, "Visa fler" utan färskhetsvakt, och en verkningslös `min-h` på sidfoten). Ett avvisat.
- `type-check`, `lint`, **1424 tester** och `build` gröna. Datumtesterna körda under både `TZ=UTC` och `TZ=Europe/Stockholm`.

## Att veta efteråt

- **Prospekttalen på översikten är strukturellt noll** — `crm_customers.status` är kundstatusen, `createCrmProspect` skriver `'active'`, och alla 778 rader har det. Det var så före den här grenen också; bevarat och dokumenterat.
- **Öppen fråga:** ska en avbruten order räknas i ordervärdet mot budget? Idag gör den det, i alla tre vyerna, för `reports.ts` är statusagnostiskt med flit.
- Samtal (50 rader) och uppgifter (100) har kvar sina hårda tak i sina egna vyer. Siffrorna påverkas inte längre.

🤖 Generated with [Claude Code](https://claude.com/claude-code)