### PR TITLE
fix(crm): ROT-arbetskostnaden är ett à-pris, plus bekräftelse på radborttagning

### DIFF
--- a/app/crm/arbetsorder/WorkOrderArticlesTab.tsx
+++ b/app/crm/arbetsorder/WorkOrderArticlesTab.tsx
@@ -320,9 +320,9 @@ export default function WorkOrderArticlesTab({ items, currencyCode, vatPercent, 
                         Varav arbetskostnad (ROT, kr/{laborUnitLabel})
                       </span>
                       <Input value={row.labor_cost || ''} onChange={(e) => updateRow(row.id, { labor_cost: e.target.value })} inputMode="decimal" placeholder="0" />
-                      {laborSplit.clamped ? (
-                        <span className="text-[11px] leading-snug text-amber-700">
-                          Kan inte vara högre än à-priset ({formatCurrency(parseDecimal(row.unit_price), currencyCode)}/{laborUnitLabel}) och räknas som hela priset.
+                      {laborSplit.leavesNoMaterial ? (
+                        <span className="text-[11px] leading-snug text-rose-700">
+                          Arbetet är hela à-priset ({formatCurrency(parseDecimal(row.unit_price), currencyCode)}/{laborUnitLabel}) — inget material blir kvar. Ingen arbetskostnad bryts ut förrän det rättas.
                         </span>
                       ) : laborSplit.labor > 0 ? (
                         <span className="text-[11px] leading-snug text-slate-500">

--- a/app/crm/arbetsorder/WorkOrderArticlesTab.tsx
+++ b/app/crm/arbetsorder/WorkOrderArticlesTab.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo, useState } from 'react';
 import Input from '../../../components/ui/Input';
 import { cn } from '@/lib/shared/cn';
 import { crm } from '@/app/crm/lib/crmTokens';
-import { computePricing, lineItemRowTotal, splitRowLabor, type PricingLineItem } from '@/lib/domains/crm/pricing';
+import { computePricing, lineItemRowTotal, lineItemUnitPrice, splitRowLabor, type PricingLineItem } from '@/lib/domains/crm/pricing';
 import { lineItemQuantity } from '@/lib/domains/crm/lineItems';
 import { inferMaterialFromArticle, sacksFor } from '@/lib/domains/crm/materials';
 import { parseDecimal } from '@/lib/shared/number';
@@ -26,7 +26,8 @@ export type ArticleLineItem = {
   discount_percent?: string;
   is_rot_work?: boolean;
   house_work_type?: string;
-  // Labour carved out of a material row for ROT — summed onto the "Arbetskostnad ROT" Fortnox row.
+  // Labour carved out of a material row for ROT, as kr PER UNIT — ett à-pris som räknas mot
+  // antalet, utbrutet UR à-priset och inte lagt till det. Se splitRowLabor i pricing.ts.
   labor_cost?: string;
   // Avskriven rad: såld men aldrig utförd. Ligger kvar (indexen bär fakturarundornas antal) men
   // räknas bort ur summan och skickas inte till Fortnox.
@@ -233,7 +234,11 @@ export default function WorkOrderArticlesTab({ items, currencyCode, vatPercent, 
               const laborUnitLabel = mode === 'm3' ? 'm³' : (row.article_unit_name?.trim() || 'st');
               const laborSplit = splitRowLabor({
                 laborCostPerUnit: row.labor_cost,
-                unitPrice: parseDecimal(row.unit_price),
+                // Samma priskälla som rowTotal ovan, computePricing i den här fliken och pushen:
+                // explicit unit_price när det finns, annars artikelns pris. Läste vi bara
+                // unit_price här skulle en rad som prissätts av artikeln visa "inget material blir
+                // kvar" bredvid en radtotal som säger något helt annat.
+                unitPrice: lineItemUnitPrice(row as PricingLineItem),
                 discountPercent: parseDecimal(row.discount_percent),
                 quantity: lineItemQuantity(row as PricingLineItem),
               });
@@ -322,7 +327,7 @@ export default function WorkOrderArticlesTab({ items, currencyCode, vatPercent, 
                       <Input value={row.labor_cost || ''} onChange={(e) => updateRow(row.id, { labor_cost: e.target.value })} inputMode="decimal" placeholder="0" />
                       {laborSplit.leavesNoMaterial ? (
                         <span className="text-[11px] leading-snug text-rose-700">
-                          Arbetet är hela à-priset ({formatCurrency(parseDecimal(row.unit_price), currencyCode)}/{laborUnitLabel}) — inget material blir kvar. Ingen arbetskostnad bryts ut förrän det rättas.
+                          Arbetet är hela à-priset ({formatCurrency(lineItemUnitPrice(row as PricingLineItem), currencyCode)}/{laborUnitLabel}) — inget material blir kvar. Ingen arbetskostnad bryts ut förrän det rättas.
                         </span>
                       ) : laborSplit.labor > 0 ? (
                         <span className="text-[11px] leading-snug text-slate-500">

--- a/app/crm/arbetsorder/WorkOrderArticlesTab.tsx
+++ b/app/crm/arbetsorder/WorkOrderArticlesTab.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo, useState } from 'react';
 import Input from '../../../components/ui/Input';
 import { cn } from '@/lib/shared/cn';
 import { crm } from '@/app/crm/lib/crmTokens';
-import { computePricing, lineItemRowTotal, type PricingLineItem } from '@/lib/domains/crm/pricing';
+import { computePricing, lineItemRowTotal, splitRowLabor, type PricingLineItem } from '@/lib/domains/crm/pricing';
 import { lineItemQuantity } from '@/lib/domains/crm/lineItems';
 import { inferMaterialFromArticle, sacksFor } from '@/lib/domains/crm/materials';
 import { parseDecimal } from '@/lib/shared/number';
@@ -230,6 +230,13 @@ export default function WorkOrderArticlesTab({ items, currencyCode, vatPercent, 
             {rows.map((row) => {
               const mode = row.pricing_mode === 'item' ? 'item' : 'm3';
               const rowTotal = lineItemRowTotal(row as PricingLineItem);
+              const laborUnitLabel = mode === 'm3' ? 'm³' : (row.article_unit_name?.trim() || 'st');
+              const laborSplit = splitRowLabor({
+                laborCostPerUnit: row.labor_cost,
+                unitPrice: parseDecimal(row.unit_price),
+                discountPercent: parseDecimal(row.discount_percent),
+                quantity: lineItemQuantity(row as PricingLineItem),
+              });
               return (
                 <div key={row.id} className="grid gap-2 rounded-xl border border-[#e0e8dc] bg-[#f1f5ee] px-3 py-3">
                   <div className="flex items-start justify-between gap-2">
@@ -302,11 +309,30 @@ export default function WorkOrderArticlesTab({ items, currencyCode, vatPercent, 
 
                   {/* Carve out the labour portion of a material row → the aggregated "Arbetskostnad
                       ROT" Fortnox row (row reduced by it, total unchanged). Hidden when the whole row
-                      is flagged as ROT-arbete. */}
+                      is flagged as ROT-arbete.
+
+                      ⚠️ Beloppet är ett À-PRIS som räknas mot antalet, precis som À-priset ovanför,
+                      och det bryts UT ur det — det läggs inte till. Samma fält och samma räkning som
+                      i offertformuläret; texten under står här av samma skäl som där. */}
                   {rotEnabled && !row.is_rot_work ? (
                     <label className="grid gap-1">
-                      <span className="text-[10px] font-bold uppercase tracking-[0.1em] text-slate-400">Varav arbetskostnad (ROT, kr)</span>
+                      <span className="text-[10px] font-bold uppercase tracking-[0.1em] text-slate-400">
+                        Varav arbetskostnad (ROT, kr/{laborUnitLabel})
+                      </span>
                       <Input value={row.labor_cost || ''} onChange={(e) => updateRow(row.id, { labor_cost: e.target.value })} inputMode="decimal" placeholder="0" />
+                      {laborSplit.clamped ? (
+                        <span className="text-[11px] leading-snug text-amber-700">
+                          Kan inte vara högre än à-priset ({formatCurrency(parseDecimal(row.unit_price), currencyCode)}/{laborUnitLabel}) och räknas som hela priset.
+                        </span>
+                      ) : laborSplit.labor > 0 ? (
+                        <span className="text-[11px] leading-snug text-slate-500">
+                          {formatCurrency(laborSplit.labor, currencyCode)} arbete av radens {formatCurrency(rowTotal, currencyCode)}.
+                        </span>
+                      ) : (
+                        <span className="text-[11px] leading-snug text-slate-400">
+                          Per {laborUnitLabel}, som à-priset. Bryts ut ur det.
+                        </span>
+                      )}
                     </label>
                   ) : null}
                 </div>

--- a/app/crm/components/CrmConfirmDialog.tsx
+++ b/app/crm/components/CrmConfirmDialog.tsx
@@ -1,5 +1,6 @@
 "use client";
 import CrmModal from '@/app/crm/components/CrmModal';
+import { cn } from '@/lib/shared/cn';
 
 // Bekräftelsedialog i CRM:s egen yta, i stället för webbläsarens window.confirm.
 //
@@ -16,6 +17,7 @@ export default function CrmConfirmDialog({
   confirmLabel = 'Bekräfta',
   cancelLabel = 'Avbryt',
   busy = false,
+  tone = 'primary',
   onConfirm,
   onCancel,
 }: {
@@ -26,9 +28,17 @@ export default function CrmConfirmDialog({
   cancelLabel?: string;
   /** Håller knapparna låsta medan åtgärden pågår, så den inte kan startas två gånger. */
   busy?: boolean;
+  /**
+   * 'danger' för åtgärder som tar bort något. Två skillnader mot 'primary', båda avsiktliga:
+   * bekräftelseknappen bär rött i stället för CRM:ets primärgröna (grönt läser som "fortsätt,
+   * det här är bra"), och autofokus flyttas till Avbryt — en dialog som finns för att fånga
+   * felklick ska inte utföra åtgärden på ett reflexmässigt Enter.
+   */
+  tone?: 'primary' | 'danger';
   onConfirm: () => void;
   onCancel: () => void;
 }) {
+  const dangerous = tone === 'danger';
   return (
     <CrmModal
       onClose={onCancel}
@@ -46,6 +56,7 @@ export default function CrmConfirmDialog({
             type="button"
             onClick={onCancel}
             disabled={busy}
+            autoFocus={dangerous}
             className="flex-1 rounded-xl border border-slate-200 bg-white py-2.5 text-sm font-semibold text-slate-600 transition hover:border-slate-300 disabled:cursor-not-allowed disabled:opacity-60 sm:flex-none sm:px-5"
           >
             {cancelLabel}
@@ -54,9 +65,12 @@ export default function CrmConfirmDialog({
             type="button"
             onClick={onConfirm}
             disabled={busy}
-            autoFocus
-            className="flex-1 rounded-xl py-2.5 text-sm font-semibold text-white shadow-sm transition hover:brightness-95 disabled:cursor-not-allowed disabled:opacity-60 sm:ml-auto sm:flex-none sm:px-5"
-            style={{ backgroundColor: 'var(--crm-primary)' }}
+            autoFocus={!dangerous}
+            className={cn(
+              'flex-1 rounded-xl py-2.5 text-sm font-semibold text-white shadow-sm transition hover:brightness-95 disabled:cursor-not-allowed disabled:opacity-60 sm:ml-auto sm:flex-none sm:px-5',
+              dangerous && 'bg-rose-600',
+            )}
+            style={dangerous ? undefined : { backgroundColor: 'var(--crm-primary)' }}
           >
             {confirmLabel}
           </button>

--- a/app/crm/offerter/QuoteFormClient.tsx
+++ b/app/crm/offerter/QuoteFormClient.tsx
@@ -219,6 +219,10 @@ type EffectiveRow = QuoteLineItem & {
   label: string;
   mode: 'm3' | 'item';
   rowTotal: number;
+  // Radens utbrutna ROT-arbetskostnad i kronor (labor_cost per enhet × antal, rabatt inräknad).
+  // Räknas här av samma skäl som rowTotal: formuläret prissätter auto-rader med sin egen stub, och
+  // pricing.ts lineItemRotLabor hade gett dem 0. Se splitRowLabor.
+  rotLabor: number;
   isConfigured: boolean;
 };
 
@@ -929,30 +933,41 @@ function MarginBadge({ marginPercent, className }: { marginPercent: number | nul
 
 // Hur "Varav arbetskostnad" delar radens pris, i klartext under fältet.
 //
-// Beloppet är en UTBRYTNING, inte ett tillägg — se splitRowLabor. Den som läser det som ett tillägg
-// prissätter offerten för lågt utan att något varnar, så raden här säger alltid vad som faktiskt
-// händer med kronorna.
-function LaborCarveoutHint({ rowTotal, laborCost }: { rowTotal: number; laborCost: string }) {
-  const { labor, material, clamped } = splitRowLabor(rowTotal, laborCost);
+// Två saker har lästs fel i verkligheten, och raden här finns för att båda ska synas direkt:
+// beloppet är ett À-PRIS som räknas mot kubiken (500 kr arbete på 10 m³ blir 5 000 kr, på 30 m³
+// blir det 15 000), och det är en UTBRYTNING ur A-priset, inte ett tillägg ovanpå det.
+function LaborCarveoutHint({
+  laborCost, unitPrice, discountPercent, quantity, unitLabel,
+}: {
+  laborCost: string;
+  unitPrice: number;
+  discountPercent: number;
+  quantity: number;
+  unitLabel: string;
+}) {
+  const { labor, material, rowTotal, clamped } = splitRowLabor({
+    laborCostPerUnit: laborCost, unitPrice, discountPercent, quantity,
+  });
 
   if (clamped) {
     return (
       <p className="m-0 mt-1 text-[11px] leading-snug text-amber-700">
-        Beloppet är större än radens {formatCurrency(rowTotal, 'SEK')} och räknas som hela raden.
+        Arbetskostnaden kan inte vara högre än A-priset ({formatCurrency(unitPrice, 'SEK')}/{unitLabel}) och
+        räknas som hela priset.
       </p>
     );
   }
   if (labor > 0) {
     return (
       <p className="m-0 mt-1 text-[11px] leading-snug text-slate-500">
-        Av radens {formatCurrency(rowTotal, 'SEK')} är {formatCurrency(labor, 'SEK')} arbete
-        och {formatCurrency(material, 'SEK')} material.
+        {formatCurrency(labor, 'SEK')} arbete av radens {formatCurrency(rowTotal, 'SEK')} — resten,
+        {' '}{formatCurrency(material, 'SEK')}, är material.
       </p>
     );
   }
   return (
     <p className="m-0 mt-1 text-[11px] leading-snug text-slate-400">
-      Bryts ut ur radpriset — höjer det inte.
+      Per {unitLabel}, som A-priset. Bryts ut ur det — höjer det inte.
     </p>
   );
 }
@@ -993,6 +1008,8 @@ function LineItemRow({
   // The ROT labour carve-out field sits on the economy row next to A-pris/Rabatt, but only when ROT
   // is on and the row isn't already flagged as full ROT work (its whole price is then the labour).
   const showLaborField = rotEnabled && !row.is_rot_work;
+  // Samma enhet som raden prissätts i, så "kr/m³" respektive "kr/st" står bredvid rätt tal.
+  const laborUnitLabel = isM3 ? 'm³' : (row.article_unit_name?.trim() || 'st');
 
   // ── Collapsed: single overview line ──────────────────────────────────────────
   if (!expanded) {
@@ -1101,9 +1118,15 @@ function LineItemRow({
             begärs på 200 kr i stället för 200 kr × volymen. Texten visar delningen i kronor så fort
             ett belopp finns, så felet syns i samma ögonblick det görs. */}
         {showLaborField ? (
-          <Field label="Varav arbetskostnad (ROT, kr)">
+          <Field label={`Varav arbetskostnad (ROT, kr/${laborUnitLabel})`}>
             <Input value={row.labor_cost} onChange={(e) => onChange({ labor_cost: e.target.value })} inputMode="decimal" placeholder="0" />
-            <LaborCarveoutHint rowTotal={metrics?.rowTotal ?? 0} laborCost={row.labor_cost} />
+            <LaborCarveoutHint
+              laborCost={row.labor_cost}
+              unitPrice={metrics?.unit ?? 0}
+              discountPercent={parseDecimal(row.discount_percent)}
+              quantity={metrics?.amount ?? 0}
+              unitLabel={laborUnitLabel}
+            />
           </Field>
         ) : null}
         <Field label="Rabatt %"><Input value={row.discount_percent} onChange={(e) => onChange({ discount_percent: e.target.value })} inputMode="decimal" placeholder="0" /></Field>
@@ -1764,10 +1787,14 @@ export default function QuoteFormClient({ quoteId, canReassign = false }: { quot
       const constructionLabel = item.construction === 'vagg' ? 'Vägg' : item.construction === 'snedtak' ? 'Snedtak' : item.construction === 'vind' ? 'Vind' : '';
       const baseLabel = item.article_name ? `${item.article_name}${item.article_number ? ` (${item.article_number})` : ''}` : `${constructionLabel || 'Okänd'}${item.thickness_mm ? ` ${item.thickness_mm} mm` : ''}`;
       const unitSuffix = mode === 'm3' ? ' (m³)' : item.article_unit_name ? ` (${item.article_unit_name})` : '';
+      const laborSplit = splitRowLabor({
+        laborCostPerUnit: item.labor_cost, unitPrice: baseUnit, discountPercent: discount, quantity: amount,
+      });
       return {
         ...item, amount, unit: baseUnit, effectiveUnit,
         label: `${baseLabel}${unitSuffix}`,
         mode, rowTotal: amount * effectiveUnit,
+        rotLabor: laborSplit.labor,
         isConfigured: Boolean(item.article_name || item.m2 || item.quantity || item.unit_price),
       };
     });
@@ -1784,12 +1811,12 @@ export default function QuoteFormClient({ quoteId, canReassign = false }: { quot
     // Skatteverket (ROT reductions drop the öre), e.g. 393,75 → 393. Flooring is also
     // the safe direction for the business: the deduction is never overstated.
     // The ROT base is labour: a row flagged fully as ROT work contributes its whole total, an
-    // unflagged material row only its carved-out `labor_cost` (clamped to the row total). Mirrors
+    // unflagged material row only its carved-out labour (labor_cost per enhet × antal). Mirrors
     // lib/domains/crm/pricing.ts and the Fortnox push (flagged rows + the "Arbetskostnad ROT" row).
     const rotActive = draft.quote_type === 'private' && draft.rot_enabled;
     const rotLaborBase = rotActive
       ? effectiveRows.reduce((sum, r) => {
-          const base = r.is_rot_work ? r.rowTotal : Math.min(Math.max(0, parseDecimal(r.labor_cost)), r.rowTotal);
+          const base = r.is_rot_work ? r.rowTotal : Math.min(r.rotLabor, r.rowTotal);
           return sum + base;
         }, 0)
       : 0;
@@ -1803,7 +1830,7 @@ export default function QuoteFormClient({ quoteId, canReassign = false }: { quot
     // Carved-out labour only (excludes fully-flagged ROT rows) — surfaced in the ROT section so the
     // seller sees what becomes the separate "Arbetskostnad ROT" row.
     const carvedLabor = rotActive
-      ? effectiveRows.reduce((sum, r) => (r.is_rot_work ? sum : sum + Math.min(Math.max(0, parseDecimal(r.labor_cost)), r.rowTotal)), 0)
+      ? effectiveRows.reduce((sum, r) => (r.is_rot_work ? sum : sum + Math.min(r.rotLabor, r.rowTotal)), 0)
       : 0;
 
     return { subtotal, vat, total, rotDeduction, toPay: total - rotDeduction, carvedLabor };

--- a/app/crm/offerter/QuoteFormClient.tsx
+++ b/app/crm/offerter/QuoteFormClient.tsx
@@ -8,7 +8,7 @@ import DatePicker from '../../../components/ui/DatePicker';
 import { useToast } from '@/lib/Toast';
 import { cn } from '@/lib/shared/cn';
 import { parseDecimal } from '@/lib/shared/number';
-import { lineItemQuantity } from '@/lib/domains/crm/lineItems';
+import { lineItemQuantity, isBlankLineItem } from '@/lib/domains/crm/lineItems';
 import {
   rowMarginPercent, marginTier, quoteMargin, MARGIN_THRESHOLDS,
   type MarginRow, type MarginTier,
@@ -16,6 +16,7 @@ import {
 import { crm } from '@/app/crm/lib/crmTokens';
 import AddressAutocompleteInput from '@/app/crm/components/AddressAutocompleteInput';
 import CrmModal from '@/app/crm/components/CrmModal';
+import CrmConfirmDialog from '@/app/crm/components/CrmConfirmDialog';
 import { formatPersonalNumber, isValidPersonalNumber, PERSONAL_NUMBER_ERROR } from '@/lib/domains/crm/personalNumber';
 import { DndContext, closestCenter, PointerSensor, TouchSensor, useSensor, useSensors, type DragEndEvent } from '@dnd-kit/core';
 import { SortableContext, verticalListSortingStrategy, arrayMove, useSortable } from '@dnd-kit/sortable';
@@ -1156,6 +1157,22 @@ export default function QuoteFormClient({ quoteId, canReassign = false }: { quot
   const [expandedRowId, setExpandedRowId] = useState<string | null>(
     () => (initialDraft.items[0] && !initialDraft.items[0].article_name ? initialDraft.items[0].id : null),
   );
+  // Vilken artikelrad som väntar på bekräftelse innan den tas bort. Krysset på en hopfälld rad
+  // sitter tätt intill raden man klickar på för att fälla ut den, och borttagningen går inte att
+  // ångra — artikeln, priset, rabatten och radnoteringen är borta ur draften direkt. Tomma rader
+  // hoppar över frågan (se isBlankLineItem); där finns inget att förlora.
+  const [pendingRemoveRowId, setPendingRemoveRowId] = useState<string | null>(null);
+
+  // Sista raden tas aldrig bort helt — den ersätts med en tom, så formuläret alltid har en rad att
+  // fylla i. Samma regel gällde före bekräftelsedialogen och ligger här så att båda vägarna in
+  // (direkt för tomma rader, bekräftad för ifyllda) delar den.
+  function removeLineItem(id: string) {
+    setDraft((d) => ({
+      ...d,
+      items: d.items.length > 1 ? d.items.filter((item) => item.id !== id) : [createEmptyLineItem()],
+    }));
+    setPendingRemoveRowId(null);
+  }
   const [loadedQuote, setLoadedQuote] = useState<QuoteItem | null>(null);
   const [selectedCustomer, setSelectedCustomer] = useState<CrmCustomerLite | null>(null);
   // What the customer card gave when the customer was picked. The reference the refresh-on-return
@@ -2268,6 +2285,13 @@ export default function QuoteFormClient({ quoteId, canReassign = false }: { quot
   const doneSteps = requiredSections.filter((s) => s.done).length;
   const stepOf = (id: string) => sections.findIndex((s) => s.id === id) + 1;
 
+  // Slås upp mot draften i stället för att lägga undan hela raden i state: raden kan redigeras
+  // medan dialogen står öppen (den täcker inte formuläret på desktop), och en kopia hade då kunnat
+  // visa ett artikelnamn som inte längre stämmer.
+  const pendingRemoveRow = pendingRemoveRowId
+    ? draft.items.find((item) => item.id === pendingRemoveRowId) ?? null
+    : null;
+
   return (
     <div className="grid gap-6 pb-20 lg:pb-0">
 
@@ -2793,7 +2817,7 @@ export default function QuoteFormClient({ quoteId, canReassign = false }: { quot
                     ...item, article_id: null, article_name: null, article_number: null, article_price: null, article_unit_name: null, article_note: null,
                   } : item),
                 }))}
-                onRemove={() => setDraft((d) => ({ ...d, items: d.items.length > 1 ? d.items.filter((item) => item.id !== row.id) : [createEmptyLineItem()] }))}
+                onRemove={() => { if (isBlankLineItem(row)) removeLineItem(row.id); else setPendingRemoveRowId(row.id); }}
               />
                 )}
               </SortableLineItem>
@@ -3371,6 +3395,21 @@ export default function QuoteFormClient({ quoteId, canReassign = false }: { quot
             </Field>
           </div>
         </CrmModal>
+      ) : null}
+
+      {pendingRemoveRow ? (
+        <CrmConfirmDialog
+          title="Ta bort raden?"
+          message={
+            pendingRemoveRow.article_name
+              ? `${pendingRemoveRow.article_name} tas bort från offerten. Det går inte att ångra.`
+              : 'Raden tas bort från offerten. Det går inte att ångra.'
+          }
+          confirmLabel="Ta bort rad"
+          tone="danger"
+          onConfirm={() => removeLineItem(pendingRemoveRow.id)}
+          onCancel={() => setPendingRemoveRowId(null)}
+        />
       ) : null}
     </div>
   );

--- a/app/crm/offerter/QuoteFormClient.tsx
+++ b/app/crm/offerter/QuoteFormClient.tsx
@@ -223,6 +223,9 @@ type EffectiveRow = QuoteLineItem & {
   // Räknas här av samma skäl som rowTotal: formuläret prissätter auto-rader med sin egen stub, och
   // pricing.ts lineItemRotLabor hade gett dem 0. Se splitRowLabor.
   rotLabor: number;
+  // Arbetskostnaden är högre än A-priset → ingen utbrytning sker. Spärrar sparningen; se
+  // getValidationIssues och splitRowLabor.
+  rotLaborLeavesNoMaterial: boolean;
   isConfigured: boolean;
 };
 
@@ -432,6 +435,22 @@ function getValidationIssues(draft: QuoteDraft, effectiveRows: EffectiveRow[]) {
   if (hasAnyLineItemInput) {
     const hasInvalidRow = effectiveRows.some((item) => item.isConfigured && (!(item.amount > 0) || !(item.effectiveUnit >= 0)));
     if (hasInvalidRow) issues.push('Ofullständiga rader — mängd och pris krävs');
+  }
+  // Spärr, inte en varning. En arbetskostnad över A-priset bryter inte ut något (se splitRowLabor),
+  // så offerten skulle gå till Fortnox utan det ROT-underlag säljaren tror att den har. Det gäller
+  // varenda rad som sparats under den gamla tolkningen, där beloppet var ett klumpbelopp för hela
+  // raden — de dyker upp här i samma stund någon öppnar offerten, i stället för att märkas när
+  // kunden undrar var avdraget tog vägen.
+  if (draft.quote_type === 'private' && draft.rot_enabled) {
+    const over = effectiveRows.filter((r) => r.isConfigured && !r.is_rot_work && r.rotLaborLeavesNoMaterial);
+    if (over.length) {
+      const rader = over.map((r) => effectiveRows.indexOf(r) + 1).join(', ');
+      issues.push(
+        over.length === 1
+          ? `Rad ${rader}: arbetskostnaden äter hela A-priset — inget material blir kvar`
+          : `Rad ${rader}: arbetskostnaden äter hela A-priset — inget material blir kvar`,
+      );
+    }
   }
   return issues;
 }
@@ -945,15 +964,16 @@ function LaborCarveoutHint({
   quantity: number;
   unitLabel: string;
 }) {
-  const { labor, material, rowTotal, clamped } = splitRowLabor({
+  const { labor, material, rowTotal, leavesNoMaterial } = splitRowLabor({
     laborCostPerUnit: laborCost, unitPrice, discountPercent, quantity,
   });
 
-  if (clamped) {
+  if (leavesNoMaterial) {
     return (
-      <p className="m-0 mt-1 text-[11px] leading-snug text-amber-700">
-        Arbetskostnaden kan inte vara högre än A-priset ({formatCurrency(unitPrice, 'SEK')}/{unitLabel}) och
-        räknas som hela priset.
+      <p className="m-0 mt-1 text-[11px] leading-snug text-rose-700">
+        Arbetet är hela A-priset ({formatCurrency(unitPrice, 'SEK')}/{unitLabel}) — inget material blir
+        kvar. Ingen arbetskostnad bryts ut förrän det rättas. A-priset ska vara HELA priset, och det
+        här beloppet den del av det som är arbete.
       </p>
     );
   }
@@ -1795,6 +1815,7 @@ export default function QuoteFormClient({ quoteId, canReassign = false }: { quot
         label: `${baseLabel}${unitSuffix}`,
         mode, rowTotal: amount * effectiveUnit,
         rotLabor: laborSplit.labor,
+        rotLaborLeavesNoMaterial: laborSplit.leavesNoMaterial,
         isConfigured: Boolean(item.article_name || item.m2 || item.quantity || item.unit_price),
       };
     });

--- a/app/crm/offerter/QuoteFormClient.tsx
+++ b/app/crm/offerter/QuoteFormClient.tsx
@@ -43,7 +43,7 @@ import {
   hasMeasurementBlock,
   replaceMeasurementBlock,
 } from '@/lib/domains/crm/measurementBlock';
-import { ROT_HOUSE_WORK_TYPES } from '@/lib/domains/fortnox/types';
+import { ROT_HOUSE_WORK_TYPES, ROT_LABOR_ARTICLE_NUMBER, ROT_LABOR_DESCRIPTION } from '@/lib/domains/fortnox/types';
 
 // Swedish labels for the Fortnox ROT HouseWorkType codes shown in the ROT section.
 const ROT_HOUSE_WORK_LABELS: Record<(typeof ROT_HOUSE_WORK_TYPES)[number], string> = {
@@ -2214,16 +2214,17 @@ export default function QuoteFormClient({ quoteId, canReassign = false }: { quot
   // vi om här skulle en auto-rad bidra med 0 kr till TG:n men synas i Delsumman, och inte ens
   // flaggas som obedömd. Se MarginRow i pricing.ts.
   //
-  // `isLabor` sätts BARA när ROT faktiskt är aktivt på offerten. `is_rot_work` betyder "den här
-  // raden är ROT-arbete" och kryssrutan visas inte annars — en kvarglömd flagga på en offert där
-  // ROT stängts av ska inte tyst ge raden full TG. Samma villkor som ROT-underlaget i `totals`,
-  // så de två inte kan säga emot varandra.
-  const rotActiveForMargin = draft.quote_type === 'private' && draft.rot_enabled;
+  // Samma villkor som ROT-underlaget i `totals` OCH som pushen (`rot_details.enabled && !reverseVat`
+  // — omvänd skattskyldighet är en företagsgrej och ROT är privat, så de kan aldrig kollidera).
+  // Styr två saker: att `isLabor` bara sätts när ROT faktiskt är aktivt — en kvarglömd kryssruta på
+  // en offert där ROT stängts av ska inte tyst ge raden full TG — och att den genererade
+  // arbetskostnadsraden visas exakt när pushen faktiskt skickar den.
+  const rotActive = draft.quote_type === 'private' && draft.rot_enabled;
   const marginRows: MarginRow[] = effectiveRows.map((r) => ({
     revenue: r.rowTotal,
     quantity: r.amount,
     purchasePrice: r.article_number ? purchasePrices[r.article_number] ?? null : null,
-    isLabor: rotActiveForMargin && Boolean(r.is_rot_work),
+    isLabor: rotActive && Boolean(r.is_rot_work),
   }));
   const quoteMarginResult = quoteMargin(marginRows);
   const quoteMarginTier = marginTier(quoteMarginResult.marginPercent);
@@ -2832,6 +2833,37 @@ export default function QuoteFormClient({ quoteId, canReassign = false }: { quot
           </div>
           </SortableContext>
           </DndContext>
+
+          {/* ── Den genererade arbetskostnadsraden ────────────────────────────────────────────
+              Ligger ALLTID sist, som på Fortnox-offerten: pushen lägger den efter artikelraderna.
+              Den är läsvy och finns inte i `draft.items` — den syntetiseras först vid pushen
+              (buildOfferRows → rotLaborRow) och får aldrig lagras som en riktig rad. Gjorde vi det
+              skulle pushen bryta ut arbetet EN GÅNG TILL ovanpå den och dubbelräkna det.
+
+              ⚠️ Beloppet är INTE ett tillägg. Det är redan utbrutet ur raderna ovan, som visas till
+              sitt fulla pris här medan Fortnox-dokumentet visar dem sänkta med samma belopp — summan
+              är densamma på båda hållen. Därför "Varav" och ingen egen summering: en säljare som
+              adderar radbeloppen i huvudet ska inte landa på en annan siffra än Delsumman.
+
+              Visas bara när något faktiskt bryts ut. Rader med "ROT-arbete" ikryssad går INTE hit —
+              de blir egna husarbete-rader med sin egen artikel, precis som i pushen. */}
+          {rotActive && totals.carvedLabor > 0 ? (
+            <div className="mt-2 flex items-center gap-2 rounded-xl border border-dashed border-emerald-200 bg-emerald-50/40 px-3.5 py-2.5">
+              <span className="shrink-0 text-xs font-semibold tabular-nums text-emerald-600/60">{draft.items.length + 1}</span>
+              <div className="min-w-0 flex-1">
+                <p className="m-0 truncate text-sm font-medium text-emerald-900">
+                  {ROT_LABOR_DESCRIPTION} <span className="font-normal text-emerald-700/70">({ROT_LABOR_ARTICLE_NUMBER})</span>
+                </p>
+                <p className="m-0 text-[11px] leading-snug text-emerald-700/70">
+                  Skapas automatiskt på Fortnox-offerten. Beloppet är redan utbrutet ur raderna ovan.
+                </p>
+              </div>
+              <span className="shrink-0 text-right text-sm font-semibold tabular-nums text-emerald-900">
+                <span className="mr-1 text-[11px] font-normal text-emerald-700/70">Varav</span>
+                {formatCurrency(totals.carvedLabor, 'SEK')}
+              </span>
+            </div>
+          ) : null}
 
           <button
             type="button"

--- a/app/crm/offerter/QuoteFormClient.tsx
+++ b/app/crm/offerter/QuoteFormClient.tsx
@@ -2213,10 +2213,17 @@ export default function QuoteFormClient({ quoteId, canReassign = false }: { quot
   // Formuläret prissätter auto-prissatta rader med sin egen stub medan pricing.ts ger dem 0 — räknade
   // vi om här skulle en auto-rad bidra med 0 kr till TG:n men synas i Delsumman, och inte ens
   // flaggas som obedömd. Se MarginRow i pricing.ts.
+  //
+  // `isLabor` sätts BARA när ROT faktiskt är aktivt på offerten. `is_rot_work` betyder "den här
+  // raden är ROT-arbete" och kryssrutan visas inte annars — en kvarglömd flagga på en offert där
+  // ROT stängts av ska inte tyst ge raden full TG. Samma villkor som ROT-underlaget i `totals`,
+  // så de två inte kan säga emot varandra.
+  const rotActiveForMargin = draft.quote_type === 'private' && draft.rot_enabled;
   const marginRows: MarginRow[] = effectiveRows.map((r) => ({
     revenue: r.rowTotal,
     quantity: r.amount,
     purchasePrice: r.article_number ? purchasePrices[r.article_number] ?? null : null,
+    isLabor: rotActiveForMargin && Boolean(r.is_rot_work),
   }));
   const quoteMarginResult = quoteMargin(marginRows);
   const quoteMarginTier = marginTier(quoteMarginResult.marginPercent);

--- a/app/crm/offerter/QuoteFormClient.tsx
+++ b/app/crm/offerter/QuoteFormClient.tsx
@@ -10,7 +10,7 @@ import { cn } from '@/lib/shared/cn';
 import { parseDecimal } from '@/lib/shared/number';
 import { lineItemQuantity, isBlankLineItem } from '@/lib/domains/crm/lineItems';
 import {
-  rowMarginPercent, marginTier, quoteMargin, MARGIN_THRESHOLDS,
+  rowMarginPercent, marginTier, quoteMargin, splitRowLabor, MARGIN_THRESHOLDS,
   type MarginRow, type MarginTier,
 } from '@/lib/domains/crm/pricing';
 import { crm } from '@/app/crm/lib/crmTokens';
@@ -927,6 +927,36 @@ function MarginBadge({ marginPercent, className }: { marginPercent: number | nul
   );
 }
 
+// Hur "Varav arbetskostnad" delar radens pris, i klartext under fältet.
+//
+// Beloppet är en UTBRYTNING, inte ett tillägg — se splitRowLabor. Den som läser det som ett tillägg
+// prissätter offerten för lågt utan att något varnar, så raden här säger alltid vad som faktiskt
+// händer med kronorna.
+function LaborCarveoutHint({ rowTotal, laborCost }: { rowTotal: number; laborCost: string }) {
+  const { labor, material, clamped } = splitRowLabor(rowTotal, laborCost);
+
+  if (clamped) {
+    return (
+      <p className="m-0 mt-1 text-[11px] leading-snug text-amber-700">
+        Beloppet är större än radens {formatCurrency(rowTotal, 'SEK')} och räknas som hela raden.
+      </p>
+    );
+  }
+  if (labor > 0) {
+    return (
+      <p className="m-0 mt-1 text-[11px] leading-snug text-slate-500">
+        Av radens {formatCurrency(rowTotal, 'SEK')} är {formatCurrency(labor, 'SEK')} arbete
+        och {formatCurrency(material, 'SEK')} material.
+      </p>
+    );
+  }
+  return (
+    <p className="m-0 mt-1 text-[11px] leading-snug text-slate-400">
+      Bryts ut ur radpriset — höjer det inte.
+    </p>
+  );
+}
+
 function LineItemRow({
   row,
   index,
@@ -1063,10 +1093,17 @@ function LineItemRow({
           />
         </Field>
         {/* Carve out the labour portion of a material row for ROT: the amount here is moved onto the
-            separate "Arbetskostnad ROT" row and deducted from this row (total unchanged). */}
+            separate "Arbetskostnad ROT" row and deducted from this row (total unchanged).
+
+            ⚠️ Hjälptexten under fältet är inte pynt. "Varav" har lästs som "plus": säljaren sänkte
+            A-priset från 500 till 300 kr/m³ och skrev 200 här i tron att raden landade på 500 igen.
+            Den gör den inte — raden blir 300 kr/m³, offerten blir billigare än den skulle, och ROT
+            begärs på 200 kr i stället för 200 kr × volymen. Texten visar delningen i kronor så fort
+            ett belopp finns, så felet syns i samma ögonblick det görs. */}
         {showLaborField ? (
           <Field label="Varav arbetskostnad (ROT, kr)">
             <Input value={row.labor_cost} onChange={(e) => onChange({ labor_cost: e.target.value })} inputMode="decimal" placeholder="0" />
+            <LaborCarveoutHint rowTotal={metrics?.rowTotal ?? 0} laborCost={row.labor_cost} />
           </Field>
         ) : null}
         <Field label="Rabatt %"><Input value={row.discount_percent} onChange={(e) => onChange({ discount_percent: e.target.value })} inputMode="decimal" placeholder="0" /></Field>

--- a/app/crm/offerter/QuoteFormClient.tsx
+++ b/app/crm/offerter/QuoteFormClient.tsx
@@ -91,8 +91,13 @@ type QuoteLineItem = {
   line_note: string;
   is_rot_work: boolean;
   house_work_type: string;
-  // Labour carved out of a material row for ROT (kr, ex VAT). Summed onto a single "Arbetskostnad
-  // ROT" row on the Fortnox document; the material row is reduced by it so the total is unchanged.
+  // Labour carved out of a material row for ROT, as kr PER UNIT ex VAT — ett à-pris precis som
+  // `unit_price`, som räknas mot antalet. Summeras till en enda "Arbetskostnad ROT"-rad på
+  // Fortnox-dokumentet; materialraden sänks med lika mycket, så totalen är oförändrad.
+  //
+  // ⚠️ Det är en UTBRYTNING ur A-priset, inte ett tillägg: A-priset är HELA priset och det här
+  // beloppet den del av det som är arbete. Äter beloppet hela A-priset bryts ingenting ut och
+  // sparningen spärras — se splitRowLabor i lib/domains/crm/pricing.ts, som äger tolkningen.
   labor_cost: string;
   density: string;
 };
@@ -446,9 +451,7 @@ function getValidationIssues(draft: QuoteDraft, effectiveRows: EffectiveRow[]) {
     if (over.length) {
       const rader = over.map((r) => effectiveRows.indexOf(r) + 1).join(', ');
       issues.push(
-        over.length === 1
-          ? `Rad ${rader}: arbetskostnaden äter hela A-priset — inget material blir kvar`
-          : `Rad ${rader}: arbetskostnaden äter hela A-priset — inget material blir kvar`,
+        `${over.length === 1 ? 'Rad' : 'Rader'} ${rader}: arbetskostnaden äter hela A-priset — inget material blir kvar`,
       );
     }
   }

--- a/lib/domains/crm/lineItems.ts
+++ b/lib/domains/crm/lineItems.ts
@@ -20,3 +20,42 @@ export function lineItemQuantity(item: LineItemQuantitySource): number {
   }
   return parseDecimal(item.quantity);
 }
+
+export type LineItemContentSource = {
+  article_name?: string | null;
+  article_number?: string | null;
+  construction?: string | null;
+  m2?: string | null;
+  thickness_mm?: string | null;
+  quantity?: string | null;
+  unit_price?: string | null;
+  discount_percent?: string | null;
+  line_note?: string | null;
+  labor_cost?: string | null;
+  density?: string | null;
+  is_rot_work?: boolean | null;
+};
+
+// Har raden något som skulle gå förlorat om den togs bort? Styr om offertformulärets ta bort-kryss
+// frågar först eller tar bort raden direkt: att kräva en bekräftelse för en rad utan innehåll är
+// bara i vägen, medan en ifylld rad inte går att få tillbaka.
+//
+// `auto_price` och `house_work_type` räknas medvetet INTE som innehåll — de bär defaultvärden som
+// en orörd rad har utan att någon valt dem, och hade gjort varje ny rad "ifylld".
+export function isBlankLineItem(item: LineItemContentSource): boolean {
+  const empty = (v: string | null | undefined) => !v || !v.trim();
+  return (
+    empty(item.article_name) &&
+    empty(item.article_number) &&
+    empty(item.construction) &&
+    empty(item.m2) &&
+    empty(item.thickness_mm) &&
+    empty(item.quantity) &&
+    empty(item.unit_price) &&
+    empty(item.discount_percent) &&
+    empty(item.line_note) &&
+    empty(item.labor_cost) &&
+    empty(item.density) &&
+    !item.is_rot_work
+  );
+}

--- a/lib/domains/crm/pricing.ts
+++ b/lib/domains/crm/pricing.ts
@@ -72,8 +72,11 @@ export type RowLaborSplit = {
   material: number;
   /** Hela radens pris efter rabatt — arbete + material. */
   rowTotal: number;
-  /** Det inskrivna beloppet per enhet översteg A-priset och kapades ner till det. */
-  clamped: boolean;
+  /**
+   * Arbetskostnaden lämnar inget material kvar (den är minst lika stor som A-priset). Då bryts
+   * INGEN arbetskostnad ut — se kommentaren på splitRowLabor om varför det är den säkra riktningen.
+   */
+  leavesNoMaterial: boolean;
 };
 
 /**
@@ -91,8 +94,17 @@ export type RowLaborSplit = {
  * Rabatten träffar båda delarna lika. Rabatteras jobbet 10 % sjunker den fakturerade
  * arbetskostnaden lika mycket, och ROT får bara begäras på det som faktiskt debiteras.
  *
- * Kapningen sitter mot A-PRISET, inte mot radtotalen: material får aldrig gå negativt, och en
- * gräns per enhet är den enda som håller oavsett antal.
+ * ⚠️ EN ARBETSKOSTNAD SOM ÄTER HELA A-PRISET BRYTER UT NOLL, inte allt. På en MATERIALrad är det
+ * alltid ett fel att arbetet är hela priset — då skickas ett Fortnox-dokument som begär ROT på
+ * material, vilket inte är tillåtet. Två verkliga vägar dit, båda tysta före den här spärren:
+ *
+ *   • en rad sparad under den gamla klumpbeloppstolkningen (8000 mot ett A-pris på 200), och
+ *   • att A-priset satts till bara materialdelen och arbetet skrivits som ett PÅSLAG (250 + 250),
+ *     vilket är en annan modell än den här funktionen räknar efter.
+ *
+ * Båda är datafel, inte instruktioner att bryta ut allt. Det säkra svaret är att inte bryta ut
+ * något och låta felet synas: offertformuläret spärrar sparningen och pekar ut raden. Vill man
+ * verkligen att hela raden ska vara arbete finns kryssrutan "ROT-arbete", som säger det uttryckligen.
  */
 export function splitRowLabor(input: {
   laborCostPerUnit: string | number | null | undefined;
@@ -103,12 +115,13 @@ export function splitRowLabor(input: {
 }): RowLaborSplit {
   const unitPrice = Math.max(0, input.unitPrice);
   const entered = Math.max(0, parseDecimal(input.laborCostPerUnit));
-  const perUnit = Math.min(entered, unitPrice);
+  const leavesNoMaterial = entered > 0 && entered >= unitPrice;
+  const perUnit = leavesNoMaterial ? 0 : entered;
   const quantity = Math.max(0, input.quantity);
   const keep = 1 - Math.min(100, Math.max(0, input.discountPercent)) / 100;
   const labor = perUnit * keep * quantity;
   const rowTotal = unitPrice * keep * quantity;
-  return { perUnit, labor, material: Math.max(0, rowTotal - labor), rowTotal, clamped: entered > unitPrice };
+  return { perUnit, labor, material: Math.max(0, rowTotal - labor), rowTotal, leavesNoMaterial };
 }
 
 /**

--- a/lib/domains/crm/pricing.ts
+++ b/lib/domains/crm/pricing.ts
@@ -62,6 +62,37 @@ export function lineItemRowTotal(item: PricingLineItem): number {
   return Math.max(0, lineItemQuantity(item) * lineItemEffectiveUnitPrice(item));
 }
 
+export type RowLaborSplit = {
+  /** Utbruten arbetskostnad i kronor, kapad till radtotalen. */
+  labor: number;
+  /** Det som blir kvar av radpriset när arbetet brutits ut. */
+  material: number;
+  /** Det inskrivna beloppet översteg radtotalen och kapades ner till den. */
+  clamped: boolean;
+};
+
+/**
+ * Hur en rads pris delas av "Varav arbetskostnad (ROT, kr)".
+ *
+ * ⚠️ FÄLTET ÄR EN UTBRYTNING, INTE ETT TILLÄGG. Beloppet höjer aldrig radpriset — det säger hur
+ * stor DEL av det befintliga priset som är arbete. Sätter säljaren A-priset till 300 kr/m³ och
+ * skriver 200 i fältet blir raden 300 kr/m³, inte 500.
+ *
+ * Finns för att kunna visa delningen i klartext under fältet. Speglar `rowRotLaborCarveout` i
+ * lib/domains/fortnox/helpers.ts, som gör samma kapning vid pushen — den modulen importerar
+ * getSupabaseAdmin och kan därför aldrig nå en klientkomponent, så beräkningen bor här och båda
+ * hållen kapar likadant.
+ */
+export function splitRowLabor(
+  rowTotal: number,
+  laborCostInput: string | number | null | undefined,
+): RowLaborSplit {
+  const total = Math.max(0, rowTotal);
+  const entered = Math.max(0, parseDecimal(laborCostInput));
+  const labor = Math.min(entered, total);
+  return { labor, material: total - labor, clamped: entered > total };
+}
+
 export function computePricing(
   items: PricingLineItem[],
   vatPercentInput: number | string | null,

--- a/lib/domains/crm/pricing.ts
+++ b/lib/domains/crm/pricing.ts
@@ -17,8 +17,9 @@ export type PricingLineItem = {
   article_price?: number | null;
   discount_percent?: string | null;
   is_rot_work?: boolean | null;
-  // Labour carved out of a material row for ROT (kr, ex VAT). Summed onto a single
-  // "Arbetskostnad ROT" row at Fortnox-push time; here it only feeds the ROT deduction base.
+  // Labour carved out of a material row for ROT, as kr PER UNIT ex VAT — an à-pris like
+  // `unit_price`, multiplied by the quantity. Summed onto a single "Arbetskostnad ROT" row at
+  // Fortnox-push time; here it only feeds the ROT deduction base. See splitRowLabor.
   labor_cost?: string | null;
 };
 
@@ -63,34 +64,68 @@ export function lineItemRowTotal(item: PricingLineItem): number {
 }
 
 export type RowLaborSplit = {
-  /** Utbruten arbetskostnad i kronor, kapad till radtotalen. */
+  /** Arbetskostnad per enhet efter kapning mot A-priset. */
+  perUnit: number;
+  /** Radens arbetskostnad i kronor: per enhet × antal, med radens rabatt. */
   labor: number;
-  /** Det som blir kvar av radpriset när arbetet brutits ut. */
+  /** Det som blir kvar av radens pris som material. */
   material: number;
-  /** Det inskrivna beloppet översteg radtotalen och kapades ner till den. */
+  /** Hela radens pris efter rabatt — arbete + material. */
+  rowTotal: number;
+  /** Det inskrivna beloppet per enhet översteg A-priset och kapades ner till det. */
   clamped: boolean;
 };
 
 /**
- * Hur en rads pris delas av "Varav arbetskostnad (ROT, kr)".
+ * Hur "Varav arbetskostnad (ROT)" delar en rads pris.
  *
- * ⚠️ FÄLTET ÄR EN UTBRYTNING, INTE ETT TILLÄGG. Beloppet höjer aldrig radpriset — det säger hur
- * stor DEL av det befintliga priset som är arbete. Sätter säljaren A-priset till 300 kr/m³ och
- * skriver 200 i fältet blir raden 300 kr/m³, inte 500.
+ * ⚠️ BELOPPET ÄR ETT À-PRIS, precis som A-priset: kr per m³ (eller per styck), och det räknas mot
+ * antalet. Rättat 2026-08-19 efter en riktig bugg — fältet lästes förut som ett klumpbelopp för
+ * hela raden, så 500 kr arbete gav 500 kr oavsett om raden var 10 m³ eller 30 m³. ROT-avdraget
+ * frös alltså vid samma krontal hur stort jobbet än blev.
  *
- * Finns för att kunna visa delningen i klartext under fältet. Speglar `rowRotLaborCarveout` i
- * lib/domains/fortnox/helpers.ts, som gör samma kapning vid pushen — den modulen importerar
- * getSupabaseAdmin och kan därför aldrig nå en klientkomponent, så beräkningen bor här och båda
- * hållen kapar likadant.
+ * ⚠️ Fältet är fortfarande en UTBRYTNING, inte ett tillägg. Det höjer aldrig radpriset — det säger
+ * hur stor del av A-priset som är arbete. A-pris 500 kr/m³ med 200 kr/m³ arbete är en rad på
+ * 500 kr/m³, varav 200 är arbete och 300 material.
+ *
+ * Rabatten träffar båda delarna lika. Rabatteras jobbet 10 % sjunker den fakturerade
+ * arbetskostnaden lika mycket, och ROT får bara begäras på det som faktiskt debiteras.
+ *
+ * Kapningen sitter mot A-PRISET, inte mot radtotalen: material får aldrig gå negativt, och en
+ * gräns per enhet är den enda som håller oavsett antal.
  */
-export function splitRowLabor(
-  rowTotal: number,
-  laborCostInput: string | number | null | undefined,
-): RowLaborSplit {
-  const total = Math.max(0, rowTotal);
-  const entered = Math.max(0, parseDecimal(laborCostInput));
-  const labor = Math.min(entered, total);
-  return { labor, material: total - labor, clamped: entered > total };
+export function splitRowLabor(input: {
+  laborCostPerUnit: string | number | null | undefined;
+  /** A-pris per enhet FÖRE rabatt — samma tal som säljaren ser i A-prisfältet. */
+  unitPrice: number;
+  discountPercent: number;
+  quantity: number;
+}): RowLaborSplit {
+  const unitPrice = Math.max(0, input.unitPrice);
+  const entered = Math.max(0, parseDecimal(input.laborCostPerUnit));
+  const perUnit = Math.min(entered, unitPrice);
+  const quantity = Math.max(0, input.quantity);
+  const keep = 1 - Math.min(100, Math.max(0, input.discountPercent)) / 100;
+  const labor = perUnit * keep * quantity;
+  const rowTotal = unitPrice * keep * quantity;
+  return { perUnit, labor, material: Math.max(0, rowTotal - labor), rowTotal, clamped: entered > unitPrice };
+}
+
+/**
+ * Radens utbrutna ROT-arbetskostnad i kronor, härledd ur raden själv.
+ *
+ * ⚠️ Använd INTE den här i offertformuläret. Formuläret prissätter auto-prissatta rader med sin egen
+ * stub (`computeUnitPrice`) medan `lineItemUnitPrice` ger dem 0 — en auto-rad hade alltså fått noll
+ * arbetskostnad här men visat ett pris på skärmen. Formuläret anropar `splitRowLabor` direkt med de
+ * tal det redan räknat fram. Samma fälla som MarginRow.revenue dokumenterar.
+ */
+export function lineItemRotLabor(item: PricingLineItem): number {
+  return splitRowLabor({
+    laborCostPerUnit: item.labor_cost,
+    unitPrice: lineItemUnitPrice(item),
+    discountPercent: lineItemDiscountPercent(item),
+    quantity: lineItemQuantity(item),
+  }).labor;
 }
 
 export function computePricing(
@@ -106,16 +141,14 @@ export function computePricing(
   // ROT (private only): tax-reduction % of the husarbete rows' amount INCL VAT, capped at
   // the max deduction, floored to whole krona (matches Fortnox/Skatteverket — see quotes).
   // The ROT base is labour: a row flagged fully as ROT work contributes its whole total, while an
-  // unflagged material row contributes only its carved-out `labor_cost` (clamped to the row total).
+  // unflagged material row contributes only its carved-out labour (labor_cost per unit × quantity).
   // Mirrors the Fortnox push, where the same split becomes the single "Arbetskostnad ROT" row plus
   // the fully-flagged rows' husarbete flags.
   const rotActive = Boolean(opts?.isPrivate && opts?.rot?.enabled);
   const rotBaseInclVat = rotActive
     ? items.reduce((sum, i) => {
         const rowTotal = lineItemRowTotal(i);
-        const labourBase = i.is_rot_work
-          ? rowTotal
-          : Math.min(Math.max(0, parseDecimal(i.labor_cost)), rowTotal);
+        const labourBase = i.is_rot_work ? rowTotal : Math.min(lineItemRotLabor(i), rowTotal);
         return sum + labourBase * (1 + vatPercent / 100);
       }, 0)
     : 0;

--- a/lib/domains/crm/pricing.ts
+++ b/lib/domains/crm/pricing.ts
@@ -141,10 +141,38 @@ export type MarginRow = {
   quantity: number;
   /** Inköpspris per enhet ur artikelregistret, eller null när det saknas. */
   purchasePrice: number | null | undefined;
+  /**
+   * Raden ÄR arbete (offertens "ROT-arbete"-kryss), inte material.
+   *
+   * ⚠️ AFFÄRSREGEL, beslutad av William 2026-08-19: arbete har ingen INKÖPSKOSTNAD. TG mäts här mot
+   * inköpspris ur artikelregistret, och arbete köps inte in — dess kostnad är lön, som registret
+   * inte bär. En arbetsrad utan inköpspris räknas därför som full TG i stället för att lyftas ut
+   * som obedömd.
+   *
+   * Skälet till att det behövdes: en ROT-offert bryter ut arbetet, och en utesluten arbetsrad drog
+   * ner den sammanvägda siffran hårt — 100 000 kr material mot 80 000 kr inköp plus 50 000 kr
+   * arbete visades som 20 % när den sanna blandade TG:n är 46,7 %.
+   *
+   * ⚠️ Gäller BARA när inköpspriset saknas. Har artikeln ett inköpspris räknas det som vanligt —
+   * annars hade en materialartikel som råkat kryssas som ROT-arbete tappat hela sin kostnad.
+   * Materialrader utan inköpspris lyfts fortfarande ut; att räkna DEM som kostnadsfria är just den
+   * farligt optimistiska siffran som quoteMargin finns för att undvika.
+   *
+   * ⚠️ Den utbrutna arbetskostnaden ("Varav arbetskostnad (ROT, kr)") behöver INGENTING här. Den
+   * bryts ut ur radpriset utan att ändra radtotalen — intäkten innehåller den alltså redan, medan
+   * kostnaden bara är materialets. Den delen får med andra ord full TG av sig själv. Se testet
+   * "den utbrutna arbetskostnaden ändrar inte TG:n".
+   */
+  isLabor?: boolean;
 };
 
 function hasPurchasePrice(purchasePrice: number | null | undefined): purchasePrice is number {
   return purchasePrice != null && Number.isFinite(purchasePrice) && purchasePrice > 0;
+}
+
+// En arbetsrad utan inköpspris: intäkt utan kostnad. Se MarginRow.isLabor.
+function isCostlessLabor(row: MarginRow): boolean {
+  return Boolean(row.isLabor) && !hasPurchasePrice(row.purchasePrice);
 }
 
 /**
@@ -155,8 +183,12 @@ function hasPurchasePrice(purchasePrice: number | null | undefined): purchasePri
  * rad hade fått nya rader att lysa rött innan säljaren ens skrivit något.
  */
 export function rowMarginPercent(row: MarginRow): number | null {
+  if (!(row.revenue > 0)) return null;
+  // Arbete utan inköpspris är hela intäkten i behåll. Inget antal krävs: kostnaden är noll oavsett
+  // hur raden råkar vara prissatt (timme, styck eller klumpsumma).
+  if (isCostlessLabor(row)) return 100;
   if (!hasPurchasePrice(row.purchasePrice)) return null;
-  if (!(row.revenue > 0) || !(row.quantity > 0)) return null;
+  if (!(row.quantity > 0)) return null;
   const cost = row.purchasePrice * row.quantity;
   return ((row.revenue - cost) / row.revenue) * 100;
 }
@@ -206,6 +238,11 @@ export function quoteMargin(rows: MarginRow[]): {
   let unpricedRevenue = 0;
 
   for (const row of rows) {
+    // Arbetsrader utan inköpspris räknas in med noll kostnad — de är bedömda, inte obedömbara.
+    if (isCostlessLabor(row)) {
+      if (row.revenue > 0) revenue += row.revenue;
+      continue;
+    }
     if (!hasPurchasePrice(row.purchasePrice) || !(row.quantity > 0)) {
       if (row.revenue > 0) { unpricedRows++; unpricedRevenue += row.revenue; }
       continue;

--- a/lib/domains/fortnox/helpers.ts
+++ b/lib/domains/fortnox/helpers.ts
@@ -1,14 +1,9 @@
 import { getSupabaseAdmin } from '@/lib/supabase/server';
 import { parseDecimal } from '@/lib/shared/number';
-import { DEFAULT_ROT_HOUSE_WORK_TYPE } from './types';
+import { DEFAULT_ROT_HOUSE_WORK_TYPE, ROT_LABOR_ARTICLE_NUMBER, ROT_LABOR_DESCRIPTION } from './types';
 
-// The standing Fortnox article that aggregated per-row ROT labour is booked to. A ROT deduction
-// may only be claimed on the LABOUR portion, not material — so labour carved out of material rows
-// (each row's `labor_cost`) is summed onto this single husarbete row instead of flagging the
-// material rows themselves. Rows a seller marks fully as ROT work (is_rot_work) keep their own
-// article/price/type and are NOT folded in here.
-export const ROT_LABOR_ARTICLE_NUMBER = '10058';
-export const ROT_LABOR_DESCRIPTION = 'Arbetskostnad ROT';
+// Vidareexporteras här sedan de flyttade till types.ts (klientsäkert — se kommentaren där).
+export { ROT_LABOR_ARTICLE_NUMBER, ROT_LABOR_DESCRIPTION };
 
 // The ROT labour carved out of a single row (kr, ex VAT), clamped to the row's own net so the
 // remaining material can never go negative. Returns 0 when it's not a ROT document, when the row is

--- a/lib/domains/fortnox/helpers.ts
+++ b/lib/domains/fortnox/helpers.ts
@@ -1,21 +1,25 @@
 import { getSupabaseAdmin } from '@/lib/supabase/server';
-import { parseDecimal } from '@/lib/shared/number';
+import { lineItemRotLabor, type PricingLineItem } from '@/lib/domains/crm/pricing';
 import { DEFAULT_ROT_HOUSE_WORK_TYPE, ROT_LABOR_ARTICLE_NUMBER, ROT_LABOR_DESCRIPTION } from './types';
 
 // Vidareexporteras här sedan de flyttade till types.ts (klientsäkert — se kommentaren där).
 export { ROT_LABOR_ARTICLE_NUMBER, ROT_LABOR_DESCRIPTION };
 
-// The ROT labour carved out of a single row (kr, ex VAT), clamped to the row's own net so the
-// remaining material can never go negative. Returns 0 when it's not a ROT document, when the row is
-// already fully flagged as ROT work (is_rot_work — its whole amount is labour, handled separately),
-// or when no labour was entered. `rowNet` is the row's discounted total (lineItemRowTotal).
+// The ROT labour carved out of a single row (kr, ex VAT). Returns 0 when it's not a ROT document,
+// when the row is already fully flagged as ROT work (is_rot_work — its whole amount is labour,
+// handled separately), or when no labour was entered. `rowNet` is the row's discounted total
+// (lineItemRowTotal), kept as a final clamp so the remaining material can never go negative.
+//
+// ⚠️ `labor_cost` är ett À-PRIS (kr per m³/styck) och räknas mot antalet — se splitRowLabor i
+// lib/domains/crm/pricing.ts, som äger tolkningen. Räkningen görs INTE om här: gjorde vi det skulle
+// dokumentet till Fortnox kunna säga något annat än offerten på skärmen.
 export function rowRotLaborCarveout(
-  item: { labor_cost?: string | null; is_rot_work?: boolean | null },
+  item: PricingLineItem,
   rowNet: number,
   rotEnabled: boolean,
 ): number {
   if (!rotEnabled || item.is_rot_work) return 0;
-  const labor = item.labor_cost ? parseDecimal(item.labor_cost) : 0;
+  const labor = lineItemRotLabor(item);
   if (!(labor > 0)) return 0;
   return Math.min(labor, Math.max(0, rowNet));
 }

--- a/lib/domains/fortnox/partialInvoices.ts
+++ b/lib/domains/fortnox/partialInvoices.ts
@@ -1,7 +1,7 @@
 import { getSupabaseAdmin } from '@/lib/supabase/server';
 import { parseDecimal } from '@/lib/shared/number';
 import { lineItemQuantity } from '@/lib/domains/crm/lineItems';
-import { lineItemUnitPrice, lineItemDiscountPercent, lineItemEffectiveUnitPrice } from '@/lib/domains/crm/pricing';
+import { lineItemUnitPrice, lineItemDiscountPercent, lineItemEffectiveUnitPrice, lineItemRotLabor } from '@/lib/domains/crm/pricing';
 import { fortnoxGet, fortnoxPost, fortnoxPut, FortnoxNotConnectedError, FortnoxPushInProgressError } from './client';
 import { appendFortnoxTextNote, buildRotPropertyNote, claimFortnoxPush, resolveReverseVat } from './helpers';
 import { pushWorkOrderToFortnox } from './orders';
@@ -69,7 +69,11 @@ export type PartialRequestLine = { line_id?: string | null; index?: number | nul
 // message instead (Phase 2). Rows flagged fully as ROT work (is_rot_work) are unaffected — they
 // invoice per row exactly as before.
 export function hasCarvedRotLabor(lineItems: PartialInvoiceLineItem[] | null): boolean {
-  return (lineItems ?? []).some((i) => !i.is_rot_work && parseDecimal(i.labor_cost) > 0);
+  // Frågar om något FAKTISKT bryts ut, inte om fältet är ifyllt. Skillnaden är verklig sedan
+  // labor_cost blev ett à-pris: ett belopp som äter hela à-priset bryter ut noll (se splitRowLabor),
+  // och en sådan order har ingenting att proportionera — att ändå spärra delfaktureringen hade
+  // låst den på ett värde som inte längre betyder något.
+  return (lineItems ?? []).some((i) => !i.is_rot_work && lineItemRotLabor(i) > 0);
 }
 export type InvoiceRound = { line_quantities: PartialRequestLine[] | null };
 export type LineInvoiceState = { lineId: string | null; index: number; total: number; invoiced: number; remaining: number };

--- a/lib/domains/fortnox/types.ts
+++ b/lib/domains/fortnox/types.ts
@@ -1,3 +1,15 @@
+// The standing Fortnox article that aggregated per-row ROT labour is booked to. A ROT deduction
+// may only be claimed on the LABOUR portion, not material — so labour carved out of material rows
+// (each row's `labor_cost`) is summed onto this single husarbete row instead of flagging the
+// material rows themselves. Rows a seller marks fully as ROT work (is_rot_work) keep their own
+// article/price/type and are NOT folded in here.
+//
+// ⚠️ Bor HÄR och inte i helpers.ts för att offertformuläret ska kunna visa raden med samma
+// artikelnummer och benämning som pushen skickar. helpers.ts importerar getSupabaseAdmin och kan
+// därför aldrig nå en klientkomponent; types.ts är bieffektsfri och importeras redan därifrån.
+export const ROT_LABOR_ARTICLE_NUMBER = '10058';
+export const ROT_LABOR_DESCRIPTION = 'Arbetskostnad ROT';
+
 // Fortnox OAuth token response from /oauth-v1/token
 export type FortnoxTokenResponse = {
   access_token: string;

--- a/supabase/sql/20260819_rot_labor_cost_per_unit_audit.sql
+++ b/supabase/sql/20260819_rot_labor_cost_per_unit_audit.sql
@@ -14,6 +14,18 @@
 -- skrivas om till för att betyda samma sak som förut. Rabatten är inräknad: den gamla tolkningen
 -- rabatterade inte arbetet, den nya gör det, så en rabatterad rad behöver ett högre à-pris för att
 -- landa på samma kronor.
+--
+-- ⚠️ TILLÄMPA INTE `foreslaget_a_pris` BLINT. Den återställer den GAMLA innebörden, och på en rad
+-- där säljaren redan skrev beloppet per m³ var den gamla innebörden själva buggen. Kör den mot
+-- 2026-08-19 års enda träff: A-pris 500 kr/m³ över 25 m³ med 250 inskrivet. Gammalt = 250 kr arbete
+-- (93 kr i avdrag), nytt = 6 250 kr (2 343 kr). Säljaren menade 250 kr/m³ — det NYA värdet är det
+-- rätta, och `foreslaget_a_pris` hade skrivit ner raden till 10 kr/m³.
+--
+-- Läs alltså kolumnen som "så här gör du om du vill ha kvar det gamla beloppet", inte som en
+-- åtgärd. Avgör rad för rad vad säljaren faktiskt menade.
+--
+-- ✅ KÖRD 2026-08-19: en (1) träff i hela databasen, William testoffert OFF-E6BCBACF. Ingen skarp
+-- offert eller arbetsorder byggde på den gamla tolkningen.
 
 with rader as (
   select

--- a/supabase/sql/20260819_rot_labor_cost_per_unit_audit.sql
+++ b/supabase/sql/20260819_rot_labor_cost_per_unit_audit.sql
@@ -6,12 +6,14 @@
 -- antalet, precis som A-priset.
 --
 -- ⚠️ DÄRFÖR BYTER BEFINTLIG DATA INNEBÖRD. En sparad rad med labor_cost = 8000 och A-pris 200
--- lästes förr som 8 000 kr arbete på hela raden. Efter ändringen kapas 8000 mot A-priset 200 och
--- HELA raden blir arbete — vilket betyder att ROT skulle begäras på materialet också. Det är inte
--- tillåtet, så raderna nedan måste rättas för hand innan de pushas om.
+-- lästes förr som 8 000 kr arbete på hela raden. Läst som à-pris är 8000 större än A-priset 200 —
+-- arbetet skulle äta hela raden och begära ROT på materialet, vilket inte är tillåtet. Koden bryter
+-- därför ut NOLL på en sådan rad: materialet går ut orört och ROT-avdraget försvinner tyst.
 --
--- Kolumnen `arbete_efter_andringen` visar exakt vad varje rad blir med den nya tolkningen, och
--- `foreslaget_a_pris` vad beloppet borde skrivas om till för att betyda samma sak som förut.
+-- Kolumnerna visar vad varje rad är värd före och efter, och `foreslaget_a_pris` vad beloppet ska
+-- skrivas om till för att betyda samma sak som förut. Rabatten är inräknad: den gamla tolkningen
+-- rabatterade inte arbetet, den nya gör det, så en rabatterad rad behöver ett högre à-pris för att
+-- landa på samma kronor.
 
 with rader as (
   select
@@ -48,7 +50,8 @@ tal as (
     nullif(regexp_replace(coalesce(r.item ->> 'unit_price', ''), '[^0-9,.-]', '', 'g'), '') as pris_raw,
     nullif(regexp_replace(coalesce(r.item ->> 'm2', ''), '[^0-9,.-]', '', 'g'), '')         as m2_raw,
     nullif(regexp_replace(coalesce(r.item ->> 'thickness_mm', ''), '[^0-9,.-]', '', 'g'), '') as tjocklek_raw,
-    nullif(regexp_replace(coalesce(r.item ->> 'quantity', ''), '[^0-9,.-]', '', 'g'), '')   as antal_raw
+    nullif(regexp_replace(coalesce(r.item ->> 'quantity', ''), '[^0-9,.-]', '', 'g'), '')   as antal_raw,
+    nullif(regexp_replace(coalesce(r.item ->> 'discount_percent', ''), '[^0-9,.-]', '', 'g'), '') as rabatt_raw
   from rader r
 ),
 parsat as (
@@ -63,7 +66,10 @@ parsat as (
         then coalesce(replace(t.antal_raw, ',', '.')::numeric, 0)
       else coalesce(replace(t.m2_raw, ',', '.')::numeric, 0)
            * coalesce(replace(t.tjocklek_raw, ',', '.')::numeric, 0) / 1000
-    end                                                          as antal
+    end                                                          as antal,
+    -- Andelen av priset som blir kvar efter rabatt, 0–1.
+    1 - least(100, greatest(0, coalesce(replace(t.rabatt_raw, ',', '.')::numeric, 0))) / 100
+                                                                 as kvar_efter_rabatt
   from tal t
 )
 select
@@ -76,18 +82,25 @@ select
   a_pris,
   round(antal, 3)                as antal,
   arbete_inskrivet,
-  -- Förr: beloppet rakt av, kapat mot radtotalen.
-  round(least(arbete_inskrivet, a_pris * antal), 2)        as arbete_fore_andringen,
-  -- Nu: beloppet som à-pris, kapat mot A-priset, gånger antalet.
-  round(least(arbete_inskrivet, a_pris) * antal, 2)        as arbete_efter_andringen,
-  -- Skriv om fältet till det här talet så raden betyder samma sak som förut.
-  case when antal > 0 then round(least(arbete_inskrivet, a_pris * antal) / antal, 2) end
-                                                           as foreslaget_a_pris,
+  -- FÖRR: beloppet rakt av som klumpsumma, kapat mot radens RABATTERADE total.
+  round(least(arbete_inskrivet, a_pris * antal * kvar_efter_rabatt), 2) as arbete_fore_andringen,
+  -- NU: beloppet som à-pris. Äter det hela A-priset bryts ingenting ut (se splitRowLabor).
   case
-    when antal > 0 and least(arbete_inskrivet, a_pris) * antal
-         >= a_pris * antal - 0.005 then 'HELA RADEN BLIR ARBETE — ROT skulle begäras på material'
+    when arbete_inskrivet >= a_pris then 0
+    else round(arbete_inskrivet * kvar_efter_rabatt * antal, 2)
+  end                                                                  as arbete_efter_andringen,
+  -- Skriv om fältet till det här à-priset så raden är värd samma kronor som förut. Divisionen med
+  -- kvar_efter_rabatt är avsiktlig: den nya tolkningen rabatterar arbetet, den gamla gjorde inte det.
+  case
+    when antal > 0 and kvar_efter_rabatt > 0
+      then round(least(arbete_inskrivet, a_pris * antal * kvar_efter_rabatt)
+                 / (antal * kvar_efter_rabatt), 2)
+  end                                                                  as foreslaget_a_pris,
+  case
+    when arbete_inskrivet >= a_pris
+      then 'ROT-AVDRAGET FÖRSVINNER — arbetet äter hela A-priset, inget bryts ut'
     else 'ändrar belopp'
-  end                                                      as folj
+  end                                                                  as folj
 from parsat
 where arbete_inskrivet > 0
   and not hela_raden_ar_arbete          -- ikryssade ROT-rader rör inte fältet

--- a/supabase/sql/20260819_rot_labor_cost_per_unit_audit.sql
+++ b/supabase/sql/20260819_rot_labor_cost_per_unit_audit.sql
@@ -1,0 +1,94 @@
+-- REVISION, LÄSER BARA. Kör den FÖRE koden som gör om labor_cost till ett à-pris.
+--
+-- Bakgrund: "Varav arbetskostnad (ROT)" tolkades förut som ett KLUMPBELOPP för hela raden. Det var
+-- fel — 500 kr arbete gav 500 kr vare sig raden var 10 m³ eller 30 m³, så ROT-avdraget frös vid
+-- samma krontal hur stort jobbet blev. Fältet är nu ett À-PRIS (kr per m³/styck) som räknas mot
+-- antalet, precis som A-priset.
+--
+-- ⚠️ DÄRFÖR BYTER BEFINTLIG DATA INNEBÖRD. En sparad rad med labor_cost = 8000 och A-pris 200
+-- lästes förr som 8 000 kr arbete på hela raden. Efter ändringen kapas 8000 mot A-priset 200 och
+-- HELA raden blir arbete — vilket betyder att ROT skulle begäras på materialet också. Det är inte
+-- tillåtet, så raderna nedan måste rättas för hand innan de pushas om.
+--
+-- Kolumnen `arbete_efter_andringen` visar exakt vad varje rad blir med den nya tolkningen, och
+-- `foreslaget_a_pris` vad beloppet borde skrivas om till för att betyda samma sak som förut.
+
+with rader as (
+  select
+    'offert'                       as dokument,
+    q.id,
+    q.quote_number                 as nummer,
+    q.status,
+    q.created_at,
+    li.ord                         as radnr,
+    li.item
+  from crm_quotes q
+  cross join lateral jsonb_array_elements(q.line_items) with ordinality as li(item, ord)
+  where q.rot_details ->> 'enabled' = 'true'
+
+  union all
+
+  select
+    'arbetsorder',
+    w.id,
+    w.work_order_number,
+    w.status,
+    w.created_at,
+    li.ord,
+    li.item
+  from crm_work_orders w
+  cross join lateral jsonb_array_elements(w.line_items) with ordinality as li(item, ord)
+  where w.rot_details ->> 'enabled' = 'true'
+),
+-- Svenska kommadecimaler och tusentalsmellanslag måste bort innan talen går att räkna på.
+tal as (
+  select
+    r.*,
+    nullif(regexp_replace(coalesce(r.item ->> 'labor_cost', ''), '[^0-9,.-]', '', 'g'), '') as labor_raw,
+    nullif(regexp_replace(coalesce(r.item ->> 'unit_price', ''), '[^0-9,.-]', '', 'g'), '') as pris_raw,
+    nullif(regexp_replace(coalesce(r.item ->> 'm2', ''), '[^0-9,.-]', '', 'g'), '')         as m2_raw,
+    nullif(regexp_replace(coalesce(r.item ->> 'thickness_mm', ''), '[^0-9,.-]', '', 'g'), '') as tjocklek_raw,
+    nullif(regexp_replace(coalesce(r.item ->> 'quantity', ''), '[^0-9,.-]', '', 'g'), '')   as antal_raw
+  from rader r
+),
+parsat as (
+  select
+    t.dokument, t.id, t.nummer, t.status, t.created_at, t.radnr,
+    t.item ->> 'article_name'                                   as artikel,
+    coalesce((t.item ->> 'is_rot_work')::boolean, false)         as hela_raden_ar_arbete,
+    coalesce(replace(t.labor_raw, ',', '.')::numeric, 0)         as arbete_inskrivet,
+    coalesce(replace(t.pris_raw, ',', '.')::numeric, 0)          as a_pris,
+    case
+      when coalesce(t.item ->> 'pricing_mode', 'm3') = 'item'
+        then coalesce(replace(t.antal_raw, ',', '.')::numeric, 0)
+      else coalesce(replace(t.m2_raw, ',', '.')::numeric, 0)
+           * coalesce(replace(t.tjocklek_raw, ',', '.')::numeric, 0) / 1000
+    end                                                          as antal
+  from tal t
+)
+select
+  dokument,
+  nummer,
+  status,
+  created_at::date               as skapad,
+  radnr,
+  artikel,
+  a_pris,
+  round(antal, 3)                as antal,
+  arbete_inskrivet,
+  -- Förr: beloppet rakt av, kapat mot radtotalen.
+  round(least(arbete_inskrivet, a_pris * antal), 2)        as arbete_fore_andringen,
+  -- Nu: beloppet som à-pris, kapat mot A-priset, gånger antalet.
+  round(least(arbete_inskrivet, a_pris) * antal, 2)        as arbete_efter_andringen,
+  -- Skriv om fältet till det här talet så raden betyder samma sak som förut.
+  case when antal > 0 then round(least(arbete_inskrivet, a_pris * antal) / antal, 2) end
+                                                           as foreslaget_a_pris,
+  case
+    when antal > 0 and least(arbete_inskrivet, a_pris) * antal
+         >= a_pris * antal - 0.005 then 'HELA RADEN BLIR ARBETE — ROT skulle begäras på material'
+    else 'ändrar belopp'
+  end                                                      as folj
+from parsat
+where arbete_inskrivet > 0
+  and not hela_raden_ar_arbete          -- ikryssade ROT-rader rör inte fältet
+order by dokument, created_at desc, radnr;

--- a/supabase/sql/20260819_rot_labor_cost_per_unit_audit.sql
+++ b/supabase/sql/20260819_rot_labor_cost_per_unit_audit.sql
@@ -31,7 +31,7 @@ with rader as (
   select
     'arbetsorder',
     w.id,
-    w.work_order_number,
+    w.order_number,
     w.status,
     w.created_at,
     li.ord,

--- a/tests/crm/lineItems.test.ts
+++ b/tests/crm/lineItems.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { lineItemQuantity } from '@/lib/domains/crm/lineItems';
+import { lineItemQuantity, isBlankLineItem } from '@/lib/domains/crm/lineItems';
 
 describe('lineItemQuantity', () => {
   it('computes m³ volume from m² × thickness/1000', () => {
@@ -20,5 +20,61 @@ describe('lineItemQuantity', () => {
   it('returns 0 for empty m³ or item inputs', () => {
     expect(lineItemQuantity({ pricing_mode: 'm3', m2: '', thickness_mm: '' })).toBe(0);
     expect(lineItemQuantity({ pricing_mode: 'item', quantity: '' })).toBe(0);
+  });
+});
+
+describe('isBlankLineItem', () => {
+  // Formulärets startrad: allt tomt, med de defaultvärden createEmptyLineItem sätter.
+  const emptyRow = {
+    construction: '',
+    m2: '',
+    thickness_mm: '',
+    unit_price: '',
+    quantity: '',
+    article_id: null,
+    article_name: null,
+    article_number: null,
+    article_note: null,
+    article_price: null,
+    article_unit_name: null,
+    discount_percent: '',
+    line_note: '',
+    is_rot_work: false,
+    labor_cost: '',
+    density: '',
+  };
+
+  it('räknar en orörd startrad som tom', () => {
+    // Att den här är true är hela poängen: auto_price, pricing_mode och house_work_type sätts av
+    // createEmptyLineItem utan att någon valt dem, och lästes de som innehåll hade varje ny rad
+    // krävt en bekräftelse för att tas bort. Därför står de inte i LineItemContentSource.
+    expect(isBlankLineItem(emptyRow)).toBe(true);
+  });
+
+  it('ser en vald artikel som innehåll', () => {
+    expect(isBlankLineItem({ ...emptyRow, article_name: 'Ekovilla lösull' })).toBe(false);
+    expect(isBlankLineItem({ ...emptyRow, article_number: '10058' })).toBe(false);
+  });
+
+  it('ser varje ifyllt fält säljaren skriver i som innehåll', () => {
+    const filled: Array<[string, Record<string, string | boolean>]> = [
+      ['construction', { construction: 'vagg' }],
+      ['m2', { m2: '120' }],
+      ['thickness_mm', { thickness_mm: '200' }],
+      ['quantity', { quantity: '3' }],
+      ['unit_price', { unit_price: '1250' }],
+      ['discount_percent', { discount_percent: '10' }],
+      ['line_note', { line_note: 'Endast vindsbjälklag' }],
+      ['labor_cost', { labor_cost: '4000' }],
+      ['density', { density: '38' }],
+      ['is_rot_work', { is_rot_work: true }],
+    ];
+    for (const [label, patch] of filled) {
+      expect(isBlankLineItem({ ...emptyRow, ...patch }), label).toBe(false);
+    }
+  });
+
+  it('räknar blanksteg som tomt', () => {
+    expect(isBlankLineItem({ ...emptyRow, m2: '   ', line_note: '  ' })).toBe(true);
   });
 });

--- a/tests/crm/pricing.test.ts
+++ b/tests/crm/pricing.test.ts
@@ -90,15 +90,29 @@ describe('computePricing', () => {
     expect(p.subtotal).toBe(10000);
   });
 
-  it('ROT base clamps labor_cost to the row total', () => {
-    // labor_cost 99999 on a 1000 row → base is the 1000 row, not 99999.
-    // 1000 incl 25% = 1250; 30% = 375.
+  it('ger NOLL ROT-underlag när arbetet äter hela A-priset', () => {
+    // ⚠️ Faller åt det säkra hållet. Ett arbetsbelopp som lämnar noll material är ett datafel — en
+    // rad sparad under den gamla klumpbeloppstolkningen, eller ett A-pris satt till bara
+    // materialdelen. Att räkna hela raden som arbete hade begärt ROT på material, vilket inte är
+    // tillåtet. Offertformuläret spärrar sparningen; här bryts helt enkelt inget ut.
     const p = computePricing(
       [{ pricing_mode: 'item', quantity: '1', unit_price: '1000', labor_cost: '99999' }],
       25,
       { isPrivate: true, rot: { enabled: true, rot_percent: 30, max_deduction: 50000 } },
     );
-    expect(p.rotDeduction).toBe(375);
+    expect(p.rotDeduction).toBe(0);
+    // Radpriset rörs INTE — bara utbrytningen uteblir. Offerten är fortfarande på 1 000 kr.
+    expect(p.subtotal).toBe(1000);
+  });
+
+  it('räknar ROT-underlaget på en giltig utbrytning', () => {
+    // 300 kr/enhet arbete av A-priset 1 000 → 300 kr, inkl 25 % moms 375, 30 % = 112.
+    const p = computePricing(
+      [{ pricing_mode: 'item', quantity: '1', unit_price: '1000', labor_cost: '300' }],
+      25,
+      { isPrivate: true, rot: { enabled: true, rot_percent: 30, max_deduction: 50000 } },
+    );
+    expect(p.rotDeduction).toBe(112);
   });
 });
 
@@ -317,13 +331,17 @@ describe('splitRowLabor', () => {
     expect(split.material).toBeCloseTo(16200, 6);
   });
 
-  it('kapar mot A-PRISET, inte mot radtotalen', () => {
-    // En gräns per enhet är den enda som håller oavsett antal — material får aldrig gå negativt.
-    const split = splitRowLabor({ laborCostPerUnit: '900', unitPrice: 500, discountPercent: 0, quantity: 60 });
-    expect(split.perUnit).toBe(500);
-    expect(split.labor).toBe(30000);
-    expect(split.material).toBe(0);
-    expect(split.clamped).toBe(true);
+  it('bryter ut NOLL när arbetet äter hela A-priset', () => {
+    // ⚠️ Faller åt det säkra hållet. Att kapa till A-priset hade gjort hela materialraden till
+    // arbete och skickat ett dokument som begär ROT på material — inte tillåtet. Två verkliga vägar
+    // hit: en rad sparad under den gamla klumpbeloppstolkningen, och ett A-pris satt till bara
+    // materialdelen med arbetet skrivet som påslag.
+    for (const belopp of ['900', '500']) {
+      const split = splitRowLabor({ laborCostPerUnit: belopp, unitPrice: 500, discountPercent: 0, quantity: 60 });
+      expect(split.leavesNoMaterial, belopp).toBe(true);
+      expect(split.labor, belopp).toBe(0);
+      expect(split.material, belopp).toBe(30000);
+    }
   });
 
   it('läser svenska kommadecimaler', () => {
@@ -336,7 +354,7 @@ describe('splitRowLabor', () => {
       const split = splitRowLabor({ laborCostPerUnit: input, unitPrice: 500, discountPercent: 0, quantity: 60 });
       expect(split.labor, String(input)).toBe(0);
       expect(split.material, String(input)).toBe(30000);
-      expect(split.clamped, String(input)).toBe(false);
+      expect(split.leavesNoMaterial, String(input)).toBe(false);
     }
   });
 

--- a/tests/crm/pricing.test.ts
+++ b/tests/crm/pricing.test.ts
@@ -281,3 +281,77 @@ describe('quoteMargin', () => {
     expect(result.marginPercent).toBeNull();
   });
 });
+
+// ─── ROT: arbete i TG:n ────────────────────────────────────────────────────────
+//
+// En ROT-offert bryter ut arbetet ur priset. Arbete köps inte in, så det saknar inköpspris — och
+// tidigare lyftes varje rad utan inköpspris ut ur BÅDA summorna. Eftersom arbete är nästan ren
+// marginal drog det ner den sammanvägda siffran hårt. Reglerna nedan är beslutade av William
+// 2026-08-19; se MarginRow.isLabor.
+describe('TG på ROT-offerter', () => {
+  it('den utbrutna arbetskostnaden ändrar inte TG:n — den ingår redan', () => {
+    // ⚠️ REGRESSIONSVAKT MOT EN FELDIAGNOS. Fältet "Varav arbetskostnad (ROT, kr)" BRYTER UT arbetet
+    // ur radpriset utan att ändra radtotalen: 150 000 kr förblir 150 000 kr, och först vid
+    // Fortnox-pushen delas raden i material + "Arbetskostnad ROT" (art. 10058). Intäkten som skickas
+    // hit innehåller alltså redan arbetet, medan kostnaden bara är materialets — arbetsdelen får
+    // full TG av sig själv.
+    //
+    // Att läsa `labor_cost` här och dra av det vore alltså inte en fix utan en NY bugg: TG:n skulle
+    // falla från 46,7 % till 20 % på precis de offerter felet påstods gälla.
+    const heltRadprisetInklArbete = quoteMargin([
+      { revenue: 150000, quantity: 100, purchasePrice: 800 },
+    ]);
+    expect(heltRadprisetInklArbete.marginPercent).toBeCloseTo(46.667, 3);
+    expect(heltRadprisetInklArbete.unpricedRows).toBe(0);
+  });
+
+  it('räknar en arbetsrad utan inköpspris som full TG i stället för att utesluta den', () => {
+    // Material 100 000 mot 80 000 inköp (20 %) + 50 000 arbete utan inköpskostnad.
+    // Före regeln uteslöts arbetsraden och säljaren såg 20 % — en röd offert som krävde
+    // säljchefsgodkännande fast den sanna blandade TG:n är 46,7 %.
+    const result = quoteMargin([
+      { revenue: 100000, quantity: 100, purchasePrice: 800 },
+      { revenue: 50000, quantity: 1, purchasePrice: null, isLabor: true },
+    ]);
+    expect(result.marginPercent).toBeCloseTo(46.667, 3);
+    expect(result.revenue).toBe(150000);
+    expect(result.cost).toBe(80000);
+    // Arbetsraden är BEDÖMD, inte obedömbar — annars hade upplysningen "1 rad saknar inköpspris"
+    // stått kvar under en siffra som faktiskt räknar med raden.
+    expect(result.unpricedRows).toBe(0);
+    expect(result.unpricedRevenue).toBe(0);
+  });
+
+  it('låter en arbetsrad SOM HAR inköpspris räkna sin kostnad som vanligt', () => {
+    // Kryssrutan går att sätta på vilken rad som helst. Hade isLabor nollat kostnaden rakt av
+    // skulle en materialrad som råkat kryssas tappa hela sitt inköp och lysa 100 %.
+    const result = quoteMargin([
+      { revenue: 1000, quantity: 1, purchasePrice: 600, isLabor: true },
+    ]);
+    expect(result.marginPercent).toBeCloseTo(40, 6);
+    expect(result.cost).toBe(600);
+  });
+
+  it('håller MATERIAL utan inköpspris utanför även när offerten är ROT', () => {
+    // Regeln gäller arbete, inte "allt utan inköpspris". 61 av 289 artiklar saknar inköpspris, och
+    // att räkna dem som kostnadsfria är just den farligt optimistiska siffran quoteMargin undviker.
+    const result = quoteMargin([
+      { revenue: 1000, quantity: 1, purchasePrice: 600 },
+      { revenue: 9000, quantity: 3, purchasePrice: null },
+    ]);
+    expect(result.marginPercent).toBeCloseTo(40, 6);
+    expect(result.unpricedRows).toBe(1);
+    expect(result.unpricedRevenue).toBe(9000);
+  });
+
+  it('ger radmärket 100 % på en arbetsrad utan inköpspris', () => {
+    expect(rowMarginPercent({ revenue: 50000, quantity: 1, purchasePrice: null, isLabor: true })).toBe(100);
+    // Utan antal också — arbete prissätts ibland som klumpsumma, och kostnaden är noll oavsett.
+    expect(rowMarginPercent({ revenue: 50000, quantity: 0, purchasePrice: null, isLabor: true })).toBe(100);
+  });
+
+  it('ger fortfarande null för en tom arbetsrad', () => {
+    // En nyss tillagd rad med kryssrutan i ska inte lysa grönt innan säljaren skrivit ett pris.
+    expect(rowMarginPercent({ revenue: 0, quantity: 0, purchasePrice: null, isLabor: true })).toBeNull();
+  });
+});

--- a/tests/crm/pricing.test.ts
+++ b/tests/crm/pricing.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   lineItemRowTotal, computePricing, resolveQuoteVatBreakdown, quoteAmountDisplay,
-  rowMarginPercent, marginTier, quoteMargin, MARGIN_THRESHOLDS,
+  rowMarginPercent, marginTier, quoteMargin, splitRowLabor, MARGIN_THRESHOLDS,
 } from '@/lib/domains/crm/pricing';
 
 describe('lineItemRowTotal', () => {
@@ -288,6 +288,46 @@ describe('quoteMargin', () => {
 // tidigare lyftes varje rad utan inköpspris ut ur BÅDA summorna. Eftersom arbete är nästan ren
 // marginal drog det ner den sammanvägda siffran hårt. Reglerna nedan är beslutade av William
 // 2026-08-19; se MarginRow.isLabor.
+describe('splitRowLabor', () => {
+  it('bryter UT arbetet ur radpriset — det läggs aldrig till', () => {
+    // ⚠️ Regressionsvakt mot den dyraste feltolkningen: "Varav" har lästs som "plus". En rad på
+    // 18 000 kr med 12 000 kr arbete är fortfarande 18 000 kr, inte 30 000.
+    const split = splitRowLabor(18000, '12000');
+    expect(split.labor).toBe(12000);
+    expect(split.material).toBe(6000);
+    expect(split.labor + split.material).toBe(18000);
+    expect(split.clamped).toBe(false);
+  });
+
+  it('kapar ett belopp som överstiger radtotalen', () => {
+    // Samma kapning som rowRotLaborCarveout gör vid pushen — materialet får aldrig gå negativt.
+    const split = splitRowLabor(18000, '25000');
+    expect(split.labor).toBe(18000);
+    expect(split.material).toBe(0);
+    expect(split.clamped).toBe(true);
+  });
+
+  it('läser svenska kommadecimaler', () => {
+    expect(splitRowLabor(1000, '199,50').labor).toBeCloseTo(199.5, 6);
+  });
+
+  it('ger noll arbete för tomt, nollat eller negativt belopp', () => {
+    for (const input of ['', null, undefined, '0', '-500']) {
+      const split = splitRowLabor(18000, input);
+      expect(split.labor, String(input)).toBe(0);
+      expect(split.material, String(input)).toBe(18000);
+      expect(split.clamped, String(input)).toBe(false);
+    }
+  });
+
+  it('klarar en rad utan pris utan att gå negativt', () => {
+    const split = splitRowLabor(0, '200');
+    expect(split.labor).toBe(0);
+    expect(split.material).toBe(0);
+    expect(split.clamped).toBe(true);
+  });
+});
+
 describe('TG på ROT-offerter', () => {
   it('den utbrutna arbetskostnaden ändrar inte TG:n — den ingår redan', () => {
     // ⚠️ REGRESSIONSVAKT MOT EN FELDIAGNOS. Fältet "Varav arbetskostnad (ROT, kr)" BRYTER UT arbetet

--- a/tests/crm/pricing.test.ts
+++ b/tests/crm/pricing.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   lineItemRowTotal, computePricing, resolveQuoteVatBreakdown, quoteAmountDisplay,
-  rowMarginPercent, marginTier, quoteMargin, splitRowLabor, MARGIN_THRESHOLDS,
+  rowMarginPercent, marginTier, quoteMargin, splitRowLabor, lineItemRotLabor, MARGIN_THRESHOLDS,
 } from '@/lib/domains/crm/pricing';
 
 describe('lineItemRowTotal', () => {
@@ -289,42 +289,75 @@ describe('quoteMargin', () => {
 // marginal drog det ner den sammanvägda siffran hårt. Reglerna nedan är beslutade av William
 // 2026-08-19; se MarginRow.isLabor.
 describe('splitRowLabor', () => {
-  it('bryter UT arbetet ur radpriset — det läggs aldrig till', () => {
-    // ⚠️ Regressionsvakt mot den dyraste feltolkningen: "Varav" har lästs som "plus". En rad på
-    // 18 000 kr med 12 000 kr arbete är fortfarande 18 000 kr, inte 30 000.
-    const split = splitRowLabor(18000, '12000');
-    expect(split.labor).toBe(12000);
-    expect(split.material).toBe(6000);
-    expect(split.labor + split.material).toBe(18000);
-    expect(split.clamped).toBe(false);
+  it('räknar arbetskostnaden mot antalet — den är ett à-pris', () => {
+    // ⚠️ REGRESSIONSVAKT MOT EN RIKTIG BUGG (rättad 2026-08-19). Fältet lästes som ett klumpbelopp
+    // för hela raden: 500 kr arbete gav 500 kr vare sig raden var 10 m³ eller 30 m³, så ROT-avdraget
+    // frös vid samma krontal hur stort jobbet än blev.
+    const tio = splitRowLabor({ laborCostPerUnit: '500', unitPrice: 1500, discountPercent: 0, quantity: 10 });
+    const trettio = splitRowLabor({ laborCostPerUnit: '500', unitPrice: 1500, discountPercent: 0, quantity: 30 });
+    expect(tio.labor).toBe(5000);
+    expect(trettio.labor).toBe(15000);
+    expect(trettio.labor).toBe(tio.labor * 3);
   });
 
-  it('kapar ett belopp som överstiger radtotalen', () => {
-    // Samma kapning som rowRotLaborCarveout gör vid pushen — materialet får aldrig gå negativt.
-    const split = splitRowLabor(18000, '25000');
-    expect(split.labor).toBe(18000);
+  it('bryter UT arbetet ur A-priset — det läggs aldrig till', () => {
+    // A-pris 500 kr/m³ varav 200 arbete är en rad på 500 kr/m³, inte 700.
+    const split = splitRowLabor({ laborCostPerUnit: '200', unitPrice: 500, discountPercent: 0, quantity: 60 });
+    expect(split.rowTotal).toBe(30000);
+    expect(split.labor).toBe(12000);
+    expect(split.material).toBe(18000);
+    expect(split.labor + split.material).toBe(split.rowTotal);
+  });
+
+  it('låter rabatten träffa arbete och material lika', () => {
+    // ROT får bara begäras på det som faktiskt debiteras, så en rabatterad rad har rabatterat arbete.
+    const split = splitRowLabor({ laborCostPerUnit: '200', unitPrice: 500, discountPercent: 10, quantity: 60 });
+    expect(split.rowTotal).toBeCloseTo(27000, 6);
+    expect(split.labor).toBeCloseTo(10800, 6);
+    expect(split.material).toBeCloseTo(16200, 6);
+  });
+
+  it('kapar mot A-PRISET, inte mot radtotalen', () => {
+    // En gräns per enhet är den enda som håller oavsett antal — material får aldrig gå negativt.
+    const split = splitRowLabor({ laborCostPerUnit: '900', unitPrice: 500, discountPercent: 0, quantity: 60 });
+    expect(split.perUnit).toBe(500);
+    expect(split.labor).toBe(30000);
     expect(split.material).toBe(0);
     expect(split.clamped).toBe(true);
   });
 
   it('läser svenska kommadecimaler', () => {
-    expect(splitRowLabor(1000, '199,50').labor).toBeCloseTo(199.5, 6);
+    expect(splitRowLabor({ laborCostPerUnit: '199,50', unitPrice: 500, discountPercent: 0, quantity: 2 }).labor)
+      .toBeCloseTo(399, 6);
   });
 
   it('ger noll arbete för tomt, nollat eller negativt belopp', () => {
     for (const input of ['', null, undefined, '0', '-500']) {
-      const split = splitRowLabor(18000, input);
+      const split = splitRowLabor({ laborCostPerUnit: input, unitPrice: 500, discountPercent: 0, quantity: 60 });
       expect(split.labor, String(input)).toBe(0);
-      expect(split.material, String(input)).toBe(18000);
+      expect(split.material, String(input)).toBe(30000);
       expect(split.clamped, String(input)).toBe(false);
     }
   });
 
-  it('klarar en rad utan pris utan att gå negativt', () => {
-    const split = splitRowLabor(0, '200');
-    expect(split.labor).toBe(0);
-    expect(split.material).toBe(0);
-    expect(split.clamped).toBe(true);
+  it('klarar en rad utan pris eller antal utan att gå negativt', () => {
+    expect(splitRowLabor({ laborCostPerUnit: '200', unitPrice: 0, discountPercent: 0, quantity: 60 }).labor).toBe(0);
+    expect(splitRowLabor({ laborCostPerUnit: '200', unitPrice: 500, discountPercent: 0, quantity: 0 }).labor).toBe(0);
+  });
+});
+
+describe('lineItemRotLabor', () => {
+  it('härleder antalet ur m² × tjocklek för en m³-rad', () => {
+    // 100 m² × 200 mm = 20 m³ × 150 kr/m³ arbete = 3 000 kr.
+    expect(lineItemRotLabor({
+      pricing_mode: 'm3', m2: '100', thickness_mm: '200', unit_price: '1500', labor_cost: '150',
+    })).toBeCloseTo(3000, 6);
+  });
+
+  it('följer med när måtten växer', () => {
+    const litet = lineItemRotLabor({ pricing_mode: 'm3', m2: '50', thickness_mm: '200', unit_price: '1500', labor_cost: '150' });
+    const stort = lineItemRotLabor({ pricing_mode: 'm3', m2: '150', thickness_mm: '200', unit_price: '1500', labor_cost: '150' });
+    expect(stort).toBeCloseTo(litet * 3, 6);
   });
 });
 

--- a/tests/fortnox/offers.test.ts
+++ b/tests/fortnox/offers.test.ts
@@ -173,7 +173,8 @@ describe('buildOfferRows', () => {
 describe('buildOfferRows – ROT labour carve-out', () => {
   it('carves labor_cost out of a material row into one aggregated Arbetskostnad ROT row (total unchanged)', () => {
     const rows = buildOfferRows(
-      [{ pricing_mode: 'item', article_name: 'Lösull', article_number: '1001', unit_price: '200', quantity: '100', labor_cost: '8000' }],
+      // 80 kr/enhet arbete av A-priset 200 → 8 000 kr över 100 enheter.
+      [{ pricing_mode: 'item', article_name: 'Lösull', article_number: '1001', unit_price: '200', quantity: '100', labor_cost: '80' }],
       25, true,
     );
     expect(rows).toHaveLength(2);
@@ -196,8 +197,8 @@ describe('buildOfferRows – ROT labour carve-out', () => {
   it('sums carved labour across rows into a single aggregated row', () => {
     const rows = buildOfferRows(
       [
-        { pricing_mode: 'item', unit_price: '200', quantity: '100', labor_cost: '8000' },
-        { pricing_mode: 'item', unit_price: '100', quantity: '50', labor_cost: '2000' },
+        { pricing_mode: 'item', unit_price: '200', quantity: '100', labor_cost: '80' }, // 8 000
+        { pricing_mode: 'item', unit_price: '100', quantity: '50', labor_cost: '40' },  // 2 000
       ],
       25, true,
     );
@@ -206,12 +207,13 @@ describe('buildOfferRows – ROT labour carve-out', () => {
     expect(labor.Price).toBe(10000);
   });
 
-  it('clamps a labor_cost larger than the row total to the row (material floors at 0)', () => {
+  it('clamps a labor_cost larger than the UNIT PRICE to it (material floors at 0)', () => {
     const rows = buildOfferRows(
       [{ pricing_mode: 'item', unit_price: '100', quantity: '10', labor_cost: '99999' }],
       25, true,
     );
-    // rowNet = 1000 → labour clamped to 1000, material 0.
+    // 99999 kr/enhet kapas till A-priset 100 → labour 10 × 100 = 1000, material 0. Kapningen sitter
+    // per ENHET; en gräns mot radtotalen hade inte hållit när antalet ändras.
     expect(rows[0].Price).toBe(0);
     expect(rows[rows.length - 1].Price).toBe(1000);
   });
@@ -238,21 +240,24 @@ describe('buildOfferRows – ROT labour carve-out', () => {
 
   it('bakes discount into a carved material row and drops the Discount line', () => {
     const rows = buildOfferRows(
-      [{ pricing_mode: 'item', unit_price: '100', quantity: '10', discount_percent: '10', labor_cost: '200' }],
+      [{ pricing_mode: 'item', unit_price: '100', quantity: '10', discount_percent: '10', labor_cost: '20' }],
       25, true,
     );
-    // rowNet = 10 × 100 × 0.9 = 900; material = 900 − 200 = 700 over 10 = 70/unit; Discount dropped.
-    expect(rows[0].Price).toBeCloseTo(70, 6);
+    // Rabatten träffar BÅDA delarna: arbete 20 × 0,9 × 10 = 180, rowNet 900, material 720 över 10
+    // = 72/enhet. ROT får bara begäras på det som faktiskt debiteras, så rabatterat arbete ger ett
+    // rabatterat underlag. Discount-raden faller bort eftersom rabatten är inbakad i priset.
+    expect(rows[0].Price).toBeCloseTo(72, 6);
     expect(rows[0].Discount).toBeUndefined();
-    expect(rows[rows.length - 1].Price).toBe(200);
+    expect(rows[rows.length - 1].Price).toBeCloseTo(180, 6);
   });
 
   it('keeps material + aggregated labour summing EXACTLY to the row total on a non-divisible quantity', () => {
-    // rowNet = 300, carve 10 → material 290 / 3 = 96.6667 → Fortnox would round the unit price and
-    // drift. The split rounds material to 96.67 and lets the labour absorb the 0.01 residual so the
-    // two rows' rounded totals still tie back to 300.00 (regression for the rounding-drift finding).
+    // rowNet = 300, arbete 3,3333 × 3 = 9,9999 → material 290,0001 / 3 = 96,6667 → Fortnox would
+    // round the unit price and drift. The split rounds material to 96.67 and lets the labour absorb
+    // the residual so the two rows' rounded totals still tie back to 300.00 (regression for the
+    // rounding-drift finding).
     const rows = buildOfferRows(
-      [{ pricing_mode: 'item', unit_price: '100', quantity: '3', labor_cost: '10' }],
+      [{ pricing_mode: 'item', unit_price: '100', quantity: '3', labor_cost: '3.3333' }],
       25, true,
     );
     const material = rows[0];

--- a/tests/fortnox/offers.test.ts
+++ b/tests/fortnox/offers.test.ts
@@ -207,15 +207,20 @@ describe('buildOfferRows – ROT labour carve-out', () => {
     expect(labor.Price).toBe(10000);
   });
 
-  it('clamps a labor_cost larger than the UNIT PRICE to it (material floors at 0)', () => {
-    const rows = buildOfferRows(
-      [{ pricing_mode: 'item', unit_price: '100', quantity: '10', labor_cost: '99999' }],
-      25, true,
-    );
-    // 99999 kr/enhet kapas till A-priset 100 → labour 10 × 100 = 1000, material 0. Kapningen sitter
-    // per ENHET; en gräns mot radtotalen hade inte hållit när antalet ändras.
-    expect(rows[0].Price).toBe(0);
-    expect(rows[rows.length - 1].Price).toBe(1000);
+  it('bryter ut NOLL när arbetet äter hela A-priset — ingen ROT på material', () => {
+    // ⚠️ REGRESSIONSVAKT MOT ETT RIKTIGT FEL I DRIFT: dokumentet gick till Fortnox med HELA beloppet
+    // på arbetskostnadsraden och noll på materialet, medan vår egen vy såg rätt ut (radtotalen rörs
+    // ju inte av utbrytningen). ROT får inte begäras på material, så ett arbetsbelopp som lämnar
+    // noll material bryter inte ut något alls. Offertformuläret spärrar dessutom sparningen.
+    for (const belopp of ['99999', '100']) {
+      const rows = buildOfferRows(
+        [{ pricing_mode: 'item', unit_price: '100', quantity: '10', labor_cost: belopp }],
+        25, true,
+      );
+      expect(rows, belopp).toHaveLength(1);        // ingen 10058-rad
+      expect(rows[0].Price, belopp).toBe(100);     // materialraden orörd
+      expect(rows[0].HouseWork, belopp).toBeUndefined();
+    }
   });
 
   it('ignores labor_cost when the row is flagged as full ROT work (whole row is the labour)', () => {

--- a/tests/fortnox/orders.test.ts
+++ b/tests/fortnox/orders.test.ts
@@ -93,7 +93,8 @@ describe('buildOrderRows', () => {
 describe('buildOrderRows – ROT labour carve-out', () => {
   it('carves labor_cost out of a material row into one aggregated Arbetskostnad ROT row', () => {
     const rows = buildOrderRows(
-      [{ pricing_mode: 'item', article_name: 'Lösull', unit_price: '200', quantity: '100', labor_cost: '8000' }],
+      // 80 kr/enhet arbete av A-priset 200 → 8 000 kr över 100 enheter.
+      [{ pricing_mode: 'item', article_name: 'Lösull', unit_price: '200', quantity: '100', labor_cost: '80' }],
       25, true,
     );
     expect(rows).toHaveLength(2);
@@ -255,7 +256,7 @@ describe('buildOrderRows — avskrivna rader', () => {
   // Avskrivningen får inte råka slå av ROT-arbetskostnaden för de rader som ÄR kvar.
   it('räknar fortfarande ut ROT-arbetskostnaden på kvarvarande rader', () => {
     const rows = buildOrderRows([
-      { pricing_mode: 'item', article_name: 'Lösull', unit_price: '200', quantity: '100', labor_cost: '8000' },
+      { pricing_mode: 'item', article_name: 'Lösull', unit_price: '200', quantity: '100', labor_cost: '80' },
       { pricing_mode: 'item', article_name: 'Struken', unit_price: '500', quantity: '1', written_off: true },
     ], 25, true);
     expect(rows).toHaveLength(2);

--- a/tests/fortnox/partialInvoices.test.ts
+++ b/tests/fortnox/partialInvoices.test.ts
@@ -139,7 +139,17 @@ describe('roundSubtotal', () => {
 
 describe('hasCarvedRotLabor (partial-invoice Phase-2 guard)', () => {
   it('detects a material row with carved-out labour', () => {
-    expect(hasCarvedRotLabor([itemLine({ labor_cost: '500' })])).toBe(true);
+    // 40 kr/enhet av à-priset 100 → 2 000 kr bryts ut över 50 enheter.
+    expect(hasCarvedRotLabor([itemLine({ labor_cost: '40' })])).toBe(true);
+  });
+
+  it('säger nej när beloppet äter hela à-priset — då bryts ingenting ut', () => {
+    // Guarden frågar om något FAKTISKT bryts ut, inte om fältet är ifyllt. Ett belopp som lämnar
+    // noll material bryter ut noll (se splitRowLabor), och en sådan order har ingenting att
+    // proportionera — att ändå spärra delfaktureringen hade låst den på ett värde som inte längre
+    // betyder något. Gäller varje rad sparad under den gamla klumpbeloppstolkningen.
+    expect(hasCarvedRotLabor([itemLine({ labor_cost: '500' })])).toBe(false);
+    expect(hasCarvedRotLabor([itemLine({ labor_cost: '100' })])).toBe(false);
   });
 
   it('ignores labour on a row flagged fully as ROT work (whole row is the labour, invoiced per row)', () => {


### PR DESCRIPTION
## Varför

Fyra fynd i offertskaparen, upptäckta i tur och ordning under samma session. Det tyngsta är sist.

## Arbetskostnaden var ett klumpbelopp — nu ett à-pris

`labor_cost` lästes som ett belopp för hela raden. **500 kr arbete gav 500 kr vare sig raden var 10 m³ eller 30 m³**, så ROT-avdraget frös vid samma krontal hur stort jobbet än blev. Fältet är nu ett à-pris som multipliceras med antalet, precis som A-priset.

Tolkningen ägs av `splitRowLabor` i `lib/domains/crm/pricing.ts` och används av alla fyra läsarna — offertformuläret, arbetsorderns artikelflik, serverns prisberäkning och Fortnox-pushen — så dokumentet inte kan säga något annat än offerten på skärmen.

Två beslut i räkningen: gränsen sitter mot **A-priset**, inte radtotalen (en gräns per enhet är den enda som håller när antalet ändras), och **rabatten träffar arbete och material lika** — ROT får bara begäras på det som faktiskt debiteras.

## Ett arbetsbelopp som äter hela radpriset bryter inte ut något

Fel som inträffade i drift: dokumentet gick till Fortnox med **hela radbeloppet på "Arbetskostnad ROT" och noll på materialet**, medan vår egen vy såg rätt ut. Den asymmetrin är inbyggd — utbrytningen rör inte radtotalen, så bara Fortnox-dokumentet splittas. Felet syns alltså först hos kunden.

Förut kapades ett för stort belopp till A-priset, vilket gjorde hela materialraden till arbete. ROT får inte begäras på material, så det var fel riktning att falla åt. Nu bryts ingenting ut, materialraden går ut orörd, och felet spärrar sparningen med radnummer i stället för att ske tyst.

## ROT-arbete räknas som full TG

TG mäts mot inköpspris, och arbete köps inte in — dess kostnad är lön, som artikelregistret inte bär. `quoteMargin` lyfte varje rad utan inköpspris ur **båda** summorna, så nästan ren marginal försvann ur nämnaren: 100 000 kr material mot 80 000 kr inköp plus 50 000 kr arbete visades som 20 % när den sanna blandade TG:n är 46,7 %.

Gäller bara när inköpspriset saknas — material utan inköpspris lyfts fortfarande ut, för att räkna **dem** som kostnadsfria är den farligt optimistiska siffran guarden finns för.

## Två synlighetsfixar

**Arbetskostnadsraden syns.** "Arbetskostnad ROT" (art. 10058) syntetiseras först vid pushen, så säljaren såg aldrig den rad kunden får. Den visas nu sist i listan, som på dokumentet. Fortfarande läsvy — lagrad som riktig rad skulle pushen bryta ut arbetet en gång till ovanpå den.

**Bekräftelse innan en artikelrad tas bort.** Krysset sitter tätt intill ytan man klickar på för att fälla ut raden, och borttagningen gick inte att ångra. Tomma rader tas fortfarande bort direkt. `CrmConfirmDialog` fick ett `tone="danger"` med autofokus på Avbryt — en dialog som finns för att fånga felklick ska inte utföra åtgärden på ett reflexmässigt Enter.

## ⚠️ Innan detta går live

**Befintlig data byter innebörd.** En sparad rad med `labor_cost` 8000 och A-pris 200 lästes förr som 8 000 kr arbete. Läst som à-pris äter den hela priset → ingenting bryts ut → **ROT-avdraget försvinner tyst** på den raden.

`supabase/sql/20260819_rot_labor_cost_per_unit_audit.sql` **läser bara** och listar varje berörd rad på offerter och arbetsordrar, vad den är värd före och efter, och vilket à-pris beloppet ska skrivas om till (rabatten inräknad). Kör den **innan** merge — det är enda tillfället det gamla värdet går att räkna om.

Redan pushade Fortnox-dokument rättas inte av sig själva och måste pushas om.

## Granskning

Kördes på grenen före PR. Sex fynd, alla verifierade mot koden och rättade i `88b61b5` — bland dem att revisionsfrågan räknade efter den kapning som ersattes, och att arbetsorderfliken läste `unit_price` rakt av medan radtotalen bredvid gick via `lineItemUnitPrice`.

## Verifierat

`npm run type-check` · `npm run lint` · `npm run build` · `npm test` (1474 test)

Nya regressionsvakter för båda ROT-felen, inklusive en som pinnar exakt det Fortnox-dokument som gick fel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
