### PR TITLE
feat(crm): spärra offert → arbetsorder när uppgifter saknas

### DIFF
--- a/app/api/crm/quotes/[id]/work-order/route.ts
+++ b/app/api/crm/quotes/[id]/work-order/route.ts
@@ -4,7 +4,7 @@ import { createCrmWorkOrderFromQuote, getWorkOrderReadinessForQuote } from '@/li
 import { workOrderReadinessErrorCode } from '@/lib/domains/crm/workOrderReadiness';
 import { pushWorkOrderToFortnox } from '@/lib/domains/fortnox/orders';
 import { FortnoxNotConnectedError, friendlyFortnoxMessage } from '@/lib/domains/fortnox/client';
-import { ok, requirePermission, routeError } from '../../_lib';
+import { invalidUuidParam, ok, requirePermission, routeError } from '../../_lib';
 
 type RouteContext = {
   params: {
@@ -23,6 +23,9 @@ export async function GET(_req: Request, context: RouteContext) {
   try {
     const crmUser = await requirePermission('crm.workorder.write');
     if (crmUser.response || !crmUser.currentUser) return crmUser.response;
+
+    const badId = invalidUuidParam(context.params.id);
+    if (badId) return badId;
 
     const supabase = createRouteHandlerClient({ cookies });
     const result = await getWorkOrderReadinessForQuote(supabase, context.params.id);
@@ -45,6 +48,9 @@ export async function POST(_req: Request, context: RouteContext) {
     const crmUser = await requirePermission('crm.workorder.write');
     if (crmUser.response || !crmUser.currentUser) return crmUser.response;
 
+    const badId = invalidUuidParam(context.params.id);
+    if (badId) return badId;
+
     const supabase = createRouteHandlerClient({ cookies });
     const result = await createCrmWorkOrderFromQuote(supabase, context.params.id, crmUser.currentUser.id);
 
@@ -61,13 +67,13 @@ export async function POST(_req: Request, context: RouteContext) {
       // Är det fler blir det `crm_work_order_incomplete` och listan visas i stället, eftersom en
       // prompt då bara hade lagat en av sakerna innan nästa fel dök upp.
       if (result.reason === 'incomplete') {
-        const readiness = await getWorkOrderReadinessForQuote(supabase, context.params.id);
-        const blockers = readiness.data?.blockers ?? [];
+        const readiness = 'readiness' in result ? result.readiness : null;
+        const blockers = readiness?.blockers ?? [];
         return routeError(
           409,
           blockers.length > 0 ? workOrderReadinessErrorCode(blockers) : 'crm_work_order_incomplete',
           result.error?.message || 'Uppgifter saknas innan arbetsorder kan skapas',
-          { blockers, warnings: readiness.data?.warnings ?? [] },
+          { blockers, warnings: readiness?.warnings ?? [] },
         );
       }
 

--- a/app/api/crm/quotes/[id]/work-order/route.ts
+++ b/app/api/crm/quotes/[id]/work-order/route.ts
@@ -1,6 +1,7 @@
 import { cookies } from 'next/headers';
 import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
-import { createCrmWorkOrderFromQuote } from '@/lib/domains/crm/work-orders';
+import { createCrmWorkOrderFromQuote, getWorkOrderReadinessForQuote } from '@/lib/domains/crm/work-orders';
+import { workOrderReadinessErrorCode } from '@/lib/domains/crm/workOrderReadiness';
 import { pushWorkOrderToFortnox } from '@/lib/domains/fortnox/orders';
 import { FortnoxNotConnectedError, friendlyFortnoxMessage } from '@/lib/domains/fortnox/client';
 import { ok, requirePermission, routeError } from '../../_lib';
@@ -10,6 +11,34 @@ type RouteContext = {
     id: string;
   };
 };
+
+/**
+ * Vad som saknas innan offerten kan bli en arbetsorder.
+ *
+ * Läses av offertformuläret och den delade offertpanelen så att listan syns INNAN säljaren
+ * trycker. Samma funktion som skapandet använder — checklistan och spärren kan därför inte säga
+ * emot varandra.
+ */
+export async function GET(_req: Request, context: RouteContext) {
+  try {
+    const crmUser = await requirePermission('crm.workorder.write');
+    if (crmUser.response || !crmUser.currentUser) return crmUser.response;
+
+    const supabase = createRouteHandlerClient({ cookies });
+    const result = await getWorkOrderReadinessForQuote(supabase, context.params.id);
+
+    if (result.error || !result.data) {
+      if (result.reason === 'not_found') {
+        return routeError(404, 'crm_quote_not_found', 'Offerten hittades inte');
+      }
+      return routeError(500, 'crm_work_order_readiness_failed', result.error?.message || 'Kunde inte läsa offerten');
+    }
+
+    return ok(result.data);
+  } catch (e: any) {
+    return routeError(500, 'crm_work_order_unexpected', e?.message || 'Failed to read work-order readiness');
+  }
+}
 
 export async function POST(_req: Request, context: RouteContext) {
   try {
@@ -24,19 +53,22 @@ export async function POST(_req: Request, context: RouteContext) {
         return routeError(404, 'crm_quote_not_found', result.error?.message || 'Offerten hittades inte');
       }
 
-      // Emit the same code the standalone route uses so the client's personnummer prompt
-      // (which keys off crm_work_order_missing_personal_number) fires on both order paths.
-      // `invalid_personal_number` (tio siffror i stället för tolv) delar kod: åtgärden är densamma
-      // — fyll i ett fullständigt nummer — och meddelandet förklarar skillnaden.
-      if (result.reason === 'missing_personal_number' || result.reason === 'invalid_personal_number') {
-        return routeError(409, 'crm_work_order_missing_personal_number', result.error?.message || 'Personnummer krävs för privatkund innan order kan skapas');
-      }
-
-      // ROT without fastighetsbeteckning/BRF org.nr. Its own code so the quote form can open the
-      // prompt that collects it; the quote list (no prompt there) just shows the message, which
-      // says where to fill it in.
-      if (result.reason === 'missing_rot_property') {
-        return routeError(409, 'crm_work_order_missing_rot_property', result.error?.message || 'Fastighetsbeteckning krävs för ROT innan order kan skapas');
+      // Ofullständig offert. Hela listan hämtas om och skickas med, så klienten kan visa allt som
+      // saknas i stället för ett fynd i taget.
+      //
+      // Koden är fortfarande den specifika (`…missing_personal_number` / `…missing_rot_property`)
+      // när fyndet är ENSAMT — offertformuläret öppnar en prompt på dem och rättar dem på plats.
+      // Är det fler blir det `crm_work_order_incomplete` och listan visas i stället, eftersom en
+      // prompt då bara hade lagat en av sakerna innan nästa fel dök upp.
+      if (result.reason === 'incomplete') {
+        const readiness = await getWorkOrderReadinessForQuote(supabase, context.params.id);
+        const blockers = readiness.data?.blockers ?? [];
+        return routeError(
+          409,
+          blockers.length > 0 ? workOrderReadinessErrorCode(blockers) : 'crm_work_order_incomplete',
+          result.error?.message || 'Uppgifter saknas innan arbetsorder kan skapas',
+          { blockers, warnings: readiness.data?.warnings ?? [] },
+        );
       }
 
       if (result.reason === 'quote_not_won' || result.reason === 'already_created') {

--- a/app/crm/components/CrmConfirmDialog.tsx
+++ b/app/crm/components/CrmConfirmDialog.tsx
@@ -1,0 +1,71 @@
+"use client";
+import CrmModal from '@/app/crm/components/CrmModal';
+
+// Bekräftelsedialog i CRM:s egen yta, i stället för webbläsarens window.confirm.
+//
+// Skälet är inte bara utseendet. `window.confirm` fryser hela fliken, kan inte bära formaterad
+// text, och ser ut som ett systemvarningsfönster — i en app som annars äger sina dialoger läser
+// det som att något gått fel. Den här delar CrmModal med appens övriga tolv modaler, så
+// tangentbord, Escape, mobilens bottenark och överlagringen beter sig likadant överallt.
+//
+// Anropas genom att lägga undan det som ska ske och rendera dialogen; window.confirm blockerar,
+// det här gör det inte.
+export default function CrmConfirmDialog({
+  title,
+  message,
+  confirmLabel = 'Bekräfta',
+  cancelLabel = 'Avbryt',
+  busy = false,
+  onConfirm,
+  onCancel,
+}: {
+  title: string;
+  /** Bryts ut på egen rad under rubriken. Håll den till konsekvensen av att fortsätta. */
+  message?: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  /** Håller knapparna låsta medan åtgärden pågår, så den inte kan startas två gånger. */
+  busy?: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}) {
+  return (
+    <CrmModal
+      onClose={onCancel}
+      ariaLabel={title}
+      maxWidth="sm:max-w-[420px]"
+      header={
+        <>
+          <h2 className="text-lg font-bold text-slate-900">{title}</h2>
+          {message ? <p className="m-0 mt-0.5 text-sm text-slate-500">{message}</p> : null}
+        </>
+      }
+      footer={
+        <>
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={busy}
+            className="flex-1 rounded-xl border border-slate-200 bg-white py-2.5 text-sm font-semibold text-slate-600 transition hover:border-slate-300 disabled:cursor-not-allowed disabled:opacity-60 sm:flex-none sm:px-5"
+          >
+            {cancelLabel}
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            disabled={busy}
+            autoFocus
+            className="flex-1 rounded-xl py-2.5 text-sm font-semibold text-white shadow-sm transition hover:brightness-95 disabled:cursor-not-allowed disabled:opacity-60 sm:ml-auto sm:flex-none sm:px-5"
+            style={{ backgroundColor: 'var(--crm-primary)' }}
+          >
+            {confirmLabel}
+          </button>
+        </>
+      }
+    >
+      {/* Kroppen är tom med flit: rubriken och meningen under den bär hela frågan, och en tom
+          kropp håller dialogen på höjden av det den faktiskt frågar. */}
+      <span className="sr-only">{message ?? title}</span>
+    </CrmModal>
+  );
+}

--- a/app/crm/components/QuoteDetailPanel.tsx
+++ b/app/crm/components/QuoteDetailPanel.tsx
@@ -13,6 +13,7 @@ import { quoteCustomerName, isQuoteOverdue } from '@/app/crm/lib/quoteDisplay';
 import type { EmailableDocument } from '@/app/crm/components/useDocumentEmail';
 import type { WorkOrderReadinessIssue } from '@/lib/domains/crm/workOrderReadiness';
 import WorkOrderReadinessNotice from '@/app/crm/components/WorkOrderReadinessNotice';
+import CrmConfirmDialog from '@/app/crm/components/CrmConfirmDialog';
 
 // The quote detail modal, shared by the offer list and the Säljtavla board.
 //
@@ -137,6 +138,12 @@ export default function QuoteDetailPanel({
   // som skapandet använder) — panelens rad bär bara en beskuren snapshot och kan inte avgöra det.
   const [readiness, setReadiness] = useState<{ blockers: WorkOrderReadinessIssue[]; warnings: WorkOrderReadinessIssue[] } | null>(null);
 
+  // Bekräftelsen före "Vunnen" väntar här i stället för i ett window.confirm. Statusen läggs undan
+  // och plockas upp när dialogen svarar — annars hade anropet behövt blockera tråden.
+  const [pendingWonStatus, setPendingWonStatus] = useState<QuoteDetailItem['status'] | null>(null);
+  const [readinessNonce, setReadinessNonce] = useState(0);
+  const [rechecking, setRechecking] = useState(false);
+
   // Hämtas bara i det läge knappen är tänkt att gå att trycka på, alltså vunnen offert utan order.
   const readinessQuoteId = quote.status === 'won' && !quote.work_order_id ? quote.id : null;
 
@@ -149,9 +156,14 @@ export default function QuoteDetailPanel({
         if (cancelled || !json?.ok) return;
         setReadiness({ blockers: json.data?.blockers ?? [], warnings: json.data?.warnings ?? [] });
       })
-      .catch(() => { /* tyst — servern nekar ändå om något saknas */ });
+      .catch(() => { /* tyst — servern nekar ändå om något saknas */ })
+      .finally(() => { if (!cancelled) setRechecking(false); });
     return () => { cancelled = true; };
-  }, [readinessQuoteId]);
+  }, [readinessQuoteId, readinessNonce]);
+
+  // Avstängd bara när vi VET att något saknas. Misslyckades hämtningen lämnas knappen aktiv —
+  // servern spärrar ändå, och en död knapp utan förklaring är värre än ett fel efter klicket.
+  const workOrderBlocked = (readiness?.blockers.length ?? 0) > 0;
 
 
   // A work order locks the offer in Fortnox — unless the last sync failed, in which case the
@@ -160,18 +172,19 @@ export default function QuoteDetailPanel({
   const display = quoteAmountDisplay(quote.quote_type, resolveQuoteVatBreakdown(quote));
   const customerName = quoteCustomerName(quote);
 
+  // Won is a meaningful transition — confirm it, exactly as the board's drag-and-drop does. A
+  // linked prospect is converted to a customer server-side and that cannot be undone from here,
+  // so the same board offering two different safety levels for one transition would be worse than
+  // offering none.
+  function requestMoveToStatus(nextStatus: QuoteDetailItem['status']) {
+    if (quote.status === nextStatus) return;
+    if (nextStatus === 'won') { setPendingWonStatus(nextStatus); return; }
+    void moveQuoteToStatus(nextStatus);
+  }
+
   async function moveQuoteToStatus(nextStatus: QuoteDetailItem['status']) {
     if (quote.status === nextStatus) return;
-    // Won is a meaningful transition — confirm it, exactly as the board's drag-and-drop does. A
-    // linked prospect is converted to a customer server-side and that cannot be undone from here,
-    // so the same board offering two different safety levels for one transition would be worse than
-    // offering none.
-    if (nextStatus === 'won') {
-      const message = quote.prospect_id
-        ? 'Markera offerten som vunnen? En kopplad prospekt konverteras då till kund.'
-        : 'Markera offerten som vunnen?';
-      if (!window.confirm(message)) return;
-    }
+    setPendingWonStatus(null);
     setMoving(true);
     try {
       const res = await fetch(`/api/crm/quotes/${quote.id}`, {
@@ -384,7 +397,7 @@ export default function QuoteDetailPanel({
                       key={s}
                       type="button"
                       disabled={moving || isCurrent}
-                      onClick={() => void moveQuoteToStatus(s)}
+                      onClick={() => requestMoveToStatus(s)}
                       className={cn(
                         'inline-flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-xs font-semibold transition',
                         isCurrent
@@ -443,7 +456,7 @@ export default function QuoteDetailPanel({
                       <button
                         type="button"
                         onClick={() => void createWorkOrder()}
-                        disabled={quote.status !== 'won' || creatingWorkOrder}
+                        disabled={quote.status !== 'won' || creatingWorkOrder || workOrderBlocked}
                         className="rounded-lg border border-emerald-700 bg-emerald-700 px-3 py-1.5 text-sm font-semibold text-white transition hover:bg-emerald-800 disabled:cursor-not-allowed disabled:border-slate-200 disabled:bg-white disabled:text-slate-400"
                       >
                         {creatingWorkOrder ? 'Skapar…' : 'Skapa arbetsorder'}
@@ -459,6 +472,8 @@ export default function QuoteDetailPanel({
                     warnings={readiness.warnings}
                     customerHref={quote.customer_id ? `/crm/kunder/${quote.customer_id}?returnTo=${encodeURIComponent(returnTo)}` : null}
                     quoteHref={`/crm/offerter/${quote.id}/redigera?returnTo=${encodeURIComponent(returnTo)}`}
+                    onRecheck={readiness.blockers.length > 0 ? () => { setRechecking(true); setReadinessNonce((n) => n + 1); } : null}
+                    rechecking={rechecking}
                   />
                 ) : null}
 
@@ -619,6 +634,21 @@ export default function QuoteDetailPanel({
             ) : null}
           </div>
         </div>
+
+      {pendingWonStatus ? (
+        <CrmConfirmDialog
+          title="Markera offerten som vunnen?"
+          message={
+            quote.prospect_id
+              ? 'Ett kopplat prospekt konverteras då till kund. Det går inte att ångra härifrån.'
+              : undefined
+          }
+          confirmLabel="Markera som vunnen"
+          busy={moving}
+          onConfirm={() => void moveQuoteToStatus(pendingWonStatus)}
+          onCancel={() => setPendingWonStatus(null)}
+        />
+      ) : null}
     </div>
   );
 }

--- a/app/crm/components/QuoteDetailPanel.tsx
+++ b/app/crm/components/QuoteDetailPanel.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { cn } from '@/lib/shared/cn';
@@ -11,6 +11,8 @@ import { withReturnTo } from '@/app/crm/lib/returnTo';
 import { resolveQuoteVatBreakdown, quoteAmountDisplay } from '@/lib/domains/crm/pricing';
 import { quoteCustomerName, isQuoteOverdue } from '@/app/crm/lib/quoteDisplay';
 import type { EmailableDocument } from '@/app/crm/components/useDocumentEmail';
+import type { WorkOrderReadinessIssue } from '@/lib/domains/crm/workOrderReadiness';
+import WorkOrderReadinessNotice from '@/app/crm/components/WorkOrderReadinessNotice';
 
 // The quote detail modal, shared by the offer list and the Säljtavla board.
 //
@@ -131,6 +133,26 @@ export default function QuoteDetailPanel({
   const [pushingFortnox, setPushingFortnox] = useState(false);
   const [loadingOfferPdf, setLoadingOfferPdf] = useState(false);
   const [loadingOrderPdf, setLoadingOrderPdf] = useState(false);
+  // Vad som saknas innan offerten kan bli en arbetsorder. Servern räknar ut det (samma funktion
+  // som skapandet använder) — panelens rad bär bara en beskuren snapshot och kan inte avgöra det.
+  const [readiness, setReadiness] = useState<{ blockers: WorkOrderReadinessIssue[]; warnings: WorkOrderReadinessIssue[] } | null>(null);
+
+  // Hämtas bara i det läge knappen är tänkt att gå att trycka på, alltså vunnen offert utan order.
+  const readinessQuoteId = quote.status === 'won' && !quote.work_order_id ? quote.id : null;
+
+  useEffect(() => {
+    if (!readinessQuoteId) { setReadiness(null); return; }
+    let cancelled = false;
+    fetch(`/api/crm/quotes/${readinessQuoteId}/work-order`, { cache: 'no-store' })
+      .then((r) => r.json().catch(() => ({})))
+      .then((json) => {
+        if (cancelled || !json?.ok) return;
+        setReadiness({ blockers: json.data?.blockers ?? [], warnings: json.data?.warnings ?? [] });
+      })
+      .catch(() => { /* tyst — servern nekar ändå om något saknas */ });
+    return () => { cancelled = true; };
+  }, [readinessQuoteId]);
+
 
   // A work order locks the offer in Fortnox — unless the last sync failed, in which case the
   // re-sync button stays available so the user can recover.
@@ -193,7 +215,16 @@ export default function QuoteDetailPanel({
     try {
       const res = await fetch(`/api/crm/quotes/${quote.id}/work-order`, { method: 'POST', headers: { 'Content-Type': 'application/json' } });
       const json = await res.json().catch(() => ({}));
-      if (!res.ok || !json.ok) { toast.error(json?.error || 'Kunde inte skapa arbetsorder'); return; }
+      if (!res.ok || !json.ok) {
+        // Saknade uppgifter kommer tillbaka som en lista. Panelen har ingen prompt att rätta dem i
+        // (offertformuläret har det), så den visar listan och pekar vidare dit den rättas.
+        const details = json?.errorDetails?.details as { blockers?: WorkOrderReadinessIssue[]; warnings?: WorkOrderReadinessIssue[] } | undefined;
+        if (details?.blockers?.length) {
+          setReadiness({ blockers: details.blockers, warnings: details.warnings ?? [] });
+        }
+        toast.error(json?.error || 'Kunde inte skapa arbetsorder');
+        return;
+      }
       const updated = json?.data?.item as QuoteDetailItem | undefined;
       onQuoteChanged(patchFromItem(quote.id, updated, {}));
       const workOrder = json?.data?.workOrder as { id?: string; order_number?: string } | undefined;
@@ -420,6 +451,16 @@ export default function QuoteDetailPanel({
                     )}
                   </div>
                 </div>
+
+                {!quote.work_order_id && quote.status === 'won' && readiness ? (
+                  <WorkOrderReadinessNotice
+                    className="mt-3"
+                    blockers={readiness.blockers}
+                    warnings={readiness.warnings}
+                    customerHref={quote.customer_id ? `/crm/kunder/${quote.customer_id}?returnTo=${encodeURIComponent(returnTo)}` : null}
+                    quoteHref={`/crm/offerter/${quote.id}/redigera?returnTo=${encodeURIComponent(returnTo)}`}
+                  />
+                ) : null}
 
                 {/* Order confirmation — once a work order (Fortnox order) exists */}
                 {quote.work_order_id ? (

--- a/app/crm/components/WorkOrderReadinessNotice.tsx
+++ b/app/crm/components/WorkOrderReadinessNotice.tsx
@@ -25,6 +25,14 @@ type Props = {
   onOpenCustomerCard?: (() => void) | null;
   /** Offertens redigeringsvy. Utelämnas när man redan står i den. */
   quoteHref?: string | null;
+  /**
+   * Hämtar kontrollen på nytt. Knappen till arbetsordern är avstängd så länge något saknas, och
+   * uppgifterna rättas på en ANNAN sida — utan en väg att kontrollera om blir en rättning som
+   * gjorts i en annan flik osynlig här, och knappen sitter kvar avstängd utan förklaring.
+   */
+  onRecheck?: (() => void) | null;
+  /** Sant medan omkontrollen pågår. */
+  rechecking?: boolean;
   className?: string;
 };
 
@@ -46,7 +54,7 @@ function IssueList({ issues, tone }: { issues: WorkOrderReadinessIssue[]; tone: 
   );
 }
 
-export default function WorkOrderReadinessNotice({ blockers, warnings, customerHref, onOpenCustomerCard, quoteHref, className }: Props) {
+export default function WorkOrderReadinessNotice({ blockers, warnings, customerHref, onOpenCustomerCard, quoteHref, onRecheck, rechecking = false, className }: Props) {
   if (blockers.length === 0 && warnings.length === 0) return null;
 
   // Bara de länkar som någon av fynden faktiskt pekar på — en "Öppna kundkortet" bredvid ett fynd
@@ -62,7 +70,7 @@ export default function WorkOrderReadinessNotice({ blockers, warnings, customerH
             {blockers.length === 1 ? 'En uppgift saknas' : `${blockers.length} uppgifter saknas`} innan arbetsordern kan skapas
           </p>
           <IssueList issues={blockers} tone="blocker" />
-          {(needsCustomerCard && (onOpenCustomerCard || customerHref)) || (needsQuote && quoteHref) ? (
+          {(needsCustomerCard && (onOpenCustomerCard || customerHref)) || (needsQuote && quoteHref) || onRecheck ? (
             <div className="mt-2 flex flex-wrap gap-2">
               {needsCustomerCard && onOpenCustomerCard ? (
                 <button type="button" onClick={onOpenCustomerCard} className={actionClass}>
@@ -77,6 +85,11 @@ export default function WorkOrderReadinessNotice({ blockers, warnings, customerH
                 <Link href={quoteHref} className={actionClass}>
                   Öppna offerten
                 </Link>
+              ) : null}
+              {onRecheck ? (
+                <button type="button" onClick={onRecheck} disabled={rechecking} className={cn(actionClass, 'disabled:opacity-60')}>
+                  {rechecking ? 'Kontrollerar…' : 'Kontrollera igen'}
+                </button>
               ) : null}
             </div>
           ) : null}

--- a/app/crm/components/WorkOrderReadinessNotice.tsx
+++ b/app/crm/components/WorkOrderReadinessNotice.tsx
@@ -1,0 +1,94 @@
+"use client";
+import Link from 'next/link';
+import { cn } from '@/lib/shared/cn';
+import type { WorkOrderReadinessIssue } from '@/lib/domains/crm/workOrderReadiness';
+
+// Checklistan mellan offert och arbetsorder.
+//
+// Poängen med att visa den FÖRE klicket: spärren sitter på servern och svarar med ett fel, men ett
+// fel som dyker upp efter att man tryckt lär bara ut att knappen är trasig. Listan säger i stället
+// vad som fattas och var det rättas — och eftersom både den och spärren läser
+// `evaluateWorkOrderReadiness` kan de inte säga emot varandra.
+//
+// Delad av offertformuläret och den delade offertpanelen (offertlistan + säljtavlan).
+
+type Props = {
+  blockers: WorkOrderReadinessIssue[];
+  warnings: WorkOrderReadinessIssue[];
+  /** Kundkortet — där adress, telefon, org.nr och personnummer faktiskt går att rätta. */
+  customerHref?: string | null;
+  /**
+   * Alternativ till `customerHref` för ytor som måste göra något innan de lämnar sidan.
+   * Offertformuläret lägger undan säljarens osparade utkast först — en rak länk därifrån hade
+   * ätit upp arbetet på vägen till kundkortet. Vinner över `customerHref` när båda är satta.
+   */
+  onOpenCustomerCard?: (() => void) | null;
+  /** Offertens redigeringsvy. Utelämnas när man redan står i den. */
+  quoteHref?: string | null;
+  className?: string;
+};
+
+const actionClass = 'rounded-lg border border-rose-300 bg-white px-2.5 py-1 text-[11px] font-medium text-rose-700 transition hover:border-rose-400';
+
+function IssueList({ issues, tone }: { issues: WorkOrderReadinessIssue[]; tone: 'blocker' | 'warning' }) {
+  return (
+    <ul className="m-0 grid list-none gap-1 p-0">
+      {issues.map((issue) => (
+        <li key={issue.field} className="flex gap-2 text-[11px] leading-snug">
+          <span aria-hidden className={cn('mt-[3px] h-1.5 w-1.5 shrink-0 rounded-full', tone === 'blocker' ? 'bg-rose-400' : 'bg-amber-400')} />
+          <span>
+            <span className="font-semibold">{issue.label}.</span>{' '}
+            <span className="font-normal">{issue.message}</span>
+          </span>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+export default function WorkOrderReadinessNotice({ blockers, warnings, customerHref, onOpenCustomerCard, quoteHref, className }: Props) {
+  if (blockers.length === 0 && warnings.length === 0) return null;
+
+  // Bara de länkar som någon av fynden faktiskt pekar på — en "Öppna kundkortet" bredvid ett fynd
+  // som rättas i offerten skickar säljaren åt fel håll.
+  const needsCustomerCard = blockers.some((b) => b.fixAt === 'customer_card');
+  const needsQuote = blockers.some((b) => b.fixAt === 'quote');
+
+  return (
+    <div className={cn('grid gap-2.5', className)}>
+      {blockers.length > 0 ? (
+        <div className="rounded-xl border border-rose-200 bg-rose-50 px-3.5 py-3 text-rose-800">
+          <p className="m-0 mb-1.5 text-xs font-semibold">
+            {blockers.length === 1 ? 'En uppgift saknas' : `${blockers.length} uppgifter saknas`} innan arbetsordern kan skapas
+          </p>
+          <IssueList issues={blockers} tone="blocker" />
+          {(needsCustomerCard && (onOpenCustomerCard || customerHref)) || (needsQuote && quoteHref) ? (
+            <div className="mt-2 flex flex-wrap gap-2">
+              {needsCustomerCard && onOpenCustomerCard ? (
+                <button type="button" onClick={onOpenCustomerCard} className={actionClass}>
+                  Öppna kundkortet
+                </button>
+              ) : needsCustomerCard && customerHref ? (
+                <Link href={customerHref} className={actionClass}>
+                  Öppna kundkortet
+                </Link>
+              ) : null}
+              {needsQuote && quoteHref ? (
+                <Link href={quoteHref} className={actionClass}>
+                  Öppna offerten
+                </Link>
+              ) : null}
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+
+      {warnings.length > 0 ? (
+        <div className="rounded-xl border border-amber-200 bg-amber-50 px-3.5 py-3 text-amber-800">
+          <p className="m-0 mb-1.5 text-xs font-semibold">Värt att fylla i först</p>
+          <IssueList issues={warnings} tone="warning" />
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/app/crm/offerter/QuoteFormClient.tsx
+++ b/app/crm/offerter/QuoteFormClient.tsx
@@ -1143,6 +1143,11 @@ export default function QuoteFormClient({ quoteId, canReassign = false }: { quot
   // räknas ut här: adress, telefon och org.nr bor på kundkortet och finns inte i formulärets draft,
   // och en andra uppsättning regler i klienten hade förr eller senare sagt emot spärren.
   const [readiness, setReadiness] = useState<{ blockers: WorkOrderReadinessIssue[]; warnings: WorkOrderReadinessIssue[] } | null>(null);
+  // Bumpas av "Kontrollera igen" och hämtar om kontrollen. En räknare i stället för en utbruten
+  // funktion: effekten nedan äger hämtningen, och två vägar in i samma fetch hade kunnat lämna
+  // kvar ett svar från den ena efter att den andra sagt något nytt.
+  const [readinessNonce, setReadinessNonce] = useState(0);
+  const [rechecking, setRechecking] = useState(false);
   const [pnValue, setPnValue] = useState('');
   const [draft, setDraft] = useState<QuoteDraft>(initialDraft);
   // Accordion: id of the single open article row. Starts on the empty starter row; adding
@@ -2182,9 +2187,10 @@ export default function QuoteFormClient({ quoteId, canReassign = false }: { quot
         if (cancelled || !json?.ok) return;
         setReadiness({ blockers: json.data?.blockers ?? [], warnings: json.data?.warnings ?? [] });
       })
-      .catch(() => { /* tyst — servern nekar ändå om något saknas */ });
+      .catch(() => { /* tyst — servern nekar ändå om något saknas */ })
+      .finally(() => { if (!cancelled) setRechecking(false); });
     return () => { cancelled = true; };
-  }, [readinessQuoteId]);
+  }, [readinessQuoteId, readinessNonce]);
 
   // TG räknas på SAMMA belopp som visas på skärmen (effectiveRows.rowTotal), inte ur raden på nytt.
   // Formuläret prissätter auto-prissatta rader med sin egen stub medan pricing.ts ger dem 0 — räknade
@@ -2207,6 +2213,10 @@ export default function QuoteFormClient({ quoteId, canReassign = false }: { quot
   }
 
   const hasWorkOrder = Boolean(loadedQuote?.work_order_id || loadedQuote?.work_order_number);
+  // Avstängd bara när vi VET att något saknas. Gick kontrollen inte att hämta lämnas knappen
+  // aktiv — servern spärrar ändå, och en knapp som är död för att ett bakgrundsanrop failade är
+  // värre än ett tydligt fel efter klicket.
+  const workOrderBlocked = (readiness?.blockers.length ?? 0) > 0;
   const configuredRows = effectiveRows.filter((r) => r.isConfigured);
   const hasAnyLineItemInput = draft.items.some((item) => item.article_name || item.m2 || item.quantity || item.unit_price);
 
@@ -2916,7 +2926,7 @@ export default function QuoteFormClient({ quoteId, canReassign = false }: { quot
                   <button
                     type="button"
                     onClick={createWorkOrderFromQuote}
-                    disabled={draft.status !== 'won' || hasWorkOrder || creatingWorkOrder}
+                    disabled={draft.status !== 'won' || hasWorkOrder || creatingWorkOrder || workOrderBlocked}
                     className="rounded-lg border border-slate-900 bg-slate-900 px-3.5 py-2 text-sm font-medium text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:border-slate-200 disabled:bg-white disabled:text-slate-400"
                   >
                     {creatingWorkOrder ? 'Skapar…' : hasWorkOrder ? 'Skapad' : 'Skapa arbetsorder'}
@@ -2931,6 +2941,8 @@ export default function QuoteFormClient({ quoteId, canReassign = false }: { quot
                   onOpenCustomerCard={
                     loadedQuote.customer_id ? () => goToCustomerPage(`/crm/kunder/${loadedQuote.customer_id}`) : null
                   }
+                  onRecheck={readiness.blockers.length > 0 ? () => { setRechecking(true); setReadinessNonce((n) => n + 1); } : null}
+                  rechecking={rechecking}
                 />
               ) : null}
             </div>

--- a/app/crm/offerter/QuoteFormClient.tsx
+++ b/app/crm/offerter/QuoteFormClient.tsx
@@ -34,6 +34,8 @@ import {
   type CustomerDerivedValues,
 } from './quoteSerializers';
 import { safeReturnTo, withReturnTo } from '@/app/crm/lib/returnTo';
+import type { WorkOrderReadinessIssue } from '@/lib/domains/crm/workOrderReadiness';
+import WorkOrderReadinessNotice from '@/app/crm/components/WorkOrderReadinessNotice';
 import { resolveCrmContact } from '@/lib/domains/crm/contacts';
 import {
   buildMeasurementLines,
@@ -1137,6 +1139,10 @@ export default function QuoteFormClient({ quoteId, canReassign = false }: { quot
   // beforeunload text can't be customised, so we show our own dialog where we can). Holds the
   // intended destination so the same dialog serves the back button AND intercepted link clicks.
   const [pendingLeaveHref, setPendingLeaveHref] = useState<string | null>(null);
+  // Vad som saknas innan offerten kan bli en arbetsorder. Hämtas från servern i stället för att
+  // räknas ut här: adress, telefon och org.nr bor på kundkortet och finns inte i formulärets draft,
+  // och en andra uppsättning regler i klienten hade förr eller senare sagt emot spärren.
+  const [readiness, setReadiness] = useState<{ blockers: WorkOrderReadinessIssue[]; warnings: WorkOrderReadinessIssue[] } | null>(null);
   const [pnValue, setPnValue] = useState('');
   const [draft, setDraft] = useState<QuoteDraft>(initialDraft);
   // Accordion: id of the single open article row. Starts on the empty starter row; adding
@@ -2033,6 +2039,15 @@ export default function QuoteFormClient({ quoteId, canReassign = false }: { quot
           setRotPropertyPromptOpen(true);
           return;
         }
+        // Fler än ett fynd: visa hela listan i stället för en prompt som bara lagar en sak. Listan
+        // kommer med i svaret, så den som redan stod på sidan ser den uppdaterad direkt.
+        if (json?.errorDetails?.code === 'crm_work_order_incomplete') {
+          const details = json?.errorDetails?.details as { blockers?: WorkOrderReadinessIssue[]; warnings?: WorkOrderReadinessIssue[] } | undefined;
+          const blockers = details?.blockers ?? [];
+          setReadiness({ blockers, warnings: details?.warnings ?? [] });
+          toast.error(blockers.length > 1 ? `${blockers.length} uppgifter saknas innan arbetsordern kan skapas` : (json?.error || 'Uppgifter saknas'));
+          return;
+        }
         toast.error(json?.error || 'Kunde inte skapa arbetsorder');
         return;
       }
@@ -2144,6 +2159,30 @@ export default function QuoteFormClient({ quoteId, canReassign = false }: { quot
       .catch(() => { /* tyst — TG är hjälpinformation, inte något offerten hänger på */ });
     return () => { cancelled = true; };
   }, [articleNumbersOnRows]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Checklistan hämtas när offerten är vunnen och ännu inte blivit en order — alltså precis när
+  // knappen är tänkt att gå att trycka på. Tyst vid fel: listan är hjälp på vägen, spärren sitter
+  // ändå på servern.
+  //
+  // ⚠️ Hooken måste ligga ovanför `if (loading)`-returnen nedan. En hook under en tidig return
+  // kraschar sidan med "Rendered more hooks than during the previous render" — se .eslintrc.json.
+  const readinessQuoteId =
+    isEditing && quoteId && loadedQuote?.status === 'won' && !loadedQuote?.work_order_id && !loadedQuote?.work_order_number
+      ? quoteId
+      : null;
+
+  useEffect(() => {
+    if (!readinessQuoteId) { setReadiness(null); return; }
+    let cancelled = false;
+    fetch(`/api/crm/quotes/${readinessQuoteId}/work-order`, { cache: 'no-store' })
+      .then((r) => r.json().catch(() => ({})))
+      .then((json) => {
+        if (cancelled || !json?.ok) return;
+        setReadiness({ blockers: json.data?.blockers ?? [], warnings: json.data?.warnings ?? [] });
+      })
+      .catch(() => { /* tyst — servern nekar ändå om något saknas */ });
+    return () => { cancelled = true; };
+  }, [readinessQuoteId]);
 
   // TG räknas på SAMMA belopp som visas på skärmen (effectiveRows.rowTotal), inte ur raden på nytt.
   // Formuläret prissätter auto-prissatta rader med sin egen stub medan pricing.ts ger dem 0 — räknade
@@ -2882,6 +2921,16 @@ export default function QuoteFormClient({ quoteId, canReassign = false }: { quot
                   </button>
                 </div>
               </div>
+              {!hasWorkOrder && draft.status === 'won' && readiness ? (
+                <WorkOrderReadinessNotice
+                  className="mt-3"
+                  blockers={readiness.blockers}
+                  warnings={readiness.warnings}
+                  onOpenCustomerCard={
+                    loadedQuote.customer_id ? () => goToCustomerPage(`/crm/kunder/${loadedQuote.customer_id}`) : null
+                  }
+                />
+              ) : null}
             </div>
           ) : null}
 

--- a/app/crm/offerter/QuoteFormClient.tsx
+++ b/app/crm/offerter/QuoteFormClient.tsx
@@ -2044,7 +2044,9 @@ export default function QuoteFormClient({ quoteId, canReassign = false }: { quot
         if (json?.errorDetails?.code === 'crm_work_order_incomplete') {
           const details = json?.errorDetails?.details as { blockers?: WorkOrderReadinessIssue[]; warnings?: WorkOrderReadinessIssue[] } | undefined;
           const blockers = details?.blockers ?? [];
-          setReadiness({ blockers, warnings: details?.warnings ?? [] });
+          // Bara när listan faktiskt bär något. Ett nekat anrop med tom lista betyder inte att
+          // allt är ifyllt — att skriva över checklistan med den hade sagt motsatsen till felet.
+          if (blockers.length > 0) setReadiness({ blockers, warnings: details?.warnings ?? [] });
           toast.error(blockers.length > 1 ? `${blockers.length} uppgifter saknas innan arbetsordern kan skapas` : (json?.error || 'Uppgifter saknas'));
           return;
         }

--- a/app/crm/saljtavla/SaljtavlaClient.tsx
+++ b/app/crm/saljtavla/SaljtavlaClient.tsx
@@ -12,6 +12,7 @@ import { crm, quoteStatusMeta, type QuoteStatus } from '@/app/crm/lib/crmTokens'
 import { withReturnTo } from '@/app/crm/lib/returnTo';
 import { quoteCustomerName, isQuoteOverdue } from '@/app/crm/lib/quoteDisplay';
 import QuoteDetailPanel from '@/app/crm/components/QuoteDetailPanel';
+import CrmConfirmDialog from '@/app/crm/components/CrmConfirmDialog';
 import useDocumentEmail from '@/app/crm/components/useDocumentEmail';
 import {
   quoteBoardColumn,
@@ -88,6 +89,10 @@ export default function SaljtavlaClient({ currentUserId }: { currentUserId: stri
   // unknown — [MINE] with a null id would filter every quote out and blank the board.
   const [assigneeFilter, setAssigneeFilter] = useState<AssigneeFilterValue>(currentUserId ? [MINE] : []);
   const [movingId, setMovingId] = useState<string | null>(null);
+  // Draget är redan släppt när dialogen visas. Flytten läggs undan här och körs först på
+  // bekräftelse — avbryts den händer ingenting, för den optimistiska flytten ligger efter
+  // frågan och kortet har alltså aldrig lämnat sin kolumn.
+  const [pendingWonMove, setPendingWonMove] = useState<{ quoteId: string; hasProspect: boolean } | null>(null);
   const [draggedId, setDraggedId] = useState<string | null>(null);
   const [dragOverColumn, setDragOverColumn] = useState<SaljtavlaColumn | null>(null);
   // Quote rows carry only the internal AO number; the work order's Fortnox order
@@ -193,19 +198,23 @@ export default function SaljtavlaClient({ currentUserId }: { currentUserId: stri
     return byColumn;
   }, [scopedQuotes, primaryById]);
 
+  // Won is a meaningful transition — confirm it. A linked prospect is converted to
+  // a customer on the server, so only mention that when the quote actually has one.
+  function requestMoveToStatus(quoteId: string, nextStatus: QuoteStatus) {
+    const currentItem = quotes.find((q) => q.id === quoteId);
+    if (!currentItem || currentItem.status === nextStatus) return;
+    if (nextStatus === 'won') {
+      setPendingWonMove({ quoteId, hasProspect: Boolean(currentItem.prospect_id) });
+      return;
+    }
+    void moveToStatus(quoteId, nextStatus);
+  }
+
   async function moveToStatus(quoteId: string, nextStatus: QuoteStatus) {
     const currentItem = quotes.find((q) => q.id === quoteId);
     if (!currentItem || currentItem.status === nextStatus) return;
 
-    // Won is a meaningful transition — confirm it. A linked prospect is converted to
-    // a customer on the server, so only mention that when the quote actually has one.
-    if (nextStatus === 'won') {
-      const message = currentItem.prospect_id
-        ? 'Markera offerten som vunnen? En kopplad prospekt konverteras då till kund.'
-        : 'Markera offerten som vunnen?';
-      if (!window.confirm(message)) return;
-    }
-
+    setPendingWonMove(null);
     setMovingId(quoteId);
     const optimistic = { ...currentItem, status: nextStatus, updated_at: new Date().toISOString() };
     setQuotes((current) => current.map((q) => (q.id === quoteId ? optimistic : q)));
@@ -251,7 +260,7 @@ export default function SaljtavlaClient({ currentUserId }: { currentUserId: stri
     setDraggedId(null);
     setDragOverColumn(null);
     if (!id) return;
-    void moveToStatus(id, column);
+    requestMoveToStatus(id, column);
   }
 
   const totalVisible = scopedQuotes.length;
@@ -341,6 +350,21 @@ export default function SaljtavlaClient({ currentUserId }: { currentUserId: stri
           documentEmail={documentEmail}
           onClose={() => setDetailQuoteId(null)}
           onQuoteChanged={(patch) => setQuotes((current) => current.map((q) => (q.id === patch.id ? { ...q, ...patch } : q)))}
+        />
+      ) : null}
+
+      {pendingWonMove ? (
+        <CrmConfirmDialog
+          title="Markera offerten som vunnen?"
+          message={
+            pendingWonMove.hasProspect
+              ? 'Ett kopplat prospekt konverteras då till kund. Det går inte att ångra härifrån.'
+              : undefined
+          }
+          confirmLabel="Markera som vunnen"
+          busy={movingId === pendingWonMove.quoteId}
+          onConfirm={() => void moveToStatus(pendingWonMove.quoteId, 'won')}
+          onCancel={() => setPendingWonMove(null)}
         />
       ) : null}
 

--- a/lib/domains/crm/work-orders.ts
+++ b/lib/domains/crm/work-orders.ts
@@ -251,17 +251,21 @@ function getClientName(source: QuoteSource) {
 const readinessCustomerSelect =
   'organization_number, personal_number, email, phone, mobile, visit_address, contacts:crm_customer_contacts(name, phone, email, is_primary)';
 
+// ⚠️ Felet får INTE svaljas. En tillfälligt misslyckad läsning skulle annars vara omöjlig att
+// skilja från "kunden har inga uppgifter": kontrollen hade hittat på spärrar för adress, telefon
+// och org.nr och bett säljaren fylla i fält som redan är ifyllda. Anroparen avbryter i stället.
 async function fetchReadinessCustomer(
   supabase: SupabaseClient,
   customerId: string | null,
-): Promise<ReadinessCustomerSource> {
-  if (!customerId) return null;
-  const { data } = await supabase
+): Promise<{ customer: ReadinessCustomerSource; error: { message: string } | null }> {
+  if (!customerId) return { customer: null, error: null };
+  const { data, error } = await supabase
     .from('crm_customers')
     .select(readinessCustomerSelect)
     .eq('id', customerId)
     .maybeSingle();
-  return (data as ReadinessCustomerSource) ?? null;
+  if (error) return { customer: null, error };
+  return { customer: (data as ReadinessCustomerSource) ?? null, error: null };
 }
 
 /**
@@ -282,7 +286,12 @@ export async function getWorkOrderReadinessForQuote(supabase: SupabaseClient, qu
   if (error) return { data: null, error, reason: 'quote_fetch_failed' as const };
   if (!quote) return { data: null, error: { message: 'Offerten hittades inte' }, reason: 'not_found' as const };
 
-  const customer = await fetchReadinessCustomer(supabase, (quote as { customer_id: string | null }).customer_id);
+  const { customer, error: customerError } = await fetchReadinessCustomer(
+    supabase,
+    (quote as { customer_id: string | null }).customer_id,
+  );
+  if (customerError) return { data: null, error: customerError, reason: 'customer_fetch_failed' as const };
+
   const readiness: WorkOrderReadiness = evaluateWorkOrderReadiness(quote, customer);
 
   return { data: readiness, error: null, reason: null };
@@ -317,13 +326,20 @@ export async function createCrmWorkOrderFromQuote(supabase: SupabaseClient, quot
   // auto-pushar den färdiga ordern till Fortnox — efter den punkten är en glömd uppgift ett
   // bokföringsärende i stället för ett formulärfel. Kundkortet läses om eftersom adress, telefon
   // och org.nr inte går att redigera i offertformuläret; se workOrderReadiness.ts.
-  const customerRow = await fetchReadinessCustomer(supabase, quote.customer_id);
+  const { customer: customerRow, error: customerError } = await fetchReadinessCustomer(supabase, quote.customer_id);
+  if (customerError) {
+    return { data: null, error: customerError, reason: 'customer_fetch_failed' as const };
+  }
+
   const readiness = evaluateWorkOrderReadiness(quote, customerRow);
 
   if (!readiness.ready) {
-    // Meddelandet är första fyndets, så äldre ytor som bara visar `error` fortfarande säger något
-    // begripligt. Hela listan hämtar routen via getWorkOrderReadinessForQuote.
-    return { data: null, error: { message: readiness.blockers[0].message }, reason: 'incomplete' as const };
+    // Kontrollen skickas MED, den görs inte om i routen. En andra körning kan svara annorlunda —
+    // eller misslyckas — och då hade svaret burit ett felmeddelande om saknade uppgifter men en
+    // tom lista, vilket i klienten läses som "inget saknas" och torkar checklistan från skärmen.
+    // Meddelandet är första fyndets, så ytor som bara visar `error` säger fortfarande något
+    // begripligt.
+    return { data: null, error: { message: readiness.blockers[0].message }, reason: 'incomplete' as const, readiness };
   }
 
   // "Er referens" blir ett EGET fält på arbetsordern. På offerten är den samma sak som

--- a/lib/domains/crm/work-orders.ts
+++ b/lib/domains/crm/work-orders.ts
@@ -5,6 +5,11 @@ import { resolveCrmContact, type CrmContactSource } from './contacts';
 import { computePricing, type PricingLineItem } from './pricing';
 import { activeLineItems, computeInvoiceState, validateLineItemEdit, type InvoiceRound } from '@/lib/domains/fortnox/partialInvoices';
 import { isValidPersonalNumber, PERSONAL_NUMBER_ERROR } from './personalNumber';
+import {
+  evaluateWorkOrderReadiness,
+  type ReadinessCustomerSource,
+  type WorkOrderReadiness,
+} from './workOrderReadiness';
 import type { CreateWorkOrderFileInput } from './workOrderFiles/types';
 
 export const crmWorkOrderSelect = `
@@ -240,23 +245,47 @@ function getClientName(source: QuoteSource) {
     || source.project_name;
 }
 
-function getWorkAddress(source: QuoteSource) {
-  const s = source.customer_snapshot;
-  // A separate work address (job site) is stored on the snapshot only when a street is set
-  // and it differs from the customer address (buildCustomerSnapshot enforces this). The
-  // street is the anchor: when present it IS the primary address installers navigate to
-  // (postal/city taken as entered, blank if the seller left them); otherwise the whole
-  // address falls back to the customer address (old quotes + the private case unchanged).
-  const hasWorkAddress = Boolean(s?.delivery_address);
-  return {
-    street_address: (hasWorkAddress ? s?.delivery_address : (s?.visit_address || s?.street_address)) || null,
-    postal_code: (hasWorkAddress ? s?.delivery_postal_code : s?.postal_code) || null,
-    city: (hasWorkAddress ? s?.delivery_city : s?.city) || null,
-    // Primary already holds the job site when one exists, so don't duplicate it as a
-    // separate "Leverans:" line. Kept null here; the work-order detail page can still set one.
-    delivery_address: null,
-    invoice_address: s?.invoice_address || null,
-  };
+
+// Kundkortets halva av fullständighetskontrollen. Fälten är exakt de `resolveCrmContact` och
+// `evaluateWorkOrderReadiness` läser — inget mer, eftersom raden bara används för att fylla luckor.
+const readinessCustomerSelect =
+  'organization_number, personal_number, email, phone, mobile, visit_address, contacts:crm_customer_contacts(name, phone, email, is_primary)';
+
+async function fetchReadinessCustomer(
+  supabase: SupabaseClient,
+  customerId: string | null,
+): Promise<ReadinessCustomerSource> {
+  if (!customerId) return null;
+  const { data } = await supabase
+    .from('crm_customers')
+    .select(readinessCustomerSelect)
+    .eq('id', customerId)
+    .maybeSingle();
+  return (data as ReadinessCustomerSource) ?? null;
+}
+
+/**
+ * Vad som saknas innan offerten kan bli en arbetsorder — samma bedömning som skapandet gör.
+ *
+ * Finns för att kunna svara på frågan UTAN att försöka skapa ordern: offertformuläret och den
+ * delade offertpanelen visar listan innan säljaren trycker, i stället för att ett fel dyker upp
+ * efteråt. Att den delar funktion med `createCrmWorkOrderFromQuote` är hela poängen — en egen
+ * kopia i klienten hade glidit isär från det servern faktiskt kräver.
+ */
+export async function getWorkOrderReadinessForQuote(supabase: SupabaseClient, quoteId: string) {
+  const { data: quote, error } = await supabase
+    .from('crm_quotes')
+    .select('id, customer_id, quote_type, customer_snapshot, rot_details, line_items, internal_handoff, status, work_order_id')
+    .eq('id', quoteId)
+    .maybeSingle();
+
+  if (error) return { data: null, error, reason: 'quote_fetch_failed' as const };
+  if (!quote) return { data: null, error: { message: 'Offerten hittades inte' }, reason: 'not_found' as const };
+
+  const customer = await fetchReadinessCustomer(supabase, (quote as { customer_id: string | null }).customer_id);
+  const readiness: WorkOrderReadiness = evaluateWorkOrderReadiness(quote, customer);
+
+  return { data: readiness, error: null, reason: null };
 }
 
 export async function createCrmWorkOrderFromQuote(supabase: SupabaseClient, quoteId: string, actorUserId: string) {
@@ -284,56 +313,35 @@ export async function createCrmWorkOrderFromQuote(supabase: SupabaseClient, quot
     return { data: null, error: { message: 'Arbetsorder finns redan för offerten' }, reason: 'already_created' as const };
   }
 
-  // Fortnox needs a private customer's personnummer to invoice the order. The quote snapshot may
-  // predate it (the quote was saved before the number was known), so fall back to the customer's
-  // current value and bake it into the order snapshot. If neither has it, block — the caller
-  // collects it and saves it on the customer before retrying.
+  // Fullständighetskontrollen. Allt som saknas fångas HÄR, före insert:en, eftersom routen
+  // auto-pushar den färdiga ordern till Fortnox — efter den punkten är en glömd uppgift ett
+  // bokföringsärende i stället för ett formulärfel. Kundkortet läses om eftersom adress, telefon
+  // och org.nr inte går att redigera i offertformuläret; se workOrderReadiness.ts.
+  const customerRow = await fetchReadinessCustomer(supabase, quote.customer_id);
+  const readiness = evaluateWorkOrderReadiness(quote, customerRow);
+
+  if (!readiness.ready) {
+    // Meddelandet är första fyndets, så äldre ytor som bara visar `error` fortfarande säger något
+    // begripligt. Hela listan hämtar routen via getWorkOrderReadinessForQuote.
+    return { data: null, error: { message: readiness.blockers[0].message }, reason: 'incomplete' as const };
+  }
+
   // "Er referens" blir ett EGET fält på arbetsordern. På offerten är den samma sak som
   // contact_name (fältet heter "Er referens (kontaktperson)" och är obligatoriskt där), men från
   // och med ordern skiljer sig de två: contact_name blir kundkontakten — vem vi ringer — och får
   // ändras fritt, medan your_reference är det som går till Fortnox YourReference. Utan den här
   // frysningen vid orderskapandet skulle en rättad kontaktperson skriva om kundens fakturareferens.
-  let orderSnapshot = (quote.customer_snapshot || {}) as Record<string, unknown>;
-  if (orderSnapshot.your_reference == null) {
-    orderSnapshot = { ...orderSnapshot, your_reference: orderSnapshot.contact_name ?? null };
-  }
-  if (quote.quote_type === 'private' && !orderSnapshot.personal_number) {
-    let personalNumber: string | null = null;
-    if (quote.customer_id) {
-      const { data: cust } = await supabase
-        .from('crm_customers').select('personal_number').eq('id', quote.customer_id).maybeSingle();
-      personalNumber = (cust as { personal_number?: string | null } | null)?.personal_number ?? null;
-    }
-    if (!personalNumber) {
-      return { data: null, error: { message: 'Personnummer krävs för privatkund innan order kan skapas' }, reason: 'missing_personal_number' as const };
-    }
-    orderSnapshot = { ...orderSnapshot, personal_number: personalNumber };
-  }
-
-  // Samma krav som på standalone-ordern, och det gäller BÅDE numret som redan låg i offertens
-  // snapshot och det som just hämtades från kundkortet: tio siffror ger trasiga ROT-uppgifter i
-  // Fortnox.
-  if (quote.quote_type === 'private' && !isValidPersonalNumber(String(orderSnapshot.personal_number ?? ''))) {
-    return { data: null, error: { message: PERSONAL_NUMBER_ERROR }, reason: 'invalid_personal_number' as const };
-  }
-
-  // ROT can only be filed with the property identified: fastighetsbeteckning for a småhus, or the
-  // BRF's org.nr for a bostadsrätt (Skatteverket takes either — never both). It is deliberately
-  // OPTIONAL on the quote: nothing is approved yet and the seller often doesn't have it while
-  // quoting. The order is where it becomes mandatory, because the order is the point of no return —
-  // the route auto-pushes to Fortnox the moment the order exists, and Fortnox has NO API field for
-  // the designation (whoever finalizes the invoice types it into the husarbete dialog, reading it
-  // off the text row / YourOrderNumber we send). An order created without it therefore reaches the
-  // invoice with nothing to type in, and the deduction can't be filed. This is the last point where
-  // a human is still in the loop.
-  const rot = (quote.rot_details || {}) as { enabled?: boolean | null; property_designation?: string | null; brf_org_number?: string | null };
-  if (rot.enabled === true && !rot.property_designation?.trim() && !rot.brf_org_number?.trim()) {
-    return {
-      data: null,
-      error: { message: 'Fastighetsbeteckning (eller BRF org.nr för bostadsrätt) krävs för ROT innan order kan skapas. Öppna offerten och fyll i den.' },
-      reason: 'missing_rot_property' as const,
-    };
-  }
+  //
+  // De upplösta värdena bakas in i snapshoten: kontrollen ovan godkände dem, och skrev vi något
+  // annat till ordern hade spärren prövat en uppgift ordern sedan inte bar. Snapshotens egna
+  // värden vinner alltid — `resolved` faller bara tillbaka på kundkortet när fältet är tomt.
+  const orderSnapshot: Record<string, unknown> = {
+    ...(quote.customer_snapshot || {}),
+    your_reference: quote.customer_snapshot?.your_reference ?? quote.customer_snapshot?.contact_name ?? null,
+    personal_number: quote.quote_type === 'private' ? readiness.resolved.personalNumber : (quote.customer_snapshot?.personal_number ?? null),
+    organization_number: quote.quote_type === 'business' ? readiness.resolved.organizationNumber : (quote.customer_snapshot?.organization_number ?? null),
+    phone: readiness.resolved.phone,
+  };
 
   const orderNumber = buildWorkOrderNumber(quote.id);
 
@@ -348,7 +356,7 @@ export async function createCrmWorkOrderFromQuote(supabase: SupabaseClient, quot
       client_name: getClientName(quote),
       quote_type: quote.quote_type,
       customer_snapshot: orderSnapshot,
-      work_address: getWorkAddress(quote),
+      work_address: readiness.resolved.workAddress,
       pricing_summary: quote.pricing_summary || {},
       line_items: quote.line_items || [],
       rot_details: quote.rot_details || {},

--- a/lib/domains/crm/workOrderReadiness.ts
+++ b/lib/domains/crm/workOrderReadiness.ts
@@ -1,0 +1,301 @@
+/**
+ * Fullständighetskontrollen mellan offert och arbetsorder.
+ *
+ * Orderskapandet är den sista punkten där en människa fortfarande är kvar i loopen: routen
+ * auto-pushar till Fortnox i samma andetag som ordern finns, och därefter är felet ett
+ * bokföringsärende i stället för ett formulärfel. Personnumret och ROT-fastighetsbeteckningen
+ * spärrade redan här av precis det skälet — den här modulen samlar dem med resten av de uppgifter
+ * som visade sig kunna saknas rakt igenom kedjan.
+ *
+ * ⚠️ VARFÖR KUNDKORTET LÄSES OM, INTE BARA OFFERTENS SNAPSHOT: adress, telefon och org.nr går inte
+ * att redigera i offertformuläret — de är en ögonblicksbild av kundkortet, satt när kunden väljs.
+ * Utan omläsningen hade en säljare som gör precis det spärren ber om (fyller i adressen på
+ * kundkortet) blockerats ändå, av en snapshot som skrevs innan. Kundkortet vinner därför när
+ * snapshoten är tom — aldrig tvärtom, en ifylld snapshot är ett medvetet val för just den offerten.
+ *
+ * Funktionen är ren och returnerar BÅDE fynden och de värden som lösts upp, så att
+ * `createCrmWorkOrderFromQuote` bakar in exakt det som kontrollerades i ordersnapshoten. Räknade
+ * anroparen ut adressen själv skulle de två kunna glida isär, och spärren hade godkänt en adress
+ * som ordern sedan inte bar.
+ */
+
+import { resolveCrmContact, type CrmContactSource } from './contacts';
+import { isValidPersonalNumber, PERSONAL_NUMBER_ERROR } from './personalNumber';
+
+export type WorkOrderReadinessField =
+  | 'customer_link'
+  | 'personal_number'
+  | 'organization_number'
+  | 'work_address'
+  | 'contact_phone'
+  | 'rot_property'
+  | 'line_items'
+  | 'installation_date'
+  | 'handoff_notes';
+
+export type WorkOrderReadinessIssue = {
+  field: WorkOrderReadinessField;
+  /** Kort rubrik i checklistan. */
+  label: string;
+  /** Vad som saknas och varför det spelar roll. */
+  message: string;
+  /** Var uppgiften rättas — styr vilken länk checklistan visar. */
+  fixAt: 'customer_card' | 'quote';
+};
+
+type AddressParts = {
+  street_address: string | null;
+  postal_code: string | null;
+  city: string | null;
+};
+
+export type WorkOrderReadinessResolved = {
+  personalNumber: string | null;
+  organizationNumber: string | null;
+  phone: string | null;
+  /** Adressen installatörerna navigerar till, med kundkortet som sista utväg. */
+  workAddress: AddressParts & { delivery_address: null; invoice_address: string | null };
+};
+
+export type WorkOrderReadiness = {
+  ready: boolean;
+  blockers: WorkOrderReadinessIssue[];
+  warnings: WorkOrderReadinessIssue[];
+  resolved: WorkOrderReadinessResolved;
+};
+
+export type ReadinessQuoteSource = {
+  quote_type?: 'private' | 'business' | null;
+  customer_id?: string | null;
+  customer_snapshot?: Record<string, unknown> | null;
+  rot_details?: { enabled?: boolean | null; property_designation?: string | null; brf_org_number?: string | null } | null;
+  line_items?: Array<Record<string, unknown>> | null;
+  internal_handoff?: { desired_installation_date?: string | null; handoff_notes?: string | null } | null;
+};
+
+export type ReadinessCustomerSource =
+  | (CrmContactSource & {
+      organization_number?: string | null;
+      personal_number?: string | null;
+      visit_address?: Record<string, string | null> | null;
+    })
+  | null;
+
+function text(value: unknown): string | null {
+  if (value == null) return null;
+  const trimmed = String(value).trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+/**
+ * Adressen som ordern ska bära.
+ *
+ * Gatan är ankaret, precis som i `buildCustomerSnapshot`: en separat arbetsadress lagras bara när
+ * gatan är ifylld och skiljer sig från kundadressen, och då gäller dess postnummer/ort SOM IFYLLDA
+ * (de lånas aldrig från kundadressen — det skulle ge fel ort). Saknas allt på offerten faller vi
+ * tillbaka på kundkortets besöksadress, vilket räddar gamla offerter vars snapshot skrevs innan
+ * adressen fanns på kortet.
+ */
+function resolveWorkAddress(
+  snapshot: Record<string, unknown>,
+  customer: ReadinessCustomerSource,
+): AddressParts {
+  const hasWorkAddress = Boolean(text(snapshot.delivery_address));
+  if (hasWorkAddress) {
+    return {
+      street_address: text(snapshot.delivery_address),
+      postal_code: text(snapshot.delivery_postal_code),
+      city: text(snapshot.delivery_city),
+    };
+  }
+
+  const snapshotStreet = text(snapshot.visit_address) || text(snapshot.street_address);
+  if (snapshotStreet) {
+    return {
+      street_address: snapshotStreet,
+      postal_code: text(snapshot.postal_code),
+      city: text(snapshot.city),
+    };
+  }
+
+  const visit = (customer?.visit_address || {}) as Record<string, string | null>;
+  return {
+    street_address: text(visit.street) || text(visit.street_address),
+    postal_code: text(visit.postal_code),
+    city: text(visit.city),
+  };
+}
+
+const ADDRESS_PART_LABELS: Array<[keyof AddressParts, string]> = [
+  ['street_address', 'gatuadress'],
+  ['postal_code', 'postnummer'],
+  ['city', 'ort'],
+];
+
+function joinSwedish(parts: string[]): string {
+  if (parts.length <= 1) return parts.join('');
+  return parts.slice(0, -1).join(', ') + ' och ' + parts[parts.length - 1];
+}
+
+/**
+ * Har offerten en rad som faktiskt bär något? Samma villkor som offertvalideringen använder för
+ * att skilja en påbörjad rad från en tom platshållare (`app/api/crm/quotes/_lib.ts`).
+ */
+function hasPopulatedLineItem(lineItems: Array<Record<string, unknown>>): boolean {
+  return lineItems.some((item) => text(item.article_name) || text(item.m2) || text(item.quantity) || text(item.unit_price));
+}
+
+export function evaluateWorkOrderReadiness(
+  quote: ReadinessQuoteSource,
+  customer: ReadinessCustomerSource,
+): WorkOrderReadiness {
+  const snapshot = (quote.customer_snapshot || {}) as Record<string, unknown>;
+  const isPrivate = quote.quote_type === 'private';
+  const blockers: WorkOrderReadinessIssue[] = [];
+  const warnings: WorkOrderReadinessIssue[] = [];
+
+  const personalNumber = text(snapshot.personal_number) || text(customer?.personal_number);
+  const organizationNumber = text(snapshot.organization_number) || text(customer?.organization_number);
+  const contact = customer ? resolveCrmContact(customer) : { name: '', email: '', phone: '' };
+  const phone = text(snapshot.phone) || text(snapshot.end_contact_phone) || text(contact.phone);
+  const workAddress = resolveWorkAddress(snapshot, customer);
+
+  // 1. Kundkopplingen först: den är förutsättningen för att de andra ens går att slå upp, och
+  //    utan den kan ordern aldrig nå Fortnox (pushen resolvar kundnumret via customer_id).
+  if (!text(quote.customer_id)) {
+    blockers.push({
+      field: 'customer_link',
+      label: 'Kund i kundregistret',
+      message: 'Offerten är inte kopplad till en kund i kundregistret. Utan kopplingen får arbetsordern ingen kund och kan inte synkas till Fortnox.',
+      fixAt: 'quote',
+    });
+  }
+
+  // 2. Personnummer på privatkund — Fortnox OrganisationNumber. Tio siffror dödar ROT- och
+  //    husarbetesuppgifterna TYST (FORTNOX_INTEGRATION.md 4e), så formatet prövas här också.
+  if (isPrivate && !personalNumber) {
+    blockers.push({
+      field: 'personal_number',
+      label: 'Personnummer',
+      message: 'Personnummer krävs för privatkund innan order kan skapas',
+      fixAt: 'customer_card',
+    });
+  } else if (isPrivate && !isValidPersonalNumber(personalNumber as string)) {
+    blockers.push({
+      field: 'personal_number',
+      label: 'Personnummer',
+      message: PERSONAL_NUMBER_ERROR,
+      fixAt: 'customer_card',
+    });
+  }
+
+  // 3. Org.nr på företagskund — motsvarigheten på andra sidan: fakturan hittar inte rätt hos
+  //    kunden utan det, och offertvalideringen kräver bara företagsnamnet.
+  if (!isPrivate && !organizationNumber) {
+    blockers.push({
+      field: 'organization_number',
+      label: 'Organisationsnummer',
+      message: 'Organisationsnummer saknas på företagskunden. Det behövs för att fakturan ska hitta rätt.',
+      fixAt: 'customer_card',
+    });
+  }
+
+  // 4. Arbetsadressen är det installatörerna navigerar efter i fältvyn. Alla tre delarna behövs —
+  //    en gata utan ort duger inte i en kartapp.
+  const missingAddressParts = ADDRESS_PART_LABELS.filter(([key]) => !workAddress[key]).map(([, label]) => label);
+  if (missingAddressParts.length > 0) {
+    blockers.push({
+      field: 'work_address',
+      label: 'Arbetsadress',
+      message: `Arbetsadressen saknar ${joinSwedish(missingAddressParts)}. Installatörerna navigerar till den ur arbetsordern.`,
+      fixAt: text(snapshot.delivery_address) ? 'quote' : 'customer_card',
+    });
+  }
+
+  // 5. Ett nummer någon svarar i. "Er referens" kräver bara ett NAMN, så en order kunde nå fältet
+  //    utan att besättningen hade något sätt att höra av sig när de står på plats.
+  if (!phone) {
+    blockers.push({
+      field: 'contact_phone',
+      label: 'Telefonnummer',
+      message: 'Telefonnummer saknas. Besättningen måste kunna nå kunden när de är på plats.',
+      fixAt: 'customer_card',
+    });
+  }
+
+  // 6. ROT utan identifierad fastighet går inte att deklarera, och Fortnox har inget API-fält för
+  //    beteckningen — den som slutför fakturan läser den ur textraden vi skickar.
+  const rot = quote.rot_details || {};
+  if (rot.enabled === true && !text(rot.property_designation) && !text(rot.brf_org_number)) {
+    blockers.push({
+      field: 'rot_property',
+      label: 'Fastighetsbeteckning',
+      message: 'Fastighetsbeteckning (eller BRF org.nr för bostadsrätt) krävs för ROT innan order kan skapas. Öppna offerten och fyll i den.',
+      fixAt: 'quote',
+    });
+  }
+
+  // ── Varningar: syns i checklistan, spärrar inte. Williams val 2026-08-19. ──
+  const lineItems = quote.line_items || [];
+  if (lineItems.length === 0 || !hasPopulatedLineItem(lineItems)) {
+    warnings.push({
+      field: 'line_items',
+      label: 'Artikelrader',
+      message: 'Offerten har inga ifyllda artikelrader — arbetsordern skapas tom.',
+      fixAt: 'quote',
+    });
+  }
+
+  const handoff = quote.internal_handoff || {};
+  if (!text(handoff.desired_installation_date)) {
+    warnings.push({
+      field: 'installation_date',
+      label: 'Önskat installationsdatum',
+      message: 'Önskat installationsdatum saknas — planeringen har inget att utgå från.',
+      fixAt: 'quote',
+    });
+  }
+
+  if (!text(handoff.handoff_notes)) {
+    warnings.push({
+      field: 'handoff_notes',
+      label: 'Arbetsbeskrivning',
+      message: 'Arbetsbeskrivning saknas — installatörerna får ingen instruktion med sig.',
+      fixAt: 'quote',
+    });
+  }
+
+  return {
+    ready: blockers.length === 0,
+    blockers,
+    warnings,
+    resolved: {
+      personalNumber,
+      organizationNumber,
+      phone,
+      workAddress: {
+        ...workAddress,
+        // Primäradressen bär redan arbetsplatsen när en sådan finns — dubblera den inte som en
+        // egen "Leverans:"-rad. Ordervyn kan fortfarande sätta en.
+        delivery_address: null,
+        invoice_address: text(snapshot.invoice_address),
+      },
+    },
+  };
+}
+
+/**
+ * Den felkod routen ska svara med.
+ *
+ * Personnummer och fastighetsbeteckning har egna koder eftersom offertformuläret öppnar en prompt
+ * på dem och rättar dem på plats. Den prompten ska bara fyra när fyndet är ENSAMT — annars fixar
+ * säljaren en sak, trycker igen, och möts av nästa. Är det fler visas hela listan på en gång.
+ */
+export function workOrderReadinessErrorCode(blockers: WorkOrderReadinessIssue[]): string {
+  if (blockers.length === 1) {
+    const only = blockers[0];
+    if (only.field === 'personal_number') return 'crm_work_order_missing_personal_number';
+    if (only.field === 'rot_property') return 'crm_work_order_missing_rot_property';
+  }
+  return 'crm_work_order_incomplete';
+}

--- a/lib/domains/crm/workOrderReadiness.ts
+++ b/lib/domains/crm/workOrderReadiness.ts
@@ -145,6 +145,44 @@ function hasPopulatedLineItem(lineItems: Array<Record<string, unknown>>): boolea
   return lineItems.some((item) => text(item.article_name) || text(item.m2) || text(item.quantity) || text(item.unit_price));
 }
 
+// ── Varningar: syns i checklistan, spärrar inte. Williams val 2026-08-19. ──
+//
+// Rör bara offerten själv, aldrig kundkortet — därför kan de räknas ut även när kundkopplingen
+// saknas och resten av kontrollen kortsluter.
+function collectWarnings(quote: ReadinessQuoteSource): WorkOrderReadinessIssue[] {
+  const warnings: WorkOrderReadinessIssue[] = [];
+  const lineItems = quote.line_items || [];
+  if (lineItems.length === 0 || !hasPopulatedLineItem(lineItems)) {
+    warnings.push({
+      field: 'line_items',
+      label: 'Artikelrader',
+      message: 'Offerten har inga ifyllda artikelrader — arbetsordern skapas tom.',
+      fixAt: 'quote',
+    });
+  }
+
+  const handoff = quote.internal_handoff || {};
+  if (!text(handoff.desired_installation_date)) {
+    warnings.push({
+      field: 'installation_date',
+      label: 'Önskat installationsdatum',
+      message: 'Önskat installationsdatum saknas — planeringen har inget att utgå från.',
+      fixAt: 'quote',
+    });
+  }
+
+  if (!text(handoff.handoff_notes)) {
+    warnings.push({
+      field: 'handoff_notes',
+      label: 'Arbetsbeskrivning',
+      message: 'Arbetsbeskrivning saknas — installatörerna får ingen instruktion med sig.',
+      fixAt: 'quote',
+    });
+  }
+
+  return warnings;
+}
+
 export function evaluateWorkOrderReadiness(
   quote: ReadinessQuoteSource,
   customer: ReadinessCustomerSource,
@@ -157,18 +195,42 @@ export function evaluateWorkOrderReadiness(
   const personalNumber = text(snapshot.personal_number) || text(customer?.personal_number);
   const organizationNumber = text(snapshot.organization_number) || text(customer?.organization_number);
   const contact = customer ? resolveCrmContact(customer) : { name: '', email: '', phone: '' };
-  const phone = text(snapshot.phone) || text(snapshot.end_contact_phone) || text(contact.phone);
+  // KUNDENS nummer — det som skrivs till ordern. Slutkundens nummer (end_contact_phone) är en
+  // ANNAN person, en kontakt på plats vid sidan av kundkortet, och får aldrig hamna här: ordervyn
+  // visar fältet som kundens telefon bredvid kundens kontaktnamn, seedar redigeringsfältet ur det
+  // och skickar det vidare till installatörerna. En felmärkning som nästa sparning gör permanent.
+  const phone = text(snapshot.phone) || text(contact.phone);
+  // Kravet är att NÅGON går att nå på plats, och där duger slutkundens nummer — det är ofta det
+  // enda som finns när beställaren är en förvaltare. Prövas alltså bredare än det som lagras.
+  const reachablePhone = phone || text(snapshot.end_contact_phone);
   const workAddress = resolveWorkAddress(snapshot, customer);
 
   // 1. Kundkopplingen först: den är förutsättningen för att de andra ens går att slå upp, och
   //    utan den kan ordern aldrig nå Fortnox (pushen resolvar kundnumret via customer_id).
   if (!text(quote.customer_id)) {
-    blockers.push({
-      field: 'customer_link',
-      label: 'Kund i kundregistret',
-      message: 'Offerten är inte kopplad till en kund i kundregistret. Utan kopplingen får arbetsordern ingen kund och kan inte synkas till Fortnox.',
-      fixAt: 'quote',
-    });
+    // KORTSLUTER med flit. Adress, telefon, org.nr och personnummer hämtas från kundkortet, och
+    // utan koppling finns inget kort att hämta dem ur — listar vi dem också får säljaren fyra
+    // fynd hen inte kan göra något åt, varav tre pekar på en sida som inte existerar. Ett fynd
+    // med en åtgärd är hela skillnaden mellan en spärr som vägleder och en som bara stoppar.
+    //
+    // Åtgärden är att välja kunden i offertens Kund-sektion; offerten sparas i dag utan koppling
+    // när kunden bara skrevs som fritext, och gamla offerter bär bara sin Fortnox-referens.
+    return {
+      ready: false,
+      blockers: [{
+        field: 'customer_link',
+        label: 'Kund i kundregistret',
+        message: 'Offerten är inte kopplad till en kund i kundregistret. Välj kunden i offertens Kund-sektion — annars får arbetsordern ingen kund, syns inte på kundkortet och räknas inte i rapporteringen.',
+        fixAt: 'quote',
+      }],
+      warnings: collectWarnings(quote),
+      resolved: {
+        personalNumber,
+        organizationNumber,
+        phone,
+        workAddress: { ...workAddress, delivery_address: null, invoice_address: text(snapshot.invoice_address) },
+      },
+    };
   }
 
   // 2. Personnummer på privatkund — Fortnox OrganisationNumber. Tio siffror dödar ROT- och
@@ -214,7 +276,7 @@ export function evaluateWorkOrderReadiness(
 
   // 5. Ett nummer någon svarar i. "Er referens" kräver bara ett NAMN, så en order kunde nå fältet
   //    utan att besättningen hade något sätt att höra av sig när de står på plats.
-  if (!phone) {
+  if (!reachablePhone) {
     blockers.push({
       field: 'contact_phone',
       label: 'Telefonnummer',
@@ -235,35 +297,7 @@ export function evaluateWorkOrderReadiness(
     });
   }
 
-  // ── Varningar: syns i checklistan, spärrar inte. Williams val 2026-08-19. ──
-  const lineItems = quote.line_items || [];
-  if (lineItems.length === 0 || !hasPopulatedLineItem(lineItems)) {
-    warnings.push({
-      field: 'line_items',
-      label: 'Artikelrader',
-      message: 'Offerten har inga ifyllda artikelrader — arbetsordern skapas tom.',
-      fixAt: 'quote',
-    });
-  }
-
-  const handoff = quote.internal_handoff || {};
-  if (!text(handoff.desired_installation_date)) {
-    warnings.push({
-      field: 'installation_date',
-      label: 'Önskat installationsdatum',
-      message: 'Önskat installationsdatum saknas — planeringen har inget att utgå från.',
-      fixAt: 'quote',
-    });
-  }
-
-  if (!text(handoff.handoff_notes)) {
-    warnings.push({
-      field: 'handoff_notes',
-      label: 'Arbetsbeskrivning',
-      message: 'Arbetsbeskrivning saknas — installatörerna får ingen instruktion med sig.',
-      fixAt: 'quote',
-    });
-  }
+  warnings.push(...collectWarnings(quote));
 
   return {
     ready: blockers.length === 0,

--- a/tests/crm/work-orders.test.ts
+++ b/tests/crm/work-orders.test.ts
@@ -24,7 +24,7 @@ vi.mock('@/lib/supabase/server', () => ({ getSupabaseAdmin: () => elevated.clien
 // offerten är olänkad, och nästa försök smäller på unikhetsindexet på quote_id.
 // ---------------------------------------------------------------------------
 
-function makeSupabase(quote: Record<string, unknown>) {
+function makeSupabase(quote: Record<string, unknown>, customer: Record<string, unknown> | null = COMPLETE_CUSTOMER) {
   const captured: {
     insert: Record<string, any> | null;
     quoteUpdateVia: 'session' | 'elevated' | null;
@@ -43,6 +43,12 @@ function makeSupabase(quote: Record<string, unknown>) {
             return builder;
           }),
           insert: vi.fn((payload: Record<string, any>) => { state.op = 'insert'; captured.insert = payload; return builder; }),
+          // Fullständighetskontrollen läser om kundkortet (adress, telefon, org.nr och
+          // personnummer går inte att redigera i offertformuläret) — se workOrderReadiness.ts.
+          maybeSingle: vi.fn(() => {
+            if (table === 'crm_customers') return Promise.resolve({ data: customer, error: null });
+            return Promise.resolve({ data: null, error: null });
+          }),
           single: vi.fn(() => {
             if (table === 'crm_quotes' && state.op === 'select') return Promise.resolve({ data: quote, error: null });
             if (table === 'crm_work_orders' && state.op === 'insert') return Promise.resolve({ data: { id: 'wo1', order_number: 'AO-TEST' }, error: null });
@@ -89,16 +95,36 @@ describe('createCrmWorkOrderFromQuote — återlänkningen till offerten', () =>
   });
 });
 
+// Kundkortet som fullständighetskontrollen faller tillbaka på. Håll det komplett — testerna nedan
+// tar bort EN uppgift i taget, så det som spärrar i ett test är det testet handlar om.
+const COMPLETE_CUSTOMER = {
+  organization_number: '556677-8899',
+  personal_number: null,
+  email: 'info@testab.se',
+  phone: '08-111 22 33',
+  mobile: null,
+  visit_address: { street: 'Storgatan 1', postal_code: '12345', city: 'Stockholm' },
+  contacts: [],
+};
+
 const MEASUREMENT_BLOCK = 'EKOVILLA\nVägg – 100 m² × 195 mm @ 52 kg/m³ – 73 säck\n\nTotalt: 73 säck';
 
 function wonQuote(overrides: Record<string, unknown> = {}) {
   return {
     id: '11111111-1111-1111-1111-111111111111',
     prospect_id: null,
-    customer_id: null,
+    customer_id: '22222222-2222-2222-2222-222222222222',
     customer_name: 'Test AB',
     quote_type: 'business',
-    customer_snapshot: { company_name: 'Test AB' },
+    customer_snapshot: {
+      company_name: 'Test AB',
+      organization_number: '556677-8899',
+      contact_name: 'Kalle Kund',
+      phone: '08-111 22 33',
+      street_address: 'Storgatan 1',
+      postal_code: '12345',
+      city: 'Stockholm',
+    },
     pricing_summary: {},
     line_items: [],
     rot_details: {},
@@ -137,15 +163,35 @@ describe('createCrmWorkOrderFromQuote — fält-mappning', () => {
   });
 
   it('blockerar privatorder utan personnummer (varken snapshot eller kund)', async () => {
-    const { supabase } = makeSupabase(wonQuote({ quote_type: 'private', customer_id: null, customer_snapshot: { customer_name: 'Anna' } }));
+    const { supabase, captured } = makeSupabase(
+      wonQuote({ quote_type: 'private', customer_snapshot: {
+        customer_name: 'Anna',
+        contact_name: 'Anna Andersson',
+        phone: '070-123 45 67',
+        street_address: 'Storgatan 1',
+        postal_code: '12345',
+        city: 'Stockholm',
+      } }),
+      { ...COMPLETE_CUSTOMER, personal_number: null },
+    );
     const result = await createCrmWorkOrderFromQuote(supabase as any, 'q1', 'user-1');
-    expect(result.reason).toBe('missing_personal_number');
+    expect(result.reason).toBe('incomplete');
+    expect(result.error?.message).toContain('Personnummer');
     expect(result.data).toBeNull();
+    // Ordern får inte ha hunnit skapas — routen auto-pushar den till Fortnox.
+    expect(captured.insert).toBeNull();
   });
 
   it('tillåter privatorder när snapshot har personnummer, och bevarar det på ordern', async () => {
     const { supabase, captured } = makeSupabase(
-      wonQuote({ quote_type: 'private', customer_id: null, customer_snapshot: { customer_name: 'Anna', personal_number: '19850101-1236' } }),
+      wonQuote({ quote_type: 'private', customer_snapshot: { ...{
+        customer_name: 'Anna',
+        contact_name: 'Anna Andersson',
+        phone: '070-123 45 67',
+        street_address: 'Storgatan 1',
+        postal_code: '12345',
+        city: 'Stockholm',
+      }, personal_number: '19850101-1236' } }),
     );
     const result = await createCrmWorkOrderFromQuote(supabase as any, 'q1', 'user-1');
     expect(result.error).toBeNull();
@@ -160,15 +206,22 @@ describe('createCrmWorkOrderFromQuote — fält-mappning', () => {
   const rotQuote = (rot: Record<string, unknown>) =>
     wonQuote({
       quote_type: 'private',
-      customer_id: null,
-      customer_snapshot: { customer_name: 'Anna', personal_number: '19850101-1236' },
+      customer_snapshot: { ...{
+        customer_name: 'Anna',
+        contact_name: 'Anna Andersson',
+        phone: '070-123 45 67',
+        street_address: 'Storgatan 1',
+        postal_code: '12345',
+        city: 'Stockholm',
+      }, personal_number: '19850101-1236' },
       rot_details: { enabled: true, personal_number: '19850101-1236', ...rot },
     });
 
   it('blockerar ROT-order utan fastighetsbeteckning och BRF org.nr', async () => {
     const { supabase, captured } = makeSupabase(rotQuote({ property_designation: null, brf_org_number: null }));
     const result = await createCrmWorkOrderFromQuote(supabase as any, 'q1', 'user-1');
-    expect(result.reason).toBe('missing_rot_property');
+    expect(result.reason).toBe('incomplete');
+    expect(result.error?.message).toContain('Fastighetsbeteckning');
     expect(result.data).toBeNull();
     // Ordern får inte ha hunnit skapas — annars auto-pushas den till Fortnox.
     expect(captured.insert).toBeNull();
@@ -177,7 +230,8 @@ describe('createCrmWorkOrderFromQuote — fält-mappning', () => {
   it('blockerar när beteckningen bara är blanksteg', async () => {
     const { supabase } = makeSupabase(rotQuote({ property_designation: '   ' }));
     const result = await createCrmWorkOrderFromQuote(supabase as any, 'q1', 'user-1');
-    expect(result.reason).toBe('missing_rot_property');
+    expect(result.reason).toBe('incomplete');
+    expect(result.error?.message).toContain('Fastighetsbeteckning');
   });
 
   it('släpper igenom ROT-order med fastighetsbeteckning', async () => {
@@ -335,5 +389,96 @@ describe('listCrmWorkOrdersWithFilters — radordningen', () => {
     const supabase = makeSupabaseMock({ data: [], error: null });
     await listCrmWorkOrdersWithFilters(supabase as any, { sort: 'created_desc' });
     expect((supabase._query.order as any).mock.calls).toEqual([['created_at', { ascending: false }]]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fullständighetskontrollen, sedd genom skapandet. Fält för fält prövas den i
+// workOrderReadiness.test.ts — här gäller det kopplingen: att inget skrivs när något saknas, och
+// att de värden kontrollen godkände är exakt de ordern sedan bär. Skiljer de sig åt har spärren
+// prövat en uppgift ordern inte har.
+// ---------------------------------------------------------------------------
+describe('createCrmWorkOrderFromQuote — fullständighetskontrollen', () => {
+  it('blockerar okopplad offert — utan kund kan ordern aldrig nå Fortnox', async () => {
+    const { supabase, captured } = makeSupabase(wonQuote({ customer_id: null }), null);
+    const result = await createCrmWorkOrderFromQuote(supabase as any, 'q1', 'user-1');
+    expect(result.reason).toBe('incomplete');
+    expect(result.error?.message).toContain('kundregistret');
+    expect(captured.insert).toBeNull();
+  });
+
+  it('blockerar när arbetsadressen saknas både på offerten och på kundkortet', async () => {
+    const { supabase, captured } = makeSupabase(
+      wonQuote({ customer_snapshot: { company_name: 'Test AB', organization_number: '556677-8899', contact_name: 'Kalle', phone: '08-111 22 33' } }),
+      { ...COMPLETE_CUSTOMER, visit_address: null },
+    );
+    const result = await createCrmWorkOrderFromQuote(supabase as any, 'q1', 'user-1');
+    expect(result.reason).toBe('incomplete');
+    expect(result.error?.message).toContain('Arbetsadressen');
+    expect(captured.insert).toBeNull();
+  });
+
+  it('blockerar företagsorder utan org.nr på både offert och kundkort', async () => {
+    const { supabase } = makeSupabase(
+      wonQuote({ customer_snapshot: { company_name: 'Test AB', contact_name: 'Kalle', phone: '08-111 22 33', street_address: 'Storgatan 1', postal_code: '12345', city: 'Stockholm' } }),
+      { ...COMPLETE_CUSTOMER, organization_number: null },
+    );
+    const result = await createCrmWorkOrderFromQuote(supabase as any, 'q1', 'user-1');
+    expect(result.reason).toBe('incomplete');
+    expect(result.error?.message).toContain('Organisationsnummer');
+  });
+
+  // Kärnan i varför kundkortet läses om: adress, telefon och org.nr går inte att redigera i
+  // offertformuläret. Säljaren fyller i dem på kundkortet — och då måste ordern bära dem, annars
+  // hade spärren godkänt uppgifter som aldrig nådde installatörerna eller Fortnox.
+  it('bakar in kundkortets telefon, org.nr och adress i ordern när offertens snapshot är tom', async () => {
+    const { supabase, captured } = makeSupabase(
+      wonQuote({ customer_snapshot: { company_name: 'Test AB', contact_name: 'Kalle Kund' } }),
+      COMPLETE_CUSTOMER,
+    );
+    const result = await createCrmWorkOrderFromQuote(supabase as any, 'q1', 'user-1');
+
+    expect(result.error).toBeNull();
+    expect(captured.insert!.customer_snapshot.phone).toBe('08-111 22 33');
+    expect(captured.insert!.customer_snapshot.organization_number).toBe('556677-8899');
+    expect(captured.insert!.work_address).toMatchObject({
+      street_address: 'Storgatan 1',
+      postal_code: '12345',
+      city: 'Stockholm',
+    });
+  });
+
+  // Regression: offertens egna värden är ett medvetet val för just den affären och får aldrig
+  // skrivas över av kundkortet — bara fylla luckor.
+  it('offertens snapshot vinner över kundkortet', async () => {
+    const { supabase, captured } = makeSupabase(
+      wonQuote({
+        customer_snapshot: {
+          company_name: 'Test AB',
+          organization_number: '556677-8899',
+          contact_name: 'Kalle Kund',
+          phone: '070-000 11 22',
+          street_address: 'Byggvägen 9',
+          postal_code: '43210',
+          city: 'Göteborg',
+        },
+      }),
+      COMPLETE_CUSTOMER,
+    );
+    await createCrmWorkOrderFromQuote(supabase as any, 'q1', 'user-1');
+
+    expect(captured.insert!.customer_snapshot.phone).toBe('070-000 11 22');
+    expect(captured.insert!.work_address.city).toBe('Göteborg');
+  });
+
+  // Varningarna är Williams val 2026-08-19: en offert utan rader, datum eller arbetsbeskrivning
+  // ska gå att göra order av — de syns i checklistan, de stoppar inte.
+  it('släpper igenom en offert utan rader, installationsdatum och arbetsbeskrivning', async () => {
+    const { supabase, captured } = makeSupabase(
+      wonQuote({ line_items: [], internal_handoff: { handoff_notes: null, work_scope: null, desired_installation_date: null } }),
+    );
+    const result = await createCrmWorkOrderFromQuote(supabase as any, 'q1', 'user-1');
+    expect(result.error).toBeNull();
+    expect(captured.insert).not.toBeNull();
   });
 });

--- a/tests/crm/work-orders.test.ts
+++ b/tests/crm/work-orders.test.ts
@@ -24,7 +24,12 @@ vi.mock('@/lib/supabase/server', () => ({ getSupabaseAdmin: () => elevated.clien
 // offerten är olänkad, och nästa försök smäller på unikhetsindexet på quote_id.
 // ---------------------------------------------------------------------------
 
-function makeSupabase(quote: Record<string, unknown>, customer: Record<string, unknown> | null = COMPLETE_CUSTOMER) {
+function makeSupabase(
+  quote: Record<string, unknown>,
+  customer: Record<string, unknown> | null = COMPLETE_CUSTOMER,
+  customerError: { message: string } | null = null,
+) {
+  const customerRead = { data: customerError ? null : customer, error: customerError };
   const captured: {
     insert: Record<string, any> | null;
     quoteUpdateVia: 'session' | 'elevated' | null;
@@ -46,7 +51,7 @@ function makeSupabase(quote: Record<string, unknown>, customer: Record<string, u
           // Fullständighetskontrollen läser om kundkortet (adress, telefon, org.nr och
           // personnummer går inte att redigera i offertformuläret) — se workOrderReadiness.ts.
           maybeSingle: vi.fn(() => {
-            if (table === 'crm_customers') return Promise.resolve({ data: customer, error: null });
+            if (table === 'crm_customers') return Promise.resolve(customerRead);
             return Promise.resolve({ data: null, error: null });
           }),
           single: vi.fn(() => {
@@ -415,6 +420,17 @@ describe('createCrmWorkOrderFromQuote — fullständighetskontrollen', () => {
     const result = await createCrmWorkOrderFromQuote(supabase as any, 'q1', 'user-1');
     expect(result.reason).toBe('incomplete');
     expect(result.error?.message).toContain('Arbetsadressen');
+    expect(captured.insert).toBeNull();
+  });
+
+  // Regression: läsfelet på kundkortet svaldes en gång, och då gick det inte att skilja från
+  // "kunden har inga uppgifter" — kontrollen hittade på spärrar för adress, telefon och org.nr och
+  // bad säljaren fylla i fält som redan var ifyllda.
+  it('avbryter i stället för att hitta på spärrar när kundkortet inte gick att läsa', async () => {
+    const { supabase, captured } = makeSupabase(wonQuote(), null, { message: 'timeout' });
+    const result = await createCrmWorkOrderFromQuote(supabase as any, 'q1', 'user-1');
+    expect(result.reason).toBe('customer_fetch_failed');
+    expect(result.error?.message).toBe('timeout');
     expect(captured.insert).toBeNull();
   });
 

--- a/tests/crm/workOrderReadiness.test.ts
+++ b/tests/crm/workOrderReadiness.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect } from 'vitest';
+import {
+  evaluateWorkOrderReadiness,
+  workOrderReadinessErrorCode,
+  type ReadinessCustomerSource,
+  type ReadinessQuoteSource,
+} from '@/lib/domains/crm/workOrderReadiness';
+
+// Spärren mellan offert och arbetsorder. Orderskapandet auto-pushar till Fortnox, så det här är
+// sista stället en glömd uppgift är ett formulärfel i stället för ett bokföringsärende.
+//
+// Det som gör testerna värda något är FALLBACKEN till kundkortet: adress, telefon och org.nr går
+// inte att redigera i offertformuläret, så en spärr som bara läste offertens snapshot hade
+// blockerat säljaren även efter att hen gjort precis det spärren bad om.
+
+const fullSnapshot = {
+  customer_name: 'Anna Andersson',
+  contact_name: 'Anna Andersson',
+  personal_number: '198501011236',
+  phone: '070-123 45 67',
+  street_address: 'Storgatan 1',
+  postal_code: '12345',
+  city: 'Stockholm',
+};
+
+function quote(overrides: Partial<ReadinessQuoteSource> = {}): ReadinessQuoteSource {
+  return {
+    quote_type: 'private',
+    customer_id: '11111111-1111-1111-1111-111111111111',
+    customer_snapshot: { ...fullSnapshot },
+    rot_details: { enabled: false },
+    line_items: [{ article_name: 'Ekovilla', quantity: '10' }],
+    internal_handoff: { desired_installation_date: '2026-09-01', handoff_notes: 'Vind, 400 mm' },
+    ...overrides,
+  };
+}
+
+const emptyCustomer: ReadinessCustomerSource = { email: null, phone: null, mobile: null, contacts: [] };
+
+function fields(issues: Array<{ field: string }>) {
+  return issues.map((i) => i.field);
+}
+
+describe('fullständighetskontroll offert → arbetsorder', () => {
+  it('komplett privatoffert passerar utan fynd', () => {
+    const result = evaluateWorkOrderReadiness(quote(), emptyCustomer);
+    expect(result.ready).toBe(true);
+    expect(result.blockers).toEqual([]);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it('okopplad offert spärras — utan customer_id får ordern ingen kund i Fortnox', () => {
+    const result = evaluateWorkOrderReadiness(quote({ customer_id: null }), null);
+    expect(fields(result.blockers)).toContain('customer_link');
+    expect(result.ready).toBe(false);
+  });
+
+  it('personnummer hämtas från kundkortet när offertens snapshot saknar det', () => {
+    const result = evaluateWorkOrderReadiness(
+      quote({ customer_snapshot: { ...fullSnapshot, personal_number: null } }),
+      { ...emptyCustomer, personal_number: '198501011236' },
+    );
+    expect(fields(result.blockers)).not.toContain('personal_number');
+    expect(result.resolved.personalNumber).toBe('198501011236');
+  });
+
+  it('tio siffror spärrar — ROT dör tyst i Fortnox på ett ofullständigt nummer', () => {
+    const result = evaluateWorkOrderReadiness(
+      quote({ customer_snapshot: { ...fullSnapshot, personal_number: '8501011236' } }),
+      emptyCustomer,
+    );
+    expect(fields(result.blockers)).toContain('personal_number');
+  });
+
+  it('företagskund utan org.nr spärras, privatkund berörs inte', () => {
+    const business = evaluateWorkOrderReadiness(
+      quote({ quote_type: 'business', customer_snapshot: { ...fullSnapshot, personal_number: null, organization_number: null } }),
+      emptyCustomer,
+    );
+    expect(fields(business.blockers)).toContain('organization_number');
+
+    const withOrgNr = evaluateWorkOrderReadiness(
+      quote({ quote_type: 'business', customer_snapshot: { ...fullSnapshot, personal_number: null } }),
+      { ...emptyCustomer, organization_number: '556677-8899' },
+    );
+    expect(fields(withOrgNr.blockers)).not.toContain('organization_number');
+    expect(withOrgNr.resolved.organizationNumber).toBe('556677-8899');
+  });
+
+  it('halv adress spärras och meddelandet namnger de delar som saknas', () => {
+    const result = evaluateWorkOrderReadiness(
+      quote({ customer_snapshot: { ...fullSnapshot, postal_code: null, city: null } }),
+      emptyCustomer,
+    );
+    const address = result.blockers.find((b) => b.field === 'work_address');
+    expect(address?.message).toContain('postnummer och ort');
+  });
+
+  it('adressen faller tillbaka på kundkortets besöksadress när snapshoten är tom', () => {
+    const result = evaluateWorkOrderReadiness(
+      quote({ customer_snapshot: { ...fullSnapshot, street_address: null, postal_code: null, city: null } }),
+      { ...emptyCustomer, visit_address: { street: 'Storgatan 1', postal_code: '12345', city: 'Stockholm' } },
+    );
+    expect(fields(result.blockers)).not.toContain('work_address');
+    expect(result.resolved.workAddress.city).toBe('Stockholm');
+  });
+
+  it('en separat arbetsadress vinner över kundadressen och lånar inte dess ort', () => {
+    const result = evaluateWorkOrderReadiness(
+      quote({
+        customer_snapshot: {
+          ...fullSnapshot,
+          delivery_address: 'Industrivägen 4',
+          delivery_postal_code: '43210',
+          delivery_city: 'Göteborg',
+        },
+      }),
+      emptyCustomer,
+    );
+    expect(result.resolved.workAddress).toMatchObject({
+      street_address: 'Industrivägen 4',
+      postal_code: '43210',
+      city: 'Göteborg',
+    });
+  });
+
+  it('arbetsadress utan ort rättas i OFFERTEN, kundadress utan ort på KUNDKORTET', () => {
+    const onQuote = evaluateWorkOrderReadiness(
+      quote({ customer_snapshot: { ...fullSnapshot, delivery_address: 'Industrivägen 4' } }),
+      emptyCustomer,
+    );
+    expect(onQuote.blockers.find((b) => b.field === 'work_address')?.fixAt).toBe('quote');
+
+    const onCard = evaluateWorkOrderReadiness(
+      quote({ customer_snapshot: { ...fullSnapshot, city: null } }),
+      emptyCustomer,
+    );
+    expect(onCard.blockers.find((b) => b.field === 'work_address')?.fixAt).toBe('customer_card');
+  });
+
+  it('telefon: snapshot först, sedan slutkundens nummer, sedan kundkortet', () => {
+    const noPhone = { ...fullSnapshot, phone: null };
+
+    const blocked = evaluateWorkOrderReadiness(quote({ customer_snapshot: noPhone }), emptyCustomer);
+    expect(fields(blocked.blockers)).toContain('contact_phone');
+
+    const endContact = evaluateWorkOrderReadiness(
+      quote({ customer_snapshot: { ...noPhone, end_contact_phone: '070-999 88 77' } }),
+      emptyCustomer,
+    );
+    expect(endContact.resolved.phone).toBe('070-999 88 77');
+
+    // Kontaktraden vinner över kortets nummer — samma regel som resolveCrmContact, så
+    // arbetsordern och Fortnox-dokumenten pekar på samma person.
+    const fromCard = evaluateWorkOrderReadiness(quote({ customer_snapshot: noPhone }), {
+      ...emptyCustomer,
+      phone: '08-111 222',
+      contacts: [{ name: 'Anna', phone: '070-555 44 33', is_primary: true }],
+    });
+    expect(fromCard.resolved.phone).toBe('070-555 44 33');
+  });
+
+  it('ROT utan fastighetsbeteckning spärras — BRF org.nr räcker som alternativ', () => {
+    const missing = evaluateWorkOrderReadiness(
+      quote({ rot_details: { enabled: true, property_designation: null, brf_org_number: null } }),
+      emptyCustomer,
+    );
+    expect(fields(missing.blockers)).toContain('rot_property');
+
+    const brf = evaluateWorkOrderReadiness(
+      quote({ rot_details: { enabled: true, brf_org_number: '769600-1234' } }),
+      emptyCustomer,
+    );
+    expect(fields(brf.blockers)).not.toContain('rot_property');
+  });
+
+  it('tomma rader, saknat datum och saknad arbetsbeskrivning VARNAR men spärrar inte', () => {
+    const result = evaluateWorkOrderReadiness(
+      quote({ line_items: [], internal_handoff: {} }),
+      emptyCustomer,
+    );
+    expect(result.ready).toBe(true);
+    expect(fields(result.warnings)).toEqual(['line_items', 'installation_date', 'handoff_notes']);
+  });
+
+  it('en rad utan innehåll räknas inte som en rad', () => {
+    const result = evaluateWorkOrderReadiness(
+      quote({ line_items: [{ id: 'row-1', article_name: null, quantity: '', m2: '', unit_price: '' }] }),
+      emptyCustomer,
+    );
+    expect(fields(result.warnings)).toContain('line_items');
+  });
+});
+
+describe('felkoden som routen svarar med', () => {
+  it('ensamt personnummer- eller ROT-fynd behåller sin kod så prompten fyrar', () => {
+    expect(workOrderReadinessErrorCode([{ field: 'personal_number', label: '', message: '', fixAt: 'customer_card' }]))
+      .toBe('crm_work_order_missing_personal_number');
+    expect(workOrderReadinessErrorCode([{ field: 'rot_property', label: '', message: '', fixAt: 'quote' }]))
+      .toBe('crm_work_order_missing_rot_property');
+  });
+
+  it('flera fynd ger listkoden — annars lagar prompten en sak och nästa fel dyker upp', () => {
+    expect(
+      workOrderReadinessErrorCode([
+        { field: 'personal_number', label: '', message: '', fixAt: 'customer_card' },
+        { field: 'contact_phone', label: '', message: '', fixAt: 'customer_card' },
+      ]),
+    ).toBe('crm_work_order_incomplete');
+  });
+});

--- a/tests/crm/workOrderReadiness.test.ts
+++ b/tests/crm/workOrderReadiness.test.ts
@@ -49,10 +49,24 @@ describe('fullständighetskontroll offert → arbetsorder', () => {
     expect(result.warnings).toEqual([]);
   });
 
-  it('okopplad offert spärras — utan customer_id får ordern ingen kund i Fortnox', () => {
-    const result = evaluateWorkOrderReadiness(quote({ customer_id: null }), null);
-    expect(fields(result.blockers)).toContain('customer_link');
+  it('okopplad offert spärras — och kortsluter, för resten går inte att åtgärda ändå', () => {
+    // Adress, telefon och org.nr bor på kundkortet. Utan koppling finns inget kort att rätta dem
+    // i, så en full lista hade gett fyra fynd med tre knappar som pekar på en sida som inte finns.
+    const result = evaluateWorkOrderReadiness(
+      quote({ customer_id: null, customer_snapshot: { customer_name: 'Anna' } }),
+      null,
+    );
+    expect(fields(result.blockers)).toEqual(['customer_link']);
+    expect(result.blockers[0].fixAt).toBe('quote');
     expect(result.ready).toBe(false);
+  });
+
+  it('kortslutningen tar inte varningarna med sig — de rör bara offerten', () => {
+    const result = evaluateWorkOrderReadiness(
+      quote({ customer_id: null, line_items: [], internal_handoff: {} }),
+      null,
+    );
+    expect(fields(result.warnings)).toEqual(['line_items', 'installation_date', 'handoff_notes']);
   });
 
   it('personnummer hämtas från kundkortet när offertens snapshot saknar det', () => {
@@ -144,11 +158,15 @@ describe('fullständighetskontroll offert → arbetsorder', () => {
     const blocked = evaluateWorkOrderReadiness(quote({ customer_snapshot: noPhone }), emptyCustomer);
     expect(fields(blocked.blockers)).toContain('contact_phone');
 
+    // Slutkundens nummer räcker för att NÅGON går att nå på plats — men det är en annan person
+    // än kunden, och får därför aldrig skrivas in som kundens telefon på ordern. Ordervyn visar
+    // det fältet bredvid kundens kontaktnamn och seedar redigeringsfältet ur det.
     const endContact = evaluateWorkOrderReadiness(
       quote({ customer_snapshot: { ...noPhone, end_contact_phone: '070-999 88 77' } }),
       emptyCustomer,
     );
-    expect(endContact.resolved.phone).toBe('070-999 88 77');
+    expect(fields(endContact.blockers)).not.toContain('contact_phone');
+    expect(endContact.resolved.phone).toBeNull();
 
     // Kontaktraden vinner över kortets nummer — samma regel som resolveCrmContact, så
     // arbetsordern och Fortnox-dokumenten pekar på samma person.


### PR DESCRIPTION
## Varför

Orderskapandet auto-pushar till Fortnox i samma andetag som ordern finns. Efter den punkten är en glömd uppgift ett bokföringsärende i stället för ett formulärfel — det var därför personnummer och ROT-fastighetsbeteckning redan spärrade här. Resten av uppgifterna gjorde det inte, trots att de kan saknas rakt genom kedjan:

- en offert utan kundkoppling gav en **kundlös order** som föll på Fortnox-pushen *efter* att den skapats (icke-fatalt → ordern blev liggande osynkad, syntes aldrig på kundkortet)
- **arbetsadress och telefon** kunde vara tomma hela vägen ut i installatörernas fältvy — inget att navigera till, ingen att ringa
- **org.nr** krävdes aldrig på företagskund, bara företagsnamnet

## Vad som ingår

| Hård spärr | Varning (syns, stoppar inte) |
| --- | --- |
| Kundkoppling | Minst en artikelrad |
| Arbetsadress — gata, postnr och ort | Önskat installationsdatum |
| Telefonnummer | Arbetsbeskrivning |
| Org.nr på företagskund | |

Reglerna bor i `lib/domains/crm/workOrderReadiness.ts`, som **både skapandet och UI:t** frågar — en andra uppsättning regler i klienten hade förr eller senare sagt emot spärren. Checklistan visas därför innan säljaren trycker, i offertformuläret och den delade offertpanelen (offertlistan + säljtavlan), och knappen är avstängd när något saknas.

Personnummer- och ROT-prompterna behåller sina felkoder när fyndet är **ensamt**, så de fortsätter rätta på plats. Är det fler visas hela listan.

Dessutom: bekräftelsen före "Vunnen" flyttad från `window.confirm` till en delad `CrmConfirmDialog` på CRM:s egen modalyta, på båda ytorna som gör övergången.

## Det som är lätt att missa

**Kundkortet läses om vid kontrollen.** Adress, telefon och org.nr går inte att redigera i offertformuläret — de är en ögonblicksbild av kundkortet. Utan omläsningen hade en säljare som gör precis det spärren ber om blockerats ändå, av en snapshot skriven innan. De upplösta värdena bakas in i ordern, annars prövar spärren uppgifter ordern inte bär.

**Ett avbrutet drag på tavlan gör nu ingenting alls.** `window.confirm` blockerade tråden; dialogen gör det inte, så den optimistiska flytten ligger efter frågan i stället för före.

## Granskning

Fem fynd, alla riktiga, alla åtgärdade i `eff3eab` — bl.a. att slutkundens telefonnummer skrevs in som kundens (en annan person, som fältvyn visar som kundkontakt), att ett svalt läsfel på kundkortet kunde hitta på spärrar för fält som redan var ifyllda, och att 409-svaret kunde torka checklistan från skärmen.

## Deploy

**Ingen SQL, inga miljövariabler** — deployordningen spelar ingen roll.

Befintliga offerter berörs bara i ett fall: en gammal rad som saknar kundkoppling (Zod strippade `customer_id` före juni-fixen) och är vunnen men inte konverterad. Den löses genom att välja kunden i offerten. Nya offerter kan inte hamna där — formuläret har inget fritextfält för kundnamn.

## Validering

`npm run type-check`, `npm run lint`, **1 453 tester** och `npm run build` gröna.

🤖 Generated with [Claude Code](https://claude.com/claude-code)