### PR TITLE
feat(crm): sätt status från förloppet + översiktens layoutfynd

### DIFF
--- a/app/crm/arbetsorder/WorkOrderArticlesTab.tsx
+++ b/app/crm/arbetsorder/WorkOrderArticlesTab.tsx
@@ -122,7 +122,12 @@ export default function WorkOrderArticlesTab({ items, currencyCode, vatPercent, 
   const [rows, setRows] = useState<ArticleLineItem[]>(items);
 
   // Resync from source when the work order reloads (e.g. after a successful save).
-  useEffect(() => { setRows(items); }, [items]);
+  //
+  // ⚠️ Inte medan raderna redigeras. Vilken omladdning av arbetsordern som helst ger `items` ny
+  // identitet, och den här effekten skrev då över utkastet — statusklicket i förloppet ligger
+  // ovanför flikremsan och nådde alltså in hit och nollade osparade artikelrader. Efter en
+  // lyckad sparning sätts `editing` till false, vilket kör effekten igen med färska rader.
+  useEffect(() => { if (!editing) setRows(items); }, [items, editing]);
 
   const dirty = useMemo(() => JSON.stringify(rows) !== JSON.stringify(items), [rows, items]);
   const rotEnabled = quoteType === 'private' && Boolean(rotDetails?.enabled);

--- a/app/crm/arbetsorder/WorkOrderDetailClient.tsx
+++ b/app/crm/arbetsorder/WorkOrderDetailClient.tsx
@@ -186,6 +186,7 @@ export default function WorkOrderDetailClient({ workOrderId, fortnoxConnected, c
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
+  const [statusSaving, setStatusSaving] = useState<WorkOrderStatus | null>(null);
   const [savingArticles, setSavingArticles] = useState(false);
   const [pushingFortnox, setPushingFortnox] = useState(false);
   const [creatingInvoice, setCreatingInvoice] = useState(false);
@@ -378,6 +379,26 @@ export default function WorkOrderDetailClient({ workOrderId, fortnoxConnected, c
     finally { setSaving(false); }
   }
 
+  // Sätt statusen direkt från förloppsstegen — genvägen förbi Redigera → väljaren → Spara.
+  //
+  // Bara `status` skickas: routen speglar Er referens/arbetsadress/ansvarig till Fortnox-headern
+  // och gatear på just de fälten, så en statusändring härifrån blir aldrig en Fortnox-skrivning.
+  async function setStatusFromFlow(next: WorkOrderStatus) {
+    if (!workOrder || statusSaving) return;
+    setStatusSaving(next);
+    try {
+      const res = await fetch(`/api/crm/work-orders/${workOrder.id}`, {
+        method: 'PATCH', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: next }),
+      });
+      const json = await res.json().catch(() => ({}));
+      if (!res.ok || !json.ok) { toast.error(json?.error || 'Kunde inte ändra status'); return; }
+      if (json.data?.item) applyWorkOrder(json.data.item as WorkOrderItem);
+      toast.success(`Status: ${workOrderStatusLabel[next]}`);
+    } catch { toast.error('Kunde inte ändra status'); }
+    finally { setStatusSaving(null); }
+  }
+
   // Bygg om måttblocket ur orderns artikelrader och lägg det överst i överlämningsnoteringen.
   //
   // Till skillnad från offertformuläret finns här ingen automatik som äger texten, och därmed
@@ -514,6 +535,9 @@ export default function WorkOrderDetailClient({ workOrderId, fortnoxConnected, c
   }
 
   const overdue = isWorkOrderOverdue(workOrder.desired_installation_date, workOrder.status);
+  // Förloppsstegen sätter status direkt. Låst på en färdigfakturerad order (routen nekar ändå) och
+  // medan översikten redigeras (då äger formulärets väljare statusen).
+  const statusFlowEditable = workOrder.status !== 'invoiced' && !editingOverview;
   const snapshot = workOrder.customer_snapshot || {};
   // The order's own responsible contact (snapshot) is the source of truth here — it's what the
   // picker below edits, so an edit reflects immediately. Fall back to the resolved customer
@@ -608,22 +632,46 @@ export default function WorkOrderDetailClient({ workOrderId, fortnoxConnected, c
         </div>
       </div>
 
-      {/* Status stepper */}
+      {/* Status stepper — stegen är klickbara genvägar till statusväljaren. Bara arbetsstatusarna
+          (WORK_ORDER_STATUS_OPTIONS) går att sätta för hand: fakturastatus sätts av faktureringen
+          och nekas av routen med 409, och en färdigfakturerad order är låst. Medan översikten
+          redigeras äger formulärets väljare statusen — annars hade ett klick sparat direkt mitt i
+          ett osparat utkast och tystat de övriga ändringarna. */}
       <Card className="grid gap-3">
-        <p className={crm.sectionTitle}>Förlopp</p>
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <p className={crm.sectionTitle}>Förlopp</p>
+          {statusFlowEditable ? (
+            <span className="text-xs text-slate-400">Klicka på ett steg för att ändra status</span>
+          ) : null}
+        </div>
         <div className="flex flex-wrap items-center gap-1.5">
           {WORK_ORDER_STATUS_FLOW.map((step, i) => {
             const currentIndex = WORK_ORDER_STATUS_FLOW.indexOf(workOrder.status);
             const done = currentIndex >= 0 && i <= currentIndex;
             const isCurrent = workOrder.status === step;
+            const clickable = statusFlowEditable && !isCurrent && WORK_ORDER_STATUS_OPTIONS.includes(step);
+            const stepClass = cn(
+              'rounded-full border px-3 py-1 text-xs font-semibold transition',
+              isCurrent ? 'text-white' : done ? 'border-emerald-200 bg-emerald-50 text-emerald-700' : 'border-[#e0e8dc] bg-[#f1f5ee] text-slate-400',
+            );
+            const stepStyle = isCurrent ? { backgroundColor: 'var(--crm-primary)', borderColor: 'var(--crm-primary)' } : undefined;
             return (
               <div key={step} className="flex items-center gap-1.5">
-                <span className={cn(
-                  'rounded-full border px-3 py-1 text-xs font-semibold transition',
-                  isCurrent ? 'text-white' : done ? 'border-emerald-200 bg-emerald-50 text-emerald-700' : 'border-[#e0e8dc] bg-[#f1f5ee] text-slate-400',
-                )} style={isCurrent ? { backgroundColor: 'var(--crm-primary)', borderColor: 'var(--crm-primary)' } : undefined}>
-                  {workOrderStatusLabel[step]}
-                </span>
+                {clickable ? (
+                  <button
+                    type="button"
+                    onClick={() => setStatusFromFlow(step)}
+                    disabled={statusSaving !== null}
+                    title={`Sätt status till ${workOrderStatusLabel[step]}`}
+                    className={cn(stepClass, 'hover:border-emerald-300 hover:bg-emerald-100 hover:text-emerald-800')}
+                  >
+                    {statusSaving === step ? 'Sparar…' : workOrderStatusLabel[step]}
+                  </button>
+                ) : (
+                  <span className={stepClass} style={stepStyle} aria-current={isCurrent ? 'step' : undefined}>
+                    {workOrderStatusLabel[step]}
+                  </span>
+                )}
                 {i < WORK_ORDER_STATUS_FLOW.length - 1 ? <span className={cn('h-px w-4', done ? 'bg-emerald-300' : 'bg-[#d4ddcd]')} /> : null}
               </div>
             );

--- a/app/crm/components/CrmOverview.tsx
+++ b/app/crm/components/CrmOverview.tsx
@@ -483,12 +483,14 @@ export default function CrmOverview({ role }: { role: UserRole | null }) {
       {/* Main content grid */}
       <div className="grid gap-4 xl:grid-cols-[minmax(0,1.2fr)_minmax(280px,0.6fr)]">
         <div className="grid gap-4">
-          {/* Next actions */}
+          {/* Next actions. Kortet är medvetet tight: det tar högst tre rader (buildOverviewActions
+              kapar där) och allt som ligger under det — offert- och orderkorten — ska synas utan
+              att man scrollar förbi en rubrik med luft omkring sig. */}
           <div className={crm.cardInner}>
-            <div className="mb-4 flex items-center justify-between gap-3">
+            <div className="mb-3 flex items-center justify-between gap-3">
               <div>
-                <p className={cn('mb-1', crm.sectionTitle)}>Att agera på</p>
-                <h2 className="m-0 text-lg font-bold tracking-tight text-slate-900">Nästa fokus</h2>
+                <p className={cn('mb-0.5', crm.sectionTitle)}>Att agera på</p>
+                <h2 className="m-0 text-base font-bold tracking-tight text-slate-900">Nästa fokus</h2>
               </div>
               {!loading && (
                 <span className="rounded-full border border-slate-200 bg-slate-50 px-3 py-1 text-xs font-semibold text-slate-600">
@@ -498,21 +500,21 @@ export default function CrmOverview({ role }: { role: UserRole | null }) {
             </div>
             {loading ? <OverviewLoadingRows /> : null}
             {!loading && nextActions.length === 0 ? (
-              <div className="rounded-xl border border-emerald-200 bg-emerald-50 p-4 text-sm font-medium text-emerald-800">
+              <div className="rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm font-medium text-emerald-800">
                 Läget är lugnt — inget blockerande i CRM-flödet just nu.
               </div>
             ) : null}
             {!loading && nextActions.length > 0 ? (
-              <div className="grid gap-2">
+              <div className="grid gap-1.5">
                 {nextActions.map((action) => (
                   <Link
                     key={action.title}
                     href={action.href}
-                    className="flex items-start justify-between gap-3 rounded-xl border border-slate-200 p-3.5 no-underline transition hover:border-slate-300 hover:bg-slate-50"
+                    className="flex min-w-0 items-start justify-between gap-3 rounded-xl border border-slate-200 px-3.5 py-2.5 no-underline transition hover:border-slate-300 hover:bg-slate-50"
                   >
-                    <div className="grid gap-0.5">
+                    <div className="grid min-w-0 gap-0.5">
                       <strong className="text-sm font-semibold text-slate-900">{action.title}</strong>
-                      <p className="m-0 text-xs leading-5 text-slate-500">{action.description}</p>
+                      <p className="m-0 text-xs leading-snug text-slate-500">{action.description}</p>
                     </div>
                     <span className="mt-0.5 shrink-0 text-xs font-semibold text-emerald-700">Öppna →</span>
                   </Link>
@@ -525,11 +527,16 @@ export default function CrmOverview({ role }: { role: UserRole | null }) {
               first row, then the two activity lists. Prospects had their own card here until
               2026-08-17 and were dropped — that stage isn't in use right now. */}
           <div className="grid gap-4 xl:grid-cols-2">
+            {/* ⚠️ Raderna bär `min-w-0` på själva länken, inte bara på textkolumnen. Raden är ett
+                GRID-item i listan nedan, och ett auto-spår får inte bli smalare än itemets
+                min-content — som med `truncate` (white-space: nowrap) är hela projektnamnets bredd.
+                Textkolumnens min-w-0 räcker alltså inte: raden växte förbi kortet och sköt ut
+                statusbadgen utanför kanten så fort namnet var långt. Mätt i Chrome 2026-08-17. */}
             <RecentCard title="Senaste offertlägen" href="/crm/offerter" loading={loading}>
               {state.quotes.length === 0 ? <EmptyState description="Inga offertsteg registrerade ännu." /> : (
                 <div className="grid gap-2">
                   {state.quotes.map((quote) => (
-                    <Link key={quote.id} href="/crm/offerter" className="flex items-start justify-between gap-3 rounded-xl border border-slate-100 p-3 no-underline transition hover:border-slate-200 hover:bg-slate-50">
+                    <Link key={quote.id} href="/crm/offerter" className="flex min-w-0 items-start justify-between gap-3 rounded-xl border border-slate-100 p-3 no-underline transition hover:border-slate-200 hover:bg-slate-50">
                       <div className="min-w-0">
                         <strong className="block truncate text-sm font-semibold text-slate-900">{quote.project_name}</strong>
                         <p className="m-0 truncate text-xs text-slate-500">{getQuoteCustomerName(quote)} · {formatCurrency(quote.amount, quote.currency_code)}</p>
@@ -545,7 +552,7 @@ export default function CrmOverview({ role }: { role: UserRole | null }) {
               {state.workOrders.length === 0 ? <EmptyState description="Inga arbetsordrar ännu." /> : (
                 <div className="grid gap-2">
                   {state.workOrders.map((order) => (
-                    <Link key={order.id} href={`/crm/arbetsorder/${order.id}`} className="flex items-start justify-between gap-3 rounded-xl border border-slate-100 p-3 no-underline transition hover:border-slate-200 hover:bg-slate-50">
+                    <Link key={order.id} href={`/crm/arbetsorder/${order.id}`} className="flex min-w-0 items-start justify-between gap-3 rounded-xl border border-slate-100 p-3 no-underline transition hover:border-slate-200 hover:bg-slate-50">
                       <div className="min-w-0">
                         <strong className="block truncate text-sm font-semibold text-slate-900">{order.project_name}</strong>
                         <p className="m-0 truncate text-xs text-slate-500">{order.client_name} · {formatCurrency(order.amount, order.currency_code)}</p>
@@ -561,7 +568,7 @@ export default function CrmOverview({ role }: { role: UserRole | null }) {
               {nextTasks.length === 0 ? <EmptyState description="Inga öppna uppgifter just nu." /> : (
                 <div className="grid gap-2">
                   {nextTasks.map((task) => (
-                    <Link key={task.id} href="/crm/uppgifter" className="flex items-start justify-between gap-3 rounded-xl border border-slate-100 p-3 no-underline transition hover:border-slate-200 hover:bg-slate-50">
+                    <Link key={task.id} href="/crm/uppgifter" className="flex min-w-0 items-start justify-between gap-3 rounded-xl border border-slate-100 p-3 no-underline transition hover:border-slate-200 hover:bg-slate-50">
                       <div className="min-w-0">
                         <strong className="block truncate text-sm font-semibold text-slate-900">{task.title}</strong>
                         <p className="m-0 truncate text-xs text-slate-500">{formatDate(task.due_date)}</p>
@@ -577,7 +584,7 @@ export default function CrmOverview({ role }: { role: UserRole | null }) {
               {recentCalls.length === 0 ? <EmptyState description="Inga samtal loggade ännu." /> : (
                 <div className="grid gap-2">
                   {recentCalls.map((call) => (
-                    <Link key={call.id} href="/crm/samtal" className="flex items-start justify-between gap-3 rounded-xl border border-slate-100 p-3 no-underline transition hover:border-slate-200 hover:bg-slate-50">
+                    <Link key={call.id} href="/crm/samtal" className="flex min-w-0 items-start justify-between gap-3 rounded-xl border border-slate-100 p-3 no-underline transition hover:border-slate-200 hover:bg-slate-50">
                       <div className="min-w-0">
                         <strong className="block truncate text-sm font-semibold text-slate-900">{getCallCompanyName(call)}</strong>
                         <p className="m-0 truncate text-xs text-slate-500">{formatDateTime(call.call_at)}</p>

--- a/app/crm/components/CrmOverview.tsx
+++ b/app/crm/components/CrmOverview.tsx
@@ -482,7 +482,13 @@ export default function CrmOverview({ role }: { role: UserRole | null }) {
 
       {/* Main content grid */}
       <div className="grid gap-4 xl:grid-cols-[minmax(0,1.2fr)_minmax(280px,0.6fr)]">
-        <div className="grid gap-4">
+        {/* ⚠️ `content-start` — utan den STRÄCKS korten här. Kolumnerna är grid-syskon och blir
+            lika höga, och den här kolumnens auto-rader ärver `align-content: normal`, som för grid
+            löser till stretch: raderna blåses upp och fyller vad statusbilden + topplistan bestämt.
+            Effekten är att innehållshöjd inte styr något — en trimning av "Nästa fokus" åt kortet
+            upp direkt, och korten under låg kvar. Mätt i Chrome 2026-08-17: fokuskortet 90 px
+            naturligt, 317 px utsträckt. */}
+        <div className="grid content-start gap-4">
           {/* Next actions. Kortet är medvetet tight: det tar högst tre rader (buildOverviewActions
               kapar där) och allt som ligger under det — offert- och orderkorten — ska synas utan
               att man scrollar förbi en rubrik med luft omkring sig. */}


### PR DESCRIPTION
## Arbetsordern: statusen sätts från förloppet

Statusen kunde bara sättas via Redigera → väljaren → Spara, fast förloppet högst upp redan visade var ordern låg. Nu sätter ett klick på ett steg statusen direkt.

- Klicket PATCH:ar **bara** `status`. Routen gatear Fortnox-synken på Er referens/arbetsadress/ansvarig, så genvägen blir aldrig en Fortnox-skrivning.
- Klickbara steg är arbetsstatusarna (`WORK_ORDER_STATUS_OPTIONS`). Fakturastatus sätts av faktureringsflödet och nekas ändå med 409 — de stegen förblir visning.
- En färdigfakturerad order är låst, och medan översikten redigeras äger formulärets väljare statusen: annars hade ett klick sparat mitt i ett osparat utkast.
- Statusväljaren i formuläret ligger kvar — den behövs för **Avbruten**, som inte finns i förloppet.

## Översikten: två layoutfynd, båda mätta i Chrome

**Långa namn sköt ut statusbadgen ur kortet.** Raderna i senaste-listorna är grid-item, och ett auto-spår får inte bli smalare än itemets min-content — som med `truncate` (`white-space: nowrap`) är hela projektnamnets bredd. `min-w-0` på textkolumnen låter texten krympa men säger ingenting om spåret; raden växte ~60 px förbi kortkanten. `min-w-0` på själva raden fixar det. Offert- och orderkorten var de rapporterade, men uppgifter och samtal har identisk markup och samma fel — alla fyra är fixade.

**"Nästa fokus" gick inte att göra kortare.** Kolumnerna är grid-syskon och blir lika höga, och vänsterkolumnens auto-rader ärver `align-content: normal` → stretch. Korten blåstes upp för att fylla den höjd statusbilden och topplistan satte, så en trimning av innehållet lades tillbaka som luft. `content-start` ger raderna innehållshöjd (fokuskortet 90 px naturligt mot 317 px utsträckt) — först då syns de 48 px som trimmades ur kortet, och korten under flyttar upp. Gällde bara från `xl` och uppåt.

## Granskningsfynd

Ett fynd åtgärdat i egen commit: förloppet ligger ovanför flikremsan, så ett statusklick under pågående artikelredigering laddade om ordern och resync-effekten skrev över utkastet. Effekten resynkar inte längre medan `editing` är true.

Ett fynd **inte** åtgärdat, medvetet: stegen och hjälptexten visas oavsett skrivbehörighet. Konsult (READONLY) och säljare som inte är orderns `assigned_to` får ett klick som alltid 403:ar (UPDATE-policyn är `assigned_to = auth.uid() or crm.admin`). Redigera-knappen har exakt samma lucka sedan tidigare — att gata den ordentligt kräver serverläst behörighet i `page.tsx` och hör hemma som eget jobb för hela ytan, inte som en halv gating av bara det nya.

## Verifiering

Ingen SQL, inga API-ändringar. `npm run type-check`, `npm run lint` och `npm test` (1424 tester) passerar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)