### PR TITLE
fix(schema): vald vecka och dag överlever resan till arbetsordern

### DIFF
--- a/components/dashboard/DashboardSchedule.tsx
+++ b/components/dashboard/DashboardSchedule.tsx
@@ -232,14 +232,17 @@ export default function DashboardSchedule({ compact = false, onReportTime }: { c
   useEffect(() => {
     if (!viewRestored) return;
     const url = new URL(window.location.href);
-    // Står vyn på sitt förval städas parametrarna bort igen, så en vanlig startsida har en ren URL.
-    if (weekOffset === 0 && dayIdx === defaultScheduleDayIndex()) {
-      url.searchParams.delete(WEEK_PARAM);
-      url.searchParams.delete(DAY_PARAM);
-    } else {
-      url.searchParams.set(WEEK_PARAM, range.startISO);
-      url.searchParams.set(DAY_PARAM, dayIdx == null ? DAY_ALL : String(dayIdx));
-    }
+    // ⚠️ Varje parameter står och faller för sig, aldrig som ett par. Den som står på sitt förval
+    // ska SAKNAS i URL:en, för då räknas förvalet om vid nästa montering i stället för att frysas.
+    // `range` memoiseras på weekOffset och läser klockan när den räknas, så en flik som stått öppen
+    // över ett dygnsskifte håller ett gammalt måndagsdatum. Skrevs det ut vid offset 0 skulle
+    // installatören som passerat en söndagsnatt låsas fast en vecka bakåt — förut läkte just den
+    // omstarten felet. Nu skrivs ingenting vid offset 0, och en bortbläddrad vecka som hunnit bli
+    // den aktuella läser tillbaka som 0. URL:en berättar alltid vad som stod på skärmen.
+    if (weekOffset === 0) url.searchParams.delete(WEEK_PARAM);
+    else url.searchParams.set(WEEK_PARAM, range.startISO);
+    if (dayIdx === defaultScheduleDayIndex()) url.searchParams.delete(DAY_PARAM);
+    else url.searchParams.set(DAY_PARAM, dayIdx == null ? DAY_ALL : String(dayIdx));
     window.history.replaceState({}, '', url.toString());
   }, [viewRestored, weekOffset, dayIdx, range.startISO]);
 

--- a/components/dashboard/DashboardSchedule.tsx
+++ b/components/dashboard/DashboardSchedule.tsx
@@ -8,8 +8,21 @@ import Textarea from '../ui/Textarea';
 import Badge from '../ui/Badge';
 import DashboardCardHeader from './DashboardCardHeader';
 import { crmJobToScheduleItem, type CrmJobRow } from '@/lib/domains/planning/myJobs';
-import { defaultScheduleDayIndex, scheduleWeekRange } from '@/lib/domains/planning/scheduleWeek';
+import { defaultScheduleDayIndex, scheduleWeekOffsetFor, scheduleWeekRange } from '@/lib/domains/planning/scheduleWeek';
 import { stockholmTodayISO } from '@/lib/domains/planning/timezone';
+
+// Vald vecka och vald dag bärs i adressfältet, inte bara i komponentens state.
+//
+// Ett CRM-jobb öppnas med en hård navigering till /arbetsorder/<id>, och fältvyns "← Tillbaka" är
+// ett vanligt history.back(). Startsidan monteras alltså om på vägen tillbaka, och utan de här
+// parametrarna landade installatören på dagens dag varje gång — den som ville gå igenom nästa
+// veckas jobb fick bläddra fram en vecka på nytt för varje arbetsorder.
+//
+// Veckan bärs som måndagens datum, se scheduleWeekOffsetFor. Dagen bärs som knappens index eftersom
+// den bara är meningsfull inom den vecka som står bredvid.
+const WEEK_PARAM = 'vecka';
+const DAY_PARAM = 'dag';
+const DAY_ALL = 'alla';
 
 const MONTHS_SHORT = ['jan', 'feb', 'mar', 'apr', 'maj', 'jun', 'jul', 'aug', 'sep', 'okt', 'nov', 'dec'];
 
@@ -64,6 +77,22 @@ export default function DashboardSchedule({ compact = false, onReportTime }: { c
   const [currentUserName, setCurrentUserName] = useState<string | null>(null);
   // 0=mån .. 4=fre, null=alla. Svensk veckodag, inte serverns — se scheduleWeek.ts.
   const [dayIdx, setDayIdx] = useState<number | null>(() => defaultScheduleDayIndex());
+  // URL:en läses först i en effekt, aldrig i en state-initierare: sidan är force-dynamic och
+  // server-renderas, och servern har inget `window`. Ett `typeof window`-undantag i initieraren
+  // hade gett servern förvalet och klienten den sparade vyn — alltså en hydreringskrock på precis
+  // de knappar det handlar om. Flaggan håller också tillbaka jobbhämtningen tills vyn är känd, så
+  // vi inte hämtar fel vecka först och rätt vecka direkt efteråt.
+  const [viewRestored, setViewRestored] = useState(false);
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const week = params.get(WEEK_PARAM);
+    if (week) setWeekOffset(scheduleWeekOffsetFor(week));
+    const day = params.get(DAY_PARAM);
+    if (day === DAY_ALL) setDayIdx(null);
+    else if (day && /^[0-4]$/.test(day)) setDayIdx(Number(day));
+    setViewRestored(true);
+  }, []);
 
   // Detail modal state
   const [detailOpen, setDetailOpen] = useState(false);
@@ -197,6 +226,23 @@ export default function DashboardSchedule({ compact = false, onReportTime }: { c
   // lib/domains/planning/scheduleWeek.ts med tester (tests/planning/scheduleWeek.test.ts).
   const range = useMemo(() => scheduleWeekRange(weekOffset), [weekOffset]);
 
+  // replaceState, inte router.replace: startsidan är force-dynamic, så en router-navigering hade
+  // kostat en server-rundtur per tryck på en dagknapp. Och replace, inte push, så att "← Tillbaka"
+  // i arbetsordern tar dig till schemat och inte bakåt genom varje vecka du bläddrat förbi.
+  useEffect(() => {
+    if (!viewRestored) return;
+    const url = new URL(window.location.href);
+    // Står vyn på sitt förval städas parametrarna bort igen, så en vanlig startsida har en ren URL.
+    if (weekOffset === 0 && dayIdx === defaultScheduleDayIndex()) {
+      url.searchParams.delete(WEEK_PARAM);
+      url.searchParams.delete(DAY_PARAM);
+    } else {
+      url.searchParams.set(WEEK_PARAM, range.startISO);
+      url.searchParams.set(DAY_PARAM, dayIdx == null ? DAY_ALL : String(dayIdx));
+    }
+    window.history.replaceState({}, '', url.toString());
+  }, [viewRestored, weekOffset, dayIdx, range.startISO]);
+
   useEffect(() => {
     // Load current user and name
     (async () => {
@@ -220,6 +266,7 @@ export default function DashboardSchedule({ compact = false, onReportTime }: { c
   }, [supabase]);
 
   useEffect(() => {
+    if (!viewRestored) return;
     let cancelled = false;
     (async () => {
       setLoading(true);
@@ -246,7 +293,7 @@ export default function DashboardSchedule({ compact = false, onReportTime }: { c
       }
     })();
     return () => { cancelled = true; };
-  }, [supabase, range.startISO, range.endISO]);
+  }, [supabase, viewRestored, range.startISO, range.endISO]);
 
   // Enrich items with per-segment sort_index (used for ordering, same as Planning page)
   useEffect(() => {

--- a/lib/domains/planning/scheduleWeek.ts
+++ b/lib/domains/planning/scheduleWeek.ts
@@ -80,3 +80,25 @@ export function defaultScheduleDayIndex(now: Date = new Date()): number | null {
   const dow = stockholmToday(now).getDay(); // Sun=0 .. Sat=6
   return dow >= 1 && dow <= 5 ? dow - 1 : null;
 }
+
+/**
+ * Motsatsen till `scheduleWeekRange`: hur många veckosteg bort veckan som innehåller `dateISO`
+ * ligger från veckan Sverige befinner sig i just nu. Ogiltig indata ger 0, alltså denna vecka.
+ *
+ * ⚠️ Vyn bärs i URL:en som ett ABSOLUT datum, inte som offseten, och det är hela poängen med den
+ * här funktionen. En offset betyder olika veckor beroende på NÄR den läses: lämnar man `1` i
+ * adressfältet en söndag kväll och öppnar länken efter midnatt pekar den på veckan efter den man
+ * lämnade. Ett datum betyder samma vecka för alltid.
+ */
+export function scheduleWeekOffsetFor(dateISO: string, now: Date = new Date()): number {
+  const parts = /^(\d{4})-(\d{2})-(\d{2})$/.exec(dateISO || '');
+  if (!parts) return 0;
+  const target = new Date(Number(parts[1]), Number(parts[2]) - 1, Number(parts[3]));
+  // `new Date(2026, 12, 40)` rullar vidare till ett giltigt datum i stället för att bli NaN, så
+  // siffergrindarna ovan räcker inte — bara ett datum som läses tillbaka oförändrat godtas.
+  if (Number.isNaN(target.getTime()) || toISODateLocal(target) !== dateISO) return 0;
+  // Avrundat, inte heltalsdivision: veckor som spänner över en sommartidsväxling är 23 respektive
+  // 25 timmar för korta/långa, och skulle annars trilla ett steg fel.
+  const diffMs = startOfISOWeek(target).getTime() - startOfISOWeek(stockholmToday(now)).getTime();
+  return Math.round(diffMs / (7 * 86400000));
+}

--- a/tests/planning/scheduleWeek.test.ts
+++ b/tests/planning/scheduleWeek.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { defaultScheduleDayIndex, scheduleWeekRange } from '@/lib/domains/planning/scheduleWeek';
+import { defaultScheduleDayIndex, scheduleWeekOffsetFor, scheduleWeekRange } from '@/lib/domains/planning/scheduleWeek';
 
 // Startsidans arbetsschema läste tidigare `new Date()` med lokala getters. Sidan är force-dynamic,
 // alltså server-renderad före hydrering, och servern går på UTC — så mellan 00:00 och 02:00 svensk
@@ -69,5 +69,52 @@ describe('defaultScheduleDayIndex', () => {
   it('⚠️ måndag 01:30 svensk tid väljer måndag, inte helgens "Alla"', () => {
     // Samma instant som veckotestet ovan: UTC säger söndag, Sverige säger måndag.
     expect(defaultScheduleDayIndex(new Date('2026-08-16T23:30:00Z'))).toBe(0);
+  });
+});
+
+// Vyn (vecka + dag) bärs i startsidans URL så att den överlever resan ut till en arbetsorder och
+// tillbaka. Veckan bärs som måndagens datum just för att en offset betyder olika veckor beroende
+// på när den läses tillbaka — testerna nedan är regressionsskyddet för det.
+describe('scheduleWeekOffsetFor', () => {
+  it('ger 0 för en dag i innevarande vecka', () => {
+    // Onsdag 2026-08-12 → veckan som börjar måndag 2026-08-10.
+    expect(scheduleWeekOffsetFor('2026-08-10', new Date('2026-08-12T10:00:00Z'))).toBe(0);
+  });
+
+  it('räknar steg bakåt och framåt', () => {
+    const now = new Date('2026-08-12T10:00:00Z');
+    expect(scheduleWeekOffsetFor('2026-08-17', now)).toBe(1);
+    expect(scheduleWeekOffsetFor('2026-08-31', now)).toBe(3);
+    expect(scheduleWeekOffsetFor('2026-08-03', now)).toBe(-1);
+  });
+
+  it('är motsatsen till scheduleWeekRange för varje steg', () => {
+    const now = new Date('2026-08-12T10:00:00Z');
+    for (const offset of [-8, -1, 0, 1, 5, 20]) {
+      expect(scheduleWeekOffsetFor(scheduleWeekRange(offset, now).startISO, now)).toBe(offset);
+    }
+  });
+
+  it('⚠️ håller steget över en sommartidsväxling (veckan är 23 respektive 25 timmar)', () => {
+    // Sista söndagen i mars och i oktober 2026: 29/3 (UTC+1 → +2) och 25/10 (UTC+2 → +1).
+    const beforeSpring = new Date('2026-03-25T10:00:00Z');
+    expect(scheduleWeekOffsetFor(scheduleWeekRange(1, beforeSpring).startISO, beforeSpring)).toBe(1);
+    const beforeAutumn = new Date('2026-10-21T10:00:00Z');
+    expect(scheduleWeekOffsetFor(scheduleWeekRange(1, beforeAutumn).startISO, beforeAutumn)).toBe(1);
+    // Och över hela växlingen, inte bara ett steg.
+    expect(scheduleWeekOffsetFor('2026-10-26', beforeSpring)).toBe(31);
+  });
+
+  it('normaliserar en dag mitt i veckan till samma steg som dess måndag', () => {
+    // URL:en skrivs alltid med måndagen, men en handredigerad adress ska inte hamna snett.
+    const now = new Date('2026-08-12T10:00:00Z');
+    expect(scheduleWeekOffsetFor('2026-08-23', now)).toBe(1); // söndagen i vecka 34
+  });
+
+  it('⚠️ faller tillbaka på denna vecka vid skräpindata i stället för att bygga ett NaN-intervall', () => {
+    const now = new Date('2026-08-12T10:00:00Z');
+    for (const raw of ['', 'imorgon', '2026-8-10', '2026-13-01', '2026-02-30', '10-08-2026']) {
+      expect(scheduleWeekOffsetFor(raw, now)).toBe(0);
+    }
   });
 });

--- a/tests/planning/scheduleWeek.test.ts
+++ b/tests/planning/scheduleWeek.test.ts
@@ -96,6 +96,9 @@ describe('scheduleWeekOffsetFor', () => {
   });
 
   it('⚠️ håller steget över en sommartidsväxling (veckan är 23 respektive 25 timmar)', () => {
+    // ⚠️ Det här testet biter bara i en runner vars EGEN zon har sommartid. All aritmetik här
+    // läser lokala fält (se filhuvudet), så under TZ=UTC är veckan alltid 168 timmar och
+    // avrundningen aldrig prövad. Verifierat under Europe/Stockholm och America/New_York.
     // Sista söndagen i mars och i oktober 2026: 29/3 (UTC+1 → +2) och 25/10 (UTC+2 → +1).
     const beforeSpring = new Date('2026-03-25T10:00:00Z');
     expect(scheduleWeekOffsetFor(scheduleWeekRange(1, beforeSpring).startISO, beforeSpring)).toBe(1);


### PR DESCRIPTION
## Problemet

Installatören byter dag eller vecka i arbetsschemat, öppnar en arbetsorder, går tillbaka — och står på dagens dag igen. Den som vill gå igenom hela nästa veckas projekt får bläddra fram en vecka på nytt för varje order.

Orsaken: `weekOffset` och `dayIdx` var ren komponent-state. Ett CRM-jobb öppnas med en **hård** navigering till `/arbetsorder/<id>` (`DashboardSchedule.tsx:122`), och fältvyns "← Tillbaka" är ett vanligt `history.back()`. Startsidan monteras alltså om på vägen tillbaka, och båda föll till sina förval.

## Lösningen

Vyn bärs i adressfältet (`/?vecka=2026-08-24&dag=1`), så historiken bär tillbaka den av sig själv. Samma idiom som `AdminTabsClient` redan använder: läs i en monteringseffekt, skriv tillbaka med `history.replaceState`.

Tre saker som styrde utformningen:

- **Veckan bärs som måndagens datum, inte som offseten.** En offset betyder olika veckor beroende på när den läses tillbaka — lämnar man `1` en söndag kväll och kommer tillbaka efter midnatt pekar den på veckan *efter* den man lämnade. Ny `scheduleWeekOffsetFor` i planning-domänen, med tester.
- **URL:en läses i en effekt, aldrig i en state-initierare.** Sidan är `force-dynamic` och server-renderas; ett `typeof window`-undantag hade gett servern förvalet och klienten den sparade vyn, alltså en hydreringskrock på precis de dagknappar det handlar om. Samma flagga håller tillbaka `get_my_jobs`/`get_my_crm_jobs` tills vyn är känd, så vi inte hämtar fel vecka först och rätt vecka direkt efteråt.
- **`replaceState`, inte `router.replace`.** Startsidan är `force-dynamic` — en router-navigering hade kostat en server-rundtur per tryck på en dagknapp. Och *replace*, så att tillbaka-knappen tar dig till schemat och inte bakåt genom varje vecka du bläddrat förbi.

Varje parameter står och faller för sig: den som är på sitt förval utelämnas, så att förvalet räknas om vid nästa montering i stället för att frysas. Det håller en flik som stått öppen över en söndagsnatt från att låsa sig en vecka bakåt (fynd från granskningen), och ger en ren URL på en vanlig startsida.

## Avgränsning

- Går man tillbaka via **"Hem" i menyn** i stället för tillbaka-knappen landar man på idag. Det är en ny resa, inte en retur.
- Gamla Blikk-jobb öppnas i en modal utan navigering och var aldrig drabbade.
- Ingen SQL, inga API-ändringar, ingen ändrad affärslogik.

## Granskning

Kördes på grenen före PR. Två fynd, båda låga:

1. **Åtgärdat** — den stale `range`-memon kunde frysa en gammal vecka i URL:en över ett dygnsskifte. Löst genom att skriva parametrarna var för sig i stället för som ett par.
2. **Avböjt** — förslaget att klampa offseten. En URL som namnger en absolut vecka *ska* öppna den veckan, "Gå till denna vecka" står redan bredvid, och en gräns hade varit en påhittad regel. Ogiltig indata är redan spärrad (inklusive JS tvåsiffriga årtalsfälla, `0099-…` → 1999).

## Validering

`npm run type-check` · `npm run lint` · `npm run build` · `npm test` (1430 tester, 94 filer) — alla gröna. Datumtesterna kördes dessutom under `Europe/Stockholm`, `UTC` och `America/New_York`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)